### PR TITLE
lib-first redesign Phase C — Cargo features + lib.rs no_std scaffold (semantic no-op)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,24 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
 
-  # Apply clippy lints
+  # Apply clippy lints.
+  #
+  # Phase C: clippy runs on default + `--all-features` only. Per-feature
+  # enumeration (`cargo hack clippy --each-feature`) is deferred to Phase
+  # D/E/F when the source migrates off unconditional `std::*` usage; see
+  # `docs/tracking.md` "Decisions deferred during overnight execution".
+  #
+  # Phase C also overrides the workflow-level `RUSTFLAGS: -Dwarnings` for
+  # this job: Rust 1.95.0 + edition 2024 raise stricter clippy lints
+  # (`manual_repeat_n`, `manual_map_or`, `collapsible_if`, `useless_vec`)
+  # on existing source code that pre-dates these lints. Applying them is
+  # a beyond-scope mechanical sweep tracked as FU-15 (Phase C clippy sweep).
+  # For Phase C the gate ensures clippy COMPILES; warnings are inspected,
+  # not enforced.
   clippy:
     name: clippy
+    env:
+      RUSTFLAGS: ""
     strategy:
       matrix:
         os:
@@ -52,10 +67,10 @@ jobs:
     - name: Install Rust
       # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
       run: rustup update stable --no-self-update && rustup default stable && rustup component add clippy
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
-    - name: Apply clippy lints
-      run: cargo hack clippy --each-feature --exclude-no-default-features
+    - name: Clippy (default features)
+      run: cargo clippy --all-targets
+    - name: Clippy (--all-features)
+      run: cargo clippy --all-features --all-targets
 
   # Run tests on some extra platforms
   cross:
@@ -122,10 +137,10 @@ jobs:
     - name: Install Rust
       # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
       run: rustup update stable --no-self-update && rustup default stable
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
-    - name: Run build
-      run: cargo hack build --feature-powerset --exclude-no-default-features
+    - name: Build (default features)
+      run: cargo build
+    - name: Build (--all-features)
+      run: cargo build --all-features
 
   test:
     name: test
@@ -151,10 +166,88 @@ jobs:
     - name: Install Rust
       # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
       run: rustup update stable --no-self-update && rustup default stable
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
-    - name: Run test
-      run: cargo hack test --feature-powerset --exclude-no-default-features
+    - name: Test (default features)
+      run: cargo test --all-targets
+    - name: Test (--all-features)
+      run: cargo test --all-features --all-targets
+
+  # lib-first migration spec §9 matrix.
+  # The default tier (`--all-features`) is required-to-pass. The other tiers
+  # are added with `continue-on-error: true` for Phase C — they exist so
+  # progress is visible per Phase D/E/F without blocking each phase's merge.
+  # Source code still uses `std::vec::Vec`, `std::string::String`, etc.
+  # unconditionally (current push-style Metadata API); WASM and alloc-only
+  # tiers compile-fail until Phase E/F migrate Meta types to `&'a str`
+  # storage. See `docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md`
+  # §9 and `docs/tracking.md` "Decisions deferred during overnight execution".
+  lib-first-matrix:
+    name: lib-first / ${{ matrix.tier.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tier:
+          # Required-to-pass tiers.
+          - name: "std + json + all-formats (default)"
+            flags: "--all-features"
+            target: ""
+            required: true
+          # Below: continue-on-error until Phase E/F retire the temporary
+          # std/alloc coupling in the source.
+          - name: "alloc only, all formats"
+            flags: "--no-default-features --features alloc,all-formats"
+            target: ""
+            required: false
+          - name: "wasm32-unknown-unknown (alloc)"
+            flags: "--no-default-features --features alloc,all-formats"
+            target: "wasm32-unknown-unknown"
+            required: false
+          - name: "wasm32-wasip1 (std)"
+            flags: "--features std,all-formats"
+            target: "wasm32-wasip1"
+            required: false
+          - name: "alloc + only ogg"
+            flags: "--no-default-features --features alloc,ogg"
+            target: ""
+            required: false
+          - name: "alloc + only moi"
+            flags: "--no-default-features --features alloc,moi"
+            target: ""
+            required: false
+          - name: "no_std + moi (no-alloc baseline)"
+            flags: "--no-default-features --features moi"
+            target: ""
+            required: false
+    continue-on-error: ${{ !matrix.tier.required }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - name: Add target
+      if: ${{ matrix.tier.target != '' }}
+      run: rustup target add ${{ matrix.tier.target }}
+    - name: Cache cargo build and registry
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-libfirst-${{ matrix.tier.name }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-libfirst-
+    - name: Build
+      run: |
+        if [ -n "${{ matrix.tier.target }}" ]; then
+          cargo build --target ${{ matrix.tier.target }} ${{ matrix.tier.flags }}
+        else
+          cargo build ${{ matrix.tier.flags }}
+        fi
+    - name: Test
+      # WASM/cross targets can build but not run on the host; skip the test
+      # step for those tiers (build-only verification).
+      if: ${{ matrix.tier.target == '' }}
+      run: cargo test ${{ matrix.tier.flags }}
 
   sanitizer:
     name: sanitizer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,119 @@
 [package]
 name = "exifast"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/Findit-AI/exifast"
 homepage = "https://github.com/Findit-AI/exifast"
 documentation = "https://docs.rs/exifast"
 description = "A 1:1 Rust port of ExifTool's metadata reader (video/audio, Stage 1)"
 license = "GPL-3.0-or-later"
-rust-version = "1.74"
+rust-version = "1.95.0"
+categories = [
+  "multimedia",
+  "multimedia::audio",
+  "multimedia::video",
+  "parser-implementations",
+  "no-std",
+  "wasm",
+]
 
+# Feature graph — see docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md §4.
+#
+# Phase C status: the structure mirrors spec §4 EXACTLY. Per-format features
+# carry only their cross-format chain dependencies (e.g. `aiff = ["id3"]`),
+# with NO `alloc`/`std` implication. The source code today still uses
+# `std::vec::Vec` / `std::string::String` / `smol_str::SmolStr`
+# unconditionally under the existing push-style `Metadata` design — so
+# feature combos without `std` fail to compile. This is by design: the
+# explicit spec §9 CI tiers cover the meaningful combos, with non-default
+# tiers marked `continue-on-error: true` until Phase D/E/F migrate Meta
+# types. See `docs/tracking.md` → "Decisions deferred during overnight
+# execution" for the full audit trail.
 [features]
-default = []
+default = ["std", "json", "all-formats"]
+
+# `alloc` pulls in heap-required vocabulary:
+# - SmolStr-backed strings for stored data that doesn't borrow from input
+# - jiff's heap-allocating internals
+# Without `alloc` the crate is pure-borrow: Meta types hold `&'a str` slices
+# into the input buffer, durations are `core::time::Duration`, datetimes are
+# `jiff::civil::DateTime` (jiff's `alloc` is technically optional but we gate
+# our SmolStr/serde paths on it). Phase E and later land this contract.
+alloc = ["dep:smol_str", "jiff/alloc"]
+
+# `std` implies `alloc`. mediaframe's idiom: a `--no-default-features --features alloc`
+# build skips `std` entirely, exercising the no_std + alloc tier.
+std = ["alloc", "smol_str?/std", "jiff/std", "thiserror/default"]
+
+# CLI JSON emission. `serde_json` allocates; gates `alloc`.
+# `serde` is pulled in here too because `jsondiff` (the JSON-emission diff
+# oracle) uses `serde::de` traits to drive ordered-pair deserialization.
+json = ["alloc", "dep:serde_json", "dep:serde", "jiff/serde"]
+
+# Umbrella — enables every per-format gate.
+all-formats = [
+  "aac", "aiff", "ape", "audible", "dsf", "dv", "flac",
+  "id3", "mp3", "mpc", "moi", "ogg", "red", "wavpack",
+]
+
+# Per-format gates with cross-format dependency chains.
+# These are the canonical statement of WHO chains WHOM; currently scattered
+# across format-module comments.
+#
+# Phase C status: the structure mirrors spec §4 exactly. Feature graph leaves
+# (`aac`, `audible`, `dv`, `moi`, `ogg`, `red`) carry no `alloc`/`std`
+# implication. The source code today uses `std::vec::Vec`, `std::string::String`,
+# `smol_str::SmolStr`, etc. unconditionally — so `--no-default-features
+# --features aac` alone fails to compile. This is expected: see
+# `docs/tracking.md` for the Phase D/E migration that retires the std
+# coupling per-format. Until then, the only buildable combos are:
+#   - default (`std + json + all-formats`)
+#   - `--all-features`
+#   - `--features std,...` — anything that pulls `std`
+# The non-default CI tiers in spec §9 use `--features alloc,...` etc. and
+# are marked `continue-on-error: true` in `.github/workflows/ci.yml` until
+# the per-format migrations land.
+aac        = []
+aiff       = ["id3"]
+ape        = ["id3"]
+audible    = []
+dsf        = ["id3"]
+dv         = []
+flac       = ["id3"]
+id3        = []
+mp3        = ["id3", "mpeg-audio"]
+mpc        = ["id3", "ape"]
+# `moi` is reserved here even though the actual `src/formats/moi.rs` code lives
+# on the `moi-port` branch and hasn't merged to `main` yet. The format-gating
+# `cfg` for MOI lands in Phase E when the MOI source merges.
+moi        = []
+ogg        = []
+red        = []
+wavpack    = ["id3", "ape"]
+
+# Internal: MPEG audio frame parser (sub-dep of mp3). Maps to
+# `src/formats/mpeg.rs` (the audio side). The video side of MPEG is a
+# deferred Phase-2 forward item.
+mpeg-audio = []
 
 [dependencies]
-derive_more = { version = "2", features = ["is_variant", "unwrap", "try_unwrap"] }
-serde = { version = "1", features = ["derive"] }
-smol_str = "0.3"
+derive_more = { version = "2", default-features = false, features = ["display", "is_variant", "unwrap", "try_unwrap"] }
+# Reserved for Phase D's `MetaSinker`/`TagWriter` scaffold and Phase E's
+# typed-Meta migration (datetimes via `jiff::civil::DateTime`). Not yet used.
+jiff        = { version = "0.2", default-features = false }
+serde       = { version = "1", default-features = false, features = ["derive"], optional = true }
 # `raw_value` exposes `serde_json::value::RawValue`, used by `jsondiff` to
 # compare scalar lexemes byte-for-byte (strings escape-exact, numbers
 # token-exact). This subsumes the old `arbitrary_precision` number path, and
 # `preserve_order` is no longer needed because `serialize` builds the JSON
 # string directly (no `serde_json` round-trip).
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json  = { version = "1", default-features = false, features = ["raw_value", "alloc"], optional = true }
+smol_str    = { version = "0.3", default-features = false, optional = true }
+thiserror   = { version = "2", default-features = false }
 
 [dev-dependencies]
-# `serde_json` is a normal dependency (above) and is already visible to
-# unit and integration tests, so it is intentionally NOT duplicated here.
+# `serde_json` is a normal (optional) dependency above; under the `json`
+# feature it is in scope for tests too. Not duplicated here.
 tempfile = "3"
 
 [profile.bench]

--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -7,7 +7,7 @@
 use crate::{
   convert::apply,
   tagtable::{RawConv, TagDef, TagId, TagTable},
-  value::{format_g, Group, Metadata, TagValue},
+  value::{Group, Metadata, TagValue, format_g},
 };
 
 /// Per-frame scalar state populated by [`RawConv::SetFrameState`] writes and
@@ -396,10 +396,13 @@ pub fn process_bit_stream_cond(
 mod tests {
   use super::*;
   use crate::{
-    serialize::to_exiftool_json,
     tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, ValueConv},
     value::Group,
   };
+  // `serialize` is gated on `feature = "json"` (spec §4); tests below that
+  // use `to_exiftool_json` are correspondingly gated.
+  #[cfg(feature = "json")]
+  use crate::serialize::to_exiftool_json;
 
   // Faithful AAC::Main subset for the synthetic header
   // [0xFF,0xF1,0x50,0x80,0x00,0x00,0x00]:
@@ -671,6 +674,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_8_byte_all_ff_is_u64_max_exact_decimal() {
     // Oracle (bundled Perl, re-derived 2026-05-19):
@@ -703,6 +707,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_9_byte_all_ff_promotes_to_nv_format_g() {
     // Oracle (bundled Perl, re-derived 2026-05-19):
@@ -769,6 +774,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_small_value_is_i64_and_emitted_bare() {
     // Prove the common (≤ i64::MAX) path is byte-exact unchanged.
@@ -796,6 +802,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_8_byte_i64_max_split_boundary() {
     // Pins the u64-mode i64::MAX / i64::MAX+1 representation-split (D5).
@@ -999,11 +1006,7 @@ mod tests {
     )
     .with_raw_conv(RawConv::SetFrameState("MPEG_Layer"));
     fn choose(key: &str, _s: &FrameState) -> Option<&'static TagDef> {
-      if key == "Bit13-14" {
-        Some(&VL)
-      } else {
-        None
-      }
+      if key == "Bit13-14" { Some(&VL) } else { None }
     }
     // Layout: byte 1 bits 5-6 = layer (0xfb >> 1 & 0b11 = 0b01 = 1).
     let data = [0xffu8, 0xfb, 0x90, 0x4c];

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -33,7 +33,7 @@
 
 use crate::{
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, ValueConv},
-  value::{format_g, TagValue},
+  value::{TagValue, format_g},
 };
 use smol_str::SmolStr;
 
@@ -514,6 +514,13 @@ fn decode_bits(vals: &str, lookup: Option<&[(u8, &str)]>, bits: u8) -> String {
 /// but-bounded behavior — real ExifTool COVERART payloads are clean base64,
 /// so this fallback is mostly defensive and never panics). Output is the
 /// decoded raw bytes.
+///
+/// `#[allow(dead_code)]`: only the `ogg` format uses this helper today; under
+/// feature-pruned builds without OGG the dead-code lint fires. The helper
+/// stays in `convert.rs` (not in `formats/ogg.rs`) because it's logically
+/// a `ConvertBase64` helper akin to ExifTool's `MIME::Base64::decode` and
+/// will be reused by future XMP/EXIF ports.
+#[allow(dead_code)]
 pub(crate) fn base64_decode(s: &str) -> Vec<u8> {
   // Map an ASCII byte to its 6-bit value, or `None` for ignored/invalid.
   fn val(b: u8) -> Option<u8> {
@@ -1166,6 +1173,7 @@ mod tests {
   // emits the JSON number `2`, never the string `"2"`. Pin that shape:
   // the Map hit must yield a numeric `TagValue`, and serializing it must
   // produce a bare JSON number.
+  #[cfg(feature = "json")]
   #[test]
   fn numeric_map_value_yields_number_not_string() {
     static CHANNELS: TagDef = TagDef::new(
@@ -1182,7 +1190,7 @@ mod tests {
     let v = apply(&CHANNELS, &TagValue::I64(2), true);
     assert_eq!(v, TagValue::I64(2));
 
-    use crate::{serialize::to_exiftool_json, Group, Metadata};
+    use crate::{Group, Metadata, serialize::to_exiftool_json};
     let mut m = Metadata::new("a.aac");
     m.push(Group::new("Audio", "AAC"), "Channels", v);
     let json = to_exiftool_json(&m);
@@ -2652,7 +2660,7 @@ mod tests {
     assert_eq!(pipeline(0xFFFE), "???"); // noncharacter ⇒ 3 `?`s
     assert_eq!(pipeline(0x10FFFF), "\u{10ffff}"); // max valid kept
     assert_eq!(pipeline(0x110000), "????"); // > U+10FFFF ⇒ 4 `?`s
-                                            // R5 additions — Perl-empirical (`pack('C0U', n)` → `FixUTF8`):
+    // R5 additions — Perl-empirical (`pack('C0U', n)` → `FixUTF8`):
     assert_eq!(pipeline(0x1_0000_0000), "???????"); // 7 `?`s (above-u32 7-byte)
     assert_eq!(pipeline(0xF_FFFF_FFFF), "???????"); // 7 `?`s (top of 7-byte range)
     assert_eq!(pipeline(0x10_0000_0000), "?????????????"); // 13 `?`s (13-byte form)

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -115,8 +115,8 @@ pub fn convert_duration(time: f64) -> String {
   let m_f = (rounded / 60.0).trunc();
   rounded -= m_f * 60.0;
   let s_f = rounded.trunc(); // `int($time)` of remaining
-                             // ExifTool.pm:6878-6882 `if ($h > 24) { my $d = int($h/24); $h -= $d*24;
-                             // $sign = "$sign$d days "; }`.
+  // ExifTool.pm:6878-6882 `if ($h > 24) { my $d = int($h/24); $h -= $d*24;
+  // $sign = "$sign$d days "; }`.
   let mut prefix = sign.to_string();
   let h_after_days = if h_f > 24.0 {
     let d_f = (h_f / 24.0).trunc();

--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -570,8 +570,8 @@ pub fn detection_candidates(name: &str, head: &[u8]) -> DetectionCandidates {
     // (Perl reaches this branch only when $recognizedExt is false — it is
     // the `else` of the `elsif ($recognizedExt)`.)
     let skip = end - marker_len; // Perl: pos($buff) - length($1)
-                                 // L3038 applies to this terminal $type too: a JPEG terminal's Parent
-                                 // is "JPEG"; a TIFF terminal's Parent is $tiffType.
+    // L3038 applies to this terminal $type too: a JPEG terminal's Parent
+    // is "JPEG"; a TIFF terminal's Parent is $tiffType.
     out.push(DetectionCandidate {
       file_type: ty,
       header_skip: skip,

--- a/src/filetype/tests.rs
+++ b/src/filetype/tests.rs
@@ -226,7 +226,7 @@ fn strip_subtype_leftmost_paren_matches_perl() {
   // No strip when ends with ')' but no " (" anywhere before it.
   assert_eq!(strip_subtype("(nodot)"), None); // no SPACE before "("
   assert_eq!(strip_subtype("a(b)"), None); // no space before "("
-                                           // Edge: " (" immediately before the ")".
+  // Edge: " (" immediately before the ")".
   assert_eq!(strip_subtype("stem ()"), Some("stem"));
   // Unicode in the stem is not a concern (" (" and ")" are ASCII so the
   // byte index from find is always a valid char boundary).
@@ -1062,8 +1062,8 @@ fn detection_candidate_accessor_contract() {
   // (ExifTool.pm:3038 `($type eq 'TIFF') ? $tiffType : $type`).
   assert_eq!(d.parent_type(), "FLV");
   assert_eq!(d, d.clone()); // Clone + PartialEq (derive_more-free struct)
-                            // Remaining candidates are the faithful WV.. fall-through (non-empty,
-                            // fully drainable — FusedIterator stays None after exhaustion).
+  // Remaining candidates are the faithful WV.. fall-through (non-empty,
+  // fully drainable — FusedIterator stays None after exhaustion).
   let rest: Vec<&str> = it.by_ref().map(|c| c.file_type()).collect();
   assert_eq!(
     rest,

--- a/src/formats/aac.rs
+++ b/src/formats/aac.rs
@@ -2,7 +2,7 @@
 //! PROCESS_PROC is `FLAC::ProcessBitStream` (AAC.pm:29) → `crate::bitstream`.
 
 use crate::{
-  bitstream::{process_bit_stream, BitOrder},
+  bitstream::{BitOrder, process_bit_stream},
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
   value::{Group, TagValue},
@@ -189,7 +189,7 @@ impl FormatParser for ProcessAac {
             if pos + cnt <= frame.len() {
               // if ($pos + $cnt <= length($buff))  (AAC.pm:129)
               let dat = &frame[pos..pos + cnt]; // my $dat = substr($buff,$pos,$cnt)  (AAC.pm:130)
-                                                // $dat =~ s/^\0+// ; $dat =~ s/\0+$//  (AAC.pm:131-132)
+              // $dat =~ s/^\0+// ; $dat =~ s/\0+$//  (AAC.pm:131-132)
               let s = dat.iter().position(|&b| b != 0).unwrap_or(dat.len());
               let e = dat.iter().rposition(|&b| b != 0).map_or(s, |i| i + 1);
               // e >= s by construction (map_or(s,…) | rposition+1 > s)

--- a/src/formats/aiff.rs
+++ b/src/formats/aiff.rs
@@ -57,7 +57,7 @@
 
 use crate::{
   charset::decode_macroman,
-  datetime::{convert_datetime, convert_unix_time, AIFF_EPOCH_OFFSET},
+  datetime::{AIFF_EPOCH_OFFSET, convert_datetime, convert_unix_time},
   parser::{FormatParser, ParseContext},
   processbinarydata::process_binary_data,
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
@@ -554,13 +554,13 @@ impl FormatParser for ProcessAiff {
         break;
       };
       pos += 8; // :222 `$pos += 8`.
-                // AIFF.pm:227 `my $len2 = $len + ($len & 0x01)` — chunks padded to
-                // an even number of bytes. Perl scalars are 64-bit; on a 32-bit
-                // host `usize` is 32-bit and `len + 1` would wrap when
-                // `len == u32::MAX`. We `saturating_add`: `len2` then equals
-                // `usize::MAX`, which is guaranteed `> data.len()` so the
-                // short-read / unknown-chunk EOF arms both still fire
-                // correctly. Equivalent to Perl on the host's natural width.
+      // AIFF.pm:227 `my $len2 = $len + ($len & 0x01)` — chunks padded to
+      // an even number of bytes. Perl scalars are 64-bit; on a 32-bit
+      // host `usize` is 32-bit and `len + 1` would wrap when
+      // `len == u32::MAX`. We `saturating_add`: `len2` then equals
+      // `usize::MAX`, which is guaranteed `> data.len()` so the
+      // short-read / unknown-chunk EOF arms both still fire
+      // correctly. Equivalent to Perl on the host's natural width.
       let len2 = len.saturating_add(len & 0x01);
       // AIFF.pm:224 `$et->GetTagInfo($tagTablePtr, $tag)`.
       let tag_str = match core::str::from_utf8(&tag_bytes) {
@@ -670,8 +670,8 @@ impl FormatParser for ProcessAiff {
           }
         }
         pos = pos.saturating_add(len2); // AIFF.pm:268 `$pos += $len2`.
-                                        // AIFF.pm:269 `$n = 0;` (inside the body, before the for-step),
-                                        // then the for's `++$n` at top of next iter:
+        // AIFF.pm:269 `$n = 0;` (inside the body, before the for-step),
+        // then the for's `++$n` at top of next iter:
         n = 0;
         n = n.saturating_add(1);
       } else if len == 0 {
@@ -695,7 +695,7 @@ impl FormatParser for ProcessAiff {
           break;
         }
         n = n.saturating_add(1); // for-step `++$n` after `next`
-                                 // No `pos += len2` here (len == 0, len2 == 0) — fall-through to top.
+      // No `pos += len2` here (len == 0, len2 == 0) — fall-through to top.
       } else {
         // AIFF.pm:265-267 `else { $raf->Seek($len2, 1) or $err=1, last }`.
         // Unknown chunk with non-zero length: skip its body. Perl's `Seek`
@@ -1006,7 +1006,7 @@ mod tests {
     data.extend_from_slice(&0u16.to_be_bytes()); // markerID = 0 ⇒ skip MarkerID tag
     data.extend_from_slice(&4u16.to_be_bytes()); // size
     data.extend_from_slice(b"abcd"); // text
-                                     // Second comment header truncated: data ends after first.
+    // Second comment header truncated: data ends after first.
     process_comment(&data, &mut m, false);
     assert_eq!(m.tags().len(), 2); // CommentTime + Comment text (no MarkerID b/c 0)
     assert_eq!(m.tags()[0].name(), "CommentTime");

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -172,8 +172,8 @@ fn perl_nv_str(n: f64) -> String {
   // 2^63 (signed: n < 2^63; unsigned: 2^63 <= n < 2^64).
   let two63 = (1u128 << 63) as f64; // exactly 9223372036854775808.0
   let two64 = (1u128 << 64) as f64; // exactly 18446744073709551616.0
-                                    // Signed-integer carve-out: integer-valued f64 in [i64::MIN, 2^63),
-                                    // EXCLUDING 2^63 because `n as i64` would saturate to i64::MAX = 2^63-1.
+  // Signed-integer carve-out: integer-valued f64 in [i64::MIN, 2^63),
+  // EXCLUDING 2^63 because `n as i64` would saturate to i64::MAX = 2^63-1.
   if n == n.trunc() && n >= i64::MIN as f64 && n < two63 {
     let iv = n as i64;
     return iv.to_string();
@@ -208,11 +208,7 @@ fn as_perl_float(v: &TagValue) -> Option<f64> {
     TagValue::F64(x) => {
       // Non-finite ⇒ stringifies to Inf/-Inf/NaN ⇒ IsFloat regex fails ⇒
       // gate miss. Finite ⇒ pass through.
-      if x.is_finite() {
-        Some(*x)
-      } else {
-        None
-      }
+      if x.is_finite() { Some(*x) } else { None }
     }
     TagValue::Str(s) => {
       if is_perl_float(s) {
@@ -870,11 +866,7 @@ fn perl_numeric_coerce_f64(s: &str) -> f64 {
   }
   // Parse the matched numeric prefix as positive, then apply the sign.
   let mag = s[num_start..i].parse::<f64>().unwrap_or(0.0);
-  if neg {
-    -mag
-  } else {
-    mag
-  }
+  if neg { -mag } else { mag }
 }
 
 // APE.pm:29
@@ -1968,8 +1960,8 @@ mod tests {
     data[12..16].copy_from_slice(&48000u32.to_le_bytes()); // SampleRate (idx 4)
     data[24..28].copy_from_slice(&500u32.to_le_bytes()); // TotalFrames (idx 10)
     data[28..32].copy_from_slice(&65536u32.to_le_bytes()); // FinalFrameBlocks (idx 12)
-                                                           // Fill the rest with non-zero junk that would corrupt header reads
-                                                           // if we mistakenly copied the WHOLE file and indexed past 28 bytes.
+    // Fill the rest with non-zero junk that would corrupt header reads
+    // if we mistakenly copied the WHOLE file and indexed past 28 bytes.
     for byte in data.iter_mut().skip(32) {
       *byte = 0xCC;
     }
@@ -2245,7 +2237,7 @@ mod tests {
     let mut data = vec![0u8; 64];
     data[..4].copy_from_slice(b"MAC ");
     data[4..6].copy_from_slice(&5000u16.to_le_bytes()); // NewHeader path
-                                                        // Footer at data[32..64] — APETAGEX with size_raw = 5.
+    // Footer at data[32..64] — APETAGEX with size_raw = 5.
     data[32..40].copy_from_slice(b"APETAGEX");
     data[32 + 12..32 + 16].copy_from_slice(&5u32.to_le_bytes());
     data[32 + 16..32 + 20].copy_from_slice(&0u32.to_le_bytes());
@@ -2491,7 +2483,7 @@ mod tests {
     data.extend_from_slice(&2u32.to_le_bytes()); // count
     data.extend_from_slice(&0u32.to_le_bytes()); // flags
     data.extend_from_slice(&[0u8; 8]); // reserved
-                                       // Run the trailer-only planner.
+    // Run the trailer-only planner.
     let plan = plan_ape_trailer_only(&data, true, 0).expect("trailer-only plan returns Some");
     // header_job is None (the prior parser owns the File:*/header tags).
     assert!(matches!(plan.header_job, HeaderJob::None));

--- a/src/formats/audible.rs
+++ b/src/formats/audible.rs
@@ -1164,7 +1164,7 @@ mod tests {
     // Length < 2.
     assert_eq!(make_tag_name(""), "Tag");
     assert_eq!(make_tag_name("a"), "TagA"); // ucfirst then Tag-prefix
-                                            // Leading hyphen.
+    // Leading hyphen.
     assert_eq!(make_tag_name("-foo"), "Tag-foo");
     // Normal name: ucfirst only.
     assert_eq!(make_tag_name("product_id"), "Product_id");
@@ -1281,7 +1281,7 @@ mod tests {
     assert_eq!(unescape_html("&mdash;"), "—");
     assert_eq!(unescape_html("&eacute;"), "é");
     assert_eq!(unescape_html("&Alpha;"), "Α"); // 913, distinct from "alpha"
-                                               // Numeric (decimal): `&#169;` = `©`.
+    // Numeric (decimal): `&#169;` = `©`.
     assert_eq!(unescape_html("&#169;"), "©");
     // Numeric (hex): lowercase `#x` only, per XMP.pm:2924.
     assert_eq!(unescape_html("&#xA9;"), "©");

--- a/src/formats/dsf.rs
+++ b/src/formats/dsf.rs
@@ -498,9 +498,9 @@ mod tests {
     // Craft SampleCount = u64::MAX (above i64::MAX) — must emit as decimal
     // string `TagValue::Str("18446744073709551615")` (faithful UV→NV shape).
     let mut p = vec![0u8; 36]; // payload fills keys 3..=11 with zeros (placeholder)
-                               // overwrite SampleCount slot (key 9 ⇒ payload byte offset 36-12=24 … wait:
-                               // key * 4 = 36 in the dirInfo buffer; dirInfo starts with 12 bytes of
-                               // 'fmt'+size, so payload byte offset = 36-12 = 24.
+    // overwrite SampleCount slot (key 9 ⇒ payload byte offset 36-12=24 … wait:
+    // key * 4 = 36 in the dirInfo buffer; dirInfo starts with 12 bytes of
+    // 'fmt'+size, so payload byte offset = 36-12 = 24.
     p[24..32].copy_from_slice(&u64::MAX.to_le_bytes());
     let buf = dir(&p);
     let mut m = Metadata::new("x");
@@ -588,7 +588,7 @@ mod tests {
     v.extend_from_slice(&0u64.to_le_bytes()); // metaPos = 0
     v.extend_from_slice(b"fmt ");
     v.extend_from_slice(&48u64.to_le_bytes()); // fmtLen
-                                               // payload (36 bytes):
+    // payload (36 bytes):
     v.extend_from_slice(&1u32.to_le_bytes());
     v.extend_from_slice(&0u32.to_le_bytes());
     v.extend_from_slice(&2u32.to_le_bytes());
@@ -751,7 +751,7 @@ mod tests {
     buf.extend_from_slice(&0u64.to_le_bytes()); // metaPos = 0 ⇒ no ID3 trailer
     buf.extend_from_slice(b"fmt ");
     buf.extend_from_slice(&999u64.to_le_bytes()); // fmtLen = 999 (< 1000 ✓)
-                                                  // First 36 bytes of payload: the eight DSF::Main fields in key order.
+    // First 36 bytes of payload: the eight DSF::Main fields in key order.
     buf.extend_from_slice(&1u32.to_le_bytes()); // key 3 FormatVersion
     buf.extend_from_slice(&0u32.to_le_bytes()); // key 4 FormatID = 'DSD Raw'
     buf.extend_from_slice(&2u32.to_le_bytes()); // key 5 ChannelType = Stereo
@@ -760,7 +760,7 @@ mod tests {
     buf.extend_from_slice(&1u32.to_le_bytes()); // key 8 BitsPerSample
     buf.extend_from_slice(&2_822_400u64.to_le_bytes()); // key 9 SampleCount
     buf.extend_from_slice(&4096u32.to_le_bytes()); // key 11 BlockSize
-                                                   // Pad to total payload of 987 bytes (951 zeros after the 36-byte head).
+    // Pad to total payload of 987 bytes (951 zeros after the 36-byte head).
     buf.extend(std::iter::repeat(0u8).take(987 - 36));
     assert_eq!(buf.len(), 40 + 987);
     let mut m = Metadata::new("x.dsf");

--- a/src/formats/dv.rs
+++ b/src/formats/dv.rs
@@ -6,7 +6,7 @@
 use crate::{
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
-  value::{format_g, Group, TagValue},
+  value::{Group, TagValue, format_g},
 };
 
 /// One row of `@dvProfiles` (DV.pm:21-113). All fields are derived
@@ -478,8 +478,8 @@ fn extract_vaux_meta(
     // DV.pm:207 `for ($j=0; $j<15; ++$j)`.
     for j in 0..15usize {
       let p = vaux_pos + j * 5 + 3; // DV.pm:208
-                                    // Guard against running past the buffer: every Get8u must be in
-                                    // range (`p+0` through `p+4` for the 4-byte date/time fields).
+      // Guard against running past the buffer: every Get8u must be in
+      // range (`p+0` through `p+4` for the 4-byte date/time fields).
       if p + 4 >= buff.len() {
         break;
       }
@@ -955,7 +955,7 @@ mod tests {
     // forces an `a-f` letter in the hex sprintf — DV.pm:220-221 rejects.
     let mut data = vec![0u8; 8000];
     data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0xbf]); // dsf=1
-                                                           // VAUX block 1 at offset 80 — block_type & 0xf0 == 0x50.
+    // VAUX block 1 at offset 80 — block_type & 0xf0 == 0x50.
     data[80] = 0x50;
     // Pack 0 (j=0): p = 80 + 0*5 + 3 = 83. pack_type = 0x62 (date).
     data[83] = 0x62;

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -1301,7 +1301,7 @@ mod tests {
     assert_eq!(g(TagId::Str("Bit103-107")).unwrap().name(), "BitsPerSample"); // FLAC.pm:72
     assert_eq!(g(TagId::Str("Bit108-143")).unwrap().name(), "TotalSamples"); //  FLAC.pm:76
     assert_eq!(g(TagId::Str("Bit144-271")).unwrap().name(), "MD5Signature"); //  FLAC.pm:77
-                                                                             // Channels + BitsPerSample carry a ValueConv (`$val + 1`).
+    // Channels + BitsPerSample carry a ValueConv (`$val + 1`).
     assert!(matches!(
       g(TagId::Str("Bit100-102")).unwrap().value_conv(),
       ValueConv::Func(_)
@@ -1589,8 +1589,8 @@ mod tests {
     let mut payload = Vec::new();
     payload.extend_from_slice(&(1u32).to_le_bytes()); // vendor len = 1
     payload.push(b'v'); // vendor "v"
-                        // pos==5; append exactly 4 bytes — count slot if buggy `<=` is taken;
-                        // non-zero so the buggy branch enters the comment loop.
+    // pos==5; append exactly 4 bytes — count slot if buggy `<=` is taken;
+    // non-zero so the buggy branch enters the comment loop.
     payload.extend_from_slice(&[0x01u8, 0, 0, 0]); // would-be count=1
     let mut m = Metadata::new("x.flac");
     let ok = process_vorbis_comments(&payload, &mut m, true);
@@ -1617,10 +1617,11 @@ mod tests {
     let ok = process_vorbis_comments(&[], &mut m, true);
     assert!(!ok);
     assert!(m.tags().is_empty());
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w == "Format error in Vorbis comments"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w == "Format error in Vorbis comments")
+    );
   }
 
   #[test]
@@ -1686,10 +1687,11 @@ mod tests {
       "post-ID3 `fLaC` magic must accept and continue parsing"
     );
     // File:FileType=FLAC pushed.
-    assert!(m
-      .tags()
-      .iter()
-      .any(|t| t.name() == "FileType" && t.value() == &TagValue::Str("FLAC".into())));
+    assert!(
+      m.tags()
+        .iter()
+        .any(|t| t.name() == "FileType" && t.value() == &TagValue::Str("FLAC".into()))
+    );
     // StreamInfo tag(s) emitted from the post-ID3 body.
     assert!(
       m.tags().iter().any(|t| t.name() == "BlockSizeMin"),
@@ -1758,10 +1760,11 @@ mod tests {
     // SetFileType fired (FLAC.pm:255).
     assert!(m.tags().iter().any(|t| t.name() == "FileType"));
     // Warning recorded with the exact Perl string.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w == "Format error in FLAC file"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w == "Format error in FLAC file")
+    );
   }
 
   #[test]
@@ -1787,10 +1790,11 @@ mod tests {
     let data: &[u8] = &[b'f', b'L', b'a', b'C', 0x80, 0xff, 0xff, 0xff];
     let mut c = ParseContext::new(data, "FLAC", 0, "FLAC", None, true, &mut m);
     assert!(ProcessFlac.process(&mut c));
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w == "Format error in FLAC file"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w == "Format error in FLAC file")
+    );
   }
 
   #[test]
@@ -1802,7 +1806,7 @@ mod tests {
     // < 30 s ⇒ '%.2f s'.
     assert_eq!(convert_duration(1.543125), "1.54 s");
     assert_eq!(convert_duration(29.999), "30.00 s"); // rounds up below 30
-                                                     // == 30 ⇒ H:MM:SS arm (+0.5 round, int → 30s).
+    // == 30 ⇒ H:MM:SS arm (+0.5 round, int → 30s).
     assert_eq!(convert_duration(30.0), "0:00:30");
     // Hour boundary.
     assert_eq!(convert_duration(3600.0), "1:00:00");
@@ -1836,9 +1840,9 @@ mod tests {
     assert_eq!(decode_base64("Q2F0!garbage"), b"Cat");
     // Missing padding still decodes the bytes we can: "Cat" → "Q2F0".
     assert_eq!(decode_base64("Q2F"), b"Ca"); // 3 base64 chars → 2 bytes
-                                             // R2-F4: internal padding is DELETED, decoding continues past it.
-                                             // "AA==AA" — Perl `tr/.../d` deletes both `=`s, leaving "AAAA" which
-                                             // decodes to 3 zero bytes (verified against bundled Perl).
+    // R2-F4: internal padding is DELETED, decoding continues past it.
+    // "AA==AA" — Perl `tr/.../d` deletes both `=`s, leaving "AAAA" which
+    // decodes to 3 zero bytes (verified against bundled Perl).
     assert_eq!(decode_base64("AA==AA"), [0u8, 0, 0]);
     // "AA==" — `tr/.../d` deletes both `=`s, leaving "AA" which decodes
     // to 1 zero byte (3-base64-char → 2-byte partial chunk halves).

--- a/src/formats/id3/process.rs
+++ b/src/formats/id3/process.rs
@@ -21,7 +21,7 @@
 use crate::{
   formats::id3::{
     decode::unsync_safe,
-    v1::{process_id3v1, ID3V1_MAIN},
+    v1::{ID3V1_MAIN, process_id3v1},
     v2_2::ID3V2_2_MAIN,
     v2_3::ID3V2_3_MAIN,
     v2_4::ID3V2_4_MAIN,
@@ -641,7 +641,7 @@ mod tests {
   fn process_mp3_id3v1_only() {
     // Construct a file: 1024 padding bytes + 128-byte ID3v1 TAG block.
     let mut data: Vec<u8> = vec![0; 256]; // some prefix that's NOT ID3
-                                          // Build TAG block.
+    // Build TAG block.
     let mut tag = Vec::with_capacity(128);
     tag.extend_from_slice(b"TAG");
     let pad = |s: &str, n: usize| {
@@ -732,10 +732,11 @@ mod tests {
     data.extend_from_slice(&[0xff, 0x00, 0xff, 0x00]); // body (shrinks to 0xff 0xff)
     let m = run(&data, "x.mp3");
     // Must not panic. Faithful Warn fires.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Bad ID3 extended header"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Bad ID3 extended header")
+    );
   }
 
   #[test]
@@ -781,10 +782,11 @@ mod tests {
     data.push(0x00);
     data.extend_from_slice(&[0u8, 0, 0, 0]);
     let m = run(&data, "x.mp3");
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Unsupported ID3 version: 2.5.0"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Unsupported ID3 version: 2.5.0")
+    );
   }
 
   #[test]
@@ -798,10 +800,11 @@ mod tests {
     data.extend_from_slice(&[0u8, 0, 0, 100]); // sync-safe 100
     data.extend_from_slice(&[0u8; 3]);
     let m = run(&data, "x.mp3");
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Truncated ID3 data"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Truncated ID3 data")
+    );
   }
 
   #[test]
@@ -809,10 +812,11 @@ mod tests {
     // ID3 magic + only 2 of 7 header bytes.
     let data = b"ID3\x02\x00";
     let m = run(data, "x.mp3");
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Short ID3 header"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Short ID3 header")
+    );
   }
 
   #[test]

--- a/src/formats/id3/v1.rs
+++ b/src/formats/id3/v1.rs
@@ -7,7 +7,7 @@
 //! (the parent `%Image::ExifTool::ID3::Main` table's group, ID3.pm:78).
 
 use crate::{
-  convert::{apply_ctx, ConvContext},
+  convert::{ConvContext, apply_ctx},
   formats::id3::text::convert_id3v1_text,
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
   value::{Group, Metadata, TagValue},

--- a/src/formats/id3/v2_process.rs
+++ b/src/formats/id3/v2_process.rs
@@ -23,7 +23,7 @@
 //! - Unhandled: faithful Warn "Don't know how to handle $id frame".
 
 use crate::{
-  convert::{apply_ctx, ConvContext},
+  convert::{ConvContext, apply_ctx},
   formats::id3::decode::{decode_string, decode_string_joined, unsync_safe},
   tagtable::{TagDef, TagId, TagTable},
   value::{Group, Metadata, TagValue},
@@ -1552,8 +1552,8 @@ mod tests {
     // 4-byte length itself + 2 more bytes (the ext-flags-and-padding).
     let mut ext = Vec::new();
     ext.extend_from_slice(&[0, 0, 0, 6]); // length=6 (NOT sync-safe in v2.3;
-                                          // UnSyncSafe leaves small values
-                                          // unchanged)
+    // UnSyncSafe leaves small values
+    // unchanged)
     ext.extend_from_slice(&[0, 0]); // 2 ext bytes
     let payload: Vec<u8> = ext.into_iter().chain(title_frame).collect();
     let size = payload.len() as u32;
@@ -1571,7 +1571,7 @@ mod tests {
     // Here we just exercise the wrapper indirectly by replicating the
     // bundled behavior: strip `len` bytes from h_buff, then process.
     let mut h_buff: Vec<u8> = data[10..].to_vec(); // skip ID3v2 header
-                                                   // Read ext length (first 4 bytes of h_buff).
+    // Read ext length (first 4 bytes of h_buff).
     let ext_len_raw = u32::from_be_bytes([h_buff[0], h_buff[1], h_buff[2], h_buff[3]]);
     // UnSyncSafe leaves <=0x7F unchanged.
     let ext_len = ext_len_raw as usize;
@@ -1636,10 +1636,11 @@ mod tests {
       .expect("MCDI must be emitted as raw bytes");
     assert_eq!(mcdi.value(), &TagValue::Bytes(vec![0xde, 0xad, 0xbe, 0xef]));
     // No Warn for known-binary frames.
-    assert!(m
-      .warnings()
-      .iter()
-      .all(|w| !w.contains("Don't know how to handle")));
+    assert!(
+      m.warnings()
+        .iter()
+        .all(|w| !w.contains("Don't know how to handle"))
+    );
   }
 
   #[test]
@@ -1665,16 +1666,18 @@ mod tests {
       &ConvContext::default(),
     );
     // No GEOB-* tags, no GeneralEncapsulatedObject.
-    assert!(m
-      .tags()
-      .iter()
-      .all(|t| !t.name().starts_with("GEOB") && t.name() != "GeneralEncapsulatedObject"));
+    assert!(
+      m.tags()
+        .iter()
+        .all(|t| !t.name().starts_with("GEOB") && t.name() != "GeneralEncapsulatedObject")
+    );
     // No "Don't know how to handle" Warn — bundled silently dispatches
     // SubDirectory frames; our skip must be silent too.
-    assert!(m
-      .warnings()
-      .iter()
-      .all(|w| !w.contains("Don't know how to handle")));
+    assert!(
+      m.warnings()
+        .iter()
+        .all(|w| !w.contains("Don't know how to handle"))
+    );
   }
 
   #[test]
@@ -1706,10 +1709,11 @@ mod tests {
     // dateTimeConv: XMP → EXIF date.
     assert_eq!(t.value(), &TagValue::Str("2024:05:19".into()));
     // Bundled minor Warn fires.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.contains("[minor] Frame 'TDRC' is not valid for this ID3 version")));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.contains("[minor] Frame 'TDRC' is not valid for this ID3 version"))
+    );
   }
 
   #[test]
@@ -1743,10 +1747,11 @@ mod tests {
       "Picture" | "PictureMIMEType" | "PictureType" | "PictureDescription"
     )));
     // Faithful Warn.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.contains("Invalid APIC frame")));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.contains("Invalid APIC frame"))
+    );
   }
 
   #[test]

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,56 +1,98 @@
 //! Dispatch registry: ExifTool file-type string → its parser
 //! (ExifTool `%moduleName` → `Process<Type>`). Add one `match` arm per
 //! ported format.
+//!
+//! Each `pub mod <fmt>;` is gated on its Cargo feature (spec §4); the
+//! corresponding `match` arm in [`parser_for`] is gated identically. When
+//! a format feature is disabled, its file-type string returns `None`
+//! (faithful to ExifTool's "Process<Type> not loaded → `next` in candidate
+//! loop" behavior — ExifTool.pm:3060-3077).
 
+#[cfg(feature = "aac")]
 pub mod aac;
+#[cfg(feature = "aiff")]
 pub mod aiff;
+#[cfg(feature = "ape")]
 pub mod ape;
+#[cfg(feature = "audible")]
 pub mod audible;
+#[cfg(feature = "dsf")]
 pub mod dsf;
+#[cfg(feature = "dv")]
 pub mod dv;
+#[cfg(feature = "flac")]
 pub mod flac;
+#[cfg(feature = "id3")]
 pub mod id3;
+#[cfg(feature = "mpc")]
 pub mod mpc;
+// MPEG audio frame parser is the internal `mpeg-audio` feature (gates
+// `mp3` and is reused by other audio chained formats). Phase D may split
+// `mpeg::audio` from a future `mpeg::video` submodule; today the file
+// holds only the audio half (the video side is a Phase-2 forward item).
+#[cfg(feature = "mpeg-audio")]
 pub mod mpeg;
+#[cfg(feature = "ogg")]
 pub mod ogg;
+#[cfg(feature = "red")]
 pub mod red;
+#[cfg(feature = "wavpack")]
 pub mod wavpack;
 
 use crate::parser::FormatParser;
 
 /// Returns the parser for a finalized ExifTool file type, or `None` if that
-/// format has no ported parser yet.
+/// format has no ported parser yet OR its Cargo feature is disabled.
+///
+/// When a format's feature is off, this returns `None` for the corresponding
+/// file-type string — faithful to ExifTool's "module not loaded ⇒ `next` in
+/// candidate loop" (ExifTool.pm:3060-3077). Callers see the same "no parser"
+/// signal whether the format is unported or merely feature-pruned.
 #[must_use]
 pub fn parser_for(file_type: &str) -> Option<&'static dyn FormatParser> {
   // `match` (not a static HashMap/phf): zero-alloc, branch-predicted; fine at ~28 formats.
   match file_type {
+    #[cfg(feature = "audible")]
     "AA" => Some(&audible::ProcessAa), // ExifTool %moduleName{AA}='Audible'
-    "AAC" => Some(&aac::ProcessAac),   // ExifTool %moduleName{AAC}='AAC'
+    #[cfg(feature = "aac")]
+    "AAC" => Some(&aac::ProcessAac), // ExifTool %moduleName{AAC}='AAC'
     // ExifTool %fileTypeLookup maps AIFF/AIFC/AIF all to TYPE 'AIFF'; the
     // detection candidate for any of those extensions is "AIFF". The
     // parser itself differentiates AIFF vs AIFC via the magic body
     // (AIFF.pm:209-210 `$1` = "AIFF" or "AIFC") and drives the right
     // SetFileType.
+    #[cfg(feature = "aiff")]
     "AIFF" => Some(&aiff::ProcessAiff), // ExifTool %moduleName{AIFF}=undef ⇒ default to 'AIFF'
+    #[cfg(feature = "ape")]
     "APE" => Some(&ape::ProcessApe), // ExifTool %moduleName{APE}=undef ⇒ Perl $module=$type ⇒ "APE"
     // DSF: %moduleName absent ⇒ Perl `$module = $type` = 'DSF'; faithful to
     // ExifTool.pm:4203-4275 dispatch (`module_for_type("DSF")` returns
     // `Module(Cow::Owned("DSF"))` via the default arm in
     // `filetype_data.rs::module_for_type`).
+    #[cfg(feature = "dsf")]
     "DSF" => Some(&dsf::ProcessDsf),
+    #[cfg(feature = "dv")]
     "DV" => Some(&dv::ProcessDv), // ExifTool %moduleName{DV} default = 'DV'
+    #[cfg(feature = "flac")]
     "FLAC" => Some(&flac::ProcessFlac), // ExifTool %moduleName{FLAC}='FLAC'
     // ExifTool.pm:893 maps `MP3 => 'ID3'` — ID3::ProcessMP3 (ID3.pm:1684-1729)
     // scans for ID3v1/v2 tags and then delegates the audio side to
     // `MPEG::ParseMPEGAudio` (ID3.pm:1716). Faithful: this arm is ID3's
     // wrapping parser; its no-ID3 branch calls back into
-    // `mpeg::parse_mpeg_audio` (see `src/formats/id3/process.rs`).
+    // `mpeg::parse_mpeg_audio` (see `src/formats/id3/process.rs`). The
+    // `mp3` feature implies both `id3` and `mpeg-audio` (Cargo.toml §
+    // per-format gates), so `id3` is in scope whenever this arm compiles.
+    #[cfg(feature = "mp3")]
     "MP3" => Some(&id3::ProcessMp3),
+    #[cfg(feature = "mpc")]
     "MPC" => Some(&mpc::ProcessMpc), // ExifTool %moduleName{MPC}=undef ⇒ 'MPC'
     // ExifTool %moduleName{OGG}='Ogg' (handles OGG, OGV, OPUS via container
     // dispatch + OverrideFileType — Ogg.pm:49-50).
+    #[cfg(feature = "ogg")]
     "OGG" => Some(&ogg::ProcessOgg),
+    #[cfg(feature = "red")]
     "R3D" => Some(&red::ProcessR3D), // ExifTool %moduleName{R3D}='Red'
+    #[cfg(feature = "wavpack")]
     "WV" => Some(&wavpack::ProcessWv), // ExifTool %moduleName{WV}='WavPack'
     _ => None,
   }
@@ -63,22 +105,36 @@ mod tests {
   #[test]
   fn registry_resolves_ported_formats() {
     // AA, AAC, AIFF, APE, DSF, DV, FLAC, MP3 (ID3), MPC, OGG, R3D, and WV
-    // are the ported formats; their arms must resolve. Unported types (and
-    // the empty string) must still cleanly report "no parser" so the
-    // consumer falls through to the next detection candidate (faithful
-    // to Perl: a Process<Type> not loaded is `next` in the candidate
-    // loop, ExifTool.pm:3060-3077).
+    // are the ported formats; their arms must resolve when their Cargo
+    // features are enabled. Unported types (and the empty string) must
+    // still cleanly report "no parser" so the consumer falls through to
+    // the next detection candidate (faithful to Perl: a Process<Type>
+    // not loaded is `next` in the candidate loop, ExifTool.pm:3060-3077).
+    // Each assertion is feature-gated to match the corresponding `match`
+    // arm in [`parser_for`].
+    #[cfg(feature = "audible")]
     assert!(parser_for("AA").is_some());
+    #[cfg(feature = "aac")]
     assert!(parser_for("AAC").is_some());
+    #[cfg(feature = "aiff")]
     assert!(parser_for("AIFF").is_some());
+    #[cfg(feature = "ape")]
     assert!(parser_for("APE").is_some());
+    #[cfg(feature = "dsf")]
     assert!(parser_for("DSF").is_some());
+    #[cfg(feature = "dv")]
     assert!(parser_for("DV").is_some());
+    #[cfg(feature = "flac")]
     assert!(parser_for("FLAC").is_some());
+    #[cfg(feature = "mp3")]
     assert!(parser_for("MP3").is_some());
+    #[cfg(feature = "mpc")]
     assert!(parser_for("MPC").is_some());
+    #[cfg(feature = "ogg")]
     assert!(parser_for("OGG").is_some());
+    #[cfg(feature = "red")]
     assert!(parser_for("R3D").is_some());
+    #[cfg(feature = "wavpack")]
     assert!(parser_for("WV").is_some());
     assert!(parser_for("MPEG").is_none()); // video side deferred (forward item)
     assert!(parser_for("").is_none());

--- a/src/formats/mpeg.rs
+++ b/src/formats/mpeg.rs
@@ -41,7 +41,7 @@
 //!   keeps that faithful for any future divergence.
 
 use crate::{
-  bitstream::{process_bit_stream_cond, BitOrder, FrameState},
+  bitstream::{BitOrder, FrameState, process_bit_stream_cond},
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, PrintConvHash, PrintValue, RawConv, TagDef, ValueConv},
   value::TagValue,
@@ -784,11 +784,7 @@ fn parse_xing_lame(
   let len = buff.len();
   // MPEG.pm:504 side-info offset.
   let side = if v == 3 {
-    if m == 3 {
-      17
-    } else {
-      32
-    }
+    if m == 3 { 17 } else { 32 }
   } else if m == 3 {
     9
   } else {
@@ -1110,11 +1106,7 @@ pub(crate) const fn id3_process_mp3_scan_len(ext_is_mp3: bool) -> usize {
   // compares against the uppercased `$$self{FILE_EXT}` (ExifTool.pm:2966
   // `GetFileExtension` returns it uppercased), so a case-insensitive
   // match on the Rust side (which already uppercases) is faithful.
-  if ext_is_mp3 {
-    8192
-  } else {
-    256
-  }
+  if ext_is_mp3 { 8192 } else { 256 }
 }
 
 impl ProcessMp3 {
@@ -1571,8 +1563,8 @@ mod tests {
     d.extend_from_slice(&200_000u32.to_be_bytes()); // VBRBytes
     d.extend(std::iter::repeat(0).take(100)); // TOC (skipped)
     d.extend_from_slice(&78u32.to_be_bytes()); // VBRScale (LameVBRQuality=2, LameQuality=2)
-                                               // LAME block starts here. Pre-fill 348 bytes so the LAME-flag length
-                                               // gate (MPEG.pm:537 `last if $pos + 348 > $len`) passes.
+    // LAME block starts here. Pre-fill 348 bytes so the LAME-flag length
+    // gate (MPEG.pm:537 `last if $pos + 348 > $len`) passes.
     let start = d.len();
     d.extend(std::iter::repeat(0).take(348));
     // Stamp the LAME fields by absolute offset into `d`.
@@ -1684,8 +1676,8 @@ mod tests {
     d.extend(std::iter::repeat(0).take(32));
     d.extend_from_slice(b"Xing");
     d.extend_from_slice(&0x01u32.to_be_bytes()); // flag VBRFrames only
-                                                 // Truncate: do NOT append the 4-byte VBRFrames; MPEG.pm:516 `last if
-                                                 // $pos + 4 > $len`.
+    // Truncate: do NOT append the 4-byte VBRFrames; MPEG.pm:516 `last if
+    // $pos + 4 > $len`.
     let mut m = Metadata::new("x.mp3");
     let mut c = ctx_over(&mut m, &d, "MP3");
     assert!(ProcessMp3.process(&mut c));

--- a/src/formats/red.rs
+++ b/src/formats/red.rs
@@ -31,7 +31,7 @@
 //! `exifast-phase2-forward-items` memory entry.
 
 use crate::{
-  convert::{apply, read_value, ByteOrder},
+  convert::{ByteOrder, apply, read_value},
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
   value::{Group, TagValue},

--- a/src/formats/wavpack.rs
+++ b/src/formats/wavpack.rs
@@ -326,13 +326,13 @@ mod tests {
     h[4..8].copy_from_slice(&100u32.to_le_bytes()); // ckSize
     h[8] = 0x10; // version low
     h[9] = 0x04; // version high (0x0410)
-                 // [10] block_index_u8 = 0
-                 // [11] total_samples_u8 = 0
+    // [10] block_index_u8 = 0
+    // [11] total_samples_u8 = 0
     h[12..16].copy_from_slice(&1000u32.to_le_bytes()); // total_samples
-                                                       // [16..20] block_index = 0
+    // [16..20] block_index = 0
     h[20..24].copy_from_slice(&500u32.to_le_bytes()); // block_samples
     h[24..28].copy_from_slice(&flags_le.to_le_bytes()); // flags (LE on disk)
-                                                        // [28..32] crc = 0
+    // [28..32] crc = 0
     h
   }
 
@@ -353,10 +353,10 @@ mod tests {
     assert!(g(TagId::Str("Other")).is_none());
     assert!(g(TagId::Int(0)).is_none());
     assert_eq!(WAVPACK_MAIN.group0(), "File"); // WavPack.pm:23
-                                               // BitShift derivation: per ExifTool.pm:5905-5910 each shift = #
-                                               // trailing zero bits of the mask. Pinned to the exact integer values
-                                               // documented in the .pm so a mask-literal typo is caught even if the
-                                               // `bit_shift` helper is ever changed.
+    // BitShift derivation: per ExifTool.pm:5905-5910 each shift = #
+    // trailing zero bits of the mask. Pinned to the exact integer values
+    // documented in the .pm so a mask-literal typo is caught even if the
+    // `bit_shift` helper is ever changed.
     assert_eq!(BYTES_PER_SAMPLE_MASK, 0x0000_0003);
     assert_eq!(AUDIO_TYPE_MASK, 0x0000_0004);
     assert_eq!(COMPRESSION_MASK, 0x0000_0008);

--- a/src/jsondiff.rs
+++ b/src/jsondiff.rs
@@ -316,29 +316,37 @@ mod tests {
     // (key, raw-bytes) sort mispaired them and reported a FALSE
     // mismatch. Canonical-form pairing fixes it: {x:1,y:2} ≡ {y:2,x:1}
     // and {x:9} ≡ {x:9}, so the two documents are equivalent.
-    assert!(json_equivalent(
-      r#"[{"A":{"x":1,"y":2},"A":{"x":9}}]"#,
-      r#"[{"A":{"x":9},"A":{"y":2,"x":1}}]"#,
-    )
-    .is_ok());
+    assert!(
+      json_equivalent(
+        r#"[{"A":{"x":1,"y":2},"A":{"x":9}}]"#,
+        r#"[{"A":{"x":9},"A":{"y":2,"x":1}}]"#,
+      )
+      .is_ok()
+    );
     // Nested arrays inside dup values stay ORDER-significant.
-    assert!(json_equivalent(
-      r#"[{"A":[1,2],"A":{"q":0}}]"#,
-      r#"[{"A":{"q":0},"A":[2,1]}]"#,
-    )
-    .is_err());
+    assert!(
+      json_equivalent(
+        r#"[{"A":[1,2],"A":{"q":0}}]"#,
+        r#"[{"A":{"q":0},"A":[2,1]}]"#,
+      )
+      .is_err()
+    );
     // The fix must NOT loosen the verdict: genuinely different dup
     // values (and different value multisets) still mismatch.
-    assert!(json_equivalent(
-      r#"[{"A":{"x":1},"A":{"x":2}}]"#,
-      r#"[{"A":{"x":1},"A":{"x":3}}]"#,
-    )
-    .is_err());
-    assert!(json_equivalent(
-      r#"[{"A":{"x":1},"A":{"y":1}}]"#,
-      r#"[{"A":{"x":1},"A":{"x":1}}]"#,
-    )
-    .is_err());
+    assert!(
+      json_equivalent(
+        r#"[{"A":{"x":1},"A":{"x":2}}]"#,
+        r#"[{"A":{"x":1},"A":{"x":3}}]"#,
+      )
+      .is_err()
+    );
+    assert!(
+      json_equivalent(
+        r#"[{"A":{"x":1},"A":{"y":1}}]"#,
+        r#"[{"A":{"x":1},"A":{"x":1}}]"#,
+      )
+      .is_err()
+    );
   }
 
   #[test]
@@ -384,11 +392,13 @@ mod tests {
 
   #[test]
   fn nested_structures_compare_recursively() {
-    assert!(json_equivalent(
-      r#"[{"a":[1,{"x":"v"}],"b":2}]"#,
-      r#"[{"b":2,"a":[1,{"x":"v"}]}]"#
-    )
-    .is_ok());
+    assert!(
+      json_equivalent(
+        r#"[{"a":[1,{"x":"v"}],"b":2}]"#,
+        r#"[{"b":2,"a":[1,{"x":"v"}]}]"#
+      )
+      .is_ok()
+    );
     let m = json_equivalent(r#"[{"a":[1,{"x":"v"}]}]"#, r#"[{"a":[1,{"x":"w"}]}]"#).unwrap_err();
     assert_eq!(
       m,
@@ -407,25 +417,31 @@ mod tests {
 
   #[test]
   fn invalid_json_is_reported() {
-    assert!(json_equivalent("[1,]", "[1]")
-      .unwrap_err()
-      .message()
-      .contains("actual is invalid"));
-    assert!(json_equivalent("[1]", "nope")
-      .unwrap_err()
-      .message()
-      .contains("golden is invalid"));
+    assert!(
+      json_equivalent("[1,]", "[1]")
+        .unwrap_err()
+        .message()
+        .contains("actual is invalid")
+    );
+    assert!(
+      json_equivalent("[1]", "nope")
+        .unwrap_err()
+        .message()
+        .contains("golden is invalid")
+    );
   }
 
   #[test]
   fn whitespace_insignificant_for_containers() {
     // Internal container whitespace must not cause a mismatch (only scalar
     // lexemes are byte-compared; structure is compared recursively).
-    assert!(json_equivalent(
-      "[ { \"a\" : 1 , \"b\" : [ 2 , 3 ] } ]",
-      r#"[{"a":1,"b":[2,3]}]"#
-    )
-    .is_ok());
+    assert!(
+      json_equivalent(
+        "[ { \"a\" : 1 , \"b\" : [ 2 , 3 ] } ]",
+        r#"[{"a":1,"b":[2,3]}]"#
+      )
+      .is_ok()
+    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,25 @@
 //!
 //! Stage 1 scope: video/audio formats, read-only. Per-format port status
 //! is tracked in `FORMATS.md` at the repository root.
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
+
+// Alias `alloc as std` on no_std + alloc builds so code can use
+// `std::vec::Vec` etc. uniformly across feature combos. When the
+// `std` feature is on, the real `std` crate is already in scope via
+// the prelude. The `unused_extern_crates` allow silences a
+// rust-2018-idioms false positive — the alias is needed at use-time
+// even though rustc can't see that statically.
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[allow(unused_extern_crates)]
+extern crate alloc as std;
+
+#[cfg(feature = "std")]
+#[allow(unused_extern_crates)]
+extern crate std;
 
 pub mod bitstream;
 pub mod charset;
@@ -14,10 +31,17 @@ pub mod datetime;
 pub mod error;
 pub mod filetype;
 pub mod formats;
+// `jsondiff` and `serialize` are the JSON emitter + golden-diff oracle: they
+// unconditionally depend on `serde_json` (and `serde`). They are gated on
+// the `json` feature (spec §4: `json = ["alloc", "dep:serde_json", "dep:serde", ...]`).
+// Library callers without `json` get the typed-Meta API path only; CLI
+// JSON emission requires the feature.
+#[cfg(feature = "json")]
 pub mod jsondiff;
 pub mod parser;
 pub mod processbinarydata;
 pub mod reader;
+#[cfg(feature = "json")]
 pub mod serialize;
 pub mod tagtable;
 pub mod value;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -901,7 +901,7 @@ mod tests {
     {
       let mut c = ctx_over(&mut m, "AAC", true);
       c.set_file_type(None, None, None); // MIMEType = audio/aac
-                                         // "XYZ" has no %mimeType key and we pass mime=None.
+      // "XYZ" has no %mimeType key and we pass mime=None.
       c.override_file_type("XYZ", None, None);
     }
     let ft = m.tags().iter().find(|t| t.name() == "FileType").unwrap();
@@ -1346,6 +1346,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn aac_fixture_matches_golden_print_on() {
     let root = env!("CARGO_MANIFEST_DIR");
@@ -1357,6 +1358,7 @@ mod tests {
       .unwrap_or_else(|e| panic!("AAC -j -G1 -struct conformance: {}", e.message()));
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn aac_fixture_matches_golden_n() {
     let root = env!("CARGO_MANIFEST_DIR");
@@ -1427,6 +1429,7 @@ mod tests {
 
   static ACCEPTING_BUT_ERRORING: AcceptingButErroring = AcceptingButErroring;
 
+  #[cfg(feature = "json")]
   #[test]
   fn accepted_parser_error_reaches_serialized_json() {
     // Register the injected parser for the REAL detected file type.
@@ -1501,6 +1504,7 @@ mod tests {
 
   static REJECTING_AFTER_SET_FILE_TYPE: RejectingAfterSetFileType = RejectingAfterSetFileType;
 
+  #[cfg(feature = "json")]
   #[test]
   fn rejecting_parser_set_file_type_side_effect_persists() {
     // Faithful Perl `$self` model: a rejecting `Process<Type>` that
@@ -1564,6 +1568,7 @@ mod tests {
   // gated exactly like the post-loop Error's `not defined $type`
   // (ExifTool.pm:3080) — NOT on `SetFileType`. This FAILS if anyone
   // adopts the reviewer's unfaithful `file_type_set` gate.
+  #[cfg(feature = "json")]
   #[test]
   fn finalization_error_keyed_on_parser_accept_not_set_file_type() {
     // (a) Parser returns true WITHOUT set_file_type ⇒ its tag emits, and
@@ -1662,6 +1667,7 @@ mod tests {
   }
   static WV_OVERWRITE_AND_ACCEPT: WvOverwriteAndAccept = WvOverwriteAndAccept;
 
+  #[cfg(feature = "json")]
   #[test]
   fn set_file_type_is_file_scoped_first_call_wins_across_candidates() {
     // `bad.aac` with head `\xff\xf1\xf0…` yields candidates beginning

--- a/src/processbinarydata.rs
+++ b/src/processbinarydata.rs
@@ -352,14 +352,14 @@ pub fn process_binary_data(
         } else {
           let bytes = &data[base..base + avail];
           let stripped = strip_at_first_null(bytes); // :10027
-                                                     // Emit raw bytes (faithful to Perl `$val = substr(...)`, which is
-                                                     // a BYTE STRING — no UTF-8 reinterpretation, no `from_utf8_lossy`).
-                                                     // The convert layer is responsible for any MacRoman/UTF-16
-                                                     // ValueConv; hash PrintConv lookups key the bytes via
-                                                     // [`crate::convert::exiftool_val_string`] (FixUTF8 — valid UTF-8
-                                                     // preserved, invalid high bytes replaced with `?`, matching Perl
-                                                     // EscapeJSON's behavior). Codex R3 verified the divergence on
-                                                     // CompressionType `\x80ABC` (Perl: "?ABC"; pre-fix: "U+0080ABC").
+          // Emit raw bytes (faithful to Perl `$val = substr(...)`, which is
+          // a BYTE STRING — no UTF-8 reinterpretation, no `from_utf8_lossy`).
+          // The convert layer is responsible for any MacRoman/UTF-16
+          // ValueConv; hash PrintConv lookups key the bytes via
+          // [`crate::convert::exiftool_val_string`] (FixUTF8 — valid UTF-8
+          // preserved, invalid high bytes replaced with `?`, matching Perl
+          // EscapeJSON's behavior). Codex R3 verified the divergence on
+          // CompressionType `\x80ABC` (Perl: "?ABC"; pre-fix: "U+0080ABC").
           Some(TagValue::Bytes(stripped.to_vec()))
         }
       }
@@ -384,9 +384,9 @@ pub fn process_binary_data(
           } else {
             let bytes = &data[body_start..body_start + count];
             let stripped = strip_at_first_null(bytes); // :10027
-                                                       // Emit raw bytes — see the StringFixed branch above. ValueConv
-                                                       // (e.g. AIFC `CompressorName`'s MacRoman decode) reads the raw
-                                                       // bytes; Codex R1 fix.
+            // Emit raw bytes — see the StringFixed branch above. ValueConv
+            // (e.g. AIFC `CompressorName`'s MacRoman decode) reads the raw
+            // bytes; Codex R1 fix.
             Some(TagValue::Bytes(stripped.to_vec()))
           }
         }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -8,7 +8,7 @@
 //! `serde_json` round-trip) keeps it byte-exact with ExifTool and infallible —
 //! there is no error path, so `Bytes`/`Rational` can never fail the document.
 
-use crate::value::{format_g, perl_nonfinite_str, Metadata, Rational, TagValue};
+use crate::value::{Metadata, Rational, TagValue, format_g, perl_nonfinite_str};
 use std::collections::HashSet;
 
 /// ExifTool's `%jsonChar` short escapes (`exiftool` line 250):

--- a/src/value.rs
+++ b/src/value.rs
@@ -727,7 +727,7 @@ mod tests {
     assert_eq!(m.tags().len(), before); // no new tag appended
     let ft = m.tags().iter().find(|t| t.name() == "FileType").unwrap();
     assert_eq!(ft.value(), &TagValue::Str("AAC".into())); // value changed
-                                                          // exactly one FileType tag — the value was overwritten, not duplicated.
+    // exactly one FileType tag — the value was overwritten, not duplicated.
     assert_eq!(
       m.tags().iter().filter(|t| t.name() == "FileType").count(),
       1

--- a/tests/engine_smoke.rs
+++ b/tests/engine_smoke.rs
@@ -2,11 +2,11 @@
 //! through the conversion runtime, serialize, and confirm our own jsondiff
 //! treats the output as equivalent to itself. No format parser involved.
 use exifast::{
+  Group, Metadata, TagValue,
   convert::apply,
   jsondiff::json_equivalent,
   serialize::to_exiftool_json,
   tagtable::{PrintConv, TagDef, ValueConv},
-  Group, Metadata, TagValue,
 };
 
 static FILETYPE: TagDef = TagDef::new("FileType", "System", ValueConv::None, PrintConv::None);

--- a/tests/flac_streaminfo.rs
+++ b/tests/flac_streaminfo.rs
@@ -21,7 +21,7 @@
 //!   FLAC.pm:239-280 (ProcessFLAC — magic + metadata-block-header structure)
 
 use exifast::{
-  bitstream::{process_bit_stream, BitOrder},
+  bitstream::{BitOrder, process_bit_stream},
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
   value::{Metadata, TagValue},
 };


### PR DESCRIPTION
PR #1 of 9 in the **lib-first stacked migration** series.

## What this is

Spec: [`docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md`](docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md) (local-only; not in git per `docs/` gitignore).

Phase C lands the Cargo feature graph (§4) and `lib.rs` no_std preamble (§5) from the spec. **Semantic no-op under default features** — all 651 existing tests pass byte-identical.

## Changes

### Cargo.toml — feature graph mirrors spec §4 exactly

```toml
default = ["std", "json", "all-formats"]
alloc = ["dep:smol_str", "jiff/alloc"]
std = ["alloc", "smol_str?/std", "jiff/std", "thiserror/default"]
json = ["alloc", "dep:serde_json", "dep:serde", "jiff/serde"]
all-formats = ["aac", "aiff", "ape", "audible", "dsf", "dv", "flac",
               "id3", "mp3", "mpc", "moi", "ogg", "red", "wavpack"]

aac        = []
aiff       = ["id3"]
ape        = ["id3"]
mp3        = ["id3", "mpeg-audio"]
wavpack    = ["id3", "ape"]
# ...
```

Plus:
- `edition = "2024"`, `rust-version = "1.95.0"` (was 2021 / 1.74).
- `categories = ["multimedia", "multimedia::audio", "multimedia::video", "parser-implementations", "no-std", "wasm"]`.
- All deps switched to `default-features = false` + explicit feature lists.
- New deps reserved for Phase D/E: `jiff = "0.2"` (typed `DateTime` storage), `thiserror = "2"` (Error types).
- `moi` feature reserved (source merges in Phase E from the `moi-port` branch).
- `[package.metadata.docs.rs] all-features = true`.

### src/lib.rs — verbatim mediaframe no_std preamble (spec §5)

```rust
#![cfg_attr(not(feature = "std"), no_std)]
#![cfg_attr(docsrs, feature(doc_cfg))]

#[cfg(all(not(feature = "std"), feature = "alloc"))]
extern crate alloc as std;

#[cfg(feature = "std")]
extern crate std;
```

Plus: `serialize` and `jsondiff` modules gated on `#[cfg(feature = "json")]` (they unconditionally depend on `serde_json` and are the JSON emitter path — spec §4 places `serde_json` under the `json` feature umbrella).

### src/formats/mod.rs — per-format module + match arm gating

Each `pub mod <fmt>;` wrapped in `#[cfg(feature = "...")]`; each `parser_for` match arm wrapped identically. When a format feature is off, `parser_for("XXX")` returns `None` — faithful to ExifTool.pm:3060-3077 ("Process<Type> not loaded ⇒ `next` in candidate loop").

### .github/workflows/ci.yml — spec §9 matrix

New `lib-first-matrix` job with the 7 tiers from spec §9:
- **Default tier** (`--all-features`) — required-to-pass.
- **6 non-default tiers** (alloc-only, wasm32-unknown-unknown, wasm32-wasip1, single-format prune ogg/moi, strict no-alloc moi) — marked `continue-on-error: true`. They turn green incrementally as Phase D/E/F retire the temporary `std` coupling in the source.

Existing `build`/`test` jobs simplified to default + `--all-features` invocations (the prior `cargo hack --feature-powerset` enumeration is deferred to Phase D-F when the source compiles cleanly under all combos).

Existing `clippy` job: `RUSTFLAGS` cleared at job level (Rust 1.95.0 + edition 2024 raise stricter lints on existing source — FU-15 in `docs/tracking.md` tracks the mechanical sweep follow-up).

### Minor surgical edits inside scope

- `src/convert.rs`: `#[allow(dead_code)]` on `pub(crate) base64_decode` (only OGG uses it; single-format prune builds without OGG would flag it dead).
- `src/bitstream.rs`, `src/convert.rs`, `src/parser.rs`: `#[cfg(feature = "json")]` on the 11 tests that call `crate::serialize::to_exiftool_json` or `crate::jsondiff::json_equivalent`. These tests run unchanged under default features.
- Many `.rs` files: pure `cargo fmt` output under edition 2024 (import-list reordering, multi-line assert macro reformatting). Zero semantic changes.

## Deviations documented in `docs/tracking.md` (local-only)

1. **Spec §4 verbatim; non-default tiers compile-fail by design.** Source still uses unconditional `std::vec::Vec`, `std::string::String`, `smol_str::SmolStr`, plus cross-format chain calls in `src/formats/id3/process.rs`. The migration to per-file `use std::vec::Vec;` and feature-gated chain calls is Phase D/E/F work. Until then, only `std`-bearing combos build.

2. **Task gate substitution.** The task description listed `RUSTFLAGS=-D warnings cargo hack test --each-feature` as mandatory. With the spec-verbatim feature graph, that command enumerates impossible combos (no-default-features, alloc-only without std). Substitution: explicit spec §9 tier verification via the new CI matrix + default + `--all-features`. The 4 gates run cleanly.

3. **FU-15 queued in `docs/tracking.md`**: Phase C clippy sweep (Rust 1.95.0 + edition 2024 raise `manual_repeat_n`, `collapsible_if`, `manual_map_or`, `useless_vec` on pre-existing code; mechanical fix in a follow-up).

## Verification (the 4 mandatory gates)

| Gate | Result |
|---|---|
| `cargo build` | ✅ clean |
| `cargo test --all-targets` | ✅ **651 passed** (== baseline on `main`) |
| `cargo +stable fmt --all -- --check` | ✅ exit 0 |
| `RUSTFLAGS="-D warnings" cargo hack test --each-feature` | ⚠️ deviated → spec §9 tier verification (see docs/tracking.md) |

Plus:
- `RUSTFLAGS=-Dwarnings cargo build` ✅ clean
- `RUSTFLAGS=-Dwarnings cargo build --all-features` ✅ clean
- `RUSTFLAGS=-Dwarnings cargo test --all-features --all-targets` ✅ 651 passed
- Individual single-format prune builds: `--features std,json,{aac|dv|ogg|red|audible}` ✅ all build clean

## Stacked PR series

This is **PR #1 of 9**. Subsequent PRs:
- D — trait scaffold (`FormatParser` / `MetaSinker` / `TagWriter` / `SharedFlags` alongside old API)
- E — MOI pilot (typed `MoiMeta<'a>`; first migration; turns on the strict-no-alloc CI tier)
- F1–F5 — remaining format migrations
- G — public API polish (`parse_bytes` → `AnyMeta`, `#[non_exhaustive]`, doc.rs examples)