### PR TITLE
lib-first redesign Phase F1 — leaf format migrations (AAC + DV + Audible + Red)

### DIFF
--- a/src/formats/aac.rs
+++ b/src/formats/aac.rs
@@ -1,11 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "aac")]
 //! Faithful port of `Image::ExifTool::AAC` (lib/Image/ExifTool/AAC.pm).
-//! PROCESS_PROC is `FLAC::ProcessBitStream` (AAC.pm:29) → `crate::bitstream`.
+//! PROCESS_PROC is `FLAC::ProcessBitStream` (AAC.pm:29) → [`crate::bitstream`].
+//!
+//! **Phase F1 — lib-first migration.** This format follows the MOI pilot
+//! (Phase E) pattern: a typed [`AacMeta<'a>`] is produced by the new
+//! [`crate::parser_new::FormatParser`] trait; the legacy
+//! [`crate::parser::OldFormatParser`] entry point bridges through
+//! [`crate::sink::MetadataTagWriter`] so CLI JSON output stays byte-exact
+//! during the per-format crawl.
 
 use crate::{
   bitstream::{BitOrder, process_bit_stream},
-  parser::{FormatParser, ParseContext},
+  parser::{OldFormatParser, ParseContext},
+  parser_new::{FormatParser, MetaSinker, TagWriter, parser_sealed},
+  sink::MetadataTagWriter,
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
-  value::{Group, TagValue},
+  value::{Metadata, TagValue},
 };
 
 /// `%convSampleRate` (AAC.pm:18-26) as a hash ValueConv (string keys —
@@ -86,138 +99,403 @@ pub static AAC_MAIN: TagTable = TagTable::new("AAC", aac_get);
 /// HandleTag in ProcessAAC), so it is excluded here.
 pub const AAC_BIT_KEYS: &[&str] = &["Bit016-017", "Bit018-021", "Bit023-025"];
 
+// ===========================================================================
+// Typed Meta — `AacMeta<'a>`
+// ===========================================================================
+
+/// Typed AAC metadata — the lib-first output of [`ProcessAac`].
+///
+/// Holds the **post-ValueConv** raw scalars (PrintConv is applied at emit
+/// time by [`MetaSinker::sink`], mirroring ExifTool's
+/// `$$self{OPTIONS}{PrintConv}` toggle). The bit-stream walker
+/// ([`process_bit_stream`]) extracts `ProfileType` (raw), `SampleRate`
+/// (post-hash-ValueConv u32), and `Channels` (raw); `Encoder` is the
+/// ASCII string from the filler payload of the first AAC frame
+/// (AAC.pm:130-133).
+///
+/// **D8 — no public fields, accessors only.**
+///
+/// **Lifetimes.** `AacMeta` borrows the Encoder string from the input
+/// buffer (`encoder: Option<&'a str>`); other fields are owned primitives.
+#[derive(Debug, Clone)]
+pub struct AacMeta<'a> {
+  /// ProfileType (raw 2-bit field at bits 16-17). PrintConv at emit time:
+  /// 0→"Main", 1→"Low Complexity", 2→"Scalable Sampling Rate"; 3 is
+  /// rejected upstream by [`ProcessAac::parse`]. Always present after the
+  /// header gate.
+  profile_type: u8,
+  /// SampleRate in Hz (post-hash-ValueConv from the 4-bit index at bits
+  /// 18-21). The ValueConv hash (`%convSampleRate`, AAC.pm:18-26) maps
+  /// index ⇒ Hz; the index is constrained to 0..=12 upstream by
+  /// [`ProcessAac::parse`].
+  sample_rate: u32,
+  /// Channels (raw 3-bit field at bits 23-25). PrintConv at emit time
+  /// per `%AAC::Main{Channels}` (AAC.pm:51-60).
+  channels: u8,
+  /// Encoder string (ASCII, length ≥ 1) extracted from the filler payload
+  /// of the first AAC frame (AAC.pm:112-137). Borrowed from the input
+  /// buffer. `None` if there is no filler payload or if it doesn't match
+  /// the printable-ASCII regex (AAC.pm:133 `/^[\x20-\x7e]+$/`).
+  encoder: Option<&'a str>,
+}
+
+impl<'a> AacMeta<'a> {
+  /// ProfileType raw value (0..=2).
+  #[must_use]
+  pub fn profile_type(&self) -> u8 {
+    self.profile_type
+  }
+
+  /// ProfileType PrintConv name (`%AAC::Main{ProfileType}`).
+  #[must_use]
+  pub fn profile_type_name(&self) -> &'static str {
+    match self.profile_type {
+      0 => "Main",
+      1 => "Low Complexity",
+      2 => "Scalable Sampling Rate",
+      _ => "Unknown", // unreachable: gated by `(t0 >> 16) & 0x03 != 3` (AAC.pm:102)
+    }
+  }
+
+  /// SampleRate in Hz (e.g. 44100). Post-ValueConv (`%convSampleRate`).
+  #[must_use]
+  pub fn sample_rate(&self) -> u32 {
+    self.sample_rate
+  }
+
+  /// Channels raw value (0..=7).
+  #[must_use]
+  pub fn channels(&self) -> u8 {
+    self.channels
+  }
+
+  /// Encoder string borrowed from the input buffer, if present.
+  #[must_use]
+  pub fn encoder(&self) -> Option<&'a str> {
+    self.encoder
+  }
+}
+
+// ===========================================================================
+// `ProcessAac` — the lib-first parser
+// ===========================================================================
+
 /// AAC parser (faithful `ProcessAAC`, AAC.pm:81-140).
+#[derive(Debug, Clone, Copy)]
 pub struct ProcessAac;
 
+impl parser_sealed::Sealed for ProcessAac {}
+
 impl FormatParser for ProcessAac {
+  type Meta = AacMeta<'static>;
+  type Context<'a> = &'a [u8];
+  type Error = AacError;
+
+  fn parse(&self, data: Self::Context<'_>) -> Result<Option<Self::Meta>, AacError> {
+    parse_inner(data).map(|opt| opt.map(AacMeta::into_static))
+  }
+}
+
+/// Lib-first direct entry. Same as [`FormatParser::parse`] but returns an
+/// [`AacMeta`] that borrows from the input buffer (Encoder field).
+///
+/// # Errors
+///
+/// Returns `Err` for Rust-level fatal modes (none today; reserved for
+/// future I/O wrappers).
+pub fn parse_borrowed(data: &[u8]) -> Result<Option<AacMeta<'_>>, AacError> {
+  parse_inner(data)
+}
+
+/// Inner parser — produces a borrow-from-input [`AacMeta`]. The trait's
+/// `Meta = AacMeta<'static>` shape forces an [`AacMeta::into_static`]
+/// upgrade for the closed [`crate::parser_new::AnyMeta`] enum.
+fn parse_inner(data: &[u8]) -> Result<Option<AacMeta<'_>>, AacError> {
+  // AAC.pm:99-105 header validation. A reject here returns `Ok(None)` —
+  // Perl `return 0` BEFORE `$et->SetFileType()` (AAC.pm:107).
+  if data.len() < 7 {
+    return Ok(None); // $raf->Read($buff,7)==7 or return 0  (AAC.pm:99)
+  }
+  let buff = &data[..7];
+  if buff[0] != 0xff || (buff[1] != 0xf0 && buff[1] != 0xf1) {
+    return Ok(None); // unless $buff =~ /^\xff[\xf0\xf1]/  (AAC.pm:100)
+  }
+  // my @t = unpack('NnC', $buff)  (AAC.pm:101)
+  let t0 = u32::from_be_bytes([buff[0], buff[1], buff[2], buff[3]]); // $t[0] = 'N'
+  let t1 = u16::from_be_bytes([buff[4], buff[5]]); // $t[1] = 'n'
+  let t2 = buff[6]; // $t[2] = 'C'
+
+  // Faithful 1:1 of AAC.pm:102-103. The shift offsets (>>16, >>12) are
+  // ExifTool's own — they intentionally differ from the %AAC::Main bit
+  // table's Bit016-017 / Bit018-021 extraction. Do NOT "correct" them.
+  if (t0 >> 16) & 0x03 == 3 {
+    return Ok(None); // AAC.pm:102 (reserved profile type)
+  }
+  if (t0 >> 12) & 0x0f > 12 {
+    return Ok(None); // AAC.pm:103 (validate sampling frequency index)
+  }
+  // my $len = (($t[0] << 11) & 0x1800) | (($t[1] >> 5) & 0x07ff)  (AAC.pm:104)
+  let len = (((t0 << 11) & 0x1800) | ((t1 as u32 >> 5) & 0x07ff)) as usize;
+  if len < 7 {
+    return Ok(None); // AAC.pm:105
+  }
+
+  // Bit-stream walk to extract ProfileType / SampleRate / Channels via
+  // process_bit_stream into a side Metadata. The bit-stream walker is the
+  // shared engine path used by AAC + FLAC StreamInfo + WavPack + MPC;
+  // running it here is the simplest faithful path. We then transpose the
+  // emitted (name, TagValue) triples into typed scalars on AacMeta.
+  let mut staging = Metadata::new("aac-staging");
+  // print_conv_enabled=false: we want the post-ValueConv raw scalars —
+  // PrintConv is applied at sink time per Meta's design.
+  process_bit_stream(
+    buff,
+    BitOrder::Mm,
+    AAC_BIT_KEYS,
+    &AAC_MAIN,
+    &mut staging,
+    false,
+  );
+
+  // Lift from the staging Metadata into typed Meta fields. The bit-stream
+  // walker always emits I64 for these short (≤2-byte) fields.
+  let mut profile_type: u8 = 0;
+  let mut sample_rate: u32 = 0;
+  let mut channels: u8 = 0;
+  for tag in staging.tags() {
+    match tag.name() {
+      "ProfileType" => {
+        if let TagValue::I64(n) = tag.value() {
+          profile_type = (*n as u64) as u8;
+        }
+      }
+      "SampleRate" => {
+        if let TagValue::I64(n) = tag.value() {
+          sample_rate = (*n as u64) as u32;
+        }
+      }
+      "Channels" => {
+        if let TagValue::I64(n) = tag.value() {
+          channels = (*n as u64) as u8;
+        }
+      }
+      _ => {}
+    }
+  }
+
+  // Read the first frame data to check for a filler with the encoder name
+  // (AAC.pm:112-137). The Perl `while` runs at most once: the body ends
+  // with an unconditional `last` (AAC.pm:136).
+  let encoder: Option<&str> = encoder_from_filler(data, t0, t2, len);
+
+  Ok(Some(AacMeta {
+    profile_type,
+    sample_rate,
+    channels,
+    encoder,
+  }))
+}
+
+/// Extract the Encoder string from the first AAC frame's filler payload
+/// (AAC.pm:112-137). Returns a slice borrowed from `data` (zero-alloc)
+/// or `None` if there is no filler payload OR if it doesn't match the
+/// printable-ASCII regex (AAC.pm:133 `/^[\x20-\x7e]+$/`).
+fn encoder_from_filler(data: &[u8], t0: u32, t2: u8, len: usize) -> Option<&str> {
+  // while ($len > 8 and $raf->Read($buff,$len-7) == $len-7)  (AAC.pm:113)
+  if len <= 8 || data.len() < 7 + (len - 7) {
+    return None;
+  }
+  let frame = &data[7..7 + (len - 7)]; // $buff (re-read), length == $len-7
+  let no_crc = (t0 & 0x0001_0000) != 0; // my $noCRC = ($t[0] & 0x00010000)  (AAC.pm:114)
+  let blocks = (t2 & 0x03) as usize; // my $blocks = ($t[2] & 0x03)  (AAC.pm:115)
+  let mut pos = 0usize; // my $pos = 0  (AAC.pm:116)
+  if !no_crc {
+    pos += 2 + 2 * blocks; // $pos += 2 + 2 * $blocks unless $noCRC  (AAC.pm:117)
+  }
+  if pos + 2 > frame.len() {
+    return None; // last if $pos + 2 > length($buff)  (AAC.pm:118)
+  }
+  let tmp = u16::from_be_bytes([frame[pos], frame[pos + 1]]); // unpack "x${pos}n" (AAC.pm:119)
+  let id = tmp >> 13; // my $id = $tmp >> 13  (AAC.pm:120)
+  if id != 6 {
+    return None; // AAC.pm:122 — not a filler element
+  }
+  let mut cnt = ((tmp >> 9) & 0x0f) as usize; // my $cnt = ($tmp >> 9) & 0x0f  (AAC.pm:123)
+  pos += 1; // ++$pos  (AAC.pm:124)
+  if cnt == 15 {
+    // AAC.pm:125-127. The Perl arithmetic `$cnt += (($tmp>>1)&0xff) - 1`
+    // is signed; reorder for usize safety. cnt==15 here, so `cnt - 1 == 14`
+    // cannot underflow; identical to Perl's value.
+    debug_assert_eq!(cnt, 15);
+    cnt = cnt - 1 + (((tmp >> 1) & 0xff) as usize);
+    pos += 1; // ++$pos  (AAC.pm:127)
+  }
+  if pos + cnt > frame.len() {
+    return None; // AAC.pm:129 condition false
+  }
+  let dat = &frame[pos..pos + cnt]; // my $dat = substr($buff,$pos,$cnt)  (AAC.pm:130)
+  // $dat =~ s/^\0+// ; $dat =~ s/\0+$//  (AAC.pm:131-132)
+  let s = dat.iter().position(|&b| b != 0).unwrap_or(dat.len());
+  let e = dat.iter().rposition(|&b| b != 0).map_or(s, |i| i + 1);
+  let trimmed = &dat[s..e];
+  if trimmed.is_empty() {
+    return None;
+  }
+  // HandleTag(Encoder=>$dat) if $dat =~ /^[\x20-\x7e]+$/  (AAC.pm:133)
+  if !trimmed.iter().all(|&b| (0x20..=0x7e).contains(&b)) {
+    return None;
+  }
+  // `trimmed` is printable ASCII ⇒ valid UTF-8. The slice borrows the
+  // staging frame's bytes, which are themselves borrowed from `data` —
+  // the borrow propagates through the slice chain. Compute the absolute
+  // offset into `data` so the returned `&str` carries the right lifetime.
+  let frame_start = 7;
+  let frame_offset = trimmed.as_ptr() as usize - frame.as_ptr() as usize;
+  let abs_start = frame_start + frame_offset;
+  let abs_end = abs_start + trimmed.len();
+  core::str::from_utf8(&data[abs_start..abs_end]).ok()
+}
+
+// ===========================================================================
+// `AacMeta::into_static`
+// ===========================================================================
+
+impl AacMeta<'_> {
+  /// Promote a borrow-from-input [`AacMeta`] into an owned `AacMeta<'static>`.
+  /// Used by the [`FormatParser`] impl to publish into the closed
+  /// [`crate::parser_new::AnyMeta`] enum (Phase E `into_static` pragma,
+  /// per `docs/tracking.md` 2026-05-21 entry).
+  ///
+  /// Materializes the optional `encoder` borrow into a leaked `&'static str`.
+  /// Encoder strings are short (typically `"Lavc57.107.100"`-style; ≤ 32
+  /// bytes) and exactly one per AAC file; leaking is O(1) per parse and
+  /// unobservable in practice. Phase G will retire this by threading
+  /// `AacMeta<'a>` through `AnyMeta<'a>` end-to-end.
+  fn into_static(self) -> AacMeta<'static> {
+    let encoder: Option<&'static str> = self
+      .encoder
+      .map(|s| -> &'static str { std::boxed::Box::leak(s.to_string().into_boxed_str()) });
+    AacMeta {
+      profile_type: self.profile_type,
+      sample_rate: self.sample_rate,
+      channels: self.channels,
+      encoder,
+    }
+  }
+}
+
+// ===========================================================================
+// `MetaSinker` — typed Meta → TagWriter
+// ===========================================================================
+
+impl MetaSinker for AacMeta<'_> {
+  /// Emit AAC tags into the writer in `%AAC::Main` walk order (ProfileType,
+  /// SampleRate, Channels, then Encoder) — faithful to AAC.pm:38-74 +
+  /// bit-stream walker.
+  ///
+  /// `print_conv=true` ⇒ PrintConv formatted strings (`-j` mode);
+  /// `print_conv=false` ⇒ post-ValueConv raw scalars (`-n` mode).
+  fn sink<W: TagWriter>(&self, print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    const GROUP: &str = "AAC";
+    // ProfileType (raw u8, 0..=2).
+    if print_conv {
+      out.write_str(GROUP, "ProfileType", self.profile_type_name())?;
+    } else {
+      out.write_u64(GROUP, "ProfileType", u64::from(self.profile_type))?;
+    }
+    // SampleRate (post-ValueConv u32; PrintConv is None for this tag,
+    // so -j and -n emit the same numeric value).
+    out.write_u64(GROUP, "SampleRate", u64::from(self.sample_rate))?;
+    // Channels (raw u8). PrintConv hash: 0 → "?", 1..=5 → numeric I64,
+    // 6 → "5+1", 7 → "7+1". When PrintConv yields an integer (1..=5), the
+    // serializer emits a bare JSON number — same as -n. When PrintConv
+    // yields a string (?, 5+1, 7+1), serializer emits a quoted string.
+    if print_conv {
+      match self.channels {
+        0 => out.write_str(GROUP, "Channels", "?")?,
+        1..=5 => out.write_u64(GROUP, "Channels", u64::from(self.channels))?,
+        6 => out.write_str(GROUP, "Channels", "5+1")?,
+        7 => out.write_str(GROUP, "Channels", "7+1")?,
+        // unreachable: Channels is a 3-bit field (0..=7).
+        _ => out.write_u64(GROUP, "Channels", u64::from(self.channels))?,
+      }
+    } else {
+      out.write_u64(GROUP, "Channels", u64::from(self.channels))?;
+    }
+    // Encoder (optional ASCII string). No conversions — identical under -j and -n.
+    if let Some(enc) = self.encoder {
+      out.write_str(GROUP, "Encoder", enc)?;
+    }
+    Ok(())
+  }
+}
+
+// ===========================================================================
+// `AacError` — Rust-level fatal modes (currently none)
+// ===========================================================================
+
+/// Rust-level fatal modes for AAC parsing. Currently empty — every bad
+/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
+/// wrappers if streaming readers are added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AacError {}
+
+impl core::fmt::Display for AacError {
+  fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match *self {}
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AacError {}
+
+// ===========================================================================
+// Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+// ===========================================================================
+
+impl OldFormatParser for ProcessAac {
+  /// Phase E–F migration bridge. Runs the new typed [`FormatParser::parse`]
+  /// and drives [`MetaSinker::sink`] through a [`MetadataTagWriter`] so the
+  /// CLI JSON output stays byte-exact during Phases F1–F5. Retired in
+  /// Phase G.
+  ///
+  /// Faithful order (AAC.pm:99-140): header magic + filesize + SF index
+  /// gates ⇒ `SetFileType` ⇒ bit-stream walk ⇒ Encoder filler scan.
   fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
-    let data = ctx.data();
-    // AAC.pm:99-105 header validation. A reject here returns 0 BEFORE
-    // `$et->SetFileType()` (AAC.pm:107), so nothing is pushed.
-    if data.len() < 7 {
-      return false; // $raf->Read($buff,7)==7 or return 0  (AAC.pm:99)
-    }
-    let buff = &data[..7];
-    if buff[0] != 0xff || (buff[1] != 0xf0 && buff[1] != 0xf1) {
-      return false; // unless $buff =~ /^\xff[\xf0\xf1]/  (AAC.pm:100)
-    }
-    // my @t = unpack('NnC', $buff)  (AAC.pm:101)
-    let t0 = u32::from_be_bytes([buff[0], buff[1], buff[2], buff[3]]); // $t[0] = 'N'
-    let t1 = u16::from_be_bytes([buff[4], buff[5]]); // $t[1] = 'n'
-    let t2 = buff[6]; // $t[2] = 'C'
-
-    // Faithful 1:1 of AAC.pm:102-103. The shift offsets (>>16, >>12) are
-    // ExifTool's own — they intentionally differ from the %AAC::Main bit
-    // table's Bit016-017 / Bit018-021 extraction. Do NOT "correct" them to
-    // >>14 / >>10: byte-exact conformance to bundled ExifTool requires
-    // replicating this exactly (oracle: a `ff f1 c0 ..` header ⇒ "File
-    // format error", see tests/fixtures/aac_profile3.aac conformance).
-    if (t0 >> 16) & 0x03 == 3 {
-      return false; // AAC.pm:102 (reserved profile type)
-    }
-    if (t0 >> 12) & 0x0f > 12 {
-      return false; // AAC.pm:103 (validate sampling frequency index)
-    }
-    // my $len = (($t[0] << 11) & 0x1800) | (($t[1] >> 5) & 0x07ff)  (AAC.pm:104)
-    let len = (((t0 << 11) & 0x1800) | ((t1 as u32 >> 5) & 0x07ff)) as usize;
-    if len < 7 {
-      return false; // AAC.pm:105
-    }
-    // Validation passed (AAC.pm:105). Copy the 7-byte header out of the
-    // borrowed `ctx.data()` so the upcoming `&mut ctx` (set_file_type /
-    // metadata) does not conflict with `$buff`; `buff7` IS Perl `$buff`
-    // (the first frame, before the AAC.pm:113 re-read).
-    // buff = &data[..7] (data.len() >= 7 checked above) — explicit copy is
-    // panic-free (no try_into); the local array is needed because the Encoder
-    // filler scan later borrows ctx.data() immutably.
-    let buff7: [u8; 7] = [
-      buff[0], buff[1], buff[2], buff[3], buff[4], buff[5], buff[6],
-    ];
-
-    // $et->SetFileType() (AAC.pm:107): no-arg ⇒ detected file type ("AAC").
-    // The parser drives this itself (faithful: Process<Type> calls
-    // $et->SetFileType), before ProcessDirectory.
-    ctx.set_file_type(None, None, None);
-    let print_conv_enabled = ctx.print_conv_enabled();
-
-    // $et->ProcessDirectory({DataPt=>\$buff}, AAC::Main) (AAC.pm:109-110):
-    process_bit_stream(
-      &buff7,
-      BitOrder::Mm,
-      AAC_BIT_KEYS,
-      &AAC_MAIN,
-      ctx.metadata(),
-      print_conv_enabled,
-    );
-
-    // Read the first frame data to check for a filler with the encoder name
-    // (AAC.pm:112-137). The Perl `while` runs at most once: the body ends
-    // with an unconditional `last` (AAC.pm:136). Compute the (already
-    // s///-stripped) Encoder bytes first against an immutable `ctx.data()`,
-    // then HandleTag via `ctx.metadata()` — this keeps the byte logic
-    // identical to before while satisfying the borrow checker.
-    let encoder: Option<Vec<u8>> = {
-      let data = ctx.data();
-      let mut found: Option<Vec<u8>> = None;
-      // while ($len > 8 and $raf->Read($buff,$len-7) == $len-7)  (AAC.pm:113)
-      if len > 8 && data.len() >= 7 + (len - 7) {
-        let frame = &data[7..7 + (len - 7)]; // $buff (re-read), length == $len-7
-        let no_crc = (t0 & 0x0001_0000) != 0; // my $noCRC = ($t[0] & 0x00010000)  (AAC.pm:114)
-        let blocks = (t2 & 0x03) as usize; // my $blocks = ($t[2] & 0x03)  (AAC.pm:115)
-        let mut pos = 0usize; // my $pos = 0  (AAC.pm:116)
-        if !no_crc {
-          pos += 2 + 2 * blocks; // $pos += 2 + 2 * $blocks unless $noCRC  (AAC.pm:117)
-        }
-        if pos + 2 <= frame.len() {
-          // last if $pos + 2 > length($buff)  (AAC.pm:118; here $buff == frame)
-          let tmp = u16::from_be_bytes([frame[pos], frame[pos + 1]]); // unpack "x${pos}n" (AAC.pm:119)
-          let id = tmp >> 13; // my $id = $tmp >> 13  (AAC.pm:120)
-          if id == 6 {
-            // if ($id == 6)  (AAC.pm:122 filler element)
-            let mut cnt = ((tmp >> 9) & 0x0f) as usize; // my $cnt = ($tmp >> 9) & 0x0f  (AAC.pm:123)
-            pos += 1; // ++$pos  (AAC.pm:124)
-            if cnt == 15 {
-              // if ($cnt == 15)  (AAC.pm:125)
-              // AAC.pm:126 `$cnt += (($tmp>>1)&0xff) - 1` is signed Perl; reorder
-              // for usize safety. cnt==15 here (this is the `cnt==15` branch), so
-              // `cnt - 1` == 14 cannot underflow; value is identical to Perl
-              // (15 + byte - 1 == 14 + byte).
-              debug_assert_eq!(cnt, 15, "cnt==15 is the precondition of this branch");
-              cnt = cnt - 1 + (((tmp >> 1) & 0xff) as usize);
-              pos += 1; // ++$pos  (AAC.pm:127)
-            }
-            if pos + cnt <= frame.len() {
-              // if ($pos + $cnt <= length($buff))  (AAC.pm:129)
-              let dat = &frame[pos..pos + cnt]; // my $dat = substr($buff,$pos,$cnt)  (AAC.pm:130)
-              // $dat =~ s/^\0+// ; $dat =~ s/\0+$//  (AAC.pm:131-132)
-              let s = dat.iter().position(|&b| b != 0).unwrap_or(dat.len());
-              let e = dat.iter().rposition(|&b| b != 0).map_or(s, |i| i + 1);
-              // e >= s by construction (map_or(s,…) | rposition+1 > s)
-              let trimmed = &dat[s..e];
-              // HandleTag(Encoder=>$dat) if $dat =~ /^[\x20-\x7e]+$/  (AAC.pm:133;
-              // the regex is applied to $dat AFTER the two s/// strips above).
-              if !trimmed.is_empty() && trimmed.iter().all(|&b| (0x20..=0x7e).contains(&b)) {
-                found = Some(trimmed.to_vec());
-              }
-            }
-          }
-        }
-        // `last` (AAC.pm:136): no iteration.
-      }
-      found
+    let bytes = ctx.data();
+    let meta = match parse_inner(bytes) {
+      Ok(Some(m)) => m,
+      Ok(None) => return false,
+      Err(_) => return false,
     };
-    if let Some(trimmed) = encoder {
-      if let Some(def) = (AAC_MAIN.get())(TagId::Str("Encoder")) {
-        let raw = TagValue::Str(core::str::from_utf8(&trimmed).unwrap_or_default().into());
-        let out = crate::convert::apply(def, &raw, print_conv_enabled);
-        ctx
-          .metadata()
-          .push(Group::new(AAC_MAIN.group0(), def.group1()), def.name(), out);
-      }
-    }
+    // AAC.pm:107 — `$et->SetFileType()` (no-arg). The new typed parser
+    // emits its own tags after this finalize.
+    ctx.set_file_type(None, None, None);
+    let print_conv = ctx.print_conv_enabled();
+    // The Encoder field needs the legacy `convert::apply` path for the
+    // family-1 group routing (the AAC_MAIN.group1 dispatch lands family-1
+    // as "AAC"). Use the typed sink which mirrors that mapping exactly.
+    let mut bridge = MetadataTagWriter::new(ctx.metadata());
+    let _: Result<(), core::convert::Infallible> = meta.sink(print_conv, &mut bridge);
+    // Note: the Channels PrintConv hash maps `0 ⇒ "?"`. The bundled-Perl
+    // JSON emitter writes `"?"` as a quoted JSON string. Our
+    // `MetadataTagWriter::write_str` pushes `TagValue::Str`, which the
+    // serializer quotes — byte-exact.
+    //
+    // For Channels values 1..=5, PrintConv returns I64; the bundled JSON
+    // emits a bare number. The sink calls `write_u64` for these arms ⇒
+    // bridge pushes `TagValue::I64` ⇒ serializer emits bare number ⇒
+    // byte-exact.
+    //
+    // For Channels 6/7, PrintConv returns "5+1"/"7+1" strings ⇒
+    // `write_str` ⇒ `TagValue::Str` ⇒ quoted ⇒ byte-exact.
     true // return 1  (AAC.pm:139)
   }
 }
+
+// ===========================================================================
+// Tests
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
@@ -242,10 +520,6 @@ mod tests {
     assert_eq!(CONV_SAMPLE_RATE.len(), 13);
     assert_eq!(CONV_SAMPLE_RATE[4], ("4", PrintValue::I64(44100)));
     assert_eq!(CONV_SAMPLE_RATE[11], ("11", PrintValue::I64(8000)));
-    // TEMPLATE INVARIANT: every AAC_BIT_KEYS entry must resolve through
-    // aac_get — catches the manual slice drifting out of sync with the
-    // dispatch Bit* arms if a key is added to one side only. (The reverse
-    // direction is not testable in safe Rust; keep them aligned by hand.)
     for key in AAC_BIT_KEYS {
       assert!(
         g(TagId::Str(key)).is_some(),
@@ -262,18 +536,18 @@ mod tests {
     let mut m = crate::value::Metadata::new("x");
     let data = [0u8; 7];
     let mut c = ParseContext::new(&data, "AAC", 0, "AAC", None, true, &mut m);
-    assert!(!ProcessAac.process(&mut c));
+    assert!(!OldFormatParser::process(&ProcessAac, &mut c));
     assert!(m.tags().is_empty());
     let mut m2 = crate::value::Metadata::new("x");
     let bad = [0xff, 0x00];
     let mut c2 = ParseContext::new(&bad, "AAC", 0, "AAC", None, true, &mut m2);
-    assert!(!ProcessAac.process(&mut c2)); // too short / bad sync
+    assert!(!OldFormatParser::process(&ProcessAac, &mut c2)); // too short / bad sync
     assert!(m2.tags().is_empty());
   }
 
   #[test]
   fn filler_cnt15_byte0_no_panic() {
-    use crate::parser::FormatParser;
+    use crate::parser::FormatParser as _OldFP;
     // Byte derivation:
     //   [0]=0xff [1]=0xf1 → sync OK, no_crc=true (bit16 of t0 set)
     //   t0 = 0xff_f1_00_00; (t0>>16)&0x03 = 0x01 ≠ 3 ✓; (t0>>12)&0x0f = 0x00 ≤ 12 ✓
@@ -294,7 +568,7 @@ mod tests {
     ];
     let mut m = crate::value::Metadata::new("x");
     let mut c = crate::parser::ParseContext::new(&input, "AAC", 0, "AAC", None, true, &mut m);
-    assert!(ProcessAac.process(&mut c));
+    assert!(_OldFP::process(&ProcessAac, &mut c));
     assert!(m.tags().iter().all(|t| t.name() != "Encoder"));
     // Accept ⇒ the parser drove SetFileType (AAC.pm:107): File:* present.
     assert_eq!(
@@ -304,5 +578,149 @@ mod tests {
         .map(|t| t.value()),
       Some(&TagValue::Str("AAC".into()))
     );
+  }
+
+  // ---------- Lib-first typed Meta surface --------------------------------
+
+  #[test]
+  fn parse_borrowed_extracts_fixture_fields() {
+    // Real AAC.aac fixture header: ff f1 50 80 03 ff fc → ADTS, no_crc.
+    // Synthesized minimal-but-valid prefix: borrowed from the bundled AAC.aac.
+    let bytes = std::fs::read(
+      std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/AAC.aac"),
+    )
+    .expect("read AAC.aac fixture");
+    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    // ProfileType = (0x50>>6)&0x03 raw extracted by process_bit_stream
+    // ⇒ 1 (low complexity). bit-stream emits I64; typed Meta lifts to u8.
+    assert_eq!(meta.profile_type(), 1);
+    assert_eq!(meta.profile_type_name(), "Low Complexity");
+    // SampleRate = ValueConv hash["4"] = 44100.
+    assert_eq!(meta.sample_rate(), 44100);
+    // Channels = 2.
+    assert_eq!(meta.channels(), 2);
+    // Encoder = "Lavc57.107.100" (printable ASCII, post-trim).
+    assert_eq!(meta.encoder(), Some("Lavc57.107.100"));
+  }
+
+  #[test]
+  fn parse_borrowed_rejects_short_buffer() {
+    assert!(parse_borrowed(&[]).unwrap().is_none());
+    assert!(parse_borrowed(&[0xff, 0xf1]).unwrap().is_none());
+  }
+
+  #[test]
+  fn parse_borrowed_rejects_bad_sync() {
+    let data = [0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+    assert!(parse_borrowed(&data).unwrap().is_none());
+  }
+
+  #[test]
+  fn parse_borrowed_rejects_reserved_profile() {
+    // (t0>>16)&0x03 == 3 ⇒ AAC.pm:102 reject.
+    // Construct: ff f1 c0 00 ... ⇒ t0=ff_f1_c0_00; (t0>>16)&0x03 = 0xc0&3 = 0.
+    // Try ff f1 ff 00 ⇒ t0 = ff_f1_ff_00; (t0>>16)&0x03 = 0xff&3 = 3 ⇒ reject.
+    let data = [0xff, 0xf1, 0xff, 0x00, 0x00, 0x00, 0x00];
+    assert!(parse_borrowed(&data).unwrap().is_none());
+  }
+
+  #[test]
+  fn meta_sinker_emits_typed_tags() {
+    use crate::sink::{MapTagWriter, MapValue};
+    let meta = AacMeta {
+      profile_type: 1,
+      sample_rate: 44100,
+      channels: 2,
+      encoder: Some("TestEncoder"),
+    };
+    // PrintConv on.
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("AAC", "ProfileType").map(MapValue::as_str),
+      Some("Low Complexity".to_string())
+    );
+    assert_eq!(
+      w.get("AAC", "SampleRate").map(MapValue::as_str),
+      Some("44100".to_string())
+    );
+    assert_eq!(
+      w.get("AAC", "Channels").map(MapValue::as_str),
+      Some("2".to_string())
+    );
+    assert_eq!(
+      w.get("AAC", "Encoder").map(MapValue::as_str),
+      Some("TestEncoder".to_string())
+    );
+
+    // PrintConv off.
+    let mut w = MapTagWriter::new();
+    meta.sink(false, &mut w).unwrap();
+    assert_eq!(
+      w.get("AAC", "ProfileType").map(MapValue::as_str),
+      Some("1".to_string())
+    );
+    assert_eq!(
+      w.get("AAC", "Channels").map(MapValue::as_str),
+      Some("2".to_string())
+    );
+  }
+
+  #[test]
+  fn meta_sinker_emits_channels_special_cases() {
+    use crate::sink::{MapTagWriter, MapValue};
+    // Channels=0 ⇒ "?"
+    let meta = AacMeta {
+      profile_type: 0,
+      sample_rate: 44100,
+      channels: 0,
+      encoder: None,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("AAC", "Channels").map(MapValue::as_str),
+      Some("?".to_string())
+    );
+    // Channels=6 ⇒ "5+1"
+    let meta = AacMeta {
+      profile_type: 0,
+      sample_rate: 44100,
+      channels: 6,
+      encoder: None,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("AAC", "Channels").map(MapValue::as_str),
+      Some("5+1".to_string())
+    );
+    // Channels=7 ⇒ "7+1"
+    let meta = AacMeta {
+      profile_type: 0,
+      sample_rate: 44100,
+      channels: 7,
+      encoder: None,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("AAC", "Channels").map(MapValue::as_str),
+      Some("7+1".to_string())
+    );
+  }
+
+  #[test]
+  fn format_parser_trait_returns_meta_static() {
+    let bytes = std::fs::read(
+      std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/AAC.aac"),
+    )
+    .expect("read AAC.aac fixture");
+    let meta = <ProcessAac as FormatParser>::parse(&ProcessAac, &bytes)
+      .expect("ok")
+      .expect("parsed");
+    assert_eq!(meta.profile_type(), 1);
+    assert_eq!(meta.sample_rate(), 44100);
+    assert_eq!(meta.encoder(), Some("Lavc57.107.100"));
   }
 }

--- a/src/formats/audible.rs
+++ b/src/formats/audible.rs
@@ -1,5 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "audible")]
 //! Faithful port of `Image::ExifTool::Audible` (lib/Image/ExifTool/Audible.pm),
 //! AA-side only: `ProcessAA` + the `%Audible::Main` tag table.
+//!
+//! **Phase F1 — lib-first migration.** Follows the MOI pilot (Phase E) +
+//! AAC/DV pattern: a typed [`AaMeta<'a>`] is produced by the new
+//! [`crate::parser_new::FormatParser`] trait; the legacy
+//! [`crate::parser::OldFormatParser`] entry point bridges through
+//! [`crate::sink::MetadataTagWriter`] so CLI JSON output stays byte-exact
+//! during Phase F. The bridge is retired in Phase G.
 //!
 //! **M4B-side DEFERRED to FORMATS.md row 25 (QuickTime/MOV).** The bundled
 //! Audible.pm also defines `%Audible::tags`, `%Audible::meta`, `%Audible::cvrx`,
@@ -22,10 +33,12 @@
 
 use crate::{
   convert::{fix_utf8, pack_c0u},
-  parser::{FormatParser, ParseContext},
+  parser::{OldFormatParser, ParseContext},
+  parser_new::{FormatParser, MetaSinker, TagWriter, parser_sealed},
+  sink::MetadataTagWriter,
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
-  value::{Group, TagValue},
 };
+use smol_str::SmolStr;
 
 // ---------- %Audible::Main static table (Audible.pm:24-48) -----------------
 
@@ -54,7 +67,7 @@ static COVER_ART: TagDef = TagDef::new("CoverArt", "Audible", ValueConv::None, P
 fn audible_get(id: TagId) -> Option<&'static TagDef> {
   // Audible.pm:24-48 explicit keys. Anything else falls through to the
   // dynamic-name path (`AddTagToTable`, Audible.pm:258) — implemented
-  // inline in `ProcessAa::process` so the dispatch table only carries the
+  // inline in `parse_inner` so the dispatch table only carries the
   // statically-listed entries.
   match id {
     TagId::Str("pubdate") => Some(&PUBLISH_DATE),
@@ -532,7 +545,162 @@ static ENTITY_NUM: &[(&str, u32)] = &[
     ("iuml",   239), ("mdash",   8212),
 ];
 
-// ---------- ProcessAA (Audible.pm:194-273) ----------------------------------
+// ===========================================================================
+// Typed Meta — `AaMeta<'a>` + `AaEntry<'a>` + `AaValue<'a>`
+// ===========================================================================
+
+/// One emitted tag in [`AaMeta::entries`]. Each entry carries the resolved
+/// `name` (post-`MakeTagName`/`AddTagToTable` normalization) and a typed
+/// value. The `group` is always family-0 = family-1 = `"Audible"` (the
+/// only group the AA path emits under).
+#[derive(Debug, Clone)]
+pub struct AaEntry<'a> {
+  /// Tag name (e.g. `"Author"`, `"Title"`, `"Tag7eb298ac1328"`, `"ChapterCount"`,
+  /// `"CoverArt"`). Already normalized via `MakeTagName` + `s/_(.)/\U$1/g` +
+  /// `AddTagToTable` for the dynamic-name path; matches the static `TagDef::
+  /// name()` for the explicit entries (`PublishDate`, `Author`, etc.).
+  name: SmolStr,
+  /// Tag value. Strings are post-UnescapeHTML + post-fix_utf8 (synthesized);
+  /// `I64` carries the chunk-6 ChapterCount; `Bytes` carries cover art
+  /// (chunk-11 or dict `_cover_art` after UnescapeHTML).
+  value: AaValue<'a>,
+}
+
+impl<'a> AaEntry<'a> {
+  /// Tag name (e.g. `"Author"`).
+  #[must_use]
+  pub fn name(&self) -> &str {
+    self.name.as_str()
+  }
+  /// Typed tag value.
+  #[must_use]
+  pub fn value(&self) -> &AaValue<'a> {
+    &self.value
+  }
+}
+
+/// Typed value variants emitted by an AA dict / chunk parse. The choice
+/// between `Str` and `Bytes` mirrors the bundled-Perl `Binary => 1` table
+/// flag (Audible.pm:46): `_cover_art` ⇒ `Bytes`; every other dict entry ⇒
+/// `Str`. `I64` is only used for `_chapter_count` (Audible.pm:42, the
+/// `Get32u(\$buff, 0)` u32 stored as i64 to match the existing
+/// `TagValue::I64` JSON path).
+///
+/// D8 newtype-style — variants are flat data carriers; consumers match
+/// directly.
+#[derive(Debug, Clone)]
+pub enum AaValue<'a> {
+  /// UTF-8 text post-UnescapeHTML + post-fix_utf8 (synthesized — does not
+  /// borrow from input because the pipeline materially transforms bytes).
+  /// Stored as [`SmolStr`] so small values (most AA dict tags) inline.
+  Str(SmolStr),
+  /// Signed integer (used only for `ChapterCount`).
+  I64(i64),
+  /// Raw binary data (cover art). The chunk-11 path borrows from the input
+  /// buffer (`&'a [u8]`); the dict-`_cover_art` path produces an owned
+  /// `Vec<u8>` because UnescapeHTML reshapes bytes. We unify via
+  /// [`alloc::borrow::Cow`] so the chunk-11 hot path stays zero-copy while
+  /// the dict path can still hand off owned bytes.
+  Bytes(std::borrow::Cow<'a, [u8]>),
+}
+
+/// Typed AA metadata — the lib-first output of [`ProcessAa`].
+///
+/// **D8 — no public fields, accessors only.**
+///
+/// **Shape.** AA's tag set is **dynamic**: chunk-2 dictionaries can carry
+/// any number of arbitrary `tag_string => value_string` pairs (Audible.pm:
+/// 256-258), each normalized via `MakeTagName` + `s/_(.)/\U$1/g` +
+/// `AddTagToTable`. Adding to that, two chunk types emit single
+/// well-known tags: chunk-6 ⇒ `ChapterCount` (Audible.pm:223), chunk-11 ⇒
+/// `CoverArt` (Audible.pm:234). The natural typed representation is an
+/// **ordered list of [`AaEntry`]** mirroring the bundled-Perl `FoundTag`
+/// call sequence. Last-wins (Perl `FoundTag` promote-then-overwrite +
+/// `%noDups` first-token filter, ExifTool.pm:9504-9577, exiftool:2744-2752)
+/// is applied at construction in [`parse_inner`].
+///
+/// `cover_art` and `chapter_count` are also exposed as direct accessors for
+/// library callers that want typed access without scanning the entries
+/// list; the entries list is the canonical emission order, while the
+/// dedicated slots cache the last-wins resolved values.
+///
+/// **Lifetimes.** Most fields are synthesized (entity-decoded /
+/// UTF-8-repaired) and stored as [`SmolStr`] (alloc-backed). The cover-art
+/// chunk-11 path stays zero-copy by borrowing `&'a [u8]` from input via
+/// [`AaValue::Bytes`]`(Cow::Borrowed)`. The dict-`_cover_art` path
+/// materializes an owned `Vec<u8>` (UnescapeHTML reshapes bytes).
+#[derive(Debug, Clone)]
+pub struct AaMeta<'a> {
+  /// Ordered list of emitted tags (faithful to the Perl `FoundTag` call
+  /// sequence in `ProcessAA` after last-wins resolution).
+  entries: std::vec::Vec<AaEntry<'a>>,
+  /// Warnings accumulated during parse (faithful to `$et->Warn` —
+  /// Audible.pm:210, 212, 227, 228, 238, 240, 246, 252). Mirrors
+  /// [`crate::value::Metadata::warnings`].
+  warnings: std::vec::Vec<SmolStr>,
+  /// Errors accumulated during parse (R9: HTML numeric entity above
+  /// Perl `pack('C0U')`'s i64::MAX cap, surfaced as the engine's
+  /// canonical `ExifTool:Error` substitute).
+  errors: std::vec::Vec<SmolStr>,
+}
+
+impl<'a> AaMeta<'a> {
+  /// All emitted tag entries in bundled-Perl `FoundTag` call order
+  /// (post-last-wins resolution).
+  #[must_use]
+  pub fn entries(&self) -> &[AaEntry<'a>] {
+    &self.entries
+  }
+
+  /// Accumulated warnings (Audible.pm:210 `Invalid TOC`, 212
+  /// `Truncated TOC`, 227 `Chunk N too big`, 228 `Chunk N read error`,
+  /// 238 `Bad dictionary`, 240 `Bad dictionary count`, 246
+  /// `Truncated dictionary`, 252 `Bad dictionary entry`).
+  #[must_use]
+  pub fn warnings(&self) -> &[SmolStr] {
+    &self.warnings
+  }
+
+  /// Accumulated errors (R9: numeric entity above Perl `pack('C0U')`'s
+  /// i64::MAX cap surfaces as the engine's `ExifTool:Error` substitute).
+  #[must_use]
+  pub fn errors(&self) -> &[SmolStr] {
+    &self.errors
+  }
+
+  /// `ChapterCount` extracted from chunk-6 (Audible.pm:223), if present.
+  /// Convenience accessor; the same value also appears as an [`AaEntry`]
+  /// in [`Self::entries`] named `"ChapterCount"`.
+  #[must_use]
+  pub fn chapter_count(&self) -> Option<i64> {
+    self
+      .entries
+      .iter()
+      .find_map(|e| match (e.name.as_str(), &e.value) {
+        ("ChapterCount", AaValue::I64(n)) => Some(*n),
+        _ => None,
+      })
+  }
+
+  /// `CoverArt` raw bytes from chunk-11 (Audible.pm:234) OR from
+  /// dict `_cover_art` (Audible.pm:43-47), if present. The chunk-11
+  /// path borrows from the input buffer (zero-copy); the dict path
+  /// holds owned bytes.
+  #[must_use]
+  pub fn cover_art(&self) -> Option<&[u8]> {
+    self
+      .entries
+      .iter()
+      .find_map(|e| match (e.name.as_str(), &e.value) {
+        ("CoverArt", AaValue::Bytes(b)) => Some(b.as_ref()),
+        _ => None,
+      })
+  }
+}
+
+// ===========================================================================
+// `ProcessAa` — the lib-first parser
+// ===========================================================================
 
 /// Big-endian u32 from `bytes[off..off+4]`. Faithful to Perl `Get32u(\$buf,
 /// $off)` under `SetByteOrder('MM')` (Audible.pm:208). The caller is
@@ -545,448 +713,431 @@ fn get32u_be(bytes: &[u8], off: usize) -> u32 {
 }
 
 /// AA parser (faithful `ProcessAA`, Audible.pm:194-273).
+#[derive(Debug, Clone, Copy)]
 pub struct ProcessAa;
 
+impl parser_sealed::Sealed for ProcessAa {}
+
 impl FormatParser for ProcessAa {
-  fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
-    // Audible.pm:201 — `$raf->Read($buff, 16) == 16 and $buff =~
-    // /^.{4}\x57\x90\x75\x36/s`. Magic at bytes[4..8]; first 4 bytes are
-    // unconstrained at this step. We only need a brief immutable borrow
-    // of `ctx.data()` for the gate; subsequent passes re-borrow per
-    // step so the `&mut ctx` warnings/metadata calls don't conflict.
-    let data_len = ctx.data().len();
-    if data_len < 16 {
-      return false; // short read ⇒ Perl `return 0`
+  /// AA's only borrowed lifetime is the cover-art chunk-11 path (`&'a
+  /// [u8]`). The trait shape forces `'static` via [`AaMeta::into_static`]
+  /// (Phase E `into_static` pragma, per `docs/tracking.md`).
+  type Meta = AaMeta<'static>;
+  /// Spec §8: leaf format Context is `&'a [u8]` (no shared cross-format
+  /// state — AA does not chain to ID3/APE etc.).
+  type Context<'a> = &'a [u8];
+  /// Rust-level fatal error (none today; AA parsing has no I/O modes —
+  /// every bad input either returns `Ok(None)` or accumulates warnings/
+  /// errors into the typed Meta and returns `Ok(Some)`).
+  type Error = AudibleError;
+
+  /// Parse an AA file's bytes into a typed [`AaMeta`], or `None` if the
+  /// buffer is not a valid AA (short read, wrong magic, or embedded
+  /// filesize mismatch — Audible.pm:201-205). Returns `Err` only for
+  /// Rust-level fatal modes; the current port has none.
+  fn parse(&self, data: Self::Context<'_>) -> Result<Option<Self::Meta>, AudibleError> {
+    Ok(parse_inner(data).map(AaMeta::into_static))
+  }
+}
+
+/// Lib-first direct entry. Same as [`FormatParser::parse`] but returns an
+/// [`AaMeta`] that borrows the cover-art chunk-11 payload directly from
+/// the input buffer (zero-copy).
+///
+/// # Errors
+///
+/// Returns `Err` for Rust-level fatal modes (none today; reserved for
+/// future I/O wrappers).
+pub fn parse_borrowed(data: &[u8]) -> Result<Option<AaMeta<'_>>, AudibleError> {
+  Ok(parse_inner(data))
+}
+
+/// Inner parser — produces a borrow-from-input [`AaMeta`] (chunk-11 cover
+/// art borrows). The trait's `Meta = AaMeta<'static>` shape forces an
+/// [`AaMeta::into_static`] upgrade for the closed
+/// [`crate::parser_new::AnyMeta`] enum (Phase E `into_static` pragma).
+///
+/// Faithful to `ProcessAA` (Audible.pm:194-273):
+/// 1. 16-byte magic + filesize gate (Audible.pm:201-205) — return `None`
+///    on reject (Perl `return 0`).
+/// 2. `SetFileType()` (Audible.pm:207) — the bridge runs this in the
+///    legacy `OldFormatParser::process` path, not here; the typed parser
+///    doesn't push `File:*` tags.
+/// 3. `SetByteOrder('MM')` (Audible.pm:208) — every u32 read is BE.
+/// 4. TOC walk (Audible.pm:215-271) — dispatch chunk 6 (chapter count),
+///    chunk 11 (cover art), chunk 2 (UTF-8 dictionary).
+fn parse_inner(data: &[u8]) -> Option<AaMeta<'_>> {
+  // Audible.pm:201 — `$raf->Read($buff, 16) == 16 and $buff =~
+  // /^.{4}\x57\x90\x75\x36/s`. Magic at bytes[4..8]; first 4 bytes are
+  // unconstrained at this step.
+  let data_len = data.len();
+  if data_len < 16 {
+    return None; // short read ⇒ Perl `return 0`
+  }
+  if data[4..8] != [0x57, 0x90, 0x75, 0x36] {
+    return None; // magic mismatch ⇒ Perl `return 0`
+  }
+  // Audible.pm:203-206 — `defined $$et{VALUE}{FileSize}` AND
+  // `unpack('N', $buff) == $$et{VALUE}{FileSize}`. The engine
+  // doesn't push File:FileSize on this read path (the CLI strips
+  // it), but ExifTool *internally* still has `$$self{VALUE}{
+  // FileSize}` set from the stat pre-pass — the cross-check fires.
+  // Faithful oracle: the actual data length the engine sees.
+  let claimed_size = get32u_be(data, 0);
+  if data_len as u64 != u64::from(claimed_size) {
+    // Mismatch ⇒ `return 0` (Audible.pm:205, before SetFileType).
+    return None;
+  }
+
+  // Local accumulators (the typed Meta we build up). The Perl push-style
+  // `$et->FoundTag` + `$et->Warn` calls become these in-memory pushes;
+  // last-wins / first-wins resolution runs against this Vec, NOT against
+  // engine state.
+  let mut entries: std::vec::Vec<AaEntry<'_>> = std::vec::Vec::new();
+  let mut warnings: std::vec::Vec<SmolStr> = std::vec::Vec::new();
+  let mut errors: std::vec::Vec<SmolStr> = std::vec::Vec::new();
+
+  // Audible.pm:208 — `SetByteOrder('MM')`. Every multi-byte read below
+  // uses `u32::from_be_bytes`.
+
+  // Audible.pm:209 — `my $bytes = 12 * Get32u(\$buff, 8)`. Saturating
+  // multiply ensures no overflow (Perl scalars are 64-bit; we cap at
+  // usize for the slice indexing below).
+  let toc_count = get32u_be(data, 8) as usize;
+  let toc_bytes = toc_count.saturating_mul(12);
+
+  // Audible.pm:210 — `$bytes > 0xc00 and $et->Warn('Invalid TOC'),
+  // return 1`. The comma-operator chain still returns 1 (the value of
+  // the last expression). Faithful: warn + return TRUE (accept).
+  if toc_bytes > 0xc00 {
+    warnings.push(SmolStr::new_static("Invalid TOC"));
+    return Some(AaMeta {
+      entries,
+      warnings,
+      errors,
+    });
+  }
+
+  // Audible.pm:212 — `$raf->Read($toc, $bytes) == $bytes or
+  // $et->Warn('Truncated TOC'), return 1`. TOC starts at file offset 16
+  // (right after the 16-byte read buffer).
+  let toc_start = 16usize;
+  let Some(toc_end) = toc_start.checked_add(toc_bytes) else {
+    // Numerically impossible after the 0xc00 cap, but keep panic-free.
+    warnings.push(SmolStr::new_static("Truncated TOC"));
+    return Some(AaMeta {
+      entries,
+      warnings,
+      errors,
+    });
+  };
+  if toc_end > data_len {
+    warnings.push(SmolStr::new_static("Truncated TOC"));
+    return Some(AaMeta {
+      entries,
+      warnings,
+      errors,
+    });
+  }
+  // Borrow the TOC slice from input (≤ 0xc00 = 3072 bytes). The labels
+  // below need both the TOC view and the chunk-payload view; both
+  // ultimately borrow from `data`, lifetimes coincide.
+  let toc: &[u8] = &data[toc_start..toc_end];
+
+  // Audible.pm:215-271 — TOC walk. ExifTool processes chunks in TOC
+  // order (entry index ascending); output tag order follows.
+  //
+  // R10: the dict-loop's fatal-entity arm (Perl `pack('C0U')` die
+  // at XMP.pm:2933) needs to terminate ALL further AA processing,
+  // not just the inner dict iteration. Labeled `'toc:` lets the
+  // arm break out of BOTH loops at once; subsequent type-6
+  // (ChapterCount) / type-11 (CoverArt) chunks are NOT emitted,
+  // matching Perl's process-fatal abort.
+  let mut entry = 0usize;
+  'toc: while entry < toc_bytes {
+    let chunk_type = get32u_be(toc, entry);
+    // Audible.pm:217 — `next unless $type == 2 or $type == 6 or
+    // $type == 11`.
+    if chunk_type != 2 && chunk_type != 6 && chunk_type != 11 {
+      entry += 12;
+      continue;
     }
-    {
-      let head = ctx.data();
-      if head[4..8] != [0x57, 0x90, 0x75, 0x36] {
-        return false; // magic mismatch ⇒ Perl `return 0`
-      }
-      // Audible.pm:203-206 — `defined $$et{VALUE}{FileSize}` AND
-      // `unpack('N', $buff) == $$et{VALUE}{FileSize}`. The engine
-      // doesn't push File:FileSize on this read path (the CLI strips
-      // it), but ExifTool *internally* still has `$$self{VALUE}{
-      // FileSize}` set from the stat pre-pass — the cross-check fires.
-      // Faithful oracle: the actual data length the engine sees.
-      let claimed_size = get32u_be(head, 0);
-      if data_len as u64 != u64::from(claimed_size) {
-        // Mismatch ⇒ `return 0` (Audible.pm:205, before SetFileType).
-        return false;
-      }
+    let offset = get32u_be(toc, entry + 4) as usize;
+    let length = get32u_be(toc, entry + 8) as usize;
+    // Audible.pm:219 — `Get32u(\$toc, $entry + 8) or next` — falsy
+    // length skips. After this point `length` is guaranteed > 0.
+    if length == 0 {
+      entry += 12;
+      continue;
     }
+    // Audible.pm:220 — `$raf->Seek($offset, 0) or $et->Warn("Chunk
+    // $type seek error"), last`. NOTE: `File::RandomAccess::Seek`
+    // succeeds even when the requested offset is past EOF
+    // (RandomAccess.pm:141-143 explicit: "this doesn't quite behave
+    // like seek() since it will return success even if you seek
+    // outside the limits of the file. However if you do this, you
+    // will get an error on your next Read()"). The unbuffered backing
+    // delegates to Perl's `seek()`, which only fails on broken file
+    // handles. Both non-failures mean the "Chunk $type seek error"
+    // branch is effectively dead for in-memory / normal-file
+    // backings — the actual EOF surfaces at the per-chunk Read below.
+    // Faithful port: don't gate on offset alone; let each type's own
+    // Read-length check decide between silent skip (type 6) and the
+    // "read error" warning (types 2/11). Codex R1 finding #1.
 
-    // Audible.pm:207 — `$et->SetFileType()` (no-arg). Parser drives type
-    // finalization; the engine's first-call-wins guard handles repeats.
-    ctx.set_file_type(None, None, None);
-    let print_conv_enabled = ctx.print_conv_enabled();
-
-    // Audible.pm:208 — `SetByteOrder('MM')`. Every multi-byte read below
-    // uses `u32::from_be_bytes`.
-
-    // Audible.pm:209 — `my $bytes = 12 * Get32u(\$buff, 8)`. Saturating
-    // multiply ensures no overflow (Perl scalars are 64-bit; we cap at
-    // usize for the slice indexing below).
-    let toc_count = get32u_be(ctx.data(), 8) as usize;
-    let toc_bytes = toc_count.saturating_mul(12);
-
-    // Audible.pm:210 — `$bytes > 0xc00 and $et->Warn('Invalid TOC'),
-    // return 1`. The comma-operator chain still returns 1 (the value of
-    // the last expression). Faithful: warn + return TRUE (accept).
-    if toc_bytes > 0xc00 {
-      ctx.metadata().push_warning("Invalid TOC");
-      return true;
-    }
-
-    // Audible.pm:212 — `$raf->Read($toc, $bytes) == $bytes or
-    // $et->Warn('Truncated TOC'), return 1`. TOC starts at file offset 16
-    // (right after the 16-byte read buffer).
-    let toc_start = 16usize;
-    let Some(toc_end) = toc_start.checked_add(toc_bytes) else {
-      // Numerically impossible after the 0xc00 cap, but keep panic-free.
-      ctx.metadata().push_warning("Truncated TOC");
-      return true;
-    };
-    if toc_end > data_len {
-      ctx.metadata().push_warning("Truncated TOC");
-      return true;
-    }
-    // Own the TOC bytes (≤ 0xc00 = 3072 bytes) so iterating it is
-    // borrow-checker-friendly: the warning/metadata pushes inside the
-    // loop need `&mut ctx`, and an immutable borrow of `ctx.data()`
-    // would conflict.
-    let toc: Vec<u8> = ctx.data()[toc_start..toc_end].to_vec();
-
-    // Audible.pm:215-271 — TOC walk. ExifTool processes chunks in TOC
-    // order (entry index ascending); output tag order follows.
-    //
-    // R10: the dict-loop's fatal-entity arm (Perl `pack('C0U')` die
-    // at XMP.pm:2933) needs to terminate ALL further AA processing,
-    // not just the inner dict iteration. Labeled `'toc:` lets the
-    // arm break out of BOTH loops at once; subsequent type-6
-    // (ChapterCount) / type-11 (CoverArt) chunks are NOT emitted,
-    // matching Perl's process-fatal abort.
-    let mut entry = 0usize;
-    'toc: while entry < toc_bytes {
-      let chunk_type = get32u_be(&toc, entry);
-      // Audible.pm:217 — `next unless $type == 2 or $type == 6 or
-      // $type == 11`.
-      if chunk_type != 2 && chunk_type != 6 && chunk_type != 11 {
+    if chunk_type == 6 {
+      // Audible.pm:221-225 — offset table; we only read the chapter
+      // count (the first u32 of the chunk). The inline `next if
+      // $length < 4 or $raf->Read($buff, 4) != 4` (:222) silently
+      // skips a short or unreadable type-6 chunk — no Warn.
+      if length < 4 {
         entry += 12;
         continue;
       }
-      let offset = get32u_be(&toc, entry + 4) as usize;
-      let length = get32u_be(&toc, entry + 8) as usize;
-      // Audible.pm:219 — `Get32u(\$toc, $entry + 8) or next` — falsy
-      // length skips. After this point `length` is guaranteed > 0.
-      if length == 0 {
-        entry += 12;
-        continue;
-      }
-      // Audible.pm:220 — `$raf->Seek($offset, 0) or $et->Warn("Chunk
-      // $type seek error"), last`. NOTE: `File::RandomAccess::Seek`
-      // succeeds even when the requested offset is past EOF
-      // (RandomAccess.pm:141-143 explicit: "this doesn't quite behave
-      // like seek() since it will return success even if you seek
-      // outside the limits of the file. However if you do this, you
-      // will get an error on your next Read()"). The unbuffered backing
-      // delegates to Perl's `seek()`, which only fails on broken file
-      // handles. Both non-failures mean the "Chunk $type seek error"
-      // branch is effectively dead for in-memory / normal-file
-      // backings — the actual EOF surfaces at the per-chunk Read below.
-      // Faithful port: don't gate on offset alone; let each type's own
-      // Read-length check decide between silent skip (type 6) and the
-      // "read error" warning (types 2/11). Codex R1 finding #1.
-
-      if chunk_type == 6 {
-        // Audible.pm:221-225 — offset table; we only read the chapter
-        // count (the first u32 of the chunk). The inline `next if
-        // $length < 4 or $raf->Read($buff, 4) != 4` (:222) silently
-        // skips a short or unreadable type-6 chunk — no Warn.
-        if length < 4 {
-          entry += 12;
-          continue;
-        }
-        let read_end = match offset.checked_add(4) {
-          Some(e) => e,
-          None => {
-            entry += 12;
-            continue;
-          }
-        };
-        if read_end > data_len {
-          // Short read ⇒ `next` (Audible.pm:222), silent skip.
-          entry += 12;
-          continue;
-        }
-        let count = get32u_be(ctx.data(), offset);
-        handle_static_tag(ctx, "_chapter_count", TagValue::I64(i64::from(count)));
-        entry += 12;
-        continue;
-      }
-
-      // Audible.pm:227 — `$length > 100000000 and $et->Warn("Chunk $type
-      // too big"), next`. Checked BEFORE the Read so an oversized chunk
-      // never triggers the "read error" branch even when EOF would have
-      // bitten first.
-      if length > 100_000_000 {
-        ctx
-          .metadata()
-          .push_warning(format!("Chunk {chunk_type} too big"));
-        entry += 12;
-        continue;
-      }
-      // Audible.pm:228 — `$raf->Read($buff, $length) == $length or
-      // $et->Warn("Chunk $type read error"), last`. Type 2/11 short
-      // read ⇒ Warn + STOP the TOC walk (`last`).
-      let chunk_end = match offset.checked_add(length) {
+      let read_end = match offset.checked_add(4) {
         Some(e) => e,
         None => {
-          ctx
-            .metadata()
-            .push_warning(format!("Chunk {chunk_type} read error"));
-          break;
+          entry += 12;
+          continue;
         }
       };
-      if chunk_end > data_len {
-        ctx
-          .metadata()
-          .push_warning(format!("Chunk {chunk_type} read error"));
+      if read_end > data_len {
+        // Short read ⇒ `next` (Audible.pm:222), silent skip.
+        entry += 12;
+        continue;
+      }
+      let count = get32u_be(data, offset);
+      // Last-wins replace: bundled Perl `FoundTag` (ExifTool.pm:9504-
+      // 9577) promotes the earlier `ChapterCount` to `ChapterCount (1)`
+      // and writes the new value at the base key; `%noDups` filter
+      // (exiftool:2744-2752) then drops `(1)`, emitting only the
+      // LATEST count. R6 fix: chunk-6 must go through the same
+      // last-wins helper as the dict path.
+      handle_static_entry(&mut entries, "ChapterCount", AaValue::I64(i64::from(count)));
+      entry += 12;
+      continue;
+    }
+
+    // Audible.pm:227 — `$length > 100000000 and $et->Warn("Chunk $type
+    // too big"), next`. Checked BEFORE the Read so an oversized chunk
+    // never triggers the "read error" branch even when EOF would have
+    // bitten first.
+    if length > 100_000_000 {
+      warnings.push(SmolStr::from(format!("Chunk {chunk_type} too big")));
+      entry += 12;
+      continue;
+    }
+    // Audible.pm:228 — `$raf->Read($buff, $length) == $length or
+    // $et->Warn("Chunk $type read error"), last`. Type 2/11 short
+    // read ⇒ Warn + STOP the TOC walk (`last`).
+    let chunk_end = match offset.checked_add(length) {
+      Some(e) => e,
+      None => {
+        warnings.push(SmolStr::from(format!("Chunk {chunk_type} read error")));
         break;
       }
-      // Borrow the chunk bytes directly from `ctx.data()` (which now
-      // returns `&'a [u8]` — see `ParseContext::data`). The borrow
-      // outlives every `&mut ctx` mutator call below, so no borrow-
-      // checker conflict. The previous version allocated a fresh
-      // `Vec<u8>` per chunk (Copilot PR #12 review #3271619078): for
-      // cover-art chunks that can be MB-sized, the copy doubled peak
-      // memory + cost an O(length) memcpy. Only sub-slices that MUST
-      // be owned (e.g. cover-art `Vec<u8>` for `TagValue::Bytes`
-      // ownership) are cloned now.
-      let buf: &[u8] = &ctx.data()[offset..chunk_end];
-
-      if chunk_type == 11 {
-        // Audible.pm:229-235 — cover art. `length < 8` is implicit (we
-        // need to read two u32s); explicit guard mirrors Perl.
-        if length < 8 {
-          entry += 12;
-          continue;
-        }
-        // Audible.pm:231-232 — `len = Get32u($buff, 0)`, `off = Get32u
-        // ($buff, 4)`. Both u32. `off` is an ABSOLUTE file offset (Perl
-        // semantics: matches the chunk's $offset arithmetic below).
-        let cover_len = get32u_be(buf, 0) as usize;
-        let cover_off = get32u_be(buf, 4) as usize;
-        // Audible.pm:233 — `next if $off < $offset + 8 or $off - $offset
-        // + $len > $length`. The first half guards that the cover
-        // payload starts inside this chunk (past the 2-u32 header); the
-        // second half guards that it ends within the chunk.
-        let Some(min_off) = offset.checked_add(8) else {
-          entry += 12;
-          continue;
-        };
-        if cover_off < min_off {
-          entry += 12;
-          continue;
-        }
-        // After the first guard, `cover_off >= offset + 8`, so
-        // `cover_off - offset >= 8 > 0` — no underflow. Faithful
-        // signed-Perl → unsigned-Rust pattern (see
-        // `[[exifast-phase2-forward-items]]` underflow item).
-        debug_assert!(
-          cover_off >= offset + 8,
-          "cover_off >= offset+8 (Audible.pm:233 first guard)"
-        );
-        let cover_rel = cover_off - offset;
-        let Some(cover_rel_end) = cover_rel.checked_add(cover_len) else {
-          entry += 12;
-          continue;
-        };
-        if cover_rel_end > length {
-          entry += 12;
-          continue;
-        }
-        // Audible.pm:234 — `HandleTag('_cover_art', substr($buff,
-        // $off-$offset, $len))`. Carve out the cover bytes.
-        let cover_bytes = buf[cover_rel..cover_rel_end].to_vec();
-        handle_static_tag(ctx, "_cover_art", TagValue::Bytes(cover_bytes));
-        entry += 12;
-        continue;
-      }
-
-      // chunk_type == 2 — metadata dictionary (Audible.pm:238-270).
-      // Audible.pm:238 — `length < 4 and $et->Warn('Bad dictionary'), next`.
-      if length < 4 {
-        ctx.metadata().push_warning("Bad dictionary");
-        entry += 12;
-        continue;
-      }
-      let num = get32u_be(buf, 0) as usize;
-      // Audible.pm:240 — `$num > 0x200 and $et->Warn('Bad dictionary
-      // count'), next`.
-      if num > 0x200 {
-        ctx.metadata().push_warning("Bad dictionary count");
-        entry += 12;
-        continue;
-      }
-      // Audible.pm:241 — `my $pos = 4`. dictionary starts after the
-      // count.
-      let mut pos: usize = 4;
-      // Audible.pm:244-269 — read each dictionary entry. `$i` itself is
-      // unused for the tag emission (it goes to HandleTag as Index =>
-      // $i, which the engine doesn't model).
-      for _i in 0..num {
-        // Audible.pm:245 — `my $tagPos = $pos + 9`. (`pos` is `usize`;
-        // `9` is a small const; this never overflows in practice but
-        // checked addition keeps it panic-free.)
-        let Some(tag_pos) = pos.checked_add(9) else {
-          ctx.metadata().push_warning("Truncated dictionary");
-          break;
-        };
-        // Audible.pm:246 — `$tagPos > $length and $et->Warn('Truncated
-        // dictionary'), last`.
-        if tag_pos > length {
-          ctx.metadata().push_warning("Truncated dictionary");
-          break;
-        }
-        // Audible.pm:248 — `$tagLen = Get32u($buff, $pos + 1)`. Need to
-        // read 4 bytes starting at `pos + 1`. `tag_pos > length` was
-        // false, so `pos + 9 <= length` ⇒ `pos + 5 <= length - 4` ⇒ this
-        // read is in bounds.
-        let tag_len = get32u_be(buf, pos + 1) as usize;
-        // Audible.pm:249 — `$valLen = Get32u($buff, $pos + 5)`. Same
-        // in-bounds argument: `pos + 9 <= length` ⇒ `pos + 9 <= length`,
-        // and we read `[pos+5..pos+9]`, which is within `[..length]`.
-        let val_len = get32u_be(buf, pos + 5) as usize;
-        // Audible.pm:250-251 — `$valPos = $tagPos + $tagLen`, `$nxtPos
-        // = $valPos + $valLen`. Checked addition keeps panic-free.
-        let Some(val_pos) = tag_pos.checked_add(tag_len) else {
-          ctx.metadata().push_warning("Bad dictionary entry");
-          break;
-        };
-        let Some(nxt_pos) = val_pos.checked_add(val_len) else {
-          ctx.metadata().push_warning("Bad dictionary entry");
-          break;
-        };
-        // Audible.pm:252 — `$nxtPos > $length and $et->Warn('Bad
-        // dictionary entry'), last`.
-        if nxt_pos > length {
-          ctx.metadata().push_warning("Bad dictionary entry");
-          break;
-        }
-        // Audible.pm:253-254 — extract the two byte ranges.
-        // Audible.pm:253 — `$tag = substr($buff, $tagPos, $tagLen)`.
-        // The tag id is a byte string used as a hash key — Perl does
-        // NOT decode it as UTF-8 (it's an opaque ASCII-ish identifier
-        // like "product_id"). Treat as Latin-1 / ASCII (lossy_utf8 is
-        // safe because every tag id encountered is ASCII).
-        let tag = String::from_utf8_lossy(&buf[tag_pos..val_pos]).into_owned();
-        // Audible.pm:261 — `$val = $et->Decode(UnescapeHTML($val),
-        // 'UTF8')`. The Perl pipeline operates on raw bytes:
-        //   bytes → UnescapeHTML (byte-level entity expansion,
-        //                         pack('C0U', N) per entity) → bytes
-        //   → Decode($_, 'UTF8') — no-op when from==to==UTF8
-        //                          (ExifTool.pm:6337-6340 `$from ne $to`)
-        //   → HandleTag → JSON serialize → FixUTF8 (replaces invalid
-        //                                  UTF-8 bytes with '?')
-        // Audible.pm:261 — `$val = $et->Decode(UnescapeHTML($val),
-        // 'UTF8')`. UnescapeHTML always applies (binary or text); only
-        // the post-Unescape FixUTF8 pass differs between Binary => 1
-        // (no `?`-repair, serializer's binary placeholder emits a
-        // byte count derived from the UNESCAPED length) and the text
-        // path (fix_utf8 replaces invalid UTF-8 bytes with `?`,
-        // matching Perl's JSON-tier FixUTF8).
-        //
-        // R9: a numeric entity above Perl's `pack('C0U')` max
-        // (i64::MAX, XMP.pm:2933) is fatal — bundled Perl dies with
-        // "Use of code point ... is not allowed" and exits 255 with
-        // NO JSON output. The Rust library cannot panic, so we
-        // approximate via the engine's canonical ExifTool-fatal
-        // substitute: push `ExifTool:Error` and stop iterating the
-        // dict (no further AA tags emitted). Pre-existing engine
-        // pushes (`File:FileType=AA`, `ExifTool:ExifToolVersion`,
-        // etc., emitted before `ProcessAA` reached the dict) STAY
-        // in the output — that is divergent from bundled (which
-        // emits zero bytes) but is the closest faithful behavior
-        // achievable in a non-failing library; documented in-code +
-        // [[exifast-phase2-forward-items]].
-        let unescaped_bytes = match unescape_html_bytes(&buf[val_pos..nxt_pos]) {
-          Ok(b) => b,
-          Err(FatalEntityError) => {
-            ctx
-              .metadata()
-              .push_error("Use of code point above 0x7FFFFFFFFFFFFFFF is not allowed");
-            // R10: bundled Perl `pack('C0U')` die at XMP.pm:2933
-            // aborts the entire `exiftool` process (exit 255, no
-            // JSON), not just the dict loop. Faithful Rust mirror:
-            // break out of the OUTER TOC walk via the labeled
-            // `'toc` so subsequent type-6 / type-11 chunks (e.g.
-            // `Audible:ChapterCount`, `Audible:CoverArt`) are NOT
-            // emitted. The unit test
-            // `dict_value_with_fatal_entity_stops_dict_walk` was
-            // updated to cover the inner-loop break; R10 adds
-            // `dict_fatal_entity_stops_later_toc_chunks` for the
-            // outer-loop break. R10 fix.
-            break 'toc;
-          }
-        };
-
-        // Audible.pm:255-259 — dispatch by static-table presence.
-        let table_get = (AUDIBLE_MAIN.get())(TagId::Str(known_static_key(&tag)));
-        match table_get {
-          Some(def) => {
-            // R6: `_cover_art` static def carries `Binary => 1` (Audible.pm:
-            // 43-47). Bundled Perl HandleTag stores the raw post-UnescapeHTML
-            // bytes, and the JSON tier renders the universal `(Binary data
-            // N bytes, use -b option to extract)` placeholder where N is
-            // the byte count. fix_utf8's per-`?`-byte expansion would
-            // change that count, so the binary path skips it.
-            //
-            // Copilot PR #12 review #3271619102: use `def.name()` as
-            // the explicit discriminator instead of `std::ptr::eq(def,
-            // &COVER_ART)` (pointer-identity is brittle — works for
-            // the current `static COVER_ART` but obscures intent and
-            // breaks if a future refactor introduces multiple
-            // CoverArt-named defs or duplicates the static across
-            // modules). The Perl semantic is "tag with Binary => 1",
-            // which here is exactly the one entry whose `name()` is
-            // `CoverArt` (the same name the engine's binary-blob
-            // serializer keys off, see `serialize::format_binary_blob`).
-            let value = if def.name() == "CoverArt" {
-              TagValue::Bytes(unescaped_bytes)
-            } else {
-              TagValue::Str(fix_utf8(&unescaped_bytes).into())
-            };
-            push_tag_last_wins(ctx, def, value, print_conv_enabled);
-          }
-          None => {
-            // R7: Perl `%specialTags` (ExifTool.pm:1229-1236) keys
-            // collide with table-internal fields. Their dict-loop
-            // path goes through `unless ($$tagTablePtr{$tag})` —
-            // since the table has GROUPS/FORMAT/etc. defined as
-            // hashrefs, the unless is FALSE and AddTagToTable is
-            // skipped. Then HandleTag's `GetTagInfo` (ExifTool.pm:
-            // 9119) warns and returns empty, so `FoundTag` is never
-            // reached. The faithful equivalent here is: skip
-            // entirely.
-            if is_perl_special_tag(&tag) {
-              // (Perl emits a `warn` to STDERR but does NOT push a
-              // tag-level Warning, so no ctx.metadata().push_warning
-              // here; that diverges from JSON-equality if we did.)
-              pos = nxt_pos;
-              continue;
-            }
-
-            // Audible.pm:256-258 — `$name = MakeTagName($tag); $name
-            // =~ s/_(.)/\U$1/g; AddTagToTable($tagTablePtr, $tag, {
-            // Name => $name })`. The dynamic def's family-1 group is
-            // the table's `GROUPS` value, which is "Audible" (the
-            // package family-1 default, ExifTool family-1 of every
-            // AUDIBLE_MAIN entry). Push as a plain Str (no PrintConv).
-            //
-            // Dup-handling: R5 — two dictionary entries that resolve to
-            // the same (family-0, family-1, Name) triple must surface
-            // the SECOND value, matching Perl FoundTag (ExifTool.pm:
-            // 9504-9577) promote-then-overwrite + the `%noDups`
-            // first-key-wins serializer filter at exiftool:2744-2752.
-            // See `push_dict_last_wins` for the in-place replace path.
-            //
-            // R7: when the resolved dynamic name collides with an
-            // engine-pre-emitted bare name in a DIFFERENT family-1
-            // group (e.g. `FileType`, `MIMEType` — Priority 2,
-            // ExifTool.pm:1437+), Perl FoundTag's priority gate
-            // (ExifTool.pm:9553) refuses to promote the AA push, so
-            // the FIRST AA value wins under `%noDups` JSON dedup.
-            // `push_dict_last_wins` handles this case by checking
-            // for the cross-group bare-name collision.
-            //
-            // Three-step name normalization (faithful Perl flow):
-            // 1. MakeTagName       — filter to `[-_A-Za-z0-9]`, ucfirst,
-            //                         prepend `Tag` on length<2 or
-            //                         `[-0-9]` first char (ExifTool.pm:6440)
-            // 2. s/_(.)/\U$1/g     — collapse `_X` runs into uppercased X
-            //                         (Audible.pm:257)
-            // 3. AddTagToTable     — re-apply Perl's prefix gate to the
-            //                         result; any non-letter first char
-            //                         (notably `_`) triggers `Tag` prefix
-            //                         (ExifTool.pm:9243-9254). R6 fix.
-            let dynamic_name =
-              add_tag_to_table_name_normalize(underscore_to_mixed_case(&make_tag_name(&tag)));
-            push_dict_last_wins(
-              ctx,
-              Group::new(AUDIBLE_MAIN.group0(), "Audible"),
-              dynamic_name,
-              TagValue::Str(fix_utf8(&unescaped_bytes).into()),
-            );
-          }
-        }
-        // Audible.pm:269 — `$pos = $nxtPos`.
-        pos = nxt_pos;
-      }
-      entry += 12;
+    };
+    if chunk_end > data_len {
+      warnings.push(SmolStr::from(format!("Chunk {chunk_type} read error")));
+      break;
     }
-    true // Audible.pm:272 — `return 1`.
+    // Borrow the chunk bytes directly from `data`. The borrow outlives
+    // every push below (the accumulators are local).
+    let buf: &[u8] = &data[offset..chunk_end];
+
+    if chunk_type == 11 {
+      // Audible.pm:229-235 — cover art. `length < 8` is implicit (we
+      // need to read two u32s); explicit guard mirrors Perl.
+      if length < 8 {
+        entry += 12;
+        continue;
+      }
+      // Audible.pm:231-232 — `len = Get32u($buff, 0)`, `off = Get32u
+      // ($buff, 4)`. Both u32. `off` is an ABSOLUTE file offset (Perl
+      // semantics: matches the chunk's $offset arithmetic below).
+      let cover_len = get32u_be(buf, 0) as usize;
+      let cover_off = get32u_be(buf, 4) as usize;
+      // Audible.pm:233 — `next if $off < $offset + 8 or $off - $offset
+      // + $len > $length`. The first half guards that the cover
+      // payload starts inside this chunk (past the 2-u32 header); the
+      // second half guards that it ends within the chunk.
+      let Some(min_off) = offset.checked_add(8) else {
+        entry += 12;
+        continue;
+      };
+      if cover_off < min_off {
+        entry += 12;
+        continue;
+      }
+      // After the first guard, `cover_off >= offset + 8`, so
+      // `cover_off - offset >= 8 > 0` — no underflow. Faithful
+      // signed-Perl → unsigned-Rust pattern (see
+      // `[[exifast-phase2-forward-items]]` underflow item).
+      debug_assert!(
+        cover_off >= offset + 8,
+        "cover_off >= offset+8 (Audible.pm:233 first guard)"
+      );
+      let cover_rel = cover_off - offset;
+      let Some(cover_rel_end) = cover_rel.checked_add(cover_len) else {
+        entry += 12;
+        continue;
+      };
+      if cover_rel_end > length {
+        entry += 12;
+        continue;
+      }
+      // Audible.pm:234 — `HandleTag('_cover_art', substr($buff,
+      // $off-$offset, $len))`. Borrow the cover bytes from input
+      // (zero-copy via Cow::Borrowed).
+      let cover_bytes: &[u8] = &buf[cover_rel..cover_rel_end];
+      handle_static_entry(
+        &mut entries,
+        "CoverArt",
+        AaValue::Bytes(std::borrow::Cow::Borrowed(cover_bytes)),
+      );
+      entry += 12;
+      continue;
+    }
+
+    // chunk_type == 2 — metadata dictionary (Audible.pm:238-270).
+    // Audible.pm:238 — `length < 4 and $et->Warn('Bad dictionary'), next`.
+    if length < 4 {
+      warnings.push(SmolStr::new_static("Bad dictionary"));
+      entry += 12;
+      continue;
+    }
+    let num = get32u_be(buf, 0) as usize;
+    // Audible.pm:240 — `$num > 0x200 and $et->Warn('Bad dictionary
+    // count'), next`.
+    if num > 0x200 {
+      warnings.push(SmolStr::new_static("Bad dictionary count"));
+      entry += 12;
+      continue;
+    }
+    // Audible.pm:241 — `my $pos = 4`. dictionary starts after the
+    // count.
+    let mut pos: usize = 4;
+    // Audible.pm:244-269 — read each dictionary entry. `$i` itself is
+    // unused for the tag emission (it goes to HandleTag as Index =>
+    // $i, which the engine doesn't model).
+    for _i in 0..num {
+      // Audible.pm:245 — `my $tagPos = $pos + 9`.
+      let Some(tag_pos) = pos.checked_add(9) else {
+        warnings.push(SmolStr::new_static("Truncated dictionary"));
+        break;
+      };
+      // Audible.pm:246 — `$tagPos > $length and $et->Warn('Truncated
+      // dictionary'), last`.
+      if tag_pos > length {
+        warnings.push(SmolStr::new_static("Truncated dictionary"));
+        break;
+      }
+      // Audible.pm:248 — `$tagLen = Get32u($buff, $pos + 1)`.
+      let tag_len = get32u_be(buf, pos + 1) as usize;
+      // Audible.pm:249 — `$valLen = Get32u($buff, $pos + 5)`.
+      let val_len = get32u_be(buf, pos + 5) as usize;
+      // Audible.pm:250-251 — `$valPos = $tagPos + $tagLen`, `$nxtPos
+      // = $valPos + $valLen`. Checked addition keeps panic-free.
+      let Some(val_pos) = tag_pos.checked_add(tag_len) else {
+        warnings.push(SmolStr::new_static("Bad dictionary entry"));
+        break;
+      };
+      let Some(nxt_pos) = val_pos.checked_add(val_len) else {
+        warnings.push(SmolStr::new_static("Bad dictionary entry"));
+        break;
+      };
+      // Audible.pm:252 — `$nxtPos > $length and $et->Warn('Bad
+      // dictionary entry'), last`.
+      if nxt_pos > length {
+        warnings.push(SmolStr::new_static("Bad dictionary entry"));
+        break;
+      }
+      // Audible.pm:253-254 — extract the two byte ranges.
+      // Audible.pm:253 — `$tag = substr($buff, $tagPos, $tagLen)`.
+      // The tag id is a byte string used as a hash key — Perl does
+      // NOT decode it as UTF-8 (it's an opaque ASCII-ish identifier
+      // like "product_id"). Treat as Latin-1 / ASCII (lossy_utf8 is
+      // safe because every tag id encountered is ASCII).
+      let tag = String::from_utf8_lossy(&buf[tag_pos..val_pos]).into_owned();
+      // Audible.pm:261 — `$val = $et->Decode(UnescapeHTML($val),
+      // 'UTF8')`. The Perl pipeline operates on raw bytes (see
+      // unescape_html_bytes docs); R9: a numeric entity above Perl's
+      // pack('C0U') i64::MAX cap is fatal.
+      let unescaped_bytes = match unescape_html_bytes(&buf[val_pos..nxt_pos]) {
+        Ok(b) => b,
+        Err(FatalEntityError) => {
+          errors.push(SmolStr::new_static(
+            "Use of code point above 0x7FFFFFFFFFFFFFFF is not allowed",
+          ));
+          // R10: bundled Perl `pack('C0U')` die at XMP.pm:2933 aborts
+          // the entire `exiftool` process. Faithful Rust mirror:
+          // labeled break out of both loops.
+          break 'toc;
+        }
+      };
+
+      // Audible.pm:255-259 — dispatch by static-table presence.
+      let table_get = (AUDIBLE_MAIN.get())(TagId::Str(known_static_key(&tag)));
+      match table_get {
+        Some(def) => {
+          // R6: `_cover_art` static def carries `Binary => 1` (Audible.pm:
+          // 43-47). Bundled Perl HandleTag stores raw post-UnescapeHTML
+          // bytes; the JSON tier renders the universal binary
+          // placeholder where N is the byte count. fix_utf8's per-`?`
+          // expansion would change that count, so the binary path
+          // skips it.
+          let value = if def.name() == "CoverArt" {
+            AaValue::Bytes(std::borrow::Cow::Owned(unescaped_bytes))
+          } else {
+            AaValue::Str(SmolStr::from(fix_utf8(&unescaped_bytes)))
+          };
+          // Last-wins: bundled Perl FoundTag promote-then-overwrite +
+          // `%noDups` first-token filter ⇒ replace in-place at first
+          // slot, preserving order.
+          handle_static_entry(&mut entries, def.name(), value);
+        }
+        None => {
+          // R7: Perl `%specialTags` (ExifTool.pm:1229-1236) keys collide
+          // with table-internal fields. Their dict-loop path goes
+          // through `unless ($$tagTablePtr{$tag})` — since the table has
+          // GROUPS/FORMAT/etc. defined as hashrefs, the unless is FALSE
+          // and AddTagToTable is skipped. Then HandleTag's `GetTagInfo`
+          // warns and returns empty, so `FoundTag` is never reached.
+          // The faithful equivalent here is: skip entirely.
+          if is_perl_special_tag(&tag) {
+            pos = nxt_pos;
+            continue;
+          }
+
+          // Audible.pm:256-258 — dynamic-name path. Three-step
+          // normalization (faithful Perl flow):
+          // 1. MakeTagName       — ExifTool.pm:6440
+          // 2. s/_(.)/\U$1/g     — Audible.pm:257
+          // 3. AddTagToTable     — ExifTool.pm:9243-9254 prefix gate
+          let dynamic_name =
+            add_tag_to_table_name_normalize(underscore_to_mixed_case(&make_tag_name(&tag)));
+          let value = AaValue::Str(SmolStr::from(fix_utf8(&unescaped_bytes)));
+
+          // R7: dynamic-name collisions with engine pre-emitted
+          // Priority-2 tags (only `FileType`) need first-wins. The
+          // engine pushes `File:FileType=AA` UNCONDITIONALLY (via
+          // `ctx.set_file_type` after this parser accepts), so we can
+          // hardcode "any dict `FileType` triggers first-wins" without
+          // peeking at engine state.
+          handle_dynamic_entry(&mut entries, dynamic_name, value);
+        }
+      }
+      // Audible.pm:269 — `$pos = $nxtPos`.
+      pos = nxt_pos;
+    }
+    entry += 12;
   }
+
+  Some(AaMeta {
+    entries,
+    warnings,
+    errors,
+  })
 }
 
 /// Helper: `AUDIBLE_MAIN.get()` needs a `&'static str` to dispatch on; the
@@ -1011,122 +1162,232 @@ fn known_static_key(tag: &str) -> &'static str {
   }
 }
 
-/// Faithful `$et->HandleTag($tagTablePtr, $tag, $val, ...)` for a static
-/// tag: look up the def, run convert::apply, push with the def's
-/// group/name AND Perl's `FoundTag` last-wins duplicate semantics.
-/// Two same-group/name entries from chunk 6 (ChapterCount) or chunk 11
-/// (CoverArt) surface the LATEST value, matching bundled Perl. R6.
-fn handle_static_tag(ctx: &mut ParseContext<'_>, id: &'static str, raw: TagValue) {
-  let print_conv_enabled = ctx.print_conv_enabled();
-  let Some(def) = (AUDIBLE_MAIN.get())(TagId::Str(id)) else {
-    // Unreachable: every caller passes a known static key.
-    debug_assert!(false, "handle_static_tag: unknown id {id}");
-    return;
-  };
-  push_tag_last_wins(ctx, def, raw, print_conv_enabled);
-}
-
-/// Static-table dictionary push with Perl `FoundTag` last-wins semantics
-/// for duplicates. ExifTool.pm:9504-9577 promotes the earlier entry to
+/// Push a static-table entry with Perl `FoundTag` last-wins semantics for
+/// duplicates. ExifTool.pm:9504-9577 promotes the earlier entry to
 /// `$tag (1)` and writes the new value at the base `$tag` key; the
 /// `%noDups` serializer (exiftool:2744-2752) then suppresses `(1)`,
 /// emitting only the LATEST value. We collapse that round-trip to a
 /// direct in-place replace at the original slot (preserves insertion
 /// order so `%noDups` keyed by `<family1>:<name>` remains first-token).
 ///
-/// Pinned to the AA dictionary loop only — the engine-wide HandleTag
-/// promotion is a Phase-2 forward-item.
-fn push_tag_last_wins(
-  ctx: &mut ParseContext<'_>,
-  def: &TagDef,
-  raw: TagValue,
-  print_conv_enabled: bool,
+/// Pinned to the AA path only — the engine-wide HandleTag promotion is a
+/// Phase-2 forward-item.
+fn handle_static_entry<'a>(
+  entries: &mut std::vec::Vec<AaEntry<'a>>,
+  name: &str,
+  value: AaValue<'a>,
 ) {
-  let out = crate::convert::apply(def, &raw, print_conv_enabled);
-  let group = Group::new(AUDIBLE_MAIN.group0(), def.group1());
-  push_dict_last_wins(ctx, group, def.name().to_string(), out);
-}
-
-/// Generic last-wins replace-or-push for the AA dictionary path. Shared
-/// by both the static-table (post-ValueConv/PrintConv) and dynamic-name
-/// branches.
-///
-/// Last-wins (Perl FoundTag promote-then-overwrite) is the COMMON arm.
-/// The exception is R7: when the bare `name` matches an engine-pushed
-/// HIGHER-PRIORITY tag (Priority ≥ 2, only `File:FileType` among the
-/// pre-AA emissions per ExifTool.pm:1437+), Perl FoundTag
-/// (ExifTool.pm:9553) declines to promote the AA push because the AA
-/// priority (default 1) is BELOW the engine priority. ALL AA pushes
-/// then cluster at copy-suffix keys (`Name (1)`, `Name (2)`); the
-/// JSON `%noDups` dedup (exiftool:2951) keys by `<family1>:<Name>` and
-/// emits only the FIRST. We collapse that round-trip to first-wins.
-///
-/// R8: NARROWED from "any cross-group same-name" to "exact match
-/// against the known Priority-2 engine tag name". The other engine-
-/// emitted tags (`FileTypeExtension`, `MIMEType`, `ExifToolVersion`)
-/// use the DEFAULT priority of 1, so the standard symmetric promote
-/// arm runs and bundled Perl emits the SECOND AA dict value. The
-/// previous over-broad helper triggered first-wins for those too;
-/// new fixtures empirically confirm last-wins is correct there.
-fn push_dict_last_wins(ctx: &mut ParseContext<'_>, group: Group, name: String, value: TagValue) {
-  let meta = ctx.metadata();
-  let same_slot = meta.has_tag(&group, &name);
-  if same_slot {
-    // First-wins exception: only when the bare `name` collides with a
-    // pre-emitted Priority-2 engine tag (`FileType`). The check is by
-    // NAME alone — there is no engine-pushed Priority-2 `FileType` in
-    // any family-1 group other than `File:` for the AA read path, so
-    // a same-name tag is sufficient to detect the collision.
-    if collides_with_priority2_engine_tag(meta, &name) {
-      return; // first-wins (matches Perl no-promotion arm + %noDups)
-    }
-    let replaced = meta.set_tag_value(&group, &name, value);
-    debug_assert!(replaced, "has_tag/set_tag_value disagree on existence");
+  if let Some(existing) = entries.iter_mut().find(|e| e.name == name) {
+    existing.value = value;
   } else {
-    meta.push(group, name, value);
+    entries.push(AaEntry {
+      name: SmolStr::from(name),
+      value,
+    });
   }
 }
 
-/// True iff metadata contains a Priority-2 engine-emitted tag whose
-/// bare name matches `name`. Pre-AA emissions from the engine that
-/// declare `Priority => 2` (ExifTool.pm:1437+): `FileType`. The other
-/// pre-emitted bare names (`FileTypeExtension`, `MIMEType`,
-/// `ExifToolVersion`) use the default Priority 1 and therefore do NOT
-/// trigger Perl FoundTag's no-promotion arm; AA dict duplicates of
-/// those resolve to last-wins (the symmetric promote case).
+/// Push a dynamic-name (post-MakeTagName) dict entry with last-wins
+/// semantics. The R7 exception is the engine cross-group Priority-2
+/// collision: when the resolved dynamic name is `FileType`, the engine's
+/// `File:FileType=AA` (Priority 2; pushed by the bridge's
+/// `ctx.set_file_type` BEFORE sink time) wins the promotion-gate, so the
+/// FIRST AA push survives and subsequent dups are dropped.
 ///
-/// Implementation: a small name-allowlist gate (cheap) plus a single
-/// scan of `meta.tags()` to confirm the tag IS present (faithful to
-/// the runtime check — even though `File:FileType` is engine-emitted
-/// before any AA dict push, this guards against future engine changes).
-fn collides_with_priority2_engine_tag(meta: &crate::value::Metadata, name: &str) -> bool {
-  // Single-name allowlist for the AA read path. Extend faithfully when
-  // future engine pre-emissions add Priority-2 names.
-  if name != "FileType" {
-    return false;
+/// R8 narrowed the cross-group first-wins from "any cross-group same-name"
+/// to "exact match against the known Priority-2 engine tag name"
+/// (`FileType` is the only one; `FileTypeExtension`/`MIMEType`/
+/// `ExifToolVersion` use default Priority 1 and stay last-wins).
+fn handle_dynamic_entry<'a>(
+  entries: &mut std::vec::Vec<AaEntry<'a>>,
+  name: String,
+  value: AaValue<'a>,
+) {
+  if let Some(existing) = entries.iter_mut().find(|e| e.name == name.as_str()) {
+    if collides_with_priority2_engine_tag(&name) {
+      // R7/R8 first-wins exception: keep the existing (first) value.
+      return;
+    }
+    existing.value = value;
+  } else {
+    entries.push(AaEntry {
+      name: SmolStr::from(name),
+      value,
+    });
   }
-  // Tighten to "is there a File:FileType in metadata?". The earlier
-  // version checked only by bare `name`, which AFTER the same-name
-  // `Audible:FileType` push always returned true even if the engine
-  // had never emitted `File:FileType` — semantically wrong per
-  // Copilot review (PR #12 comment #3271619040) and breaks the
-  // "Priority-2 ENGINE tag" docstring. The engine emits FileType
-  // under the `File` family-0 group (ExifTool.pm:1437; see
-  // `ParseContext::set_file_type` for the construction), so any
-  // same-name tag in a NON-File group (e.g. the just-pushed
-  // `Audible:FileType`) MUST NOT trigger first-wins.
-  meta
-    .tags()
-    .iter()
-    .any(|t| t.name() == name && t.group().family0() == "File")
 }
 
-// ---------- Unit tests ------------------------------------------------------
+/// True iff the dynamic-name resolves to a Priority-2 engine pre-emitted
+/// bare name. Pre-AA emissions from the engine that declare `Priority => 2`
+/// (ExifTool.pm:1437+): `FileType`. The other pre-emitted bare names
+/// (`FileTypeExtension`, `MIMEType`, `ExifToolVersion`) use the default
+/// Priority 1 and therefore do NOT trigger Perl FoundTag's no-promotion
+/// arm; AA dict duplicates of those resolve to last-wins (the symmetric
+/// promote case).
+///
+/// Hardcoded: because `ctx.set_file_type` runs UNCONDITIONALLY for an
+/// accepted AA file (Audible.pm:207), the cross-group `File:FileType`
+/// is ALWAYS present at sink time. The previous engine-state check
+/// (`meta.tags().iter().any(...)`) is unnecessary in the typed path.
+fn collides_with_priority2_engine_tag(name: &str) -> bool {
+  name == "FileType"
+}
+
+// ===========================================================================
+// `AaMeta::into_static`
+// ===========================================================================
+
+impl AaMeta<'_> {
+  /// Promote a borrow-from-input [`AaMeta`] into an owned `AaMeta<'static>`.
+  /// Used by the [`FormatParser`] impl to publish into the closed
+  /// [`crate::parser_new::AnyMeta`] enum (Phase E `into_static` pragma,
+  /// per `docs/tracking.md` 2026-05-21 entry).
+  ///
+  /// AA's only borrowed field is `AaValue::Bytes(Cow::Borrowed(...))` for
+  /// chunk-11 cover art; materializing into `Cow::Owned(Vec)` is the
+  /// faithful upgrade. Cover-art payloads are typically a few hundred KB;
+  /// this is a one-time clone per file. Phase G will retire this by
+  /// threading `AaMeta<'a>` through `AnyMeta<'a>` end-to-end.
+  fn into_static(self) -> AaMeta<'static> {
+    let entries: std::vec::Vec<AaEntry<'static>> = self
+      .entries
+      .into_iter()
+      .map(|e| AaEntry {
+        name: e.name,
+        value: match e.value {
+          AaValue::Str(s) => AaValue::Str(s),
+          AaValue::I64(n) => AaValue::I64(n),
+          // Materialize any borrowed bytes into an owned Cow. The
+          // `into_owned()` is a no-op for `Cow::Owned` and a single
+          // memcpy for `Cow::Borrowed`.
+          AaValue::Bytes(b) => AaValue::Bytes(std::borrow::Cow::Owned(b.into_owned())),
+        },
+      })
+      .collect();
+    AaMeta {
+      entries,
+      warnings: self.warnings,
+      errors: self.errors,
+    }
+  }
+}
+
+// ===========================================================================
+// `MetaSinker` — typed Meta → TagWriter
+// ===========================================================================
+
+impl MetaSinker for AaMeta<'_> {
+  /// Emit AA tags into the writer in `ProcessAA` extraction order
+  /// (Audible.pm:215-271): TOC-walk order of (chunk_type ∈ {2, 6, 11})
+  /// emissions, post-last-wins/first-wins resolution.
+  ///
+  /// AA has no PrintConv conversions — every static `TagDef` carries
+  /// `ValueConv::None` + `PrintConv::None` (Audible.pm:24-48); dynamic
+  /// dict entries are plain strings. So `-j` and `-n` emit identical
+  /// tag values from this sink; the `print_conv` parameter is
+  /// accepted for trait conformance but has no effect on AA emission.
+  /// (The only -j vs -n difference for AA files is the engine's
+  /// `File:FileTypeExtension` PrintConv `"aa"` vs `"AA"`, applied by
+  /// `ctx.set_file_type` outside this sink.)
+  fn sink<W: TagWriter>(&self, _print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    const GROUP: &str = "Audible";
+    // Tags first (TOC walk order, last-wins resolved at parse time).
+    for entry in &self.entries {
+      match &entry.value {
+        AaValue::Str(s) => out.write_str(GROUP, entry.name.as_str(), s.as_str())?,
+        AaValue::I64(n) => out.write_i64(GROUP, entry.name.as_str(), *n)?,
+        AaValue::Bytes(b) => out.write_bytes(GROUP, entry.name.as_str(), b.as_ref())?,
+      }
+    }
+    // Warnings (Audible.pm `$et->Warn` accumulator). The CLI serializer
+    // emits only the FIRST warning (`%noDups` first-token filter +
+    // copy-suffix dedup); pushing every warning here lets a future
+    // engine grow `-a`/Duplicates without breaking the typed path.
+    for w in &self.warnings {
+      out.write_warning(w.as_str())?;
+    }
+    // Errors (R9 fatal-entity ExifTool:Error substitute).
+    for e in &self.errors {
+      out.write_error(e.as_str())?;
+    }
+    Ok(())
+  }
+}
+
+// ===========================================================================
+// `AudibleError` — Rust-level fatal modes (currently none)
+// ===========================================================================
+
+/// Rust-level fatal modes for AA parsing. Currently empty — every bad
+/// input either produces `Ok(None)` (Perl `return 0`) or surfaces
+/// warnings/errors inside the typed [`AaMeta`] (Perl `$et->Warn` /
+/// `$et->Error`). Reserved for future I/O wrappers if streaming readers
+/// are added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudibleError {}
+
+impl core::fmt::Display for AudibleError {
+  fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match *self {}
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AudibleError {}
+
+// ===========================================================================
+// Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+// ===========================================================================
+
+impl OldFormatParser for ProcessAa {
+  /// Phase E–F migration bridge. Runs the new typed [`parse_inner`] and
+  /// drives [`MetaSinker::sink`] through a [`MetadataTagWriter`] so the
+  /// CLI JSON output stays byte-exact during Phases F1–F5. Retired in
+  /// Phase G.
+  ///
+  /// Faithful order (Audible.pm:201-272):
+  /// 1. Magic + filesize gate (lines 201-205) — reject ⇒ `return 0`.
+  /// 2. `SetFileType()` (line 207) — pushes `File:FileType=AA`,
+  ///    `File:FileTypeExtension`, `File:MIMEType` BEFORE the AA:* tags.
+  ///    The first-wins R7 collision detection in `parse_inner` depends
+  ///    on this push happening unconditionally.
+  /// 3. Sink the typed Meta — emits Audible:* tags in TOC walk order
+  ///    plus accumulated warnings/errors.
+  /// 4. `return 1` (line 272).
+  fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
+    let bytes = ctx.data();
+    let meta = match parse_inner(bytes) {
+      Some(m) => m,
+      None => return false, // Magic / filesize gate failed (Perl `return 0`).
+    };
+    // Audible.pm:207 — `$et->SetFileType()` (no-arg). Engine pushes
+    // File:* tags BEFORE the AA:* tags (the bundled emission order
+    // under `-j -G1`).
+    ctx.set_file_type(None, None, None);
+    // Bridge: typed `AaMeta` ⇒ `Metadata` via `MetadataTagWriter`.
+    // `print_conv` is accepted for trait conformance but unused for AA
+    // (no PrintConv on any static def — see [`MetaSinker::sink`] docs).
+    let print_conv = ctx.print_conv_enabled();
+    let mut bridge = MetadataTagWriter::new(ctx.metadata());
+    // `MetadataTagWriter::Error` is `Infallible` — the sink cannot fail.
+    let _: Result<(), core::convert::Infallible> = meta.sink(print_conv, &mut bridge);
+    // The bridge maps `write_str` to `Group::new(group, group)` (family-0
+    // == family-1 == "Audible") which matches the existing AA path
+    // exactly — Audible.pm static defs all have `group1 = "Audible"` and
+    // the dynamic-name path used `Group::new(AUDIBLE_MAIN.group0(),
+    // "Audible")` (also `("Audible", "Audible")`).
+    true // Audible.pm:272 — `return 1`.
+  }
+}
+
+// ===========================================================================
+// Unit tests
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::value::Metadata;
+  use crate::value::{Metadata, TagValue};
 
   // ----- Static table -----
 
@@ -1183,20 +1444,9 @@ mod tests {
 
   #[test]
   fn underscore_to_mixed_case_capitalizes_after_underscore() {
-    // The path `MakeTagName → s/_(.)/\U$1/g`. `pub_date_start` → ucfirst
-    // → `Pub_date_start`, then s/// → `PubDateStart`. But the static
-    // table has `pub_date_start => Name => 'PublishDateStart'`, so the
-    // dynamic path NEVER fires for that key; this test pins the
-    // helper directly.
     assert_eq!(underscore_to_mixed_case("Pub_date_start"), "PubDateStart");
-    // No underscores: no-op.
     assert_eq!(underscore_to_mixed_case("ProductId"), "ProductId");
-    // Trailing underscore: stays literal (no captured char).
     assert_eq!(underscore_to_mixed_case("foo_"), "foo_");
-    // Multiple in a row: Perl `s/_(.)/\U$1/g` is left-to-right
-    // non-overlapping; the first `_` consumes the second `_` as its
-    // captured char (`\U` of `_` is `_`), then the scan resumes past
-    // both — so `b` is NOT captured. Result: `a_b`.
     assert_eq!(underscore_to_mixed_case("a__b"), "a_b");
   }
 
@@ -1204,32 +1454,18 @@ mod tests {
 
   #[test]
   fn add_tag_to_table_name_normalize_perl_pin() {
-    // R6: Perl `AddTagToTable` re-prefixes any name that doesn't start
-    // with an ASCII letter (or is shorter than 2 chars). Empirical
-    // verification against bundled ExifTool:
-    //   __foo  → MakeTagName + s/_(.)/\U$1/g ⇒ _foo  ⇒ Tag_foo
-    //   _foo   → _foo                                  ⇒ Tag_foo
-    //   -bar   → MakeTagName already prefixed         ⇒ already `Tag-bar`
-    //   foo    → no prefix needed                      ⇒ `foo`
-    //   A      → length 1 (< 2)                       ⇒ TagA (MakeTagName already does this)
-    //   ""     → length 0                              ⇒ Tag (MakeTagName already does this)
     assert_eq!(
       add_tag_to_table_name_normalize("_foo".to_string()),
       "Tag_foo"
     );
-    // ASCII letter first char — pass through (no prefix).
     assert_eq!(add_tag_to_table_name_normalize("Foo".to_string()), "Foo");
     assert_eq!(add_tag_to_table_name_normalize("foo".to_string()), "foo");
-    // Length < 2 still gets prefix.
     assert_eq!(add_tag_to_table_name_normalize("a".to_string()), "Taga");
     assert_eq!(add_tag_to_table_name_normalize("".to_string()), "Tag");
-    // Already starts with `Tag` and letter — no extra prefix.
     assert_eq!(
       add_tag_to_table_name_normalize("Tag_foo".to_string()),
       "Tag_foo"
     );
-    // Digit first char (would have been handled by MakeTagName, but
-    // pin defensive behavior: still prefixes).
     assert_eq!(
       add_tag_to_table_name_normalize("1foo".to_string()),
       "Tag1foo"
@@ -1238,27 +1474,12 @@ mod tests {
 
   #[test]
   fn full_dynamic_name_pipeline_perl_pin() {
-    // Compose make_tag_name + underscore_to_mixed_case +
-    // add_tag_to_table_name_normalize and pin the result against
-    // bundled Perl for the regression input `__foo` (R6 Codex finding).
     let pipeline = |tag: &str| -> String {
       add_tag_to_table_name_normalize(underscore_to_mixed_case(&make_tag_name(tag)))
     };
     assert_eq!(pipeline("__foo"), "Tag_foo");
-    // Empirical: a single leading underscore goes the same way (the
-    // `s/_(.)/\U$1/g` strips it but the result starts with the next
-    // char — if that's a letter, no prefix; if not, prefix).
     assert_eq!(pipeline("_foo"), "Foo");
-    // Triple underscore: `___foo` ⇒ MakeTagName(unchanged) ⇒
-    // s///: `_` matches `__`, then `_foo` left, `_` matches `_f`,
-    // then `oo` left → `_Foo` after first pair (Perl \U on `_` = `_`)
-    // → then `F` after second pair. Wait, walk through more carefully:
-    //   ___foo: pos 0 `_`, pos 1 `_` (consumed), \U `_` ⇒ `_`. out=`_`.
-    //   pos 2 `_`, pos 3 `f` (consumed), \U `f` ⇒ `F`. out=`_F`.
-    //   pos 4 `o`, pos 5 `o` ⇒ out=`_Foo`.
-    // AddTagToTable: `_Foo` first char `_` ⇒ `Tag_Foo`.
     assert_eq!(pipeline("___foo"), "Tag_Foo");
-    // Regular MakeTagName-prefix already firing keeps Tag-prefix:
     assert_eq!(pipeline("7eb298ac1328"), "Tag7eb298ac1328");
   }
 
@@ -1273,21 +1494,17 @@ mod tests {
     assert_eq!(unescape_html("&lt;tag&gt;"), "<tag>");
     assert_eq!(unescape_html("&quot;x&quot;"), "\"x\"");
     assert_eq!(unescape_html("don&apos;t"), "don't");
-    // Named non-XML entities from the full HTML 4 table (HTML.pm:38-124).
-    // Codex R1 finding #2 — `&copy;` / `&nbsp;` / `&mdash;` are common in
-    // AA dictionary text.
+    // Named non-XML entities.
     assert_eq!(unescape_html("&copy;"), "©");
     assert_eq!(unescape_html("&nbsp;"), "\u{00a0}");
     assert_eq!(unescape_html("&mdash;"), "—");
     assert_eq!(unescape_html("&eacute;"), "é");
-    assert_eq!(unescape_html("&Alpha;"), "Α"); // 913, distinct from "alpha"
+    assert_eq!(unescape_html("&Alpha;"), "Α");
     // Numeric (decimal): `&#169;` = `©`.
     assert_eq!(unescape_html("&#169;"), "©");
     // Numeric (hex): lowercase `#x` only, per XMP.pm:2924.
     assert_eq!(unescape_html("&#xA9;"), "©");
-    // Uppercase `#X` is NOT a valid hex entity — XMP.pm:2924 regex
-    // `^#x([0-9a-fA-F]+)$` is case-sensitive on the `x`. Falls to the
-    // "leave unchanged" fallthrough at XMP.pm:2929.
+    // Uppercase `#X` is NOT a valid hex entity.
     assert_eq!(unescape_html("&#XA9;"), "&#XA9;");
     // Unknown entity: literal pass-through (XMP.pm:2929).
     assert_eq!(unescape_html("&fubar;"), "&fubar;");
@@ -1297,21 +1514,12 @@ mod tests {
     assert_eq!(unescape_html("&;"), "&;");
     // Multiple consecutive entities.
     assert_eq!(unescape_html("&lt;&amp;&gt;"), "<&>");
-    // Entity body interrupted by a non-`\w` character: regex fails to
-    // match, the `&` stays literal and the scan resumes.
+    // Entity body interrupted by a non-`\w` character.
     assert_eq!(unescape_html("&amp ;"), "&amp ;");
   }
 
   #[test]
   fn unescape_html_numeric_entity_above_u32_matches_perl_pack_c0u() {
-    // R5 finding: Perl `chr(hex($1))` + `pack('C0U', $val)` accepts
-    // codepoints up to i64::MAX (`0x7FFF_FFFF_FFFF_FFFF`). The previous
-    // u32-only path returned None for hex bodies of 9+ digits and left
-    // the entity literal. Empirical (R5):
-    //   "&#x100000000;"  → 7 `?` (7-byte form, lead 0xFE)
-    //   "&#x1000000000;" → 13 `?` (13-byte form, lead 0xFF)
-    //   "&#x7FFFFFFFFFFFFFFF;" → 13 `?`
-    //   Decimal 4294967296 = 0x100000000 → 7 `?`
     assert_eq!(unescape_html("X&#x100000000;Y"), "X???????Y");
     assert_eq!(unescape_html("X&#x1000000000;Y"), "X?????????????Y");
     assert_eq!(unescape_html("X&#x7FFFFFFFFFFFFFFF;Y"), "X?????????????Y");
@@ -1320,38 +1528,21 @@ mod tests {
 
   #[test]
   fn unescape_html_numeric_entity_above_i64_max_is_fatal() {
-    // R9 finding: numeric entities above Perl's `pack('C0U')` max
-    // (i64::MAX = 0x7FFFFFFFFFFFFFFF) cause Perl to DIE at XMP.pm:2933,
-    // aborting the entire `exiftool` process (exit 255, no stdout).
-    // The R5 code silently returned None and the unescaper left the
-    // entity literal — diverging from bundled because Rust accepted
-    // input that Perl refuses to expose. R9 lifts this to a
-    // `FatalEntityError` that the AA dict loop surfaces as
-    // `ExifTool:Error`.
     assert_eq!(
       unescape_html_try("X&#x8000000000000000;Y"),
       Err(FatalEntityError),
-      "hex codepoint above i64::MAX is fatal"
     );
-    // Same threshold via decimal: 2^63 = 9223372036854775808.
     assert_eq!(
       unescape_html_try("X&#9223372036854775808;Y"),
       Err(FatalEntityError),
-      "decimal codepoint above i64::MAX is fatal"
     );
-    // Above u64 (17 hex digits) — Perl `hex()` saturates to u64::MAX
-    // which is still > i64::MAX, so pack still dies. We mark fatal.
     assert_eq!(
       unescape_html_try("X&#xFFFFFFFFFFFFFFFFF;Y"),
       Err(FatalEntityError),
-      "hex body larger than u64 is fatal"
     );
-    // Boundary: exactly i64::MAX is the LARGEST valid value (last
-    // 13-byte form).
     assert_eq!(
       unescape_html_try("X&#x7FFFFFFFFFFFFFFF;Y"),
       Ok("X?????????????Y".to_string()),
-      "exactly i64::MAX must NOT be fatal"
     );
   }
 
@@ -1362,7 +1553,7 @@ mod tests {
     let mut m = Metadata::new("x");
     let data = [0u8; 8]; // < 16
     let mut c = ParseContext::new(&data, "AA", 0, "AA", None, true, &mut m);
-    assert!(!ProcessAa.process(&mut c));
+    assert!(!OldFormatParser::process(&ProcessAa, &mut c));
     assert!(m.tags().is_empty());
   }
 
@@ -1370,10 +1561,9 @@ mod tests {
   fn reject_bad_magic_does_not_set_filetype() {
     let mut m = Metadata::new("x");
     let mut data = [0u8; 16];
-    // bytes 4..8 must be 57 90 75 36; set anything else.
     data[4..8].copy_from_slice(&[0, 0, 0, 0]);
     let mut c = ParseContext::new(&data, "AA", 0, "AA", None, true, &mut m);
-    assert!(!ProcessAa.process(&mut c));
+    assert!(!OldFormatParser::process(&ProcessAa, &mut c));
     assert!(m.tags().is_empty());
   }
 
@@ -1381,26 +1571,21 @@ mod tests {
   fn reject_file_size_mismatch_does_not_set_filetype() {
     let mut m = Metadata::new("x");
     let mut data = [0u8; 20];
-    // Magic OK, size field claims 999 but data.len() == 20.
     data[0..4].copy_from_slice(&[0, 0, 3, 0xe7]); // 999 BE
     data[4..8].copy_from_slice(&[0x57, 0x90, 0x75, 0x36]);
-    // TOC count = 0 so no further reads needed.
     let mut c = ParseContext::new(&data, "AA", 0, "AA", None, true, &mut m);
-    assert!(!ProcessAa.process(&mut c));
+    assert!(!OldFormatParser::process(&ProcessAa, &mut c));
     assert!(m.tags().is_empty());
   }
 
   #[test]
   fn accept_empty_toc_emits_only_filetype_triplet() {
-    // size = 16 (the 16-byte header is the whole file), TOC count = 0.
     let mut m = Metadata::new("x");
     let mut data = [0u8; 16];
     data[0..4].copy_from_slice(&[0, 0, 0, 16]);
     data[4..8].copy_from_slice(&[0x57, 0x90, 0x75, 0x36]);
-    // toc_count at bytes 8..12 = 0.
     let mut c = ParseContext::new(&data, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
-    // SetFileType triplet only.
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let names: Vec<&str> = m.tags().iter().map(|t| t.name()).collect();
     assert_eq!(names, ["FileType", "FileTypeExtension", "MIMEType"]);
     assert_eq!(
@@ -1414,40 +1599,30 @@ mod tests {
 
   #[test]
   fn invalid_toc_warns_and_accepts() {
-    // toc_count > 0xc00/12 ⇒ Warn 'Invalid TOC' and return true.
     let mut m = Metadata::new("x");
     let mut data = vec![0u8; 16];
     data[0..4].copy_from_slice(&[0, 0, 0, 16]);
     data[4..8].copy_from_slice(&[0x57, 0x90, 0x75, 0x36]);
-    // toc_count = 0x100 ⇒ toc_bytes = 0x300 < 0xc00 — bump it.
-    // 0xc00 / 12 = 256; pick 257 ⇒ 3084 > 3072.
-    data[8..12].copy_from_slice(&[0, 0, 0x01, 0x01]); // 257
+    data[8..12].copy_from_slice(&[0, 0, 0x01, 0x01]); // 257 ⇒ 3084 > 3072
     let mut c = ParseContext::new(&data, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     assert_eq!(m.warnings(), &["Invalid TOC"]);
   }
 
   #[test]
   fn truncated_toc_warns_and_accepts() {
-    // toc_count*12 > data.len()-16 ⇒ Warn 'Truncated TOC'.
     let mut m = Metadata::new("x");
     let mut data = vec![0u8; 16];
     data[0..4].copy_from_slice(&[0, 0, 0, 16]);
     data[4..8].copy_from_slice(&[0x57, 0x90, 0x75, 0x36]);
-    // toc_count = 5 ⇒ toc_bytes = 60 but data.len() - 16 = 0.
     data[8..12].copy_from_slice(&[0, 0, 0, 5]);
-    // Force data.len() == 16 so the read at file[16..76] is truncated.
     let mut c = ParseContext::new(&data, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     assert_eq!(m.warnings(), &["Truncated TOC"]);
   }
 
   /// Build a minimal AA file with a single type-2 dictionary chunk.
-  /// `entries` is a slice of `(tag, value)` pairs; the result is a
-  /// well-formed AA byte stream parsed by `ProcessAa`.
   fn build_aa_with_dict(entries: &[(&str, &str)]) -> Vec<u8> {
-    // Per-entry layout (Audible.pm:248-254):
-    //   1 unknown byte | 4 byte tagLen (BE) | 4 byte valLen (BE) | tag | val
     let mut dict = Vec::new();
     dict.extend_from_slice(&(entries.len() as u32).to_be_bytes()); // count
     for (tag, val) in entries {
@@ -1458,23 +1633,18 @@ mod tests {
       dict.extend_from_slice(val.as_bytes());
     }
     let dict_len = dict.len();
-
-    // TOC: single entry (type=2, offset=<after-header-and-toc>, length=<dict_len>).
     let toc_size = 12u32;
-    let dict_offset = 16 + toc_size; // header + toc
+    let dict_offset = 16 + toc_size;
     let mut toc = Vec::with_capacity(toc_size as usize);
-    toc.extend_from_slice(&2u32.to_be_bytes()); // type
-    toc.extend_from_slice(&dict_offset.to_be_bytes()); // offset
-    toc.extend_from_slice(&(dict_len as u32).to_be_bytes()); // length
-
-    // Header: file_size | magic | toc_count | reserved
+    toc.extend_from_slice(&2u32.to_be_bytes());
+    toc.extend_from_slice(&dict_offset.to_be_bytes());
+    toc.extend_from_slice(&(dict_len as u32).to_be_bytes());
     let total = 16 + toc.len() + dict.len();
     let mut header = Vec::with_capacity(16);
     header.extend_from_slice(&(total as u32).to_be_bytes());
     header.extend_from_slice(&[0x57, 0x90, 0x75, 0x36]);
     header.extend_from_slice(&1u32.to_be_bytes()); // toc count
-    header.extend_from_slice(&[0, 0, 0, 0]); // reserved
-
+    header.extend_from_slice(&[0, 0, 0, 0]);
     let mut out = Vec::with_capacity(total);
     out.extend(header);
     out.extend(toc);
@@ -1485,69 +1655,52 @@ mod tests {
 
   #[test]
   fn duplicate_static_dict_tag_emits_last_value() {
-    // R5: two `author` dict entries (static-table key, group1="Audible",
-    // Name="Author"). Perl `FoundTag` promotes the first to `Author (1)`
-    // and the second to base `Author`; `%noDups` then drops `(1)` and
-    // emits the SECOND value. Our last-wins replace must mirror that —
-    // exactly one Audible:Author tag with value "SECOND".
     let bytes = build_aa_with_dict(&[("author", "FIRST"), ("author", "SECOND")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let author_tags: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible" && t.name() == "Author")
       .collect();
-    assert_eq!(author_tags.len(), 1, "must collapse to one Author tag");
+    assert_eq!(author_tags.len(), 1);
     assert_eq!(author_tags[0].value(), &TagValue::Str("SECOND".into()));
   }
 
   #[test]
   fn duplicate_dynamic_dict_tag_emits_last_value() {
-    // R5: two entries with the same dynamic key (`title` is NOT in the
-    // static AUDIBLE_MAIN table — it takes the MakeTagName path).
-    // MakeTagName("title") + s/_(.)/\U$1/g ⇒ "Title". Both entries
-    // resolve to (Audible, Title); last-wins must emit the SECOND.
     let bytes = build_aa_with_dict(&[("title", "FIRST"), ("title", "SECOND")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let title_tags: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible" && t.name() == "Title")
       .collect();
-    assert_eq!(title_tags.len(), 1, "must collapse to one Title tag");
+    assert_eq!(title_tags.len(), 1);
     assert_eq!(title_tags[0].value(), &TagValue::Str("SECOND".into()));
   }
 
   #[test]
   fn duplicate_dict_tag_preserves_first_position() {
-    // R5: dup-handling must REPLACE the FIRST slot's value (not push
-    // to the end). Perl `%noDups` keys by `<family1>:<name>` and emits
-    // the FIRST insertion-order token; for the last-wins value to win,
-    // the underlying tag list must keep the FIRST position. Verify
-    // the insertion order is unchanged.
     let bytes = build_aa_with_dict(&[("author", "A"), ("title", "T"), ("author", "B")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let audible_tags: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible")
       .collect();
-    assert_eq!(audible_tags.len(), 2, "two distinct (group, name) pairs");
-    // First-position author = "B" (last value); second is title = "T".
+    assert_eq!(audible_tags.len(), 2);
     assert_eq!(audible_tags[0].name(), "Author");
     assert_eq!(audible_tags[0].value(), &TagValue::Str("B".into()));
     assert_eq!(audible_tags[1].name(), "Title");
     assert_eq!(audible_tags[1].value(), &TagValue::Str("T".into()));
   }
 
-  /// Build a minimal AA file with two type-6 ChapterCount chunks
-  /// (the chunk-tag last-wins R6 fixture, in-memory form).
   fn build_aa_with_two_chap_chunks(c1: u32, c2: u32) -> Vec<u8> {
     let count1 = c1.to_be_bytes();
     let count2 = c2.to_be_bytes();
@@ -1577,37 +1730,25 @@ mod tests {
 
   #[test]
   fn duplicate_chapter_count_chunks_emit_last_value() {
-    // R6: chunk-6 (ChapterCount) was using plain `push` instead of the
-    // last-wins helper, so duplicate type-6 TOC entries surfaced the
-    // FIRST count via the serializer's `%noDups` first-token filter.
-    // Bundled Perl FoundTag promote-then-overwrite emits the LATEST
-    // count; we now route all `handle_static_tag` through last-wins.
     let bytes = build_aa_with_two_chap_chunks(1, 2);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let chap_tags: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible" && t.name() == "ChapterCount")
       .collect();
-    assert_eq!(chap_tags.len(), 1, "must collapse to one ChapterCount");
+    assert_eq!(chap_tags.len(), 1);
     assert_eq!(chap_tags[0].value(), &TagValue::I64(2));
   }
 
   #[test]
   fn dict_cover_art_uses_binary_placeholder() {
-    // R6: `_cover_art` static def carries `Binary => 1` (Audible.pm:43-47).
-    // When found in the dict path (rare but legal), bundled Perl
-    // HandleTag stores raw bytes and the JSON tier renders
-    // `(Binary data N bytes, use -b option to extract)`. The previous
-    // dict path stored a UTF-8-repaired `TagValue::Str`, which both
-    // lost the binary semantics and could change the visible byte
-    // count via `fix_utf8`'s per-`?`-byte replacement.
     let bytes = build_aa_with_dict(&[("_cover_art", "ABCDE")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let cover: Vec<_> = m
       .tags()
       .iter()
@@ -1622,51 +1763,33 @@ mod tests {
 
   #[test]
   fn reserved_special_dict_tags_are_dropped() {
-    // R7: dict tags in Perl's `%specialTags` (`GROUPS`, `FORMAT`, etc.)
-    // collide with table-internal hashref keys. Perl's
-    // `unless ($$tagTablePtr{$tag})` branch is false (a hashref IS
-    // defined at that key); then HandleTag's GetTagInfo warns and
-    // returns empty so FoundTag is never reached. The faithful Rust
-    // equivalent: skip the dynamic-name push entirely.
     let bytes = build_aa_with_dict(&[("GROUPS", "g_val"), ("FORMAT", "f_val"), ("title", "T")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let audible_tags: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible")
       .collect();
-    // Only `Title` should be emitted; GROUPS / FORMAT are dropped.
-    assert_eq!(audible_tags.len(), 1, "GROUPS and FORMAT must be dropped");
+    assert_eq!(audible_tags.len(), 1);
     assert_eq!(audible_tags[0].name(), "Title");
     assert_eq!(audible_tags[0].value(), &TagValue::Str("T".into()));
   }
 
   #[test]
   fn dynamic_name_colliding_with_engine_filetype_is_first_wins() {
-    // R7: dict entries `file_type` and `FileType` both resolve to
-    // dynamic name `FileType`. Engine has already pushed
-    // `File:FileType=AA` (Priority 2). Perl FoundTag's priority gate
-    // declines to promote AA tags (Priority 1) — BOTH AA pushes
-    // cluster at `FileType (N)` keys, and `%noDups` picks the FIRST
-    // occurrence under the `Audible:FileType` token. The R7 fix:
-    // `push_dict_last_wins` detects the cross-group bare-name
-    // collision and skips the replace on subsequent dups.
     let bytes = build_aa_with_dict(&[("file_type", "FIRST"), ("FileType", "SECOND")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let audible_filetype: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible" && t.name() == "FileType")
       .collect();
-    // First-wins (`FIRST`) under cross-group priority collision.
     assert_eq!(audible_filetype.len(), 1);
     assert_eq!(audible_filetype[0].value(), &TagValue::Str("FIRST".into()));
-    // The engine-pushed File:FileType must still equal "AA"
-    // (unchanged by the AA dict pushes).
     let file_filetype: Vec<_> = m
       .tags()
       .iter()
@@ -1678,106 +1801,63 @@ mod tests {
 
   #[test]
   fn dynamic_name_colliding_with_engine_filetypeextension_is_last_wins() {
-    // R8 negative case: `FileTypeExtension` uses default Priority 1
-    // (no `Priority =>` line in ExifTool.pm:1444+), so FoundTag's
-    // promote arm fires symmetrically — last AA push wins. The R7
-    // helper was over-broad (treated EVERY cross-group same-name as
-    // first-wins, including symmetric-priority cases); R8 narrows
-    // the helper to the single Priority-2 name `FileType`.
     let bytes = build_aa_with_dict(&[
       ("file_type_extension", "FIRST"),
       ("FileTypeExtension", "SECOND"),
     ]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let audible_ftypeext: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible" && t.name() == "FileTypeExtension")
       .collect();
     assert_eq!(audible_ftypeext.len(), 1);
-    assert_eq!(
-      audible_ftypeext[0].value(),
-      &TagValue::Str("SECOND".into()),
-      "FileTypeExtension is symmetric-priority ⇒ last-wins"
-    );
+    assert_eq!(audible_ftypeext[0].value(), &TagValue::Str("SECOND".into()));
   }
 
   #[test]
   fn dynamic_name_colliding_with_engine_exiftoolversion_is_last_wins() {
-    // R8 negative case: `ExifToolVersion` uses default Priority 1
-    // (no `Priority =>` line in ExifTool.pm:1451+), so the symmetric
-    // promote arm fires — last AA push wins. Same shape as the
-    // `FileTypeExtension` case; pinned independently to prevent
-    // re-introduction of the over-broad helper.
     let bytes = build_aa_with_dict(&[
       ("exif_tool_version", "FIRST"),
       ("ExifToolVersion", "SECOND"),
     ]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let audible_etver: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible" && t.name() == "ExifToolVersion")
       .collect();
     assert_eq!(audible_etver.len(), 1);
-    assert_eq!(
-      audible_etver[0].value(),
-      &TagValue::Str("SECOND".into()),
-      "ExifToolVersion is symmetric-priority ⇒ last-wins"
-    );
+    assert_eq!(audible_etver[0].value(), &TagValue::Str("SECOND".into()));
   }
 
   #[test]
   fn dict_value_with_fatal_numeric_entity_emits_exiftool_error() {
-    // R9: dict value `"X&#x8000000000000000;Y"` resolves to a numeric
-    // entity ABOVE Perl `pack('C0U')`'s i64::MAX cap. Bundled Perl
-    // dies at XMP.pm:2933 with "Use of code point ... is not allowed"
-    // and exits 255 with NO JSON stdout. The Rust library
-    // (panic-free) cannot replicate the silent abort; instead the AA
-    // dict loop surfaces the fatal via `ExifTool:Error` (the engine's
-    // canonical ExifTool-fatal substitute), stops iterating further
-    // dict entries, and lets the pre-emitted engine tags (`File:
-    // FileType=AA`, `ExifTool:ExifToolVersion`) ride through. This
-    // is a deliberate non-fatal divergence — documented + pinned by
-    // this test (R9 finding) and in [[exifast-phase2-forward-items]].
     let bytes = build_aa_with_dict(&[("title", "X&#x8000000000000000;Y")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
-    // No AA-emitted tags from the dict (loop broke before push).
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let audible_tags: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible")
       .collect();
-    assert!(
-      audible_tags.is_empty(),
-      "fatal entity must break the dict loop before any push"
-    );
-    // ExifTool:Error surfaced (engine merges into errors list, not
-    // into m.tags()).
+    assert!(audible_tags.is_empty());
     let errs = m.errors();
-    assert_eq!(errs.len(), 1, "exactly one ExifTool:Error");
-    assert!(
-      errs[0].contains("Use of code point"),
-      "error string mentions the Perl die message: {:?}",
-      errs[0]
-    );
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].contains("Use of code point"));
   }
 
   #[test]
   fn dict_value_with_fatal_decimal_entity_emits_exiftool_error() {
-    // R9 sibling case: decimal numeric entity above i64::MAX.
-    // 0x8000000000000000 = 9223372036854775808. Same Perl die,
-    // same Rust ExifTool:Error substitute.
     let bytes = build_aa_with_dict(&[("title", "X&#9223372036854775808;Y")]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let errs = m.errors();
     assert_eq!(errs.len(), 1);
     assert!(errs[0].contains("Use of code point"));
@@ -1785,12 +1865,6 @@ mod tests {
 
   #[test]
   fn dict_value_with_fatal_entity_stops_dict_walk() {
-    // R9: a fatal numeric entity in one dict value must BREAK the
-    // dict loop — subsequent entries are not pushed. This matches
-    // Perl's behavior (the die aborts the loop). Verified here by
-    // a sequence: valid `author=A`, fatal value, valid `title=B`.
-    // The first push succeeds; the second triggers Error and stops;
-    // the third is NEVER reached.
     let bytes = build_aa_with_dict(&[
       ("author", "A"),
       ("title", "Y&#x8000000000000000;Z"),
@@ -1798,22 +1872,17 @@ mod tests {
     ]);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let names: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible")
       .map(|t| t.name())
       .collect();
-    // Only `Author` made it in; `Title` triggered the break;
-    // `Narrator` was never reached.
-    assert_eq!(names, vec!["Author"], "dict walk stops at the fatal entry");
+    assert_eq!(names, vec!["Author"]);
     assert_eq!(m.errors().len(), 1);
   }
 
-  /// Build a minimal AA file with one type-2 dict chunk followed by
-  /// one type-6 ChapterCount chunk (the R10 regression fixture). The
-  /// dict has a single entry; the chunk-6 holds a single u32 count.
   fn build_aa_dict_then_chap(dict_entries: &[(&str, &str)], chapter_count: u32) -> Vec<u8> {
     let mut dict = Vec::new();
     dict.extend_from_slice(&(dict_entries.len() as u32).to_be_bytes());
@@ -1853,30 +1922,104 @@ mod tests {
 
   #[test]
   fn dict_fatal_entity_stops_later_toc_chunks() {
-    // R10: a fatal numeric entity must abort ALL further AA
-    // processing, not just the inner dict loop. Bundled Perl
-    // `pack('C0U')` die at XMP.pm:2933 aborts the entire
-    // `exiftool` process (exit 255, no JSON); a subsequent type-6
-    // ChapterCount chunk is NEVER reached. The Rust mirror is a
-    // labeled `break 'toc` on the fatal arm so the outer TOC walk
-    // stops too. Without the label (R9's unlabeled `break`), the
-    // chunk-6 would parse and emit `Audible:ChapterCount=7`.
     let bytes = build_aa_dict_then_chap(&[("title", "X&#x8000000000000000;Y")], 7);
     let mut m = Metadata::new("x");
     let mut c = ParseContext::new(&bytes, "AA", 0, "AA", None, true, &mut m);
-    assert!(ProcessAa.process(&mut c));
-    // No AA-family tags at all (neither Title from dict nor
-    // ChapterCount from the later chunk).
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
     let audible_tags: Vec<_> = m
       .tags()
       .iter()
       .filter(|t| t.group().family1() == "Audible")
       .collect();
-    assert!(
-      audible_tags.is_empty(),
-      "fatal entity must abort the outer TOC walk, no later chunks: {audible_tags:?}"
-    );
-    assert_eq!(m.errors().len(), 1, "exactly one ExifTool:Error");
+    assert!(audible_tags.is_empty());
+    assert_eq!(m.errors().len(), 1);
     assert!(m.errors()[0].contains("Use of code point"));
+  }
+
+  // ----- Lib-first typed Meta surface -----
+
+  #[test]
+  fn parse_borrowed_returns_typed_meta() {
+    let bytes = build_aa_with_dict(&[("author", "Alice"), ("title", "Book")]);
+    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let names: Vec<&str> = meta.entries().iter().map(|e| e.name()).collect();
+    assert_eq!(names, vec!["Author", "Title"]);
+    match &meta.entries()[0].value() {
+      AaValue::Str(s) => assert_eq!(s.as_str(), "Alice"),
+      other => panic!("expected Str, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn parse_borrowed_returns_chapter_count_accessor() {
+    let bytes = build_aa_with_two_chap_chunks(1, 42);
+    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    assert_eq!(meta.chapter_count(), Some(42));
+  }
+
+  #[test]
+  fn parse_borrowed_rejects_short_buffer() {
+    assert!(parse_borrowed(&[]).unwrap().is_none());
+    assert!(parse_borrowed(&[0u8; 8]).unwrap().is_none());
+  }
+
+  #[test]
+  fn format_parser_trait_returns_meta_static() {
+    let bytes = build_aa_with_dict(&[("author", "Alice")]);
+    let meta = <ProcessAa as FormatParser>::parse(&ProcessAa, &bytes)
+      .expect("ok")
+      .expect("parsed");
+    assert_eq!(meta.entries().len(), 1);
+    assert_eq!(meta.entries()[0].name(), "Author");
+  }
+
+  #[test]
+  fn meta_sinker_emits_typed_tags() {
+    use crate::sink::{MapTagWriter, MapValue};
+    let bytes = build_aa_with_dict(&[("author", "Alice"), ("title", "Book")]);
+    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("Audible", "Author").map(MapValue::as_str),
+      Some("Alice".to_string())
+    );
+    assert_eq!(
+      w.get("Audible", "Title").map(MapValue::as_str),
+      Some("Book".to_string())
+    );
+  }
+
+  #[test]
+  fn meta_sinker_emits_chapter_count_as_i64() {
+    use crate::sink::{MapTagWriter, MapValue};
+    let bytes = build_aa_with_two_chap_chunks(1, 7);
+    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("Audible", "ChapterCount").map(MapValue::as_str),
+      Some("7".to_string())
+    );
+  }
+
+  #[test]
+  fn meta_sinker_emits_warnings() {
+    use crate::sink::MapTagWriter;
+    let mut m = Metadata::new("x");
+    let mut data = vec![0u8; 16];
+    data[0..4].copy_from_slice(&[0, 0, 0, 16]);
+    data[4..8].copy_from_slice(&[0x57, 0x90, 0x75, 0x36]);
+    data[8..12].copy_from_slice(&[0, 0, 0x01, 0x01]); // 257
+    let mut c = ParseContext::new(&data, "AA", 0, "AA", None, true, &mut m);
+    assert!(OldFormatParser::process(&ProcessAa, &mut c));
+    // The bridge picks up the warning via push_warning ⇒ MetadataTagWriter.
+    assert_eq!(m.warnings(), &["Invalid TOC"]);
+
+    // Also verify the typed path: parse_borrowed produces the same warning.
+    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert!(w.warnings().iter().any(|s| s == "Invalid TOC"));
   }
 }

--- a/src/formats/dv.rs
+++ b/src/formats/dv.rs
@@ -1,12 +1,22 @@
+#![cfg(feature = "dv")]
 //! Faithful port of `Image::ExifTool::DV` (`lib/Image/ExifTool/DV.pm`).
 //! Module-name dispatch: `%moduleName{DV}` defaults to `Module("DV")`
 //! (no explicit row, so Perl `$module = $type`); registered in
 //! [`crate::formats::parser_for`].
+//!
+//! **Phase F1 — lib-first migration.** Follows the MOI pilot (Phase E)
+//! pattern: a typed [`DvMeta<'a>`] is produced by the new
+//! [`crate::parser_new::FormatParser`] trait; the legacy
+//! [`crate::parser::OldFormatParser`] entry point bridges through
+//! [`crate::sink::MetadataTagWriter`] so CLI JSON output stays byte-exact
+//! during Phase F. The bridge is retired in Phase G.
 
 use crate::{
-  parser::{FormatParser, ParseContext},
+  parser::{OldFormatParser, ParseContext},
+  parser_new::{FormatParser, MetaSinker, TagWriter, parser_sealed},
+  sink::MetadataTagWriter,
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
-  value::{Group, TagValue, format_g},
+  value::{TagValue, format_g},
 };
 
 /// One row of `@dvProfiles` (DV.pm:21-113). All fields are derived
@@ -544,40 +554,150 @@ fn extract_vaux_meta(
 /// Computed result of the bytewise parse (`compute`). Distinguishes the
 /// Perl reject paths from the two accept paths so each is independently
 /// testable; the live driver matches and runs the `&mut ctx` finalize.
-enum Parsed {
+enum Parsed<'a> {
   /// DV.pm:158 `or return 0` — `$raf->Read` empty.
   RejectEmpty,
   /// DV.pm:167 `return 0 unless defined $start` — no DIF header.
   RejectNoDif,
   /// DV.pm:171 `return 0 if $start + 80 * 6 > $len` — buffer too short.
   RejectShortDif,
-  /// DV.pm:188 `Warn("Unrecognized DV profile"), return 1`.
+  /// DV.pm:188 `Warn("Unrecognized DV profile"), return 1`. Carries
+  /// `'a` only for shape parity with [`Parsed::Found`]; no borrow today.
   UnrecognizedProfile,
   /// DV.pm:267-270 — emit tags in @dvTags order.
-  Found(ParsedFound),
+  Found(DvMeta<'a>),
 }
 
-/// All emit-time values from a successful parse (DV.pm:267-270 inputs).
-/// D8: PRIVATE fields, accessors only.
-struct ParsedFound {
+// ===========================================================================
+// Typed Meta — `DvMeta<'a>`
+// ===========================================================================
+
+/// Typed DV metadata — the lib-first output of [`ProcessDv`].
+///
+/// Holds the post-ValueConv raw scalars from `ProcessDV` (DV.pm:151-273)
+/// plus the `Profile`/`VideoFormat`/`Colorimetry` `&'static str` slices
+/// borrowed from [`DV_PROFILES`]. PrintConv (`ConvertDuration`,
+/// `ConvertBitrate`, FrameRate rounding) is applied at emit time by
+/// [`MetaSinker::sink`] to mirror ExifTool's
+/// `$$self{OPTIONS}{PrintConv}` toggle.
+///
+/// **D8 — no public fields, accessors only.**
+///
+/// **Lifetimes.** `'a` is held for shape parity with formats that
+/// borrow string slices from the input; DV's only string fields are
+/// `&'static str` from the profile table, so `'a` is effectively
+/// `'static` in practice. The `date_time_original` is the only owned
+/// allocation (`String` produced by the VAUX scan).
+#[derive(Debug, Clone)]
+pub struct DvMeta<'a> {
+  /// `DateTimeOriginal` — VAUX-decoded date/time. `None` when the
+  /// VAUX scan failed or rejected the hex-component decode
+  /// (DV.pm:220-221).
   date_time_original: Option<String>,
+  /// `ImageWidth` from the matched [`DvProfile`].
   image_width: u32,
+  /// `ImageHeight` from the matched [`DvProfile`].
   image_height: u32,
+  /// `Duration` in seconds = file-size / byte-rate (DV.pm:196).
   duration: f64,
+  /// `TotalBitrate` in bps = 8 * frame-size * frame-rate (DV.pm:194).
   total_bitrate: f64,
-  video_format: &'static str,
-  video_scan_type: Option<&'static str>,
+  /// `VideoFormat` from the matched [`DvProfile`].
+  video_format: &'a str,
+  /// `VideoScanType` — `Some("Interlaced")` / `Some("Progressive")` if the
+  /// VAUX `0x61` pack was found; `None` otherwise (DV.pm:242).
+  video_scan_type: Option<&'a str>,
+  /// `FrameRate` in Hz = profile.frame_rate_num / profile.frame_rate_den.
   frame_rate: f64,
-  aspect_ratio: Option<&'static str>,
-  colorimetry: &'static str,
+  /// `AspectRatio` — `"16:9"` / `"4:3"` from the VAUX `0x61` pack
+  /// (DV.pm:241); `None` if not present.
+  aspect_ratio: Option<&'a str>,
+  /// `Colorimetry` from the matched [`DvProfile`].
+  colorimetry: &'a str,
+  /// `AudioChannels` — DV.pm:258-262 (0/2/4/8). `None` if no audio pack.
   audio_channels: Option<i64>,
+  /// `AudioSampleRate` — DV.pm:256-257 (48000/44100/32000). `None` if
+  /// no audio pack.
   audio_sample_rate: Option<i64>,
+  /// `AudioBitsPerSample` — DV.pm:263 (12 or 16). `None` if no audio
+  /// pack.
   audio_bits_per_sample: Option<i64>,
+}
+
+impl<'a> DvMeta<'a> {
+  /// `DateTimeOriginal` as a fixed-format `"YYYY:MM:DD hh:mm:ss"` string
+  /// (DV.pm:239). `None` if the VAUX scan failed.
+  #[must_use]
+  pub fn date_time_original(&self) -> Option<&str> {
+    self.date_time_original.as_deref()
+  }
+  /// `ImageWidth` in pixels (DV.pm `@dvProfiles{ImageWidth}`).
+  #[must_use]
+  pub fn image_width(&self) -> u32 {
+    self.image_width
+  }
+  /// `ImageHeight` in pixels.
+  #[must_use]
+  pub fn image_height(&self) -> u32 {
+    self.image_height
+  }
+  /// `Duration` in seconds (file-size / byte-rate, DV.pm:196).
+  #[must_use]
+  pub fn duration_secs(&self) -> f64 {
+    self.duration
+  }
+  /// `TotalBitrate` in bits-per-second (DV.pm:194).
+  #[must_use]
+  pub fn total_bitrate_bps(&self) -> f64 {
+    self.total_bitrate
+  }
+  /// `VideoFormat` (e.g. `"IEC 61834 - 625/50 (PAL)"`).
+  #[must_use]
+  pub fn video_format(&self) -> &'a str {
+    self.video_format
+  }
+  /// `VideoScanType` — `"Interlaced"` / `"Progressive"`. `None` if no
+  /// VAUX `0x61` pack.
+  #[must_use]
+  pub fn video_scan_type(&self) -> Option<&'a str> {
+    self.video_scan_type
+  }
+  /// `FrameRate` raw value in Hz (post-ValueConv `num/den`,
+  /// pre-PrintConv rounding).
+  #[must_use]
+  pub fn frame_rate(&self) -> f64 {
+    self.frame_rate
+  }
+  /// `AspectRatio` — `"16:9"` / `"4:3"`. `None` if no VAUX `0x61` pack.
+  #[must_use]
+  pub fn aspect_ratio(&self) -> Option<&'a str> {
+    self.aspect_ratio
+  }
+  /// `Colorimetry` (e.g. `"4:2:0"`).
+  #[must_use]
+  pub fn colorimetry(&self) -> &'a str {
+    self.colorimetry
+  }
+  /// `AudioChannels` count. `None` if no audio pack.
+  #[must_use]
+  pub fn audio_channels(&self) -> Option<i64> {
+    self.audio_channels
+  }
+  /// `AudioSampleRate` in Hz. `None` if no audio pack.
+  #[must_use]
+  pub fn audio_sample_rate(&self) -> Option<i64> {
+    self.audio_sample_rate
+  }
+  /// `AudioBitsPerSample` in bits (12 or 16). `None` if no audio pack.
+  #[must_use]
+  pub fn audio_bits_per_sample(&self) -> Option<i64> {
+    self.audio_bits_per_sample
+  }
 }
 
 /// Bytewise parse of the 12 KiB window. `total_len` is the full file
 /// length (`$$et{VALUE}{FileSize}`, used by DV.pm:196 for Duration).
-fn compute(buff: &[u8], total_len: usize) -> Parsed {
+fn compute(buff: &[u8], total_len: usize) -> Parsed<'static> {
   if buff.is_empty() {
     return Parsed::RejectEmpty;
   }
@@ -676,7 +796,7 @@ fn compute(buff: &[u8], total_len: usize) -> Parsed {
     audio_bits_per_sample = Some(if quant != 0 { 12 } else { 16 }); // DV.pm:263
   }
 
-  Parsed::Found(ParsedFound {
+  Parsed::Found(DvMeta {
     date_time_original,
     image_width: profile.image_width(),
     image_height: profile.image_height(),
@@ -693,61 +813,218 @@ fn compute(buff: &[u8], total_len: usize) -> Parsed {
   })
 }
 
+// ===========================================================================
+// `ProcessDv` — the lib-first parser
+// ===========================================================================
+
 /// DV parser. Faithful `ProcessDV` (DV.pm:151-273).
+#[derive(Debug, Clone, Copy)]
 pub struct ProcessDv;
 
+impl parser_sealed::Sealed for ProcessDv {}
+
+/// Result of a typed `ProcessDv::parse`. Distinguishes the recognized-but-
+/// unrecognized-profile branch (DV.pm:188 `Warn(...), return 1`) from the
+/// full-data success branch (DV.pm:267-270). Both are positive
+/// `Some(...)` returns: the legacy bridge translates them into
+/// `Warn` + return-true vs. tag-emission + return-true respectively.
+///
+/// The `Parsed::Reject*` arms map to `Ok(None)` (Perl `return 0`).
+#[derive(Debug, Clone)]
+pub enum DvParseOutcome<'a> {
+  /// DV.pm:188 — recognized DIF header but no profile match. Bundled
+  /// Perl emits `Warning => "Unrecognized DV profile"` and returns 1
+  /// without pushing any DV:* tags.
+  UnrecognizedProfile,
+  /// DV.pm:267-270 — full success; emit tags in @dvTags order.
+  Meta(DvMeta<'a>),
+}
+
 impl FormatParser for ProcessDv {
+  /// Spec §8: leaf format with no shared state; reads a single byte slice.
+  type Meta = DvParseOutcome<'static>;
+  /// Spec §8: leaf format Context is `&'a [u8]`.
+  type Context<'a> = &'a [u8];
+  /// Rust-level fatal error (none today; DV parsing has no I/O modes).
+  type Error = DvError;
+
+  /// Parse a DV file's bytes into a typed [`DvParseOutcome`], or `None`
+  /// if the buffer is not a valid DV file (short read, no DIF header,
+  /// fewer than 6 blocks). Returns `Err` only for Rust-level fatal
+  /// modes; the current port has none.
+  fn parse(&self, data: Self::Context<'_>) -> Result<Option<Self::Meta>, DvError> {
+    Ok(parse_outcome(data))
+  }
+}
+
+/// Lib-first direct entry. Same as [`FormatParser::parse`] but produces
+/// a `DvParseOutcome` whose `Meta` arm carries borrows out of
+/// [`DV_PROFILES`] (i.e. `'static` in practice; the `&str` slices are
+/// const-table entries).
+///
+/// # Errors
+///
+/// Returns `Err` for Rust-level fatal modes (none today; reserved for
+/// future I/O wrappers).
+pub fn parse_borrowed(data: &[u8]) -> Result<Option<DvParseOutcome<'static>>, DvError> {
+  Ok(parse_outcome(data))
+}
+
+fn parse_outcome(data: &[u8]) -> Option<DvParseOutcome<'static>> {
+  let total_len = data.len();
+  let cap = total_len.min(12_000);
+  match compute(&data[..cap], total_len) {
+    Parsed::RejectEmpty | Parsed::RejectNoDif | Parsed::RejectShortDif => None,
+    Parsed::UnrecognizedProfile => Some(DvParseOutcome::UnrecognizedProfile),
+    Parsed::Found(meta) => Some(DvParseOutcome::Meta(meta)),
+  }
+}
+
+// ===========================================================================
+// `DvMeta::into_static`
+// ===========================================================================
+
+// NOTE: DV's typed parser always produces `DvMeta<'static>` because every
+// `&'a str` field originates from the `'static` [`DV_PROFILES`] table; no
+// `into_static` shim is necessary (unlike MOI / AAC which carry
+// borrow-from-input strings). The `<'a>` parameter is kept on the struct
+// for shape parity with the rest of the Phase F1 leaves and to leave room
+// for future bytes-borrowed accessors (e.g. a raw DIF-block view).
+
+// ===========================================================================
+// `MetaSinker` — typed Meta → TagWriter
+// ===========================================================================
+
+impl MetaSinker for DvMeta<'_> {
+  /// Emit DV tags into the writer in `@dvTags` order (DV.pm:116-121) —
+  /// faithful to the bundled-Perl iteration.
+  ///
+  /// `print_conv=true` ⇒ PrintConv formatted strings (`-j` mode);
+  /// `print_conv=false` ⇒ post-ValueConv raw scalars (`-n` mode).
+  fn sink<W: TagWriter>(&self, print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    const GROUP: &str = "DV";
+    for &tag_name in DV_TAGS {
+      match tag_name {
+        "DateTimeOriginal" => {
+          if let Some(s) = self.date_time_original.as_deref() {
+            // DV.pm:128 PrintConv => ConvertDateTime; default options
+            // pass through unchanged ⇒ same string under -j and -n.
+            out.write_str(GROUP, "DateTimeOriginal", s)?;
+          }
+        }
+        "ImageWidth" => out.write_u64(GROUP, "ImageWidth", u64::from(self.image_width))?,
+        "ImageHeight" => out.write_u64(GROUP, "ImageHeight", u64::from(self.image_height))?,
+        "Duration" => {
+          if print_conv {
+            // PrintConv: ConvertDuration formatted string.
+            out.write_fmt(GROUP, "Duration", |w| {
+              w.write_str(&convert_duration_str(&TagValue::F64(self.duration)))
+            })?;
+          } else {
+            out.write_f64(GROUP, "Duration", self.duration)?;
+          }
+        }
+        "TotalBitrate" => {
+          if print_conv {
+            out.write_fmt(GROUP, "TotalBitrate", |w| {
+              w.write_str(&convert_bitrate_str(&TagValue::F64(self.total_bitrate)))
+            })?;
+          } else {
+            out.write_f64(GROUP, "TotalBitrate", self.total_bitrate)?;
+          }
+        }
+        "VideoFormat" => out.write_str(GROUP, "VideoFormat", self.video_format)?,
+        "VideoScanType" => {
+          if let Some(s) = self.video_scan_type {
+            out.write_str(GROUP, "VideoScanType", s)?;
+          }
+        }
+        "FrameRate" => {
+          if print_conv {
+            // DV.pm:139 PrintConv: int($val * 1000 + 0.5) / 1000.
+            let rounded = ((self.frame_rate * 1000.0 + 0.5).floor()) / 1000.0;
+            out.write_f64(GROUP, "FrameRate", rounded)?;
+          } else {
+            out.write_f64(GROUP, "FrameRate", self.frame_rate)?;
+          }
+        }
+        "AspectRatio" => {
+          if let Some(s) = self.aspect_ratio {
+            out.write_str(GROUP, "AspectRatio", s)?;
+          }
+        }
+        "Colorimetry" => out.write_str(GROUP, "Colorimetry", self.colorimetry)?,
+        "AudioChannels" => {
+          if let Some(n) = self.audio_channels {
+            out.write_i64(GROUP, "AudioChannels", n)?;
+          }
+        }
+        "AudioSampleRate" => {
+          if let Some(n) = self.audio_sample_rate {
+            out.write_i64(GROUP, "AudioSampleRate", n)?;
+          }
+        }
+        "AudioBitsPerSample" => {
+          if let Some(n) = self.audio_bits_per_sample {
+            out.write_i64(GROUP, "AudioBitsPerSample", n)?;
+          }
+        }
+        _ => {} // unreachable: DV_TAGS is a fixed const list
+      }
+    }
+    Ok(())
+  }
+}
+
+// ===========================================================================
+// `DvError` — Rust-level fatal modes (currently none)
+// ===========================================================================
+
+/// Rust-level fatal modes for DV parsing. Currently empty — every bad
+/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
+/// wrappers if streaming readers are added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DvError {}
+
+impl core::fmt::Display for DvError {
+  fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match *self {}
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DvError {}
+
+// ===========================================================================
+// Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+// ===========================================================================
+
+impl OldFormatParser for ProcessDv {
+  /// Phase E–F migration bridge. Runs the new typed [`FormatParser::parse`]
+  /// and drives [`MetaSinker::sink`] through a [`MetadataTagWriter`] so the
+  /// CLI JSON output stays byte-exact during Phases F1–F5. Retired in
+  /// Phase G.
   fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
-    // Capture the inputs needed for parsing under an immutable borrow,
-    // release it BEFORE the `&mut ctx` finalize block. `total_len` is the
-    // FULL file length ($$et{VALUE}{FileSize}); the parser sees the
-    // 12 KiB DV.pm:158 window.
-    let parsed: Parsed = {
+    let outcome: Option<DvParseOutcome<'static>> = {
       let data = ctx.data();
-      let total_len = data.len();
-      let cap = total_len.min(12_000);
-      compute(&data[..cap], total_len)
+      parse_outcome(data)
     };
-    match parsed {
-      Parsed::RejectEmpty | Parsed::RejectNoDif | Parsed::RejectShortDif => false,
-      Parsed::UnrecognizedProfile => {
+    match outcome {
+      None => false, // RejectEmpty / RejectNoDif / RejectShortDif
+      Some(DvParseOutcome::UnrecognizedProfile) => {
         ctx.set_file_type(None, None, None); // DV.pm:173 (runs BEFORE the foreach)
         ctx.metadata().push_warning("Unrecognized DV profile"); // DV.pm:188
         true
       }
-      Parsed::Found(found) => {
+      Some(DvParseOutcome::Meta(meta)) => {
         ctx.set_file_type(None, None, None); // DV.pm:173
-        let print_on = ctx.print_conv_enabled();
-        let g = Group::new(DV_MAIN.group0(), "DV");
-        for &tag_name in DV_TAGS {
-          let raw: Option<TagValue> = match tag_name {
-            "DateTimeOriginal" => found
-              .date_time_original
-              .clone()
-              .map(|s| TagValue::Str(s.into())),
-            "ImageWidth" => Some(TagValue::I64(i64::from(found.image_width))),
-            "ImageHeight" => Some(TagValue::I64(i64::from(found.image_height))),
-            "Duration" => Some(TagValue::F64(found.duration)),
-            "TotalBitrate" => Some(TagValue::F64(found.total_bitrate)),
-            "VideoFormat" => Some(TagValue::Str(found.video_format.into())),
-            "VideoScanType" => found.video_scan_type.map(|s| TagValue::Str(s.into())),
-            "FrameRate" => Some(TagValue::F64(found.frame_rate)),
-            "AspectRatio" => found.aspect_ratio.map(|s| TagValue::Str(s.into())),
-            "Colorimetry" => Some(TagValue::Str(found.colorimetry.into())),
-            "AudioChannels" => found.audio_channels.map(TagValue::I64),
-            "AudioSampleRate" => found.audio_sample_rate.map(TagValue::I64),
-            "AudioBitsPerSample" => found.audio_bits_per_sample.map(TagValue::I64),
-            _ => None,
-          };
-          let Some(raw) = raw else {
-            continue; // DV.pm:268 `next unless defined $$profile{$tag}`
-          };
-          let Some(def) = (DV_MAIN.get())(TagId::Str(tag_name)) else {
-            continue; // unreachable: every @dvTags entry has a %DV::Main def
-          };
-          let out = crate::convert::apply(def, &raw, print_on);
-          ctx.metadata().push(g.clone(), def.name(), out);
-        }
+        let print_conv = ctx.print_conv_enabled();
+        // Bridge: typed `DvMeta` ⇒ `Metadata` via the Phase E–F
+        // `MetadataTagWriter` adapter. Faithful to DV.pm:267-270
+        // `HandleTag` semantics — emits the same DV:* tags in the same
+        // order with the same PrintConv vs ValueConv toggling.
+        let mut bridge = MetadataTagWriter::new(ctx.metadata());
+        let _: Result<(), core::convert::Infallible> = meta.sink(print_conv, &mut bridge);
         true // DV.pm:272 `return 1`
       }
     }
@@ -1032,8 +1309,109 @@ mod tests {
     data[451] = 0x1f;
     let mut m = Metadata::new("x.dv");
     let mut c = ParseContext::new(&data, "DV", 0, "DV", None, true, &mut m);
-    assert!(ProcessDv.process(&mut c));
+    assert!(OldFormatParser::process(&ProcessDv, &mut c));
     assert_eq!(m.warnings(), &["Unrecognized DV profile"]);
     assert!(m.tags().iter().all(|t| t.group().family1() != "DV"));
+  }
+
+  // ---------- Lib-first typed Meta surface --------------------------------
+
+  #[test]
+  fn parse_borrowed_returns_meta_outcome_for_pal_default() {
+    // PAL 25Mbps 4:2:0 default — profile[1].
+    let mut data = vec![0u8; 8000];
+    data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0xbf]); // dsf=1
+    data[451] = 0x00; // stype = 0 ⇒ profile[1] (PAL)
+    let outcome = parse_borrowed(&data).expect("ok").expect("parsed");
+    match outcome {
+      DvParseOutcome::Meta(m) => {
+        assert_eq!(m.image_width(), 720);
+        assert_eq!(m.image_height(), 576);
+        assert_eq!(m.video_format(), "IEC 61834 - 625/50 (PAL)");
+        assert_eq!(m.colorimetry(), "4:2:0");
+        assert!((m.frame_rate() - 25.0).abs() < 1e-12);
+      }
+      DvParseOutcome::UnrecognizedProfile => panic!("expected Meta"),
+    }
+  }
+
+  #[test]
+  fn parse_borrowed_returns_unrecognized_for_off_table_stype() {
+    let mut data = vec![0u8; 480];
+    data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0x3f]);
+    data[451] = 0x1f;
+    let outcome = parse_borrowed(&data).expect("ok").expect("parsed");
+    assert!(matches!(outcome, DvParseOutcome::UnrecognizedProfile));
+  }
+
+  #[test]
+  fn parse_borrowed_rejects_empty() {
+    assert!(parse_borrowed(&[]).unwrap().is_none());
+  }
+
+  #[test]
+  fn meta_sinker_emits_typed_tags() {
+    use crate::sink::{MapTagWriter, MapValue};
+    // Construct a DvMeta directly so we don't depend on a fixture.
+    let meta = DvMeta {
+      date_time_original: Some("2024:01:15 12:30:45".to_string()),
+      image_width: 720,
+      image_height: 576,
+      duration: 8.16,
+      total_bitrate: 28_800_000.0,
+      video_format: "IEC 61834 - 625/50 (PAL)",
+      video_scan_type: Some("Interlaced"),
+      frame_rate: 25.0,
+      aspect_ratio: Some("16:9"),
+      colorimetry: "4:2:0",
+      audio_channels: Some(2),
+      audio_sample_rate: Some(32_000),
+      audio_bits_per_sample: Some(16),
+    };
+    // PrintConv on: ConvertDuration/ConvertBitrate strings, FrameRate rounded.
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("DV", "Duration").map(MapValue::as_str),
+      Some("8.16 s".to_string())
+    );
+    assert_eq!(
+      w.get("DV", "TotalBitrate").map(MapValue::as_str),
+      Some("28.8 Mbps".to_string())
+    );
+    assert_eq!(
+      w.get("DV", "FrameRate").map(MapValue::as_str),
+      Some("25".to_string())
+    );
+    assert_eq!(
+      w.get("DV", "ImageWidth").map(MapValue::as_str),
+      Some("720".to_string())
+    );
+    assert_eq!(
+      w.get("DV", "VideoFormat").map(MapValue::as_str),
+      Some("IEC 61834 - 625/50 (PAL)".to_string())
+    );
+    // PrintConv off: raw scalars (Duration as f64, etc.).
+    let mut w = MapTagWriter::new();
+    meta.sink(false, &mut w).unwrap();
+    assert_eq!(
+      w.get("DV", "Duration").map(MapValue::as_str),
+      Some("8.16".to_string())
+    );
+    assert_eq!(
+      w.get("DV", "TotalBitrate").map(MapValue::as_str),
+      Some("28800000".to_string())
+    );
+  }
+
+  #[test]
+  fn format_parser_trait_returns_outcome() {
+    let mut data = vec![0u8; 8000];
+    data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0xbf]);
+    data[451] = 0x00;
+    let outcome = <ProcessDv as FormatParser>::parse(&ProcessDv, &data)
+      .expect("ok")
+      .expect("parsed");
+    assert!(matches!(outcome, DvParseOutcome::Meta(_)));
   }
 }

--- a/src/formats/red.rs
+++ b/src/formats/red.rs
@@ -1,7 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "red")]
 //! Faithful port of `Image::ExifTool::Red` (`lib/Image/ExifTool/Red.pm`):
 //! reads Redcode R3D version 1 + version 2 video files.
 //!
-//! R3D structure (Red.pm:219-223):
+//! **Phase F1 — lib-first migration.** Follows the MOI pilot (Phase E) +
+//! AAC/DV pattern: a typed [`R3dMeta<'a>`] is produced by the new
+//! [`crate::parser_new::FormatParser`] trait; the legacy
+//! [`crate::parser::OldFormatParser`] entry point bridges through
+//! [`crate::sink::MetadataTagWriter`] so CLI JSON output stays byte-exact
+//! during Phases F1–F5. The bridge is retired in Phase G.
+//!
+//! ## R3D structure (Red.pm:219-223)
+//!
 //!  - Each block begins with `int32u block-size` then a 4-byte block-type.
 //!  - The first block is `RED1` (version 1) or `RED2` (version 2).
 //!  - In version 2 blocks start on `0x1000`-byte boundaries (immaterial here:
@@ -13,7 +25,7 @@
 //! data...` entries).
 //!
 //! Each directory tag-ID is 16 bits: the **top 4 bits encode the format code**
-//! (Red.pm:281 `$fmt = $redFormat{$tag >> 12}`) — see [`RED_FORMAT`].
+//! (Red.pm:281 `$fmt = $redFormat{$tag >> 12}`) — see [`red_format`].
 //!
 //! Byte order: **MM (big-endian)** for the entire file (Red.pm:231
 //! `SetByteOrder('MM')`).
@@ -31,10 +43,11 @@
 //! `exifast-phase2-forward-items` memory entry.
 
 use crate::{
-  convert::{ByteOrder, apply, read_value},
-  parser::{FormatParser, ParseContext},
-  tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
-  value::{Group, TagValue},
+  convert::{ByteOrder, read_value},
+  parser::{OldFormatParser, ParseContext},
+  parser_new::{FormatParser, MetaSinker, TagWriter, parser_sealed},
+  sink::MetadataTagWriter,
+  value::{Rational, TagValue, format_g},
 };
 
 // ── ValueConv / PrintConv helpers ────────────────────────────────────────
@@ -58,44 +71,21 @@ use crate::{
 /// `"nan"` (any case, optional leading sign) ⇒ `±Inf` / `NaN`, matching
 /// Perl's `"inf"+0==Inf`, `"nan"+0==NaN`.
 ///
-/// This is the *arithmetic-context* sibling of
-/// [`crate::convert::perl_numeric_coerce`] (which is bitwise-`&`-context,
-/// returning `u64` for `DecodeBits`). The two have different rules: this
-/// one yields IEEE infinity/NaN for the named words; the bitwise one
-/// would `(UV)Inf == u64::MAX` etc. Both follow Perl's actual semantics
-/// in their respective contexts.
-///
-/// **Scope:** the input shapes reachable from the Red.pm port are
-/// (a) `read_value`-joined strings (space-separated, no embedded
-/// whitespace around individual numbers) and (b) `exiftool_val_str`'s
-/// `"inf"` / `"undef"` for zero-denominator rationals. Both shapes
-/// preserve Perl-exact semantics here. Some quirky Perl forms — e.g.
-/// `"- 1"+0 == -1` (whitespace after the sign) — are NOT reproduced;
-/// they are unreachable through any path that feeds this helper.
+/// **Safety:** compare on raw `bytes[after_sign..]` (a byte slice — no
+/// UTF-8 boundary requirement) rather than slicing into `&s[..]`. A
+/// 3-byte string slice like `&s[..3]` PANICS when the 3-byte mark
+/// splits a multi-byte UTF-8 codepoint.
 fn perl_arithmetic_to_f64(s: &str) -> f64 {
   let bytes = s.as_bytes();
-  // Perl's number parser is whitespace-tolerant on the left (`" 123 "+0
-  // == 123`). Skip leading ASCII whitespace.
   let mut i = 0;
   while i < bytes.len() && bytes[i].is_ascii_whitespace() {
     i += 1;
   }
   let start = i;
-  // Optional leading sign.
   if i < bytes.len() && (bytes[i] == b'+' || bytes[i] == b'-') {
     i += 1;
   }
   let after_sign = i;
-  // Recognize Perl's named-special-value words first ("inf", "infinity",
-  // "nan"; any case). Perl: `"inf"+0==Inf`, `"-Inf"+0==-Inf`, `"NaN"+0==NaN`.
-  //
-  // **Safety:** compare on raw `bytes[after_sign..]` (a byte slice — no
-  // UTF-8 boundary requirement) rather than slicing into `&s[..]`. A
-  // 3-byte string slice like `&s[..3]` PANICS when the 3-byte mark
-  // splits a multi-byte UTF-8 codepoint (e.g. `"éé"` — byte 3 is inside
-  // the second `é`, two-byte 0xC3 0xA9). Byte-level prefix compares
-  // are panic-free for any input and produce the same answer for the
-  // ASCII-only words `"inf"`/`"nan"`.
   let is_neg = i > start && bytes[start] == b'-';
   let after_sign_bytes = &bytes[after_sign..];
   let starts_with_ci = |needle: &[u8]| -> bool {
@@ -106,9 +96,6 @@ fn perl_arithmetic_to_f64(s: &str) -> f64 {
         .all(|(a, b)| a.eq_ignore_ascii_case(b))
   };
   if starts_with_ci(b"inf") {
-    // Accept "inf" or "infinity"; trailing characters after the recognized
-    // word fall through Perl's numeric parser as harmless (no numeric
-    // prefix remains, so `"inf$junk"+0` still yields `Inf`).
     return if is_neg {
       f64::NEG_INFINITY
     } else {
@@ -118,7 +105,6 @@ fn perl_arithmetic_to_f64(s: &str) -> f64 {
   if starts_with_ci(b"nan") {
     return f64::NAN;
   }
-  // Standard numeric prefix: digits, optional `.digits`, optional `e±digits`.
   let digits_start = i;
   while i < bytes.len() && bytes[i].is_ascii_digit() {
     i += 1;
@@ -130,16 +116,12 @@ fn perl_arithmetic_to_f64(s: &str) -> f64 {
     while i < bytes.len() && bytes[i].is_ascii_digit() {
       i += 1;
     }
-    // `.` with no digits on either side is not numeric (Perl: `"."+0==0`).
     if !had_int_digits && i == frac_start {
       return 0.0;
     }
   } else if !had_int_digits {
-    // Only a sign, or nothing ⇒ Perl `+0`/empty/`-`/`+` ⇒ 0.0.
     return 0.0;
   }
-  // Optional exponent. Perl: `"1e"+0==1` (incomplete exponent dropped),
-  // `"1e+10"+0==1e10`.
   if i < bytes.len() && (bytes[i] == b'e' || bytes[i] == b'E') {
     let exp_word_start = i;
     i += 1;
@@ -151,50 +133,22 @@ fn perl_arithmetic_to_f64(s: &str) -> f64 {
       i += 1;
     }
     if i == exp_digits_start {
-      // No exponent digits ⇒ Perl rolls back to before the `e`.
       i = exp_word_start;
     }
   }
-  // Parse the leading prefix (including the sign) as f64. The longest
-  // valid prefix matches Rust's `f64::from_str`, so parsing
-  // `&s[start..i]` is exact.
   s[start..i].parse::<f64>().unwrap_or(0.0)
 }
 
 /// Red.pm:56 / :61 / :66 OtherDate1/2/3 ValueConv:
 /// `$val =~ s/(\d{4})_(\d{2})_/$1:$2:/; $val =~ tr/_/ /; $val`.
-/// Replaces the FIRST `YYYY_MM_` with `YYYY:MM:` and then converts ALL
-/// remaining `_` to spaces. Faithful: regex applies once (no `/g` flag),
-/// the `tr///` is global.
-fn other_date_value_conv(v: &TagValue) -> TagValue {
-  let s = match v {
-    TagValue::Str(s) => s.as_str(),
-    _ => return v.clone(),
-  };
+fn other_date_value_conv(s: &str) -> String {
   let s = replace_yyyy_mm_underscore(s);
-  TagValue::Str(s.replace('_', " ").into())
+  s.replace('_', " ")
 }
 
-/// Helper for [`other_date_value_conv`]: replace the first occurrence of
-/// `<4 digits>_<2 digits>_` with `<4 digits>:<2 digits>:` (faithful Perl
-/// `s/(\d{4})_(\d{2})_/$1:$2:/` — one-shot, no `/g`).
-///
-/// **Codex round-8 F1:** the match window is *byte-position-aligned*
-/// (all 8 matched bytes are ASCII digits or underscores, so they are
-/// also valid UTF-8 char boundaries). Non-matching regions before/
-/// after the match are emitted via `push_str(&s[start..end])`, which
-/// preserves any multi-byte UTF-8 sequences verbatim. The previous
-/// implementation walked one byte at a time and used `b[i] as char`,
-/// mojibaking each non-ASCII byte (e.g. `é` = `\xC3\xA9` became `Ã©`
-/// instead of `é`). Mirror Perl's byte-level `s///` faithfully: only
-/// the matched ASCII span is rewritten; everything else is byte-for-
-/// byte preserved (here as char-for-char preserved, since each char in
-/// a non-matched region maps 1:1 to its original bytes via `&s[...]`).
+/// Helper: replace first `<4 digits>_<2 digits>_` with `<4 digits>:<2 digits>:`.
 fn replace_yyyy_mm_underscore(s: &str) -> String {
   let b = s.as_bytes();
-  // Scan byte-by-byte for the first 8-byte match window. The window
-  // contains only ASCII (digits/underscores), so a match index is
-  // always a valid UTF-8 char boundary (split-safe for `&s[i..i+8]`).
   for i in 0..b.len().saturating_sub(7) {
     if b[i..i + 4].iter().all(u8::is_ascii_digit)
       && b[i + 4] == b'_'
@@ -203,95 +157,45 @@ fn replace_yyyy_mm_underscore(s: &str) -> String {
       && b[i + 7] == b'_'
     {
       let mut out = String::with_capacity(s.len());
-      // Unmatched prefix: byte-for-byte (and thus UTF-8-char-for-UTF-8-
-      // char) preserved.
       out.push_str(&s[..i]);
-      out.push_str(&s[i..i + 4]); // YYYY
+      out.push_str(&s[i..i + 4]);
       out.push(':');
-      out.push_str(&s[i + 5..i + 7]); // MM
+      out.push_str(&s[i + 5..i + 7]);
       out.push(':');
-      // Unmatched suffix.
       out.push_str(&s[i + 8..]);
       return out;
     }
   }
-  // No match ⇒ Perl `s///` leaves `$val` unchanged. Return the input
-  // verbatim (cheaper than rebuilding the String).
   s.to_string()
 }
 
 /// Red.pm:72 DateTimeOriginal ValueConv:
 /// `$val =~ s/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})/$1:$2:$3 $4:$5:/`.
-/// Replaces the FIRST 12-digit run `YYYYMMDDHHMM` with `YYYY:MM:DD HH:MM:`
-/// (note the trailing colon — the seconds portion follows as the
-/// remaining digits, becoming `:SS` once concatenated with the rest of
-/// `$val`). Faithful: single-shot (no `/g`).
-///
-/// The Perl regex has 5 capture groups summing to **12 digits** (4+2+2+
-/// 2+2), not 14 — `YYYYMMDDHHMM`. The substitution `$1:$2:$3 $4:$5:`
-/// emits `YYYY:MM:DD HH:MM:`; any tail digits (e.g. the `SS` seconds)
-/// stay verbatim after the trailing colon, producing the canonical
-/// `YYYY:MM:DD HH:MM:SS` shape for a 14-digit input.
-///
-/// Faithful to Perl's regex backtracking: at every byte offset we ask
-/// "does a 12-digit run start here?" and if so consume it. A 10-digit
-/// prefix that lacks two more consecutive digits should NOT terminate
-/// the scan — Perl's NFA would advance past the partial match and
-/// continue looking. (Codex round-7 oracle: Perl
-/// `s/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})/$1:$2:$3 $4:$5:/` on
-/// `"1234567890xx20160118213555"` yields `"1234567890xx2016:01:18
-/// 21:35:55"` — the leading 10 digits are skipped because the regex
-/// needs 12 consecutive, and continues to position 12 where the real
-/// match begins.)
-fn datetime_original_value_conv(v: &TagValue) -> TagValue {
-  let s = match v {
-    TagValue::Str(s) => s.as_str(),
-    _ => return v.clone(),
-  };
+fn datetime_original_value_conv(s: &str) -> String {
   let b = s.as_bytes();
-  // Find the first occurrence of a 12-ASCII-digit run.
   for i in 0..b.len().saturating_sub(11) {
     if b[i..i + 12].iter().all(u8::is_ascii_digit) {
       let mut out = String::with_capacity(s.len() + 4);
       out.push_str(&s[..i]);
-      out.push_str(&s[i..i + 4]); // YYYY
+      out.push_str(&s[i..i + 4]);
       out.push(':');
-      out.push_str(&s[i + 4..i + 6]); // MM
+      out.push_str(&s[i + 4..i + 6]);
       out.push(':');
-      out.push_str(&s[i + 6..i + 8]); // DD
+      out.push_str(&s[i + 6..i + 8]);
       out.push(' ');
-      out.push_str(&s[i + 8..i + 10]); // HH
+      out.push_str(&s[i + 8..i + 10]);
       out.push(':');
-      out.push_str(&s[i + 10..i + 12]); // MM
+      out.push_str(&s[i + 10..i + 12]);
       out.push(':');
-      out.push_str(&s[i + 12..]); // remaining tail (typically SS)
-      return TagValue::Str(out.into());
+      out.push_str(&s[i + 12..]);
+      return out;
     }
   }
-  v.clone()
+  s.to_string()
 }
 
-/// Red.pm:73 DateTimeOriginal PrintConv: `$self->ConvertDateTime($val)`.
-/// `ConvertDateTime` with default options (no `DateFormat`, no
-/// `QuickTimeUTC`, no `StrictDate`) is essentially the identity for a
-/// well-formed `YYYY:MM:DD HH:MM:SS` value. Red.pm's golden for the
-/// bundled fixture is `"2016:01:18 21:35:55"` — same as the post-ValueConv
-/// string. Faithful identity here; if a fixture later exposes a non-trivial
-/// `ConvertDateTime` shape, derive then.
-fn convert_date_time_passthrough(v: &TagValue) -> TagValue {
-  v.clone()
-}
-
-/// Red.pm:82 / :87 / :95 / :100 — date/time fixups: insert a colon after
-/// every 2 digits (or 4-then-2 for DateCreated/StorageFormatDate).
-///
-/// `$val =~ s/(\d{4})(\d{2})/$1:$2:/` (Red.pm:82,95) on `YYYYMMDD` ⇒
-/// `YYYY:MM:DD` (the post-match tail `DD` keeps `$1:$2:` then `DD`).
-fn date_created_value_conv(v: &TagValue) -> TagValue {
-  let s = match v {
-    TagValue::Str(s) => s.as_str(),
-    _ => return v.clone(),
-  };
+/// Red.pm:82 / :95 — `s/(\d{4})(\d{2})/$1:$2:/` on `YYYYMMDD`.
+fn date_created_value_conv(s: &str) -> String {
   let b = s.as_bytes();
   for i in 0..b.len().saturating_sub(5) {
     if b[i..i + 6].iter().all(u8::is_ascii_digit) {
@@ -302,20 +206,14 @@ fn date_created_value_conv(v: &TagValue) -> TagValue {
       out.push_str(&s[i + 4..i + 6]);
       out.push(':');
       out.push_str(&s[i + 6..]);
-      return TagValue::Str(out.into());
+      return out;
     }
   }
-  v.clone()
+  s.to_string()
 }
 
-/// Red.pm:87 / :100 — TimeCreated/StorageFormatTime ValueConv:
-/// `$val =~ s/(\d{2})(\d{2})/$1:$2:/` on `HHMMSS` ⇒ `HH:MM:SS` (tail SS
-/// follows the `$1:$2:` replacement). One-shot.
-fn time_created_value_conv(v: &TagValue) -> TagValue {
-  let s = match v {
-    TagValue::Str(s) => s.as_str(),
-    _ => return v.clone(),
-  };
+/// Red.pm:87 / :100 — `s/(\d{2})(\d{2})/$1:$2:/` on `HHMMSS`.
+fn time_created_value_conv(s: &str) -> String {
   let b = s.as_bytes();
   for i in 0..b.len().saturating_sub(3) {
     if b[i..i + 4].iter().all(u8::is_ascii_digit) {
@@ -326,184 +224,93 @@ fn time_created_value_conv(v: &TagValue) -> TagValue {
       out.push_str(&s[i + 2..i + 4]);
       out.push(':');
       out.push_str(&s[i + 4..]);
-      return TagValue::Str(out.into());
+      return out;
     }
   }
-  v.clone()
+  s.to_string()
 }
 
-/// Red.pm:141 — `FNumber` ValueConv `$val / 10`. Input is int16u (I64 in
-/// the engine), so produce an `F64`; Perl `/` is float division.
-///
-/// **Codex round-4 F1:** `walk_red_directory` derives `count =
-/// payload_size / elem_size`, so an adversarial overlong directory
-/// entry for tag `0x406a` (`len > 8`, format 4 = int16u, elem = 2)
-/// makes `read_value` return a space-joined `TagValue::Str` like
-/// `"123 456"`. Perl `"123 456" / 10 == 12.3` — coerces the leading
-/// numeric prefix. Mirror via [`perl_arithmetic_to_f64`].
-fn divide_by_10(v: &TagValue) -> TagValue {
+/// Red.pm:141 — `FNumber` ValueConv `$val / 10`.
+fn divide_by_10(v: &TagValue) -> f64 {
   match v {
-    TagValue::I64(n) => TagValue::F64(*n as f64 / 10.0),
-    TagValue::F64(n) => TagValue::F64(*n / 10.0),
-    TagValue::Str(s) => TagValue::F64(perl_arithmetic_to_f64(s) / 10.0),
-    _ => v.clone(),
+    TagValue::I64(n) => *n as f64 / 10.0,
+    TagValue::F64(n) => *n / 10.0,
+    TagValue::Str(s) => perl_arithmetic_to_f64(s) / 10.0,
+    _ => 0.0,
   }
 }
 
-/// Red.pm:147 — `FocusDistance` ValueConv `$val / 1000` (int32s ⇒ float
-/// meters).
-///
-/// **Codex round-4 F1:** same overlong-directory shape as
-/// [`divide_by_10`]: `read_value` can hand a space-joined
-/// `TagValue::Str` here. Perl `"$first $rest" / 1000` coerces the
-/// leading numeric prefix.
-fn divide_by_1000(v: &TagValue) -> TagValue {
+/// Red.pm:147 — `FocusDistance` ValueConv `$val / 1000`.
+fn divide_by_1000(v: &TagValue) -> f64 {
   match v {
-    TagValue::I64(n) => TagValue::F64(*n as f64 / 1000.0),
-    TagValue::F64(n) => TagValue::F64(*n / 1000.0),
-    TagValue::Str(s) => TagValue::F64(perl_arithmetic_to_f64(s) / 1000.0),
-    _ => v.clone(),
+    TagValue::I64(n) => *n as f64 / 1000.0,
+    TagValue::F64(n) => *n / 1000.0,
+    TagValue::Str(s) => perl_arithmetic_to_f64(s) / 1000.0,
+    _ => 0.0,
   }
 }
 
-/// Red.pm:147 — `FocusDistance` PrintConv `"$val m"`. Wraps the value text
-/// with a trailing ` m`. `$val` is the post-ValueConv float; Perl
-/// stringifies with `%g`-ish — use `format_g(_, 15)` for parity with
-/// the serializer.
-fn focus_distance_print_conv(v: &TagValue) -> TagValue {
-  use crate::value::format_g;
-  let text = match v {
-    TagValue::F64(n) if n.is_finite() => format_g(*n, 15),
-    TagValue::F64(n) => n.to_string(),
-    TagValue::I64(n) => n.to_string(),
-    TagValue::Str(s) => return TagValue::Str(format!("{s} m").into()),
-    _ => return v.clone(),
+/// Red.pm:147 — `FocusDistance` PrintConv `"$val m"`.
+fn focus_distance_print_conv(v: f64) -> String {
+  let text = if v.is_finite() {
+    format_g(v, 15)
+  } else {
+    v.to_string()
   };
-  TagValue::Str(format!("{text} m").into())
+  let mut out = String::with_capacity(text.len() + 2);
+  out.push_str(&text);
+  out.push_str(" m");
+  out
 }
 
 /// Red.pm:134, :169, :202 — FrameRate / OriginalFrameRate PrintConv:
-/// `int($val * 1000 + 0.5) / 1000` — round to 3 decimal places via
-/// half-up (Perl `int` truncates toward zero, so this rounds toward
-/// positive infinity for positive `$val`).
+/// `int($val * 1000 + 0.5) / 1000`.
 ///
 /// **Subtle (Codex round-1 F1):** for a `TagValue::Rational`, Perl's
-/// `ReadValue` (`ExifTool.pm:6275-6321`) has ALREADY passed the value
-/// through `RoundFloat(num/denom, 7)` (`ExifTool.pm:6087,6094,6101,6108`
-/// = `sprintf("%.7g", n/d)` for rational32, `%.10g` for rational64)
-/// before the PrintConv runs. So `$val` at PrintConv time is the
-/// stringified-and-then-numeric-coerced value of THAT rounded text — NOT
-/// the exact `num/denom` ratio. Boundary case: `1106/101 = 10.95049504…`
+/// `ReadValue` has ALREADY passed the value through `RoundFloat(num/denom,
+/// 7)` before PrintConv runs. Boundary case: `1106/101 = 10.95049504…`
 /// exact ⇒ Rust would emit `10.95`, but Perl rounds to `"10.9505"` first
 /// ⇒ PrintConv emits `10.951`. The Rational branch below mirrors Perl
 /// faithfully by going through `exiftool_val_str()` (the SAME `%.{sig}g`
 /// formatter; sig=7 for rational32) and re-parsing as f64.
 ///
 /// **Codex round-4 F2:** `Rational` with denominator 0 — reachable for
-/// RED1 `FrameRate` (Red.pm:166-170, rational32u at offset 0x3e) when
-/// the on-disk denominator bytes are `\x00\x00`. `Rational::
-/// exiftool_val_str` returns the bare word `"undef"` (numerator 0) or
-/// `"inf"` (numerator ≠ 0). Perl's PrintConv arithmetic coerces
-/// `"undef"` to `0` (`int(0*1000+0.5)/1000 == 0`) and `"inf"` to `Inf`
-/// (`int(Inf*1000+0.5)/1000 == Inf`). Route both through
-/// [`perl_arithmetic_to_f64`] so the typed-Rational input no longer
-/// leaks the raw rational, matching the bundled `perl exiftool` output
-/// for the `\x00\x00\x00\x00` (denom=0,num=0) header → `0` and
-/// `\x00\x01\x00\x00` (denom=0,num=1) → `Inf` shapes.
+/// RED1 `FrameRate` when the denominator bytes are `\x00\x00`. Route
+/// through [`perl_arithmetic_to_f64`].
 ///
-/// **Codex round-4 F1 (PrintConv-side mirror of the ValueConv-side
-/// adversarial overlong shape):** `OriginalFrameRate` (Red.pm:131-135,
-/// format 2 = float, elem = 4) for `count > 1` arrives as a
-/// space-joined `TagValue::Str` like `"23.976 30"`. Perl PrintConv
-/// coerces the leading numeric prefix; route via
-/// [`perl_arithmetic_to_f64`] (yields `23.976` for the joined-string
-/// example), then through the standard `int(... + 0.5)/1000` rounding.
-fn round_to_3dp_print_conv(v: &TagValue) -> TagValue {
+/// **Codex round-5 F1:** Perl `int($x)` operates in NV space (double),
+/// not IV (i64). Keep the truncation in `f64` via `.trunc()`.
+///
+/// **Codex round-6 F1:** for negative inputs in `(-0.0005, 0.0)`,
+/// `f64::trunc()` returns negative zero in IEEE-754. Perl's `int()`
+/// does not preserve the sign of zero. Normalize via `scaled.trunc() +
+/// 0.0` (IEEE: `-0.0 + 0.0 == +0.0`).
+fn round_to_3dp(v: &TagValue) -> f64 {
   let f = match v {
     TagValue::F64(n) if n.is_finite() => *n,
-    // ExifTool.pm:6087/6094 RoundFloat(n/d, 7) — go through the same
-    // `%.{sig}g` text Perl propagates, then back to f64 (so `1106/101`
-    // becomes `10.9505` here, matching bundled `perl exiftool`). Same
-    // shared `exiftool_val_str` is also the truth for the zero-denom
-    // arm: `"undef"` (0/0) ⇒ 0.0, `"inf"` (N/0) ⇒ Inf — Perl's
-    // arithmetic coercion. Folded into a single `Rational` arm because
-    // `exiftool_val_str` handles both the rounded-quotient and the
-    // bare-word cases internally.
     TagValue::Rational(r) => perl_arithmetic_to_f64(&r.exiftool_val_str()),
-    // Codex round-4 F1: overlong/space-joined Str (e.g. count > 1
-    // through `read_value`). Perl coerces the leading numeric prefix.
     TagValue::Str(s) => perl_arithmetic_to_f64(s),
-    _ => return v.clone(),
+    TagValue::F64(n) => return *n,
+    _ => return 0.0,
   };
-  // Perl `int(...)` on a non-finite double propagates the value
-  // unchanged: `int(Inf) == Inf`, `int(NaN) == NaN`. Mirror that here so
-  // an `"inf"`-coerced input lands as `F64(Inf)` (the JSON-serialize-as-
-  // null gap remains the documented Phase-2 forward item #1 — not this
-  // helper's concern).
   if !f.is_finite() {
-    return TagValue::F64(f);
+    return f;
   }
-  // Perl `int(...)` truncates toward zero; +0.5 then `int` matches
-  // half-up for positive values, half-down (toward zero) for negative.
-  //
-  // **Codex round-5 F1:** Perl `int($x)` operates in **NV space (double),
-  // not IV (i64)** — so any finite NV ≤ `f64::MAX` is preserved verbatim
-  // when its fractional part is dropped. Casting `(f * 1000.0 + 0.5)`
-  // to `i64` would silently saturate for any `|f * 1000.0| > i64::MAX
-  // ≈ 9.22e18` (e.g. crafted RED `OriginalFrameRate` from a `float32`
-  // payload bytes near `f32::MAX ≈ 3.4e38` would land as `~9.22e15`,
-  // not as the Perl-preserved ~3.4e38). Keep the truncation in `f64`
-  // via `.trunc()` so the operation matches Perl `int(NV)` across the
-  // full finite range. Oracle: `perl -e 'print int(1.844e19*1000+0.5)
-  // /1000'` ⇒ `1.844e+19` (NV-preserved); the `.trunc() / 1000.0`
-  // form below reproduces this without the i64-saturation footgun.
   let scaled = f * 1000.0 + 0.5;
-  // `f * 1000.0` can overflow to ±Inf for `|f| > f64::MAX / 1000`
-  // (≈1.797e305). Perl `int(Inf*1000+0.5)/1000` ⇒ `Inf`; mirror by
-  // propagating non-finite scaled values (lands on the existing
-  // Phase-2 forward item #1 serialize-as-null seam, faithfully).
   if !scaled.is_finite() {
-    return TagValue::F64(scaled / 1000.0);
+    return scaled / 1000.0;
   }
-  // **Codex round-6 F1:** for negative inputs in `(-0.0005, 0.0)` the
-  // post-`+0.5` scaled value lands in `(-1.0, 0.0)`, whose `trunc()`
-  // is **negative zero** in IEEE-754 (Rust preserves the sign;
-  // `(-0.1_f64).trunc() == -0.0`). Perl's `int()` does not preserve
-  // the sign of zero — it produces a positive-integer zero (Devel::
-  // Peek dump of `int(-0.1)` confirms `NV = 0`, not `-0`). Then JSON
-  // would diverge: our `format_g` (faithfully `%g`) prints `-0.0` as
-  // `"-0"` (matching Perl's `%g(-0.0)`), but the actual Perl value
-  // here is positive zero ⇒ prints `"0"`. Normalize by adding `+0.0`
-  // (IEEE: `-0.0 + 0.0 == +0.0` — identical to the `truncated == 0.0
-  // ? 0.0 : truncated/1000.0` Codex recommendation, with no extra
-  // branch). Oracle: `perl -e 'use Devel::Peek; Dump int(-0.001*1000
-  // +0.5)/1000'` → `NV = 0`, positive bits.
   let truncated = scaled.trunc() + 0.0;
-  TagValue::F64(truncated / 1000.0)
+  truncated / 1000.0
 }
 
 /// Red.pm:201 — RED2 FrameRate ValueConv:
 /// `my @a = split " ", $val; ($a[1] * 0x10000 + $a[2]) / $a[0]`.
-/// Input is a space-joined `int16u[3]` string from [`read_value`]
-/// ("a b c"); we parse, build `(b*65536+c)/a`, return F64.
 ///
-/// **Subtle (Codex round-2 F1):** under [`read_value`]'s faithful
-/// count-shortening for truncated RED2 headers (ExifTool.pm:6290-6292),
-/// `$val` may also arrive as a 2-element string `"a b"` (`count` shortened
-/// to 2) or as a *scalar* `a` (`count` shortened to 1). Perl's `split " ",
-/// $val` followed by `($a[1]*0x10000 + $a[2])/$a[0]` coerces missing
-/// indices to numeric `0` (with the `use warnings` "uninitialized" warning
-/// — `ProcessR3D` runs without `use warnings`, so the warning is silent),
-/// producing `0/a = 0`. Mirror that behaviour: never fall back to the raw
-/// value for short shapes — emit `F64(0.0)` for `a ≠ 0`, leave the value
-/// unchanged only when the parse cannot recover a numeric first operand
-/// (Perl would `0/0` ⇒ `NaN`, which is faithfully *unreachable* here for
-/// a well-formed RED2 prefix; the `v.clone()` keeps the engine panic-free
-/// for hostile parsers).
-fn red2_frame_rate_value_conv(v: &TagValue) -> TagValue {
-  // Perl auto-stringifies `$val` before `split`, so accept both typed
-  // numeric scalars (`count == 1` ⇒ `TagValue::I64(a)`) and the
-  // space-joined string shape (`count >= 2`).
+/// Under [`read_value`]'s count-shortening, `$val` may arrive as 2- or
+/// 1-element shape. Perl's `split " ", $val` followed by `($a[1]*0x10000
+/// + $a[2])/$a[0]` coerces missing indices to 0.
+fn red2_frame_rate_value_conv(v: &TagValue) -> Option<f64> {
   let owned: String;
   let s = match v {
     TagValue::Str(s) => s.as_ref(),
@@ -515,553 +322,20 @@ fn red2_frame_rate_value_conv(v: &TagValue) -> TagValue {
       owned = n.to_string();
       owned.as_str()
     }
-    _ => return v.clone(),
+    _ => return None,
   };
   let parts: Vec<&str> = s.split_whitespace().collect();
-  // Perl `($a[0], $a[1], $a[2])` for an array of length k < 3 substitutes
-  // undef (numerically `0`) for indices ≥ k. Mirror that with `unwrap_or(0)`
-  // *after* the first-operand parse below.
   let parse = |p: &str| p.parse::<i64>().ok();
-  let a = match parts.first().and_then(|p| parse(p)) {
-    Some(n) => n,
-    // Empty or unparseable first operand: Perl's `$a[0]` is `undef` ⇒ `0`,
-    // and `($a[1]*0x10000 + $a[2])/0` would be a runtime division-by-zero
-    // (`Illegal division by zero` in Perl), which `ProcessR3D` would
-    // propagate as a die. We treat it as the panic-free "leave unchanged"
-    // arm — this is unreachable for any RED2 file ExifTool itself accepts.
-    None => return v.clone(),
-  };
+  let a = parts.first().and_then(|p| parse(p))?;
   if a == 0 {
-    return v.clone();
+    return None;
   }
   let b = parts.get(1).and_then(|p| parse(p)).unwrap_or(0);
   let c = parts.get(2).and_then(|p| parse(p)).unwrap_or(0);
-  TagValue::F64((b as f64 * 65536.0 + c as f64) / a as f64)
+  Some((b as f64 * 65536.0 + c as f64) / a as f64)
 }
 
-// ── %redFormat (Red.pm:22-33) ────────────────────────────────────────────
-
-/// Red.pm:22-33 `%redFormat`. Top-4-bits of the directory tag-ID resolve
-/// to the format string (`int8u`, `string`, `float`, ...). `format 7` and
-/// `format 9` are both `'undef'`; `format 3` is `'int8u'` (Perl comment
-/// "how is this different than 0?" preserved here for fidelity).
-const fn red_format(idx: u8) -> Option<&'static str> {
-  match idx {
-    0 => Some("int8u"),  // Red.pm:23
-    1 => Some("string"), // Red.pm:24
-    2 => Some("float"),  // Red.pm:25
-    3 => Some("int8u"),  // Red.pm:26 (PH: "how is this different than 0?")
-    4 => Some("int16u"), // Red.pm:27
-    5 => Some("int8s"),  // Red.pm:28 (PH: "not sure about this")
-    6 => Some("int32s"), // Red.pm:29
-    7 => Some("undef"),  // Red.pm:30 (mixed-format structure?)
-    8 => Some("int32u"), // Red.pm:31 (NC)
-    9 => Some("undef"),  // Red.pm:32 (256 bytes of zeros)
-    _ => None,
-  }
-}
-
-// ── Red::Main tag definitions (Red.pm:39-151) ────────────────────────────
-//
-// All TagDefs use family-1 group `"Red"` (Red.pm:39 `GROUPS => {2=>'Camera'}`;
-// family-0/-1 default to the package suffix `Red` for `-G1` JSON).
-
-const G1_RED: &str = "Red";
-
-// ---- format 1 (string) — Red.pm:50-125 ----
-static START_EDGE_CODE: TagDef =
-  TagDef::new("StartEdgeCode", G1_RED, ValueConv::None, PrintConv::None);
-static START_TIMECODE: TagDef =
-  TagDef::new("StartTimecode", G1_RED, ValueConv::None, PrintConv::None);
-static OTHER_DATE_1: TagDef = TagDef::new(
-  "OtherDate1",
-  G1_RED,
-  ValueConv::Func(other_date_value_conv),
-  PrintConv::None,
-);
-static OTHER_DATE_2: TagDef = TagDef::new(
-  "OtherDate2",
-  G1_RED,
-  ValueConv::Func(other_date_value_conv),
-  PrintConv::None,
-);
-static OTHER_DATE_3: TagDef = TagDef::new(
-  "OtherDate3",
-  G1_RED,
-  ValueConv::Func(other_date_value_conv),
-  PrintConv::None,
-);
-static DATE_TIME_ORIGINAL: TagDef = TagDef::new(
-  "DateTimeOriginal",
-  G1_RED,
-  ValueConv::Func(datetime_original_value_conv),
-  PrintConv::Func(convert_date_time_passthrough),
-);
-static SERIAL_NUMBER: TagDef =
-  TagDef::new("SerialNumber", G1_RED, ValueConv::None, PrintConv::None);
-static CAMERA_TYPE: TagDef = TagDef::new("CameraType", G1_RED, ValueConv::None, PrintConv::None);
-static REEL_NUMBER: TagDef = TagDef::new("ReelNumber", G1_RED, ValueConv::None, PrintConv::None);
-static TAKE: TagDef = TagDef::new("Take", G1_RED, ValueConv::None, PrintConv::None);
-static DATE_CREATED: TagDef = TagDef::new(
-  "DateCreated",
-  G1_RED,
-  ValueConv::Func(date_created_value_conv),
-  PrintConv::None,
-);
-static TIME_CREATED: TagDef = TagDef::new(
-  "TimeCreated",
-  G1_RED,
-  ValueConv::Func(time_created_value_conv),
-  PrintConv::None,
-);
-static FIRMWARE_VERSION: TagDef =
-  TagDef::new("FirmwareVersion", G1_RED, ValueConv::None, PrintConv::None);
-static REEL_TIMECODE: TagDef =
-  TagDef::new("ReelTimecode", G1_RED, ValueConv::None, PrintConv::None);
-static STORAGE_TYPE: TagDef = TagDef::new("StorageType", G1_RED, ValueConv::None, PrintConv::None);
-static STORAGE_FORMAT_DATE: TagDef = TagDef::new(
-  "StorageFormatDate",
-  G1_RED,
-  ValueConv::Func(date_created_value_conv),
-  PrintConv::None,
-);
-static STORAGE_FORMAT_TIME: TagDef = TagDef::new(
-  "StorageFormatTime",
-  G1_RED,
-  ValueConv::Func(time_created_value_conv),
-  PrintConv::None,
-);
-static STORAGE_SERIAL_NUMBER: TagDef = TagDef::new(
-  "StorageSerialNumber",
-  G1_RED,
-  ValueConv::None,
-  PrintConv::None,
-);
-static STORAGE_MODEL: TagDef =
-  TagDef::new("StorageModel", G1_RED, ValueConv::None, PrintConv::None);
-static ASPECT_RATIO: TagDef = TagDef::new("AspectRatio", G1_RED, ValueConv::None, PrintConv::None);
-static REVISION: TagDef = TagDef::new("Revision", G1_RED, ValueConv::None, PrintConv::None);
-static ORIGINAL_FILE_NAME: TagDef =
-  TagDef::new("OriginalFileName", G1_RED, ValueConv::None, PrintConv::None);
-static LENS_MAKE: TagDef = TagDef::new("LensMake", G1_RED, ValueConv::None, PrintConv::None);
-static LENS_NUMBER: TagDef = TagDef::new("LensNumber", G1_RED, ValueConv::None, PrintConv::None);
-static LENS_MODEL: TagDef = TagDef::new("LensModel", G1_RED, ValueConv::None, PrintConv::None);
-static MODEL: TagDef = TagDef::new("Model", G1_RED, ValueConv::None, PrintConv::None);
-static CAMERA_OPERATOR: TagDef =
-  TagDef::new("CameraOperator", G1_RED, ValueConv::None, PrintConv::None);
-static VIDEO_FORMAT: TagDef = TagDef::new("VideoFormat", G1_RED, ValueConv::None, PrintConv::None);
-static FILTER: TagDef = TagDef::new("Filter", G1_RED, ValueConv::None, PrintConv::None);
-static BRAIN: TagDef = TagDef::new("Brain", G1_RED, ValueConv::None, PrintConv::None);
-static SENSOR: TagDef = TagDef::new("Sensor", G1_RED, ValueConv::None, PrintConv::None);
-static QUALITY: TagDef = TagDef::new("Quality", G1_RED, ValueConv::None, PrintConv::None);
-
-// ---- format 2 (float) — Red.pm:127-135 ----
-static COLOR_TEMPERATURE: TagDef =
-  TagDef::new("ColorTemperature", G1_RED, ValueConv::None, PrintConv::None);
-static RGB_CURVES: TagDef = TagDef::new("RGBCurves", G1_RED, ValueConv::None, PrintConv::None);
-static ORIGINAL_FRAME_RATE: TagDef = TagDef::new(
-  "OriginalFrameRate",
-  G1_RED,
-  ValueConv::None,
-  PrintConv::Func(round_to_3dp_print_conv),
-);
-
-// ---- format 4 (int16u) — Red.pm:138-143 ----
-static CROP_AREA: TagDef = TagDef::new("CropArea", G1_RED, ValueConv::None, PrintConv::None);
-static ISO: TagDef = TagDef::new("ISO", G1_RED, ValueConv::None, PrintConv::None);
-static F_NUMBER: TagDef = TagDef::new(
-  "FNumber",
-  G1_RED,
-  ValueConv::Func(divide_by_10),
-  PrintConv::None,
-);
-static FOCAL_LENGTH: TagDef = TagDef::new("FocalLength", G1_RED, ValueConv::None, PrintConv::None);
-
-// ---- format 6 (int32s) — Red.pm:147 ----
-static FOCUS_DISTANCE: TagDef = TagDef::new(
-  "FocusDistance",
-  G1_RED,
-  ValueConv::Func(divide_by_1000),
-  PrintConv::Func(focus_distance_print_conv),
-);
-
-// ── RED1 / RED2 header tag tables (Red.pm:154-206) ───────────────────────
-//
-// `ProcessBinaryData` is dispatched by `HandleTag` via `SubDirectory`; we
-// implement the read directly (the only RED1/RED2 fields are five/four
-// fixed-width slots). Family-1 is `"Red"` (Red.pm:155,176 declare family-2
-// `"Video"`, but `-G1` JSON uses the package suffix).
-
-/// Red.pm:166-170 RED1 `FrameRate`: rational32u + PrintConv
-/// `int($val * 1000 + 0.5) / 1000`.
-static RED1_FRAME_RATE: TagDef = TagDef::new(
-  "FrameRate",
-  G1_RED,
-  ValueConv::None,
-  PrintConv::Func(round_to_3dp_print_conv),
-);
-/// Red.pm:161 / :181 `RedcodeVersion`: a single ASCII digit (`string[1]`).
-static REDCODE_VERSION: TagDef =
-  TagDef::new("RedcodeVersion", G1_RED, ValueConv::None, PrintConv::None);
-/// Red.pm:164,194 `ImageWidth` (RED1 int16u, RED2 int32u).
-static IMAGE_WIDTH: TagDef = TagDef::new("ImageWidth", G1_RED, ValueConv::None, PrintConv::None);
-/// Red.pm:165,195 `ImageHeight` (RED1 int16u, RED2 int32u).
-static IMAGE_HEIGHT: TagDef = TagDef::new("ImageHeight", G1_RED, ValueConv::None, PrintConv::None);
-/// Red.pm:171 RED1 `OriginalFileName` (string[32]).
-static RED1_ORIGINAL_FILE_NAME: TagDef =
-  TagDef::new("OriginalFileName", G1_RED, ValueConv::None, PrintConv::None);
-/// Red.pm:198-203 RED2 `FrameRate`: int16u[3] + custom ValueConv
-/// `($a[1] * 0x10000 + $a[2]) / $a[0]`, PrintConv `round-3dp`.
-static RED2_FRAME_RATE: TagDef = TagDef::new(
-  "FrameRate",
-  G1_RED,
-  ValueConv::Func(red2_frame_rate_value_conv),
-  PrintConv::Func(round_to_3dp_print_conv),
-);
-
-fn red_main_get(id: TagId) -> Option<&'static TagDef> {
-  match id {
-    // Red.pm:50-125 (format 1: string) — explicit numeric ids per the
-    // bundled `%Main` hash. Defining each as `TagId::Int(...)` mirrors
-    // ExifTool's hash-key shape exactly (the lookup is by 16-bit tag id).
-    TagId::Int(0x1000) => Some(&START_EDGE_CODE),
-    TagId::Int(0x1001) => Some(&START_TIMECODE),
-    TagId::Int(0x1002) => Some(&OTHER_DATE_1),
-    TagId::Int(0x1003) => Some(&OTHER_DATE_2),
-    TagId::Int(0x1004) => Some(&OTHER_DATE_3),
-    TagId::Int(0x1005) => Some(&DATE_TIME_ORIGINAL),
-    TagId::Int(0x1006) => Some(&SERIAL_NUMBER),
-    TagId::Int(0x1019) => Some(&CAMERA_TYPE),
-    TagId::Int(0x101a) => Some(&REEL_NUMBER),
-    TagId::Int(0x101b) => Some(&TAKE),
-    TagId::Int(0x1023) => Some(&DATE_CREATED),
-    TagId::Int(0x1024) => Some(&TIME_CREATED),
-    TagId::Int(0x1025) => Some(&FIRMWARE_VERSION),
-    TagId::Int(0x1029) => Some(&REEL_TIMECODE),
-    TagId::Int(0x102a) => Some(&STORAGE_TYPE),
-    TagId::Int(0x1030) => Some(&STORAGE_FORMAT_DATE),
-    TagId::Int(0x1031) => Some(&STORAGE_FORMAT_TIME),
-    TagId::Int(0x1032) => Some(&STORAGE_SERIAL_NUMBER),
-    TagId::Int(0x1033) => Some(&STORAGE_MODEL),
-    TagId::Int(0x1036) => Some(&ASPECT_RATIO),
-    TagId::Int(0x1042) => Some(&REVISION),
-    TagId::Int(0x1056) => Some(&ORIGINAL_FILE_NAME),
-    TagId::Int(0x106e) => Some(&LENS_MAKE),
-    TagId::Int(0x106f) => Some(&LENS_NUMBER),
-    TagId::Int(0x1070) => Some(&LENS_MODEL),
-    TagId::Int(0x1071) => Some(&MODEL),
-    TagId::Int(0x107c) => Some(&CAMERA_OPERATOR),
-    TagId::Int(0x1086) => Some(&VIDEO_FORMAT),
-    TagId::Int(0x1096) => Some(&FILTER),
-    TagId::Int(0x10a0) => Some(&BRAIN),
-    TagId::Int(0x10a1) => Some(&SENSOR),
-    TagId::Int(0x10be) => Some(&QUALITY),
-    // Red.pm:127-135 (format 2: float).
-    TagId::Int(0x200d) => Some(&COLOR_TEMPERATURE),
-    TagId::Int(0x204b) => Some(&RGB_CURVES),
-    TagId::Int(0x2066) => Some(&ORIGINAL_FRAME_RATE),
-    // Red.pm:138-143 (format 4: int16u).
-    TagId::Int(0x4037) => Some(&CROP_AREA),
-    TagId::Int(0x403b) => Some(&ISO),
-    TagId::Int(0x406a) => Some(&F_NUMBER),
-    TagId::Int(0x406b) => Some(&FOCAL_LENGTH),
-    // Red.pm:147 (format 6: int32s).
-    TagId::Int(0x606c) => Some(&FOCUS_DISTANCE),
-    _ => None,
-  }
-}
-
-/// `%Image::ExifTool::Red::Main` (Red.pm:39-151). Family-0 group `"Red"`.
-pub static RED_MAIN: TagTable = TagTable::new("Red", red_main_get);
-
-// ── ProcessR3D (Red.pm:212-295) ──────────────────────────────────────────
-
-/// `Image::ExifTool::Red::ProcessR3D` (Red.pm:212-295). Faithful read-only
-/// port. Returns `true` if the file was accepted (`return 1`, Red.pm:294)
-/// or a recognized-but-truncated R3D (`return $et->Warn($errTrunc)` —
-/// Red.pm:236,246 — `Warn` returns 1 unless suppressed by `NoWarning`).
-/// Returns `false` only on the two "this is not an R3D" gates:
-/// `Read != 8`/regex-miss (Red.pm:225) and `size < 8` (Red.pm:228).
-pub struct ProcessR3D;
-
-impl FormatParser for ProcessR3D {
-  fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
-    // Phase 1: header validation reads from the borrowed `ctx.data()` only;
-    // no `&mut ctx` is needed yet, so the immutable borrow is short-lived.
-    let (ver, size) = {
-      let data = ctx.data();
-      // Red.pm:225 `return 0 unless $raf->Read($buff,8) == 8 and
-      //                     $buff =~ /^\0\0..RED(1|2)/s`.
-      if data.len() < 8 {
-        return false;
-      }
-      if data[0] != 0 || data[1] != 0 {
-        return false;
-      }
-      // `..` matches any two bytes; we then need `RED` and `1` or `2`.
-      if &data[4..7] != b"RED" {
-        return false;
-      }
-      let ver = match data[7] {
-        b'1' => 1u8,
-        b'2' => 2u8,
-        _ => return false,
-      };
-      // Red.pm:227 `$size = unpack('N', $buff)` (BE int32u).
-      let size = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
-      // Red.pm:228 `return 0 if $size < 8`.
-      if size < 8 {
-        return false;
-      }
-      (ver, size)
-    };
-    // Red.pm:230 `$et->SetFileType()` — finalize the file type. After this
-    // mutable borrow, every subsequent read of `ctx.data()` is fresh.
-    ctx.set_file_type(None, None, None);
-    let print_on = ctx.print_conv_enabled();
-
-    // Red.pm:236 `$raf->Read($buf2, $size - 8) == $size - 8 or return
-    // $et->Warn($errTrunc)`. The R3D extra-header bytes must fit in `data`.
-    if ctx.data().len() < size {
-      ctx.metadata().push_warning("Truncated R3D file");
-      return true;
-    }
-
-    // Red.pm:237-240 — `$buff` is the first `$size` bytes; RED1/RED2 header
-    // subtable extraction reads fixed-offset fields from it. We do this
-    // *before* the directory walk so the immutable `ctx.data()` borrow stays
-    // confined here (the directory walk owns a private `Vec` of bytes).
-    // `ver` is already constrained to 1 or 2 by the magic check above; use
-    // a panic-free if/else (the crate's `#![forbid(unsafe_code)]` is paired
-    // with a no-panic-on-real-input contract — no `unreachable!()`).
-    if ver == 1 {
-      extract_red1_header_via(ctx, size, print_on);
-    } else {
-      extract_red2_header_via(ctx, size, print_on);
-    }
-
-    // Red.pm:244-256: compute `$pos` (start of Red directory) and the
-    // directory slice (`buff`).
-    //
-    // RED1: Red.pm:246 reads `$raf->Read($buff, 0x10000)` — a fresh buffer
-    // starting at file-offset `$size`; the directory is at offset `0x22`
-    // within it. We model this by copying `data[size..]` (clamped to 64 KiB
-    // for parity with `0x10000`).
-    //
-    // RED2: `$buff` stays the size-byte header; the directory is at
-    // `0x44 + 0x18*rdi + 0x14*rda + 0x10*rdx` within it.
-    let (buff_owned, mut pos): (Vec<u8>, usize) = if ver == 1 {
-      // Red.pm:246 `$raf->Read($buff, 0x10000) or return $et->Warn(
-      // $errTrunc)`.
-      if ctx.data().len() <= size {
-        ctx.metadata().push_warning("Truncated R3D file");
-        return true;
-      }
-      let data = ctx.data();
-      let take = (data.len() - size).min(0x10000);
-      (data[size..size + take].to_vec(), 0x22usize)
-    } else {
-      // Red.pm:251-252 `$pos = 0x44; length($buff) < $pos and return
-      // $et->Warn($errTrunc)`. `$buff` here is the declared-first-block
-      // slice (the same `$buff` the RED2 subtable extraction used above),
-      // NOT the full file. Codex round-2 F2: the previous `data.len() <
-      // 0x44` check would let a file with `size = 0x40` but trailing bytes
-      // slip past and read `rdi/rda/rdx` from outside the declared block.
-      // Faithful: guard on `size`, then read the structure bytes from the
-      // size-bounded slice (which is exactly what the subsequent `buff_owned
-      // = data[..size]` copy uses for the rest of the walk).
-      if size < 0x44 {
-        ctx.metadata().push_warning("Truncated R3D file");
-        return true;
-      }
-      let first_block = &ctx.data()[..size];
-      let rdi = first_block[0x40] as usize;
-      let rda = first_block[0x41] as usize;
-      let rdx = first_block[0x42] as usize;
-      let p = 0x44usize + 0x18 * rdi + 0x14 * rda + 0x10 * rdx;
-      (first_block.to_vec(), p)
-    };
-    let buff: &[u8] = &buff_owned;
-
-    // Red.pm:257-273 — directory length + sanity guard.
-    let dir_len: Option<usize>;
-    let dir_end: usize;
-    if pos + 8 > buff.len() {
-      // Red.pm:258 `$dirLen = 0`; the fallback scan that follows reassigns
-      // $pos via regex. We faithfully attempt the regex scan; if it fails,
-      // emit the "Can't find Red directory" Warn (Red.pm:266) and stop.
-      // Note: Red.pm later checks `$dirLen && ...` (Red.pm:282); `0` is
-      // falsy in Perl, so the unknown-format Warn is suppressed in the
-      // fallback path. We model that by keeping `dir_len = None`.
-      match scan_for_red_directory(buff) {
-        Some(p) => {
-          pos = p;
-          dir_end = buff.len();
-          dir_len = None;
-          // Red.pm:270 `$et->Warn('This R3D file is different. Please
-          // submit a sample for testing')`.
-          ctx
-            .metadata()
-            .push_warning("This R3D file is different. Please submit a sample for testing");
-        }
-        None => {
-          ctx
-            .metadata()
-            .push_warning("Can't find Red directory. Please submit sample for testing");
-          return true;
-        }
-      }
-    } else {
-      // Red.pm:260 `$dirLen = Get16u(\$buff, $pos)`; :261 `$pos += 2`.
-      let len = u16::from_be_bytes([buff[pos], buff[pos + 1]]) as usize;
-      pos += 2;
-      // Red.pm:264 sanity check: `$dirLen < 300 or $dirLen >= 2048 or
-      // $pos + $dirLen > length $buff` ⇒ fallback scan.
-      if !(300..2048).contains(&len) || pos + len > buff.len() {
-        match scan_for_red_directory(buff) {
-          Some(p) => {
-            pos = p;
-            dir_end = buff.len();
-            dir_len = None;
-            ctx
-              .metadata()
-              .push_warning("This R3D file is different. Please submit a sample for testing");
-          }
-          None => {
-            ctx
-              .metadata()
-              .push_warning("Can't find Red directory. Please submit sample for testing");
-            return true;
-          }
-        }
-      } else {
-        dir_len = Some(len);
-        dir_end = pos + len;
-      }
-    }
-
-    // Red.pm:277-291 directory walk.
-    walk_red_directory(buff, pos, dir_end, dir_len, ctx, print_on);
-
-    true // Red.pm:294 `return 1`.
-  }
-}
-
-/// Red.pm:266 fallback regex: `$buff =~ /\0\x0f\x10[\0\x06]/g` — find the
-/// pattern (tag 0x1000 with `len=0x000f`). Returns `pos($buff) - 4`
-/// (Red.pm:267): Perl's `pos()` is the offset PAST the match, so we want
-/// the byte offset where the match starts.
-fn scan_for_red_directory(buf: &[u8]) -> Option<usize> {
-  // Match 4 consecutive bytes: `\0`, `\x0f`, `\x10`, `\0`|`\x06`.
-  (0..buf.len().saturating_sub(3)).find(|&i| {
-    buf[i] == 0x00
-      && buf[i + 1] == 0x0f
-      && buf[i + 2] == 0x10
-      && (buf[i + 3] == 0x00 || buf[i + 3] == 0x06)
-  })
-}
-
-/// RED1 header subtable read (Red.pm:154-172). Reads from the first `size`
-/// bytes of `ctx.data()`. The helper reads each field via [`read_value`]
-/// into a local `TagValue` (releasing the immutable borrow before the
-/// matching `push_with_conv` call). `read_value` is bounds-checked, so a
-/// fixture too short for any particular field cleanly produces `None`
-/// (no panic), the field is skipped, and the rest still emit.
-fn extract_red1_header_via(ctx: &mut ParseContext<'_>, size: usize, print_on: bool) {
-  // Collect all field values *before* doing any mutating push, so the
-  // immutable borrow of `ctx.data()` is dropped by the time we touch
-  // `ctx.metadata()`. Faithful: the on-disk reads happen first, the
-  // FoundTag calls happen in declaration order. `size.min(data.len())`
-  // defends against a caller passing a `size` larger than the buffer
-  // (the `process()` path checks this, but keep the helper panic-free).
-  let reads: Vec<(&'static TagDef, Option<TagValue>)> = {
-    let raw = ctx.data();
-    let data = &raw[..size.min(raw.len())];
-    vec![
-      (
-        &REDCODE_VERSION,
-        read_value(data, 0x07, "string", 1, ByteOrder::Mm),
-      ),
-      (
-        &IMAGE_WIDTH,
-        read_value(data, 0x36, "int16u", 1, ByteOrder::Mm),
-      ),
-      (
-        &IMAGE_HEIGHT,
-        read_value(data, 0x3a, "int16u", 1, ByteOrder::Mm),
-      ),
-      (
-        &RED1_FRAME_RATE,
-        read_value(data, 0x3e, "rational32u", 1, ByteOrder::Mm),
-      ),
-      (
-        &RED1_ORIGINAL_FILE_NAME,
-        read_value(data, 0x43, "string", 32, ByteOrder::Mm),
-      ),
-    ]
-  };
-  for (def, v) in reads {
-    if let Some(value) = v {
-      push_with_conv(ctx, def, value, print_on);
-    }
-  }
-}
-
-/// RED2 header subtable read (Red.pm:175-206). Same shape as
-/// [`extract_red1_header_via`].
-fn extract_red2_header_via(ctx: &mut ParseContext<'_>, size: usize, print_on: bool) {
-  let reads: Vec<(&'static TagDef, Option<TagValue>)> = {
-    let raw = ctx.data();
-    let data = &raw[..size.min(raw.len())];
-    vec![
-      (
-        &REDCODE_VERSION,
-        read_value(data, 0x07, "string", 1, ByteOrder::Mm),
-      ),
-      (
-        &IMAGE_WIDTH,
-        read_value(data, 0x4c, "int32u", 1, ByteOrder::Mm),
-      ),
-      (
-        &IMAGE_HEIGHT,
-        read_value(data, 0x50, "int32u", 1, ByteOrder::Mm),
-      ),
-      // Red.pm:198-203 FrameRate @0x56 (int16u[3] + custom ValueConv).
-      (
-        &RED2_FRAME_RATE,
-        read_value(data, 0x56, "int16u", 3, ByteOrder::Mm),
-      ),
-    ]
-  };
-  for (def, v) in reads {
-    if let Some(value) = v {
-      // Red.pm:201 RED2 FrameRate ValueConv `($a[1]*0x10000 + $a[2])/$a[0]`
-      // dies with `Illegal division by zero` when `$a[0]` is 0. ExifTool's
-      // `HandleTag`/`FoundTag` runs ValueConv inside `eval` (ExifTool.pm:
-      // 10119-10131 — `eval $valueConv; if ($@) { ... return; }`), so the
-      // tag is silently dropped on conversion failure. Codex round-3 F1 +
-      // empirical oracle: `perl exiftool -j` on a RED2 fixture with `int16u[3]
-      // = 0,0,24000` emits NO `Red:FrameRate` field at all (only the upstream
-      // RedcodeVersion/ImageWidth/ImageHeight survive). Mirror that here.
-      if std::ptr::eq(def, &RED2_FRAME_RATE) && red2_frame_rate_first_word_is_zero(&value) {
-        continue;
-      }
-      push_with_conv(ctx, def, value, print_on);
-    }
-  }
-}
-
-/// Codex round-3 F1: detect the `($a[0] == 0)` case for RED2 FrameRate so
-/// we can drop the tag instead of emitting a raw value. The shapes are
-/// the ones [`read_value`] can produce for a `int16u[3]` field after the
-/// faithful count-shortening (ExifTool.pm:6290-6292) and the single-element
-/// typed-scalar return (ExifTool.pm:6318-6320):
-///
-/// - `TagValue::Str("0 …")` — `count == 3` or `2`, space-joined, first
-///   token is `0`.
-/// - `TagValue::I64(0)` — `count == 1`, typed scalar.
-/// - `TagValue::F64(0.0)` — defensive (no current path produces this for
-///   `int16u`, but Perl would treat `0.0` as falsy in division).
+/// Codex round-3 F1: detect the `($a[0] == 0)` case for RED2 FrameRate.
 fn red2_frame_rate_first_word_is_zero(v: &TagValue) -> bool {
   match v {
     TagValue::I64(0) => true,
@@ -1076,73 +350,27 @@ fn red2_frame_rate_first_word_is_zero(v: &TagValue) -> bool {
   }
 }
 
-/// Red.pm:277-291 directory walk — read each entry, dispatch the format
-/// code from the tag-ID top-4-bits, and HandleTag the resulting value
-/// against `RED_MAIN`. `dir_len` is `Some` when the directory length was
-/// taken from the header (Red.pm:260) and `None` when the fallback scan
-/// was used (Red.pm:258 `$dirLen = 0`); Red.pm:282 `$fmt or $dirLen &&
-/// $et->Warn(...)` SUPPRESSES the unknown-format warning in the fallback.
-fn walk_red_directory(
-  buff: &[u8],
-  mut pos: usize,
-  dir_end: usize,
-  dir_len: Option<usize>,
-  ctx: &mut ParseContext<'_>,
-  print_on: bool,
-) {
-  let dir_len_truthy = dir_len.is_some();
-  while pos + 4 <= dir_end {
-    let len = u16::from_be_bytes([buff[pos], buff[pos + 1]]) as usize;
-    // Red.pm:279 `last if $len < 4 or $pos + $len > $dirEnd`.
-    if len < 4 || pos + len > dir_end {
-      break;
-    }
-    let tag = u16::from_be_bytes([buff[pos + 2], buff[pos + 3]]);
-    // Red.pm:281 `$fmt = $redFormat{$tag >> 12}`.
-    let fmt_idx = (tag >> 12) as u8;
-    let fmt = match red_format(fmt_idx) {
-      Some(f) => f,
-      None => {
-        // Red.pm:282 `$fmt or $dirLen && $et->Warn('Unknown format
-        // code'), last` — Warn only when the directory length came from
-        // the header (truthy), not from the fallback scan (`$dirLen = 0`).
-        if dir_len_truthy {
-          ctx.metadata().push_warning("Unknown format code");
-        }
-        break;
-      }
-    };
-    // Red.pm:283-289 HandleTag at `$pos+4`, size `$len-4`, format `$fmt`.
-    let payload_off = pos + 4;
-    let payload_size = len - 4;
-    let elem = format_size_of(fmt);
-    if elem > 0 && payload_size > 0 {
-      let count = payload_size / elem;
-      if count > 0 {
-        if let Some(v) = read_value(buff, payload_off, fmt, count, ByteOrder::Mm) {
-          // Look up the def; an unrecognized tag-id is faithfully a HandleTag
-          // call that ExifTool drops (no entry in `%Main` ⇒ no FoundTag).
-          if let Some(def) = (RED_MAIN.get())(TagId::Int(i64::from(tag))) {
-            push_with_conv(ctx, def, v, print_on);
-          }
-        }
-      }
-    } else if fmt == "string" || fmt == "undef" {
-      // string/undef: elem == 1, payload_size IS the count.
-      if let Some(v) = read_value(buff, payload_off, fmt, payload_size, ByteOrder::Mm) {
-        if let Some(def) = (RED_MAIN.get())(TagId::Int(i64::from(tag))) {
-          push_with_conv(ctx, def, v, print_on);
-        }
-      }
-    }
-    pos += len;
+// ── %redFormat (Red.pm:22-33) ────────────────────────────────────────────
+
+/// Red.pm:22-33 `%redFormat`. Top-4-bits of the directory tag-ID resolve
+/// to the format string.
+const fn red_format(idx: u8) -> Option<&'static str> {
+  match idx {
+    0 => Some("int8u"),
+    1 => Some("string"),
+    2 => Some("float"),
+    3 => Some("int8u"),
+    4 => Some("int16u"),
+    5 => Some("int8s"),
+    6 => Some("int32s"),
+    7 => Some("undef"),
+    8 => Some("int32u"),
+    9 => Some("undef"),
+    _ => None,
   }
 }
 
-/// Mirror of `convert::format_size` for the Red.pm subset, exposed inside
-/// this module so the directory walk can compute `count = payload_size /
-/// elem_size` (faithful to `ExifTool.pm:6285-6293`). Unknown format ⇒ 0
-/// (the caller skips read).
+/// Mirror of `convert::format_size` for the Red.pm subset.
 fn format_size_of(fmt: &str) -> usize {
   match fmt {
     "int8u" | "int8s" | "string" | "undef" => 1,
@@ -1152,23 +380,1411 @@ fn format_size_of(fmt: &str) -> usize {
   }
 }
 
-/// Apply ValueConv + (optionally) PrintConv via [`apply`] and push to the
-/// `ctx.metadata()` value sink under the tag's family-0/family-1 group.
-fn push_with_conv(ctx: &mut ParseContext<'_>, def: &'static TagDef, raw: TagValue, print_on: bool) {
-  let out = apply(def, &raw, print_on);
-  ctx
-    .metadata()
-    .push(Group::new(RED_MAIN.group0(), def.group1()), def.name(), out);
+// ===========================================================================
+// Typed Meta — `R3dMeta<'a>`
+// ===========================================================================
+
+/// Typed R3D metadata — the lib-first output of [`ProcessR3D`].
+///
+/// Red.pm's `%Main` table has many tags (Red.pm:39-151) that may or may not
+/// appear in any given file. Each tag is exposed as an `Option<T>` accessor
+/// (D8: no public fields).
+///
+/// **D8 — no public fields, accessors only.**
+///
+/// **Composite tags: DEFERRED** per `docs/superpowers/plans/2026-05-20-
+/// red-port.md`. Composite tag synthesis is engine-level (Red.pm itself
+/// does not register `Composite => ...`), and this port consciously
+/// FAITHFULLY DEFERS the Composite layer.
+#[derive(Debug, Clone, Default)]
+pub struct R3dMeta<'a> {
+  /// `RedcodeVersion` from offset 0x07 — single ASCII digit byte.
+  redcode_version: Option<u8>,
+  /// `ImageWidth` from the RED1/RED2 header subtable.
+  image_width: Option<u32>,
+  /// `ImageHeight` from the RED1/RED2 header subtable.
+  image_height: Option<u32>,
+  /// `FrameRate` — RED1 rational32u or RED2 int16u[3] post-ValueConv.
+  frame_rate: Option<FrameRate>,
+  /// `OriginalFileName` from RED1 header (`string[32]` at 0x43).
+  red1_original_file_name: Option<&'a str>,
+
+  // Format-1 (string) tags from `%Main`.
+  start_edge_code: Option<&'a str>,
+  start_timecode: Option<&'a str>,
+  other_date_1: Option<String>,
+  other_date_2: Option<String>,
+  other_date_3: Option<String>,
+  date_time_original: Option<String>,
+  serial_number: Option<&'a str>,
+  camera_type: Option<&'a str>,
+  reel_number: Option<R3dStrOrInt<'a>>,
+  take: Option<&'a str>,
+  date_created: Option<String>,
+  time_created: Option<String>,
+  firmware_version: Option<&'a str>,
+  reel_timecode: Option<&'a str>,
+  storage_type: Option<&'a str>,
+  storage_format_date: Option<String>,
+  storage_format_time: Option<String>,
+  storage_serial_number: Option<&'a str>,
+  storage_model: Option<&'a str>,
+  aspect_ratio: Option<&'a str>,
+  revision: Option<&'a str>,
+  original_file_name: Option<&'a str>,
+  lens_make: Option<&'a str>,
+  lens_number: Option<&'a str>,
+  lens_model: Option<&'a str>,
+  model: Option<&'a str>,
+  camera_operator: Option<&'a str>,
+  video_format: Option<&'a str>,
+  filter: Option<&'a str>,
+  brain: Option<&'a str>,
+  sensor: Option<&'a str>,
+  quality: Option<&'a str>,
+
+  // Format-2 (float) tags.
+  color_temperature: Option<R3dValue<'a>>,
+  rgb_curves: Option<R3dValue<'a>>,
+  original_frame_rate: Option<R3dValue<'a>>,
+
+  // Format-4 (int16u) tags.
+  crop_area: Option<R3dValue<'a>>,
+  iso: Option<R3dValue<'a>>,
+  f_number: Option<f64>,
+  focal_length: Option<R3dValue<'a>>,
+
+  // Format-6 (int32s) tags.
+  focus_distance: Option<f64>,
+
+  /// Warnings to emit (all reachable warnings in Red.pm are static).
+  warnings: Vec<&'static str>,
+
+  /// Order in which directory tags appeared in the binary (Red.pm:
+  /// 277-291). Faithful: directory tags emit in walk order, not `%Main`
+  /// hash order.
+  directory_tag_order: Vec<DirectoryTag>,
 }
+
+/// One value extracted via [`read_value`] from a directory entry.
+#[derive(Debug, Clone)]
+pub enum R3dValue<'a> {
+  /// `int8u` / `int16u` / `int32u` count==1 typed scalar.
+  I64(i64),
+  /// `float` count==1 typed scalar.
+  F64(f64),
+  /// `string` / `undef` / count>1 space-joined.
+  Str(R3dStrCow<'a>),
+  /// Raw bytes.
+  Bytes(Vec<u8>),
+  /// Rational32u.
+  Rational(Rational),
+}
+
+/// Borrowed-or-owned `&str` carry. Distinct from `std::borrow::Cow` to
+/// avoid the cross-feature `alloc::borrow` dance.
+#[derive(Debug, Clone)]
+pub enum R3dStrCow<'a> {
+  /// Borrowed from input.
+  Borrowed(&'a str),
+  /// Owned (e.g. space-joined `read_value` result).
+  Owned(String),
+}
+
+impl R3dStrCow<'_> {
+  /// Returns the underlying `&str`.
+  pub fn as_str(&self) -> &str {
+    match self {
+      R3dStrCow::Borrowed(s) => s,
+      R3dStrCow::Owned(s) => s.as_str(),
+    }
+  }
+}
+
+/// `ReelNumber` typed carry (string or coerced integer).
+#[derive(Debug, Clone)]
+pub enum R3dStrOrInt<'a> {
+  /// Borrowed string slice.
+  Str(&'a str),
+  /// Typed integer.
+  I64(i64),
+}
+
+/// `FrameRate` in the typed Meta.
+#[derive(Debug, Clone)]
+pub enum FrameRate {
+  /// RED1 `rational32u` at 0x3e.
+  Rational(Rational),
+  /// RED2 post-ValueConv F64.
+  F64(f64),
+}
+
+/// Directory tag identifier — used for emission ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DirectoryTag(u16);
+
+impl DirectoryTag {
+  /// Construct from the 16-bit Red `%Main` tag ID.
+  #[must_use]
+  pub const fn new(id: u16) -> Self {
+    Self(id)
+  }
+  /// The 16-bit Red `%Main` tag ID.
+  #[must_use]
+  pub const fn id(self) -> u16 {
+    self.0
+  }
+}
+
+impl<'a> R3dMeta<'a> {
+  /// `RedcodeVersion` — ASCII digit byte (`b'1'` or `b'2'`).
+  #[must_use]
+  pub fn redcode_version(&self) -> Option<u8> {
+    self.redcode_version
+  }
+  /// `RedcodeVersion` as a `&'static str` ("1"/"2").
+  #[must_use]
+  pub fn redcode_version_str(&self) -> Option<&'static str> {
+    match self.redcode_version? {
+      b'1' => Some("1"),
+      b'2' => Some("2"),
+      _ => None,
+    }
+  }
+  /// `ImageWidth` from header subtable.
+  #[must_use]
+  pub fn image_width(&self) -> Option<u32> {
+    self.image_width
+  }
+  /// `ImageHeight` from header subtable.
+  #[must_use]
+  pub fn image_height(&self) -> Option<u32> {
+    self.image_height
+  }
+  /// `FrameRate`.
+  #[must_use]
+  pub fn frame_rate(&self) -> Option<&FrameRate> {
+    self.frame_rate.as_ref()
+  }
+  /// RED1 header `OriginalFileName`.
+  #[must_use]
+  pub fn red1_original_file_name(&self) -> Option<&'a str> {
+    self.red1_original_file_name
+  }
+  /// `StartEdgeCode` (0x1000).
+  #[must_use]
+  pub fn start_edge_code(&self) -> Option<&'a str> {
+    self.start_edge_code
+  }
+  /// `StartTimecode` (0x1001).
+  #[must_use]
+  pub fn start_timecode(&self) -> Option<&'a str> {
+    self.start_timecode
+  }
+  /// `OtherDate1` (0x1002).
+  #[must_use]
+  pub fn other_date_1(&self) -> Option<&str> {
+    self.other_date_1.as_deref()
+  }
+  /// `OtherDate2` (0x1003).
+  #[must_use]
+  pub fn other_date_2(&self) -> Option<&str> {
+    self.other_date_2.as_deref()
+  }
+  /// `OtherDate3` (0x1004).
+  #[must_use]
+  pub fn other_date_3(&self) -> Option<&str> {
+    self.other_date_3.as_deref()
+  }
+  /// `DateTimeOriginal` (0x1005).
+  #[must_use]
+  pub fn date_time_original(&self) -> Option<&str> {
+    self.date_time_original.as_deref()
+  }
+  /// `SerialNumber` (0x1006).
+  #[must_use]
+  pub fn serial_number(&self) -> Option<&'a str> {
+    self.serial_number
+  }
+  /// `CameraType` (0x1019).
+  #[must_use]
+  pub fn camera_type(&self) -> Option<&'a str> {
+    self.camera_type
+  }
+  /// `ReelNumber` (0x101a).
+  #[must_use]
+  pub fn reel_number(&self) -> Option<&R3dStrOrInt<'a>> {
+    self.reel_number.as_ref()
+  }
+  /// `Take` (0x101b).
+  #[must_use]
+  pub fn take(&self) -> Option<&'a str> {
+    self.take
+  }
+  /// `DateCreated` (0x1023).
+  #[must_use]
+  pub fn date_created(&self) -> Option<&str> {
+    self.date_created.as_deref()
+  }
+  /// `TimeCreated` (0x1024).
+  #[must_use]
+  pub fn time_created(&self) -> Option<&str> {
+    self.time_created.as_deref()
+  }
+  /// `FirmwareVersion` (0x1025).
+  #[must_use]
+  pub fn firmware_version(&self) -> Option<&'a str> {
+    self.firmware_version
+  }
+  /// `ReelTimecode` (0x1029).
+  #[must_use]
+  pub fn reel_timecode(&self) -> Option<&'a str> {
+    self.reel_timecode
+  }
+  /// `StorageType` (0x102a).
+  #[must_use]
+  pub fn storage_type(&self) -> Option<&'a str> {
+    self.storage_type
+  }
+  /// `StorageFormatDate` (0x1030).
+  #[must_use]
+  pub fn storage_format_date(&self) -> Option<&str> {
+    self.storage_format_date.as_deref()
+  }
+  /// `StorageFormatTime` (0x1031).
+  #[must_use]
+  pub fn storage_format_time(&self) -> Option<&str> {
+    self.storage_format_time.as_deref()
+  }
+  /// `StorageSerialNumber` (0x1032).
+  #[must_use]
+  pub fn storage_serial_number(&self) -> Option<&'a str> {
+    self.storage_serial_number
+  }
+  /// `StorageModel` (0x1033).
+  #[must_use]
+  pub fn storage_model(&self) -> Option<&'a str> {
+    self.storage_model
+  }
+  /// `AspectRatio` (0x1036).
+  #[must_use]
+  pub fn aspect_ratio(&self) -> Option<&'a str> {
+    self.aspect_ratio
+  }
+  /// `Revision` (0x1042).
+  #[must_use]
+  pub fn revision(&self) -> Option<&'a str> {
+    self.revision
+  }
+  /// `OriginalFileName` (0x1056) — directory tag.
+  #[must_use]
+  pub fn original_file_name(&self) -> Option<&'a str> {
+    self.original_file_name
+  }
+  /// `LensMake` (0x106e).
+  #[must_use]
+  pub fn lens_make(&self) -> Option<&'a str> {
+    self.lens_make
+  }
+  /// `LensNumber` (0x106f).
+  #[must_use]
+  pub fn lens_number(&self) -> Option<&'a str> {
+    self.lens_number
+  }
+  /// `LensModel` (0x1070).
+  #[must_use]
+  pub fn lens_model(&self) -> Option<&'a str> {
+    self.lens_model
+  }
+  /// `Model` (0x1071).
+  #[must_use]
+  pub fn model(&self) -> Option<&'a str> {
+    self.model
+  }
+  /// `CameraOperator` (0x107c).
+  #[must_use]
+  pub fn camera_operator(&self) -> Option<&'a str> {
+    self.camera_operator
+  }
+  /// `VideoFormat` (0x1086).
+  #[must_use]
+  pub fn video_format(&self) -> Option<&'a str> {
+    self.video_format
+  }
+  /// `Filter` (0x1096).
+  #[must_use]
+  pub fn filter(&self) -> Option<&'a str> {
+    self.filter
+  }
+  /// `Brain` (0x10a0).
+  #[must_use]
+  pub fn brain(&self) -> Option<&'a str> {
+    self.brain
+  }
+  /// `Sensor` (0x10a1).
+  #[must_use]
+  pub fn sensor(&self) -> Option<&'a str> {
+    self.sensor
+  }
+  /// `Quality` (0x10be).
+  #[must_use]
+  pub fn quality(&self) -> Option<&'a str> {
+    self.quality
+  }
+  /// `ColorTemperature` (0x200d).
+  #[must_use]
+  pub fn color_temperature(&self) -> Option<&R3dValue<'a>> {
+    self.color_temperature.as_ref()
+  }
+  /// `RGBCurves` (0x204b).
+  #[must_use]
+  pub fn rgb_curves(&self) -> Option<&R3dValue<'a>> {
+    self.rgb_curves.as_ref()
+  }
+  /// `OriginalFrameRate` (0x2066).
+  #[must_use]
+  pub fn original_frame_rate(&self) -> Option<&R3dValue<'a>> {
+    self.original_frame_rate.as_ref()
+  }
+  /// `CropArea` (0x4037).
+  #[must_use]
+  pub fn crop_area(&self) -> Option<&R3dValue<'a>> {
+    self.crop_area.as_ref()
+  }
+  /// `ISO` (0x403b).
+  #[must_use]
+  pub fn iso(&self) -> Option<&R3dValue<'a>> {
+    self.iso.as_ref()
+  }
+  /// `FNumber` (0x406a) post-ValueConv.
+  #[must_use]
+  pub fn f_number(&self) -> Option<f64> {
+    self.f_number
+  }
+  /// `FocalLength` (0x406b).
+  #[must_use]
+  pub fn focal_length(&self) -> Option<&R3dValue<'a>> {
+    self.focal_length.as_ref()
+  }
+  /// `FocusDistance` (0x606c) post-ValueConv.
+  #[must_use]
+  pub fn focus_distance(&self) -> Option<f64> {
+    self.focus_distance
+  }
+  /// Warnings emitted during parsing, in emission order.
+  #[must_use]
+  pub fn warnings(&self) -> &[&'static str] {
+    &self.warnings
+  }
+  /// Order in which directory tags appeared in the binary.
+  #[must_use]
+  pub fn directory_tag_order(&self) -> &[DirectoryTag] {
+    &self.directory_tag_order
+  }
+}
+
+// ===========================================================================
+// `ProcessR3D` — the lib-first parser
+// ===========================================================================
+
+/// `Image::ExifTool::Red::ProcessR3D` (Red.pm:212-295). Faithful read-only
+/// port.
+#[derive(Debug, Clone, Copy)]
+pub struct ProcessR3D;
+
+impl parser_sealed::Sealed for ProcessR3D {}
+
+impl FormatParser for ProcessR3D {
+  type Meta = R3dMeta<'static>;
+  /// Spec §8: leaf format Context is `&'a [u8]`.
+  type Context<'a> = &'a [u8];
+  type Error = R3dError;
+
+  fn parse(&self, data: Self::Context<'_>) -> Result<Option<Self::Meta>, R3dError> {
+    Ok(parse_inner(data).map(R3dMeta::into_static))
+  }
+}
+
+/// Lib-first direct entry. Returns an [`R3dMeta`] that borrows from the
+/// input buffer (zero-alloc for `&'a str` fields).
+///
+/// # Errors
+///
+/// Returns `Err` for Rust-level fatal modes (none today).
+pub fn parse_borrowed(data: &[u8]) -> Result<Option<R3dMeta<'_>>, R3dError> {
+  Ok(parse_inner(data))
+}
+
+fn parse_inner<'a>(data: &'a [u8]) -> Option<R3dMeta<'a>> {
+  // Red.pm:225 magic.
+  if data.len() < 8 {
+    return None;
+  }
+  if data[0] != 0 || data[1] != 0 {
+    return None;
+  }
+  if &data[4..7] != b"RED" {
+    return None;
+  }
+  let ver: u8 = match data[7] {
+    b'1' => 1,
+    b'2' => 2,
+    _ => return None,
+  };
+  // Red.pm:227 size.
+  let size = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+  // Red.pm:228.
+  if size < 8 {
+    return None;
+  }
+
+  let mut meta = R3dMeta::default();
+
+  // Red.pm:236 — `$raf->Read($buf2, $size-8) == $size-8 or return
+  // $et->Warn($errTrunc)`. Short-circuits Red.pm:240 HandleTag, so no
+  // RedcodeVersion etc. is emitted for this truncated shape.
+  if data.len() < size {
+    meta.warnings.push("Truncated R3D file");
+    return Some(meta);
+  }
+
+  // Red.pm:240 HandleTag("RED$ver", ...) — header subtable extraction.
+  if ver == 1 {
+    extract_red1_header(&mut meta, data, size);
+  } else {
+    extract_red2_header(&mut meta, data, size);
+  }
+
+  // Red.pm:244-256: compute directory slice (`buff`) and start position.
+  // Slice into `data` directly so resulting `&'a str` payloads borrow
+  // from the original input.
+  let (buff, mut pos): (&'a [u8], usize) = if ver == 1 {
+    // Red.pm:246.
+    if data.len() <= size {
+      meta.warnings.push("Truncated R3D file");
+      return Some(meta);
+    }
+    let take = (data.len() - size).min(0x10000);
+    (&data[size..size + take], 0x22usize)
+  } else {
+    // Red.pm:251-252.
+    if size < 0x44 {
+      meta.warnings.push("Truncated R3D file");
+      return Some(meta);
+    }
+    let first_block = &data[..size];
+    let rdi = first_block[0x40] as usize;
+    let rda = first_block[0x41] as usize;
+    let rdx = first_block[0x42] as usize;
+    let p = 0x44usize + 0x18 * rdi + 0x14 * rda + 0x10 * rdx;
+    (first_block, p)
+  };
+
+  // Red.pm:257-273.
+  let dir_len: Option<usize>;
+  let dir_end: usize;
+  if pos + 8 > buff.len() {
+    match scan_for_red_directory(buff) {
+      Some(p) => {
+        pos = p;
+        dir_end = buff.len();
+        dir_len = None;
+        meta
+          .warnings
+          .push("This R3D file is different. Please submit a sample for testing");
+      }
+      None => {
+        meta
+          .warnings
+          .push("Can't find Red directory. Please submit sample for testing");
+        return Some(meta);
+      }
+    }
+  } else {
+    let len = u16::from_be_bytes([buff[pos], buff[pos + 1]]) as usize;
+    pos += 2;
+    if !(300..2048).contains(&len) || pos + len > buff.len() {
+      match scan_for_red_directory(buff) {
+        Some(p) => {
+          pos = p;
+          dir_end = buff.len();
+          dir_len = None;
+          meta
+            .warnings
+            .push("This R3D file is different. Please submit a sample for testing");
+        }
+        None => {
+          meta
+            .warnings
+            .push("Can't find Red directory. Please submit sample for testing");
+          return Some(meta);
+        }
+      }
+    } else {
+      dir_len = Some(len);
+      dir_end = pos + len;
+    }
+  }
+
+  walk_red_directory(&mut meta, buff, pos, dir_end, dir_len);
+
+  Some(meta)
+}
+
+/// Red.pm:266 fallback regex: `$buff =~ /\0\x0f\x10[\0\x06]/g`.
+fn scan_for_red_directory(buf: &[u8]) -> Option<usize> {
+  (0..buf.len().saturating_sub(3)).find(|&i| {
+    buf[i] == 0x00
+      && buf[i + 1] == 0x0f
+      && buf[i + 2] == 0x10
+      && (buf[i + 3] == 0x00 || buf[i + 3] == 0x06)
+  })
+}
+
+/// RED1 header subtable read (Red.pm:154-172).
+fn extract_red1_header<'a>(meta: &mut R3dMeta<'a>, data: &'a [u8], size: usize) {
+  let cap = size.min(data.len());
+  let buf = &data[..cap];
+
+  if let Some(TagValue::Str(s)) = read_value(buf, 0x07, "string", 1, ByteOrder::Mm) {
+    if let Some(b) = s.as_bytes().first() {
+      meta.redcode_version = Some(*b);
+    }
+  }
+  if let Some(TagValue::I64(n)) = read_value(buf, 0x36, "int16u", 1, ByteOrder::Mm) {
+    meta.image_width = Some(n.clamp(0, i64::from(u32::MAX)) as u32);
+  }
+  if let Some(TagValue::I64(n)) = read_value(buf, 0x3a, "int16u", 1, ByteOrder::Mm) {
+    meta.image_height = Some(n.clamp(0, i64::from(u32::MAX)) as u32);
+  }
+  if let Some(v) = read_value(buf, 0x3e, "rational32u", 1, ByteOrder::Mm) {
+    if let TagValue::Rational(r) = v {
+      meta.frame_rate = Some(FrameRate::Rational(r));
+    }
+  }
+  meta.red1_original_file_name = borrowed_string(data, 0x43, 32);
+}
+
+/// RED2 header subtable read (Red.pm:175-206).
+fn extract_red2_header<'a>(meta: &mut R3dMeta<'a>, data: &'a [u8], size: usize) {
+  let cap = size.min(data.len());
+  let buf = &data[..cap];
+
+  if let Some(TagValue::Str(s)) = read_value(buf, 0x07, "string", 1, ByteOrder::Mm) {
+    if let Some(b) = s.as_bytes().first() {
+      meta.redcode_version = Some(*b);
+    }
+  }
+  if let Some(TagValue::I64(n)) = read_value(buf, 0x4c, "int32u", 1, ByteOrder::Mm) {
+    meta.image_width = Some(n.clamp(0, i64::from(u32::MAX)) as u32);
+  }
+  if let Some(TagValue::I64(n)) = read_value(buf, 0x50, "int32u", 1, ByteOrder::Mm) {
+    meta.image_height = Some(n.clamp(0, i64::from(u32::MAX)) as u32);
+  }
+  if let Some(raw) = read_value(buf, 0x56, "int16u", 3, ByteOrder::Mm) {
+    if !red2_frame_rate_first_word_is_zero(&raw) {
+      if let Some(v) = red2_frame_rate_value_conv(&raw) {
+        meta.frame_rate = Some(FrameRate::F64(v));
+      }
+    }
+  }
+}
+
+/// Read a NUL-trimmed `string[N]` slice borrowed from `data`.
+fn borrowed_string(data: &[u8], offset: usize, max_len: usize) -> Option<&str> {
+  let end = (offset + max_len).min(data.len());
+  if offset >= end {
+    return None;
+  }
+  let slice = &data[offset..end];
+  let trimmed_len = slice.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+  if trimmed_len == 0 {
+    return None;
+  }
+  core::str::from_utf8(&slice[..trimmed_len]).ok()
+}
+
+/// Red.pm:277-291 directory walk.
+fn walk_red_directory<'a>(
+  meta: &mut R3dMeta<'a>,
+  buff: &'a [u8],
+  mut pos: usize,
+  dir_end: usize,
+  dir_len: Option<usize>,
+) {
+  let dir_len_truthy = dir_len.is_some();
+  while pos + 4 <= dir_end {
+    let len = u16::from_be_bytes([buff[pos], buff[pos + 1]]) as usize;
+    if len < 4 || pos + len > dir_end {
+      break;
+    }
+    let tag = u16::from_be_bytes([buff[pos + 2], buff[pos + 3]]);
+    let fmt_idx = (tag >> 12) as u8;
+    let fmt = match red_format(fmt_idx) {
+      Some(f) => f,
+      None => {
+        if dir_len_truthy {
+          meta.warnings.push("Unknown format code");
+        }
+        break;
+      }
+    };
+    let payload_off = pos + 4;
+    let payload_size = len - 4;
+    let elem = format_size_of(fmt);
+    if elem > 0 && payload_size > 0 {
+      let count = payload_size / elem;
+      if count > 0 {
+        if let Some(v) = read_value(buff, payload_off, fmt, count, ByteOrder::Mm) {
+          dispatch_directory_tag(meta, tag, v, buff, payload_off, payload_size);
+        }
+      }
+    } else if fmt == "string" || fmt == "undef" {
+      if let Some(v) = read_value(buff, payload_off, fmt, payload_size, ByteOrder::Mm) {
+        dispatch_directory_tag(meta, tag, v, buff, payload_off, payload_size);
+      }
+    }
+    pos += len;
+  }
+}
+
+/// Route a directory entry's `read_value` result into the matching
+/// [`R3dMeta`] field. For string-typed fields we additionally pull a
+/// borrowed slice from the input buffer (zero-alloc).
+fn dispatch_directory_tag<'a>(
+  meta: &mut R3dMeta<'a>,
+  tag: u16,
+  v: TagValue,
+  buff: &'a [u8],
+  payload_off: usize,
+  payload_size: usize,
+) {
+  let borrowed = |off: usize, len: usize| -> Option<&'a str> {
+    let end = (off + len).min(buff.len());
+    if off >= end {
+      return None;
+    }
+    let slice = &buff[off..end];
+    let trimmed = slice.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+    if trimmed == 0 {
+      return None;
+    }
+    core::str::from_utf8(&slice[..trimmed]).ok()
+  };
+
+  let to_value = |v: TagValue| -> R3dValue<'a> {
+    match v {
+      TagValue::I64(n) => R3dValue::I64(n),
+      TagValue::F64(n) => R3dValue::F64(n),
+      TagValue::Str(s) => R3dValue::Str(R3dStrCow::Owned(s.to_string())),
+      TagValue::Bytes(b) => R3dValue::Bytes(b),
+      TagValue::Rational(r) => R3dValue::Rational(r),
+      TagValue::Bool(b) => R3dValue::I64(i64::from(b)),
+      TagValue::List(_) => R3dValue::Str(R3dStrCow::Owned(String::new())),
+    }
+  };
+
+  let dir_tag = DirectoryTag::new(tag);
+  match tag {
+    0x1000 => {
+      meta.start_edge_code = borrowed(payload_off, payload_size);
+      if meta.start_edge_code.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1001 => {
+      meta.start_timecode = borrowed(payload_off, payload_size);
+      if meta.start_timecode.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1002 => {
+      if let TagValue::Str(s) = v {
+        meta.other_date_1 = Some(other_date_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1003 => {
+      if let TagValue::Str(s) = v {
+        meta.other_date_2 = Some(other_date_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1004 => {
+      if let TagValue::Str(s) = v {
+        meta.other_date_3 = Some(other_date_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1005 => {
+      if let TagValue::Str(s) = v {
+        meta.date_time_original = Some(datetime_original_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1006 => {
+      meta.serial_number = borrowed(payload_off, payload_size);
+      if meta.serial_number.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1019 => {
+      meta.camera_type = borrowed(payload_off, payload_size);
+      if meta.camera_type.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x101a => match v {
+      TagValue::Str(_) => {
+        if let Some(slice) = borrowed(payload_off, payload_size) {
+          meta.reel_number = Some(R3dStrOrInt::Str(slice));
+          meta.directory_tag_order.push(dir_tag);
+        }
+      }
+      TagValue::I64(n) => {
+        meta.reel_number = Some(R3dStrOrInt::I64(n));
+        meta.directory_tag_order.push(dir_tag);
+      }
+      _ => {}
+    },
+    0x101b => {
+      meta.take = borrowed(payload_off, payload_size);
+      if meta.take.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1023 => {
+      if let TagValue::Str(s) = v {
+        meta.date_created = Some(date_created_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1024 => {
+      if let TagValue::Str(s) = v {
+        meta.time_created = Some(time_created_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1025 => {
+      meta.firmware_version = borrowed(payload_off, payload_size);
+      if meta.firmware_version.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1029 => {
+      meta.reel_timecode = borrowed(payload_off, payload_size);
+      if meta.reel_timecode.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x102a => {
+      meta.storage_type = borrowed(payload_off, payload_size);
+      if meta.storage_type.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1030 => {
+      if let TagValue::Str(s) = v {
+        meta.storage_format_date = Some(date_created_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1031 => {
+      if let TagValue::Str(s) = v {
+        meta.storage_format_time = Some(time_created_value_conv(s.as_str()));
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1032 => {
+      meta.storage_serial_number = borrowed(payload_off, payload_size);
+      if meta.storage_serial_number.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1033 => {
+      meta.storage_model = borrowed(payload_off, payload_size);
+      if meta.storage_model.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1036 => {
+      meta.aspect_ratio = borrowed(payload_off, payload_size);
+      if meta.aspect_ratio.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1042 => {
+      meta.revision = borrowed(payload_off, payload_size);
+      if meta.revision.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1056 => {
+      meta.original_file_name = borrowed(payload_off, payload_size);
+      if meta.original_file_name.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x106e => {
+      meta.lens_make = borrowed(payload_off, payload_size);
+      if meta.lens_make.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x106f => {
+      meta.lens_number = borrowed(payload_off, payload_size);
+      if meta.lens_number.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1070 => {
+      meta.lens_model = borrowed(payload_off, payload_size);
+      if meta.lens_model.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1071 => {
+      meta.model = borrowed(payload_off, payload_size);
+      if meta.model.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x107c => {
+      meta.camera_operator = borrowed(payload_off, payload_size);
+      if meta.camera_operator.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1086 => {
+      meta.video_format = borrowed(payload_off, payload_size);
+      if meta.video_format.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x1096 => {
+      meta.filter = borrowed(payload_off, payload_size);
+      if meta.filter.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x10a0 => {
+      meta.brain = borrowed(payload_off, payload_size);
+      if meta.brain.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x10a1 => {
+      meta.sensor = borrowed(payload_off, payload_size);
+      if meta.sensor.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+    0x10be => {
+      meta.quality = borrowed(payload_off, payload_size);
+      if meta.quality.is_some() {
+        meta.directory_tag_order.push(dir_tag);
+      }
+    }
+
+    0x200d => {
+      meta.color_temperature = Some(to_value(v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+    0x204b => {
+      meta.rgb_curves = Some(to_value(v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+    0x2066 => {
+      meta.original_frame_rate = Some(to_value(v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+
+    0x4037 => {
+      meta.crop_area = Some(to_value(v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+    0x403b => {
+      meta.iso = Some(to_value(v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+    0x406a => {
+      meta.f_number = Some(divide_by_10(&v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+    0x406b => {
+      meta.focal_length = Some(to_value(v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+
+    0x606c => {
+      meta.focus_distance = Some(divide_by_1000(&v));
+      meta.directory_tag_order.push(dir_tag);
+    }
+
+    _ => {
+      // Unknown tag — faithfully drop.
+    }
+  }
+}
+
+// ===========================================================================
+// `R3dMeta::into_static`
+// ===========================================================================
+
+impl R3dMeta<'_> {
+  /// Promote a borrow-from-input [`R3dMeta`] into an owned `R3dMeta<'static>`
+  /// (Phase E `into_static` pragma).
+  fn into_static(self) -> R3dMeta<'static> {
+    fn leak(s: &str) -> &'static str {
+      std::boxed::Box::leak(s.to_string().into_boxed_str())
+    }
+    fn leak_opt(s: Option<&str>) -> Option<&'static str> {
+      s.map(leak)
+    }
+    fn leak_value(v: R3dValue<'_>) -> R3dValue<'static> {
+      match v {
+        R3dValue::I64(n) => R3dValue::I64(n),
+        R3dValue::F64(n) => R3dValue::F64(n),
+        R3dValue::Str(R3dStrCow::Borrowed(s)) => R3dValue::Str(R3dStrCow::Borrowed(leak(s))),
+        R3dValue::Str(R3dStrCow::Owned(s)) => R3dValue::Str(R3dStrCow::Owned(s)),
+        R3dValue::Bytes(b) => R3dValue::Bytes(b),
+        R3dValue::Rational(r) => R3dValue::Rational(r),
+      }
+    }
+    fn leak_value_opt(v: Option<R3dValue<'_>>) -> Option<R3dValue<'static>> {
+      v.map(leak_value)
+    }
+    fn leak_reel(v: R3dStrOrInt<'_>) -> R3dStrOrInt<'static> {
+      match v {
+        R3dStrOrInt::Str(s) => R3dStrOrInt::Str(leak(s)),
+        R3dStrOrInt::I64(n) => R3dStrOrInt::I64(n),
+      }
+    }
+
+    R3dMeta::<'static> {
+      redcode_version: self.redcode_version,
+      image_width: self.image_width,
+      image_height: self.image_height,
+      frame_rate: self.frame_rate,
+      red1_original_file_name: leak_opt(self.red1_original_file_name),
+      start_edge_code: leak_opt(self.start_edge_code),
+      start_timecode: leak_opt(self.start_timecode),
+      other_date_1: self.other_date_1,
+      other_date_2: self.other_date_2,
+      other_date_3: self.other_date_3,
+      date_time_original: self.date_time_original,
+      serial_number: leak_opt(self.serial_number),
+      camera_type: leak_opt(self.camera_type),
+      reel_number: self.reel_number.map(leak_reel),
+      take: leak_opt(self.take),
+      date_created: self.date_created,
+      time_created: self.time_created,
+      firmware_version: leak_opt(self.firmware_version),
+      reel_timecode: leak_opt(self.reel_timecode),
+      storage_type: leak_opt(self.storage_type),
+      storage_format_date: self.storage_format_date,
+      storage_format_time: self.storage_format_time,
+      storage_serial_number: leak_opt(self.storage_serial_number),
+      storage_model: leak_opt(self.storage_model),
+      aspect_ratio: leak_opt(self.aspect_ratio),
+      revision: leak_opt(self.revision),
+      original_file_name: leak_opt(self.original_file_name),
+      lens_make: leak_opt(self.lens_make),
+      lens_number: leak_opt(self.lens_number),
+      lens_model: leak_opt(self.lens_model),
+      model: leak_opt(self.model),
+      camera_operator: leak_opt(self.camera_operator),
+      video_format: leak_opt(self.video_format),
+      filter: leak_opt(self.filter),
+      brain: leak_opt(self.brain),
+      sensor: leak_opt(self.sensor),
+      quality: leak_opt(self.quality),
+      color_temperature: leak_value_opt(self.color_temperature),
+      rgb_curves: leak_value_opt(self.rgb_curves),
+      original_frame_rate: leak_value_opt(self.original_frame_rate),
+      crop_area: leak_value_opt(self.crop_area),
+      iso: leak_value_opt(self.iso),
+      f_number: self.f_number,
+      focal_length: leak_value_opt(self.focal_length),
+      focus_distance: self.focus_distance,
+      warnings: self.warnings,
+      directory_tag_order: self.directory_tag_order,
+    }
+  }
+}
+
+// ===========================================================================
+// `MetaSinker` — typed Meta → TagWriter
+// ===========================================================================
+
+const GROUP: &str = "Red";
+
+impl MetaSinker for R3dMeta<'_> {
+  /// Emit R3D tags into the writer in faithful Red.pm emission order:
+  ///
+  /// 1. RED1/RED2 header subtable fields (Red.pm:240 HandleTag).
+  /// 2. Directory tags in walk order (Red.pm:277-291).
+  /// 3. Warnings via [`TagWriter::write_warning`].
+  ///
+  /// `print_conv=true` ⇒ PrintConv formatted strings (`-j`);
+  /// `print_conv=false` ⇒ post-ValueConv raw scalars (`-n`).
+  fn sink<W: TagWriter>(&self, print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    // 1. Header subtable fields.
+    if let Some(v) = self.redcode_version_str() {
+      // RedcodeVersion is an ASCII digit string; ExifTool's JSON emitter
+      // numerically-coerces such strings under -j and -n.
+      let n: u64 = v.parse().unwrap_or(0);
+      out.write_u64(GROUP, "RedcodeVersion", n)?;
+    }
+    if let Some(w) = self.image_width {
+      out.write_u64(GROUP, "ImageWidth", u64::from(w))?;
+    }
+    if let Some(h) = self.image_height {
+      out.write_u64(GROUP, "ImageHeight", u64::from(h))?;
+    }
+    if let Some(fr) = &self.frame_rate {
+      // Red.pm:169/202 PrintConv `int($val*1000+0.5)/1000`.
+      let pre_pc: TagValue = match fr {
+        FrameRate::Rational(r) => TagValue::Rational(r.clone()),
+        FrameRate::F64(n) => TagValue::F64(*n),
+      };
+      if print_conv {
+        out.write_f64(GROUP, "FrameRate", round_to_3dp(&pre_pc))?;
+      } else {
+        // -n raw: Rational → `%.7g` text → f64.
+        let raw_f = match fr {
+          FrameRate::Rational(r) => perl_arithmetic_to_f64(&r.exiftool_val_str()),
+          FrameRate::F64(n) => *n,
+        };
+        out.write_f64(GROUP, "FrameRate", raw_f)?;
+      }
+    }
+    if let Some(n) = self.red1_original_file_name {
+      out.write_str(GROUP, "OriginalFileName", n)?;
+    }
+
+    // 2. Directory tags in walk order.
+    for dt in &self.directory_tag_order {
+      self.sink_directory_tag(*dt, print_conv, out)?;
+    }
+
+    // 3. Warnings.
+    for w in &self.warnings {
+      out.write_warning(w)?;
+    }
+    Ok(())
+  }
+}
+
+impl R3dMeta<'_> {
+  /// Emit a single directory tag.
+  fn sink_directory_tag<W: TagWriter>(
+    &self,
+    dt: DirectoryTag,
+    print_conv: bool,
+    out: &mut W,
+  ) -> Result<(), W::Error> {
+    match dt.id() {
+      0x1000 => {
+        if let Some(v) = self.start_edge_code {
+          out.write_str(GROUP, "StartEdgeCode", v)?;
+        }
+      }
+      0x1001 => {
+        if let Some(v) = self.start_timecode {
+          out.write_str(GROUP, "StartTimecode", v)?;
+        }
+      }
+      0x1002 => {
+        if let Some(v) = self.other_date_1.as_deref() {
+          out.write_str(GROUP, "OtherDate1", v)?;
+        }
+      }
+      0x1003 => {
+        if let Some(v) = self.other_date_2.as_deref() {
+          out.write_str(GROUP, "OtherDate2", v)?;
+        }
+      }
+      0x1004 => {
+        if let Some(v) = self.other_date_3.as_deref() {
+          out.write_str(GROUP, "OtherDate3", v)?;
+        }
+      }
+      0x1005 => {
+        if let Some(v) = self.date_time_original.as_deref() {
+          // Red.pm:73 PrintConv `$self->ConvertDateTime($val)` is the
+          // identity under default options.
+          out.write_str(GROUP, "DateTimeOriginal", v)?;
+        }
+      }
+      0x1006 => {
+        if let Some(v) = self.serial_number {
+          out.write_str(GROUP, "SerialNumber", v)?;
+        }
+      }
+      0x1019 => {
+        if let Some(v) = self.camera_type {
+          out.write_str(GROUP, "CameraType", v)?;
+        }
+      }
+      0x101a => {
+        if let Some(v) = &self.reel_number {
+          // Bundled output: JSON integer when on-disk numeric.
+          match v {
+            R3dStrOrInt::Str(s) => out.write_str(GROUP, "ReelNumber", s)?,
+            R3dStrOrInt::I64(n) => out.write_i64(GROUP, "ReelNumber", *n)?,
+          }
+        }
+      }
+      0x101b => {
+        if let Some(v) = self.take {
+          out.write_str(GROUP, "Take", v)?;
+        }
+      }
+      0x1023 => {
+        if let Some(v) = self.date_created.as_deref() {
+          out.write_str(GROUP, "DateCreated", v)?;
+        }
+      }
+      0x1024 => {
+        if let Some(v) = self.time_created.as_deref() {
+          out.write_str(GROUP, "TimeCreated", v)?;
+        }
+      }
+      0x1025 => {
+        if let Some(v) = self.firmware_version {
+          out.write_str(GROUP, "FirmwareVersion", v)?;
+        }
+      }
+      0x1029 => {
+        if let Some(v) = self.reel_timecode {
+          out.write_str(GROUP, "ReelTimecode", v)?;
+        }
+      }
+      0x102a => {
+        if let Some(v) = self.storage_type {
+          out.write_str(GROUP, "StorageType", v)?;
+        }
+      }
+      0x1030 => {
+        if let Some(v) = self.storage_format_date.as_deref() {
+          out.write_str(GROUP, "StorageFormatDate", v)?;
+        }
+      }
+      0x1031 => {
+        if let Some(v) = self.storage_format_time.as_deref() {
+          out.write_str(GROUP, "StorageFormatTime", v)?;
+        }
+      }
+      0x1032 => {
+        if let Some(v) = self.storage_serial_number {
+          out.write_str(GROUP, "StorageSerialNumber", v)?;
+        }
+      }
+      0x1033 => {
+        if let Some(v) = self.storage_model {
+          out.write_str(GROUP, "StorageModel", v)?;
+        }
+      }
+      0x1036 => {
+        if let Some(v) = self.aspect_ratio {
+          out.write_str(GROUP, "AspectRatio", v)?;
+        }
+      }
+      0x1042 => {
+        if let Some(v) = self.revision {
+          out.write_str(GROUP, "Revision", v)?;
+        }
+      }
+      0x1056 => {
+        if let Some(v) = self.original_file_name {
+          out.write_str(GROUP, "OriginalFileName", v)?;
+        }
+      }
+      0x106e => {
+        if let Some(v) = self.lens_make {
+          out.write_str(GROUP, "LensMake", v)?;
+        }
+      }
+      0x106f => {
+        if let Some(v) = self.lens_number {
+          out.write_str(GROUP, "LensNumber", v)?;
+        }
+      }
+      0x1070 => {
+        if let Some(v) = self.lens_model {
+          out.write_str(GROUP, "LensModel", v)?;
+        }
+      }
+      0x1071 => {
+        if let Some(v) = self.model {
+          out.write_str(GROUP, "Model", v)?;
+        }
+      }
+      0x107c => {
+        if let Some(v) = self.camera_operator {
+          out.write_str(GROUP, "CameraOperator", v)?;
+        }
+      }
+      0x1086 => {
+        if let Some(v) = self.video_format {
+          out.write_str(GROUP, "VideoFormat", v)?;
+        }
+      }
+      0x1096 => {
+        if let Some(v) = self.filter {
+          out.write_str(GROUP, "Filter", v)?;
+        }
+      }
+      0x10a0 => {
+        if let Some(v) = self.brain {
+          out.write_str(GROUP, "Brain", v)?;
+        }
+      }
+      0x10a1 => {
+        if let Some(v) = self.sensor {
+          out.write_str(GROUP, "Sensor", v)?;
+        }
+      }
+      0x10be => {
+        if let Some(v) = self.quality {
+          out.write_str(GROUP, "Quality", v)?;
+        }
+      }
+      0x200d => {
+        if let Some(v) = &self.color_temperature {
+          emit_r3d_value(out, "ColorTemperature", v)?;
+        }
+      }
+      0x204b => {
+        if let Some(v) = &self.rgb_curves {
+          emit_r3d_value(out, "RGBCurves", v)?;
+        }
+      }
+      0x2066 => {
+        if let Some(v) = &self.original_frame_rate {
+          // Red.pm:131-135 PrintConv `int($val*1000+0.5)/1000`.
+          if print_conv {
+            let raw: TagValue = match v {
+              R3dValue::I64(n) => TagValue::I64(*n),
+              R3dValue::F64(n) => TagValue::F64(*n),
+              R3dValue::Str(s) => TagValue::Str(s.as_str().into()),
+              R3dValue::Bytes(_) => TagValue::I64(0),
+              R3dValue::Rational(r) => TagValue::Rational(r.clone()),
+            };
+            out.write_f64(GROUP, "OriginalFrameRate", round_to_3dp(&raw))?;
+          } else {
+            emit_r3d_value(out, "OriginalFrameRate", v)?;
+          }
+        }
+      }
+      0x4037 => {
+        if let Some(v) = &self.crop_area {
+          emit_r3d_value(out, "CropArea", v)?;
+        }
+      }
+      0x403b => {
+        if let Some(v) = &self.iso {
+          emit_r3d_value(out, "ISO", v)?;
+        }
+      }
+      0x406a => {
+        if let Some(v) = self.f_number {
+          out.write_f64(GROUP, "FNumber", v)?;
+        }
+      }
+      0x406b => {
+        if let Some(v) = &self.focal_length {
+          emit_r3d_value(out, "FocalLength", v)?;
+        }
+      }
+      0x606c => {
+        if let Some(v) = self.focus_distance {
+          if print_conv {
+            // Red.pm:147 PrintConv `"$val m"`.
+            out.write_fmt(GROUP, "FocusDistance", |w| {
+              w.write_str(&focus_distance_print_conv(v))
+            })?;
+          } else {
+            out.write_f64(GROUP, "FocusDistance", v)?;
+          }
+        }
+      }
+      _ => {}
+    }
+    Ok(())
+  }
+}
+
+/// Emit a generic `R3dValue` (no per-tag PrintConv).
+fn emit_r3d_value<W: TagWriter>(out: &mut W, name: &str, v: &R3dValue<'_>) -> Result<(), W::Error> {
+  match v {
+    R3dValue::I64(n) => out.write_i64(GROUP, name, *n),
+    R3dValue::F64(n) => out.write_f64(GROUP, name, *n),
+    R3dValue::Str(s) => out.write_str(GROUP, name, s.as_str()),
+    R3dValue::Bytes(b) => out.write_bytes(GROUP, name, b),
+    R3dValue::Rational(r) => {
+      let f = perl_arithmetic_to_f64(&r.exiftool_val_str());
+      out.write_f64(GROUP, name, f)
+    }
+  }
+}
+
+// ===========================================================================
+// `R3dError` — Rust-level fatal modes (currently none)
+// ===========================================================================
+
+/// Rust-level fatal modes for R3D parsing. Currently empty — every bad
+/// input produces `Ok(None)` (Perl `return 0`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum R3dError {}
+
+impl core::fmt::Display for R3dError {
+  fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match *self {}
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for R3dError {}
+
+// ===========================================================================
+// Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+// ===========================================================================
+
+impl OldFormatParser for ProcessR3D {
+  /// Phase F1 migration bridge. Runs the new typed [`FormatParser::parse`]
+  /// and drives [`MetaSinker::sink`] through a [`MetadataTagWriter`] so
+  /// the CLI JSON output stays byte-exact during Phases F1–F5. Retired
+  /// in Phase G.
+  fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
+    let meta = {
+      let data = ctx.data();
+      match parse_inner(data) {
+        Some(m) => m,
+        None => return false,
+      }
+    };
+    // Red.pm:230 `$et->SetFileType()` — happens BEFORE tag emission.
+    ctx.set_file_type(None, None, None);
+    let print_conv = ctx.print_conv_enabled();
+    let mut bridge = MetadataTagWriter::new(ctx.metadata());
+    let _: Result<(), core::convert::Infallible> = meta.sink(print_conv, &mut bridge);
+    true
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::value::Rational;
+  use crate::value::Metadata;
 
   #[test]
   fn red_format_table_matches_pm() {
-    // Red.pm:22-33 — every index 0..=9 must resolve; >9 ⇒ None.
     assert_eq!(red_format(0), Some("int8u"));
     assert_eq!(red_format(1), Some("string"));
     assert_eq!(red_format(2), Some("float"));
@@ -1185,7 +1801,6 @@ mod tests {
 
   #[test]
   fn reject_short_input() {
-    use crate::value::Metadata;
     let mut m = Metadata::new("Red.r3d");
     let bytes = [0u8; 7];
     let mut ctx = ParseContext::new(&bytes, "R3D", 0, "R3D", None, true, &mut m);
@@ -1195,8 +1810,6 @@ mod tests {
 
   #[test]
   fn reject_bad_magic() {
-    use crate::value::Metadata;
-    // 8 bytes, no RED1/RED2 magic.
     let mut m = Metadata::new("Red.r3d");
     let bytes = b"\x00\x00\x00\x10ABCD";
     let mut ctx = ParseContext::new(bytes, "R3D", 0, "R3D", None, true, &mut m);
@@ -1206,8 +1819,6 @@ mod tests {
 
   #[test]
   fn reject_size_less_than_8() {
-    use crate::value::Metadata;
-    // size = 4 < 8 (Red.pm:228 `return 0 if $size < 8`).
     let mut m = Metadata::new("Red.r3d");
     let bytes = b"\x00\x00\x00\x04RED1";
     let mut ctx = ParseContext::new(bytes, "R3D", 0, "R3D", None, true, &mut m);
@@ -1217,14 +1828,12 @@ mod tests {
 
   #[test]
   fn truncated_header_emits_warning_and_filetype_triplet() {
-    use crate::value::Metadata;
-    // size = 0x40 — header validates, SetFileType runs, then Read($size-8)
-    // fails (only 0 bytes remain) ⇒ Warn("Truncated R3D file").
     let mut m = Metadata::new("Red.r3d");
+    // size = 0x40 — header validates, SetFileType runs, then Read($size-8)
+    // fails ⇒ Warn("Truncated R3D file"). Faithful: no header tag emission.
     let bytes = b"\x00\x00\x00\x40RED1";
     let mut ctx = ParseContext::new(bytes, "R3D", 0, "R3D", None, true, &mut m);
     assert!(ProcessR3D.process(&mut ctx));
-    // File:FileType triplet plus the Warning.
     let names: Vec<&str> = m.tags().iter().map(|t| t.name()).collect();
     assert!(names.contains(&"FileType"));
     assert!(names.contains(&"FileTypeExtension"));
@@ -1237,169 +1846,83 @@ mod tests {
 
   #[test]
   fn other_date_value_conv_preserves_non_ascii_text() {
-    // Codex round-8 F1: `replace_yyyy_mm_underscore` previously did
-    // `out.push(b[i] as char)` byte-by-byte, mojibaking multi-byte
-    // UTF-8 sequences. Perl's `s/(\d{4})_(\d{2})_/$1:$2:/` operates
-    // on bytes and preserves non-matching bytes verbatim — the same
-    // result is achieved in Rust by slicing the original `&str` at
-    // ASCII match boundaries and `push_str`ing the unmatched regions.
-    //
-    // Bundled-Perl oracle (run with `binmode STDOUT, ':utf8'`):
-    //   my $s = "é2016_01_18_é";
-    //   $s =~ s/(\d{4})_(\d{2})_/$1:$2:/;
-    //   $s =~ tr/_/ /;  → "é2016:01:18 é"
-    //
-    // The `s///` consumes `2016_01_` (8 bytes, all ASCII); the trailing
-    // `_é` survives the regex, then `tr/_/ /` turns the lone underscore
-    // into a space, giving the trailing ` é`. The leading `é` (bytes
-    // \xC3\xA9) and the trailing `é` are preserved verbatim — the
-    // mojibake bug would have rendered them as `Ã©`.
-    let v = other_date_value_conv(&TagValue::Str("é2016_01_18_é".into()));
-    assert_eq!(v, TagValue::Str("é2016:01:18 é".into()));
-    // Underscore in the trailing portion still gets `tr/_/ /`-converted
-    // globally (Perl `tr` is byte-global; we use Rust `str::replace`
-    // which is char-global but `_` is ASCII so identical).
-    let v2 = other_date_value_conv(&TagValue::Str("é2016_01_18_T_é".into()));
-    assert_eq!(v2, TagValue::Str("é2016:01:18 T é".into()));
-    // No date match, but the input has underscores ⇒ Perl still runs
-    // `tr/_/ /` (it's the second statement). Our impl mirrors this:
-    // returns input unchanged from `replace_yyyy_mm_underscore` then
-    // applies the global `_` → ` ` replacement.
-    let v3 = other_date_value_conv(&TagValue::Str("é_é".into()));
-    assert_eq!(v3, TagValue::Str("é é".into()));
+    assert_eq!(other_date_value_conv("é2016_01_18_é"), "é2016:01:18 é");
+    assert_eq!(other_date_value_conv("é2016_01_18_T_é"), "é2016:01:18 T é");
+    assert_eq!(other_date_value_conv("é_é"), "é é");
   }
 
   #[test]
   fn other_date_value_conv_replaces_first_only() {
-    // Red.pm:56 — `s/(\d{4})_(\d{2})_/$1:$2:/` is one-shot, `tr/_/ /` global.
-    let v = other_date_value_conv(&TagValue::Str("2016_01_18".into()));
-    assert_eq!(v, TagValue::Str("2016:01:18".into()));
-    // Trailing `_TZ` ⇒ becomes space-separated.
-    let v2 = other_date_value_conv(&TagValue::Str("2016_01_18_UTC".into()));
-    assert_eq!(v2, TagValue::Str("2016:01:18 UTC".into()));
+    assert_eq!(other_date_value_conv("2016_01_18"), "2016:01:18");
+    assert_eq!(other_date_value_conv("2016_01_18_UTC"), "2016:01:18 UTC");
   }
 
   #[test]
   fn date_time_original_value_conv_splits_into_yyyy_mm_dd_hh_mm_ss() {
-    // Input: 14 digits "20160118213555" ⇒ "2016:01:18 21:35:55".
-    let v = datetime_original_value_conv(&TagValue::Str("20160118213555".into()));
-    assert_eq!(v, TagValue::Str("2016:01:18 21:35:55".into()));
+    assert_eq!(
+      datetime_original_value_conv("20160118213555"),
+      "2016:01:18 21:35:55"
+    );
   }
 
   #[test]
   fn date_time_original_value_conv_preserves_non_ascii_text() {
-    // Codex round-8 follow-up: the other three date helpers
-    // (datetime_original, date_created, time_created) ALREADY use
-    // `push_str(&s[..i])` — the correct UTF-8-safe pattern. Verify
-    // non-ASCII passes through verbatim. Bundled Perl oracle:
-    //   perl -e 'use utf8; binmode STDOUT, ":utf8";
-    //            my $s="ééé20160118213555ééé";
-    //            $s =~ s/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})/
-    //                                              $1:$2:$3 $4:$5:/;
-    //            print "$s\n"' ⇒ "ééé2016:01:18 21:35:55ééé"
-    let v = datetime_original_value_conv(&TagValue::Str("ééé20160118213555ééé".into()));
-    assert_eq!(v, TagValue::Str("ééé2016:01:18 21:35:55ééé".into()));
-    // date_created (6-digit match anywhere)
-    let v2 = date_created_value_conv(&TagValue::Str("é20160118é".into()));
-    assert_eq!(v2, TagValue::Str("é2016:01:18é".into()));
-    // time_created (4-digit match anywhere)
-    let v3 = time_created_value_conv(&TagValue::Str("é213555é".into()));
-    assert_eq!(v3, TagValue::Str("é21:35:55é".into()));
+    assert_eq!(
+      datetime_original_value_conv("ééé20160118213555ééé"),
+      "ééé2016:01:18 21:35:55ééé"
+    );
+    assert_eq!(date_created_value_conv("é20160118é"), "é2016:01:18é");
+    assert_eq!(time_created_value_conv("é213555é"), "é21:35:55é");
   }
 
   #[test]
   fn date_time_original_value_conv_skips_partial_digit_prefix() {
-    // Codex round-7 adversarial probe: Perl's regex backtracks past a
-    // partial-digit prefix (e.g. 10 digits + 'xx') to find the next
-    // 12-digit run. The previous impl bailed at a 10-digit "no-match"
-    // partial, diverging from Perl.
-    //
-    // Bundled-Perl oracle:
-    //   perl -e 'my $s="1234567890xx20160118213555";
-    //            $s =~ s/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})/$1:$2:$3 $4:$5:/;
-    //            print "$s\n"'  → "1234567890xx2016:01:18 21:35:55"
-    let v = datetime_original_value_conv(&TagValue::Str("1234567890xx20160118213555".into()));
-    assert_eq!(v, TagValue::Str("1234567890xx2016:01:18 21:35:55".into()));
-    // Longer adversarial: a 24-digit run starting at 0 matches FIRST
-    // (the regex is greedy + leftmost). Perl emits the colons starting
-    // at position 0: "0123:45:67 89:20:160118213555".
-    let v2 = datetime_original_value_conv(&TagValue::Str("012345678920160118213555".into()));
-    assert_eq!(v2, TagValue::Str("0123:45:67 89:20:160118213555".into()));
-    // Non-digit prefix + valid 14-digit suffix. Perl skips the prefix.
-    let v3 = datetime_original_value_conv(&TagValue::Str("abcdefg20160118213555".into()));
-    assert_eq!(v3, TagValue::Str("abcdefg2016:01:18 21:35:55".into()));
-    // Too few digits ⇒ regex doesn't match ⇒ value unchanged.
-    let v4 = datetime_original_value_conv(&TagValue::Str("01234567890".into()));
-    assert_eq!(v4, TagValue::Str("01234567890".into()));
+    assert_eq!(
+      datetime_original_value_conv("1234567890xx20160118213555"),
+      "1234567890xx2016:01:18 21:35:55"
+    );
+    assert_eq!(
+      datetime_original_value_conv("012345678920160118213555"),
+      "0123:45:67 89:20:160118213555"
+    );
+    assert_eq!(
+      datetime_original_value_conv("abcdefg20160118213555"),
+      "abcdefg2016:01:18 21:35:55"
+    );
+    assert_eq!(datetime_original_value_conv("01234567890"), "01234567890");
   }
 
   #[test]
   fn date_created_value_conv_inserts_colons() {
-    // Red.pm:82 — `s/(\d{4})(\d{2})/$1:$2:/` on `YYYYMMDD` ⇒ `YYYY:MM:DD`.
-    let v = date_created_value_conv(&TagValue::Str("20160118".into()));
-    assert_eq!(v, TagValue::Str("2016:01:18".into()));
+    assert_eq!(date_created_value_conv("20160118"), "2016:01:18");
   }
 
   #[test]
   fn time_created_value_conv_inserts_colons() {
-    // Red.pm:87 — `s/(\d{2})(\d{2})/$1:$2:/` on `HHMMSS` ⇒ `HH:MM:SS`.
-    let v = time_created_value_conv(&TagValue::Str("213555".into()));
-    assert_eq!(v, TagValue::Str("21:35:55".into()));
+    assert_eq!(time_created_value_conv("213555"), "21:35:55");
   }
 
   #[test]
   fn red2_frame_rate_value_conv_matches_pm() {
-    // Red.pm:201 `($a[1]*0x10000 + $a[2]) / $a[0]` — for bundled fixture
-    // the int16u[3] is `1001 0 24000` ⇒ (0*65536 + 24000)/1001 ≈ 23.976023.
     let v = red2_frame_rate_value_conv(&TagValue::Str("1001 0 24000".into()));
-    if let TagValue::F64(f) = v {
-      assert!((f - 24000.0 / 1001.0).abs() < 1e-12);
-    } else {
-      panic!("expected F64, got {v:?}");
-    }
+    assert!((v.unwrap() - 24000.0 / 1001.0).abs() < 1e-12);
   }
 
   #[test]
   fn red2_frame_rate_value_conv_partial_inputs_match_perl() {
-    // Codex round-2 F1: with `read_value`'s faithful count-shortening
-    // (ExifTool.pm:6290-6292), a truncated RED2 header at offset 0x56
-    // produces a 2-element `"a b"` string (count=2) or a scalar `a`
-    // (count=1). Perl's `split " ", $val` coerces missing indices to
-    // numeric 0, yielding `0/a = 0` in both cases (oracle below). The
-    // typed-scalar case (count==1) must also stringify-and-split (Perl
-    // `split " ", 1001` ⇒ `(1001)`). Oracle:
-    //   perl -e 'no warnings "uninitialized";
-    //            for my $val ("1001 0", 1001) {
-    //              my @a = split " ",$val;
-    //              printf "%s => %g\n", $val,
-    //                ($a[1]*0x10000+$a[2])/$a[0]; }'
-    //   1001 0 => 0
-    //   1001   => 0
     assert_eq!(
       red2_frame_rate_value_conv(&TagValue::Str("1001 0".into())),
-      TagValue::F64(0.0)
+      Some(0.0)
     );
-    assert_eq!(
-      red2_frame_rate_value_conv(&TagValue::I64(1001)),
-      TagValue::F64(0.0)
-    );
-    // `"1001"` (single token string) is the F64-stringify or string-shape
-    // analogue: same `0/1001 = 0` result.
+    assert_eq!(red2_frame_rate_value_conv(&TagValue::I64(1001)), Some(0.0));
     assert_eq!(
       red2_frame_rate_value_conv(&TagValue::Str("1001".into())),
-      TagValue::F64(0.0)
+      Some(0.0)
     );
   }
 
   #[test]
   fn red2_frame_rate_first_word_is_zero_classifies_all_read_value_shapes() {
-    // Codex round-3 F1: the FrameRate-drop site must classify every shape
-    // `read_value("int16u", 3, ...)` can produce after count-shortening
-    // (ExifTool.pm:6286-6293) + single-element typed-scalar (ExifTool.pm:
-    // 6318-6320), so the `($a[0] == 0)` Perl `Illegal division by zero`
-    // case is silently dropped end-to-end, not just inside the ValueConv.
-    //
-    // count==3 ⇒ Str("a b c"); count==2 ⇒ Str("a b"); count==1 ⇒ I64(a).
     assert!(red2_frame_rate_first_word_is_zero(&TagValue::Str(
       "0 0 24000".into()
     )));
@@ -1407,18 +1930,12 @@ mod tests {
       "0 1001".into()
     )));
     assert!(red2_frame_rate_first_word_is_zero(&TagValue::I64(0)));
-    // Non-zero first word — must NOT classify as zero.
     assert!(!red2_frame_rate_first_word_is_zero(&TagValue::Str(
       "1001 0 24000".into()
     )));
     assert!(!red2_frame_rate_first_word_is_zero(&TagValue::I64(1001)));
-    // Defensive F64 = 0.0 (no current path produces this for int16u, but
-    // Perl would treat `0.0` as falsy in division).
     assert!(red2_frame_rate_first_word_is_zero(&TagValue::F64(0.0)));
     assert!(!red2_frame_rate_first_word_is_zero(&TagValue::F64(23.976)));
-    // Unparseable or empty first token: defensively false (`a==0` not
-    // proven; the `apply` path will then send the value to ValueConv
-    // where the `parse::<i64>()` arm returns `v.clone()` unchanged).
     assert!(!red2_frame_rate_first_word_is_zero(&TagValue::Str(
       "abc".into()
     )));
@@ -1428,93 +1945,38 @@ mod tests {
   }
 
   #[test]
-  fn round_to_3dp_print_conv_matches_pm_int_pattern() {
-    // Red.pm:134,169,202: `int($val * 1000 + 0.5) / 1000`.
-    // 24000/1001 = 23.976023976... ⇒ int(23.976023976*1000 + 0.5) =
-    // int(23976.523...) = 23976 ⇒ 23.976.
-    let v = round_to_3dp_print_conv(&TagValue::F64(24000.0 / 1001.0));
-    assert_eq!(v, TagValue::F64(23.976));
-    // From a Rational (RED1 path): `Rational::rational32(num=24000,
-    // denom=1001)` ⇒ 23.976.
-    let v2 = round_to_3dp_print_conv(&TagValue::Rational(Rational::rational32(24000, 1001)));
-    assert_eq!(v2, TagValue::F64(23.976));
+  fn round_to_3dp_matches_pm_int_pattern() {
+    assert_eq!(round_to_3dp(&TagValue::F64(24000.0 / 1001.0)), 23.976);
+    assert_eq!(
+      round_to_3dp(&TagValue::Rational(Rational::rational32(24000, 1001))),
+      23.976
+    );
   }
 
   #[test]
   fn round_to_3dp_rational_routes_through_roundfloat_7g_first() {
-    // Codex round-1 F1: Perl's ReadValue rationals are pre-rounded to 7
-    // significant figures via RoundFloat (ExifTool.pm:6087,6094) BEFORE
-    // PrintConv runs. `1106/101 = 10.95049504950495...` exact ⇒
-    //   - Perl `RoundFloat(.., 7)` ⇒ `"10.9505"`
-    //   - PrintConv `int(10.9505 * 1000 + 0.5)/1000 = int(10950.5+0.5)/1000
-    //       = int(10951)/1000 = 10.951`
-    // The Rational arm of `round_to_3dp_print_conv` must produce 10.951,
-    // not the exact-ratio answer 10.95. Oracle: bundled Perl prints
-    // `10.951`.
-    //   perl -e 'use Image::ExifTool qw(:DataAccess); use strict;
-    //            my $b = pack("nn", 1106, 101);
-    //            my $v = Image::ExifTool::ReadValue(\$b, 0, "rational32u",
-    //                                                1, length($b));
-    //            printf "raw=%s\npc=%g\n", $v,
-    //                                       int($v*1000+0.5)/1000;'
-    //   raw=10.9505     pc=10.951
-    let v = round_to_3dp_print_conv(&TagValue::Rational(Rational::rational32(1106, 101)));
-    assert_eq!(v, TagValue::F64(10.951));
-    // Non-Rational F64 path uses the exact f64; that semantic is unchanged
-    // (no `%.7g` re-round for OriginalFrameRate which is `float`):
-    let v2 = round_to_3dp_print_conv(&TagValue::F64(1106.0 / 101.0));
-    assert_eq!(v2, TagValue::F64(10.95));
+    // Codex round-1 F1: 1106/101 rounds to "10.9505" first ⇒ 10.951.
+    assert_eq!(
+      round_to_3dp(&TagValue::Rational(Rational::rational32(1106, 101))),
+      10.951
+    );
+    // F64 path: exact f64 ⇒ 10.95.
+    assert_eq!(round_to_3dp(&TagValue::F64(1106.0 / 101.0)), 10.95);
   }
 
   #[test]
   fn focus_distance_value_conv_and_print_conv() {
-    // Red.pm:147 `ValueConv => $val/1000, PrintConv => "$val m"`.
-    // int32s -1 ⇒ -0.001 ⇒ "-0.001 m".
-    let vc = divide_by_1000(&TagValue::I64(-1));
-    assert_eq!(vc, TagValue::F64(-0.001));
-    let pc = focus_distance_print_conv(&vc);
-    assert_eq!(pc, TagValue::Str("-0.001 m".into()));
+    assert_eq!(divide_by_1000(&TagValue::I64(-1)), -0.001);
+    assert_eq!(focus_distance_print_conv(-0.001), "-0.001 m");
   }
 
   #[test]
   fn divide_by_10_produces_float() {
-    // Red.pm:141 `FNumber => $val / 10`. int16u 49 ⇒ 4.9.
-    let v = divide_by_10(&TagValue::I64(49));
-    assert_eq!(v, TagValue::F64(4.9));
+    assert_eq!(divide_by_10(&TagValue::I64(49)), 4.9);
   }
-
-  // ── Codex round-4 F1+F2 fixes ──────────────────────────────────────────
 
   #[test]
   fn perl_arithmetic_to_f64_matches_oracle() {
-    // Oracle (bundled Perl, `perl -e 'my $v="…"; my $r = $v + 0; print $r'`):
-    //   ""              -> 0
-    //   "  "            -> 0
-    //   "0"             -> 0
-    //   "-1"            -> -1
-    //   "1.5"           -> 1.5
-    //   "1.5e2"         -> 150
-    //   "1.5e"          -> 1.5      (incomplete exponent dropped)
-    //   "1e"            -> 1
-    //   "abc"           -> 0
-    //   "1000 2000"     -> 1000     (leading number; rest ignored)
-    //   "  123 "        -> 123
-    //   "+"             -> 0
-    //   "-"             -> 0
-    //   "1."            -> 1
-    //   ".5"            -> 0.5
-    //   "-.5"           -> -0.5
-    //   "1.5abc"        -> 1.5
-    //   "0x10"          -> 0        (no hex)
-    //   "inf"           -> Inf
-    //   "-inf"          -> -Inf
-    //   "Inf"           -> Inf
-    //   "INF"           -> Inf
-    //   "infinity"      -> Inf
-    //   "nan"           -> NaN
-    //   "NaN"           -> NaN
-    //   "undef"         -> 0        (no leading numeric prefix)
-    //   "true"          -> 0
     assert_eq!(perl_arithmetic_to_f64(""), 0.0);
     assert_eq!(perl_arithmetic_to_f64("  "), 0.0);
     assert_eq!(perl_arithmetic_to_f64("0"), 0.0);
@@ -1546,36 +2008,22 @@ mod tests {
 
   #[test]
   fn perl_arithmetic_to_f64_non_ascii_does_not_panic() {
-    // Codex round-9 indirect probe: the helper's "inf"/"nan" prefix
-    // check must NOT use `&s[..3]` (which PANICS when the 3-byte mark
-    // splits a multi-byte UTF-8 codepoint, e.g. `"éé"` — byte 3 is
-    // inside the second `é`'s 0xC3 0xA9 pair). The byte-level
-    // `starts_with_ci` form is panic-free for any UTF-8 input.
     assert_eq!(perl_arithmetic_to_f64("éé"), 0.0);
     assert_eq!(perl_arithmetic_to_f64("é"), 0.0);
-    assert_eq!(perl_arithmetic_to_f64("éinf"), 0.0); // "é" is not a sign
+    assert_eq!(perl_arithmetic_to_f64("éinf"), 0.0);
     assert_eq!(perl_arithmetic_to_f64("日本"), 0.0);
-    // ASCII inputs with the "inf" prefix + non-ASCII suffix still
-    // resolve as Perl does:
-    //   perl -e 'print 0+("infé")'   ⇒ "Inf"
     assert_eq!(perl_arithmetic_to_f64("infé"), f64::INFINITY);
     assert!(perl_arithmetic_to_f64("nanñ").is_nan());
   }
 
   #[test]
   fn perl_arithmetic_to_f64_inf_with_trailing_junk_matches_perl() {
-    // Codex round-9 explicit oracle:
-    //   perl -e 'for my $v ("infjunk","infinite","infx","nanx","+inf","-nanx") {
-    //              my $r=$v+0; print "$v=$r\n" }'
-    //   infjunk=Inf  infinite=Inf  infx=Inf  nanx=NaN
-    //   +inf=Inf     -nanx=NaN
     assert_eq!(perl_arithmetic_to_f64("infjunk"), f64::INFINITY);
     assert_eq!(perl_arithmetic_to_f64("infinite"), f64::INFINITY);
     assert_eq!(perl_arithmetic_to_f64("infx"), f64::INFINITY);
     assert!(perl_arithmetic_to_f64("nanx").is_nan());
     assert_eq!(perl_arithmetic_to_f64("+inf"), f64::INFINITY);
     assert!(perl_arithmetic_to_f64("-nanx").is_nan());
-    // Whitespace before sign + inf:
     assert_eq!(perl_arithmetic_to_f64(" inf"), f64::INFINITY);
     assert!(perl_arithmetic_to_f64(" nan").is_nan());
     assert_eq!(perl_arithmetic_to_f64(" +infx"), f64::INFINITY);
@@ -1583,194 +2031,156 @@ mod tests {
 
   #[test]
   fn divide_by_10_perl_coerces_overlong_str_to_leading_number() {
-    // Codex round-4 F1: an overlong directory entry for tag 0x406a
-    // (FNumber) produces a space-joined `TagValue::Str` from `read_value`
-    // for `count > 1`. Perl `"123 456" / 10 == 12.3` — the leading
-    // number coerces; trailing tokens are silently ignored.
-    let v = divide_by_10(&TagValue::Str("123 456".into()));
-    assert_eq!(v, TagValue::F64(12.3));
-    // No leading numeric prefix ⇒ 0.0 (Perl `"abc" / 10 == 0`).
-    let v2 = divide_by_10(&TagValue::Str("abc".into()));
-    assert_eq!(v2, TagValue::F64(0.0));
-    // Empty string ⇒ 0.0 (Perl `"" / 10 == 0`).
-    let v3 = divide_by_10(&TagValue::Str("".into()));
-    assert_eq!(v3, TagValue::F64(0.0));
+    assert_eq!(divide_by_10(&TagValue::Str("123 456".into())), 12.3);
+    assert_eq!(divide_by_10(&TagValue::Str("abc".into())), 0.0);
+    assert_eq!(divide_by_10(&TagValue::Str("".into())), 0.0);
   }
 
   #[test]
   fn divide_by_1000_perl_coerces_overlong_str_to_leading_number() {
-    // Codex round-4 F1: FocusDistance overlong directory entry.
-    // Perl: `"1000 2000" / 1000 == 1`.
-    let v = divide_by_1000(&TagValue::Str("1000 2000".into()));
-    assert_eq!(v, TagValue::F64(1.0));
-    // Negative leading number (FocusDistance is int32s; the Str shape
-    // can carry a negative leading element).
-    let v2 = divide_by_1000(&TagValue::Str("-500 0 0".into()));
-    assert_eq!(v2, TagValue::F64(-0.5));
-    // `Str` "0 0" ⇒ 0.0 (the leading 0).
-    let v3 = divide_by_1000(&TagValue::Str("0 0".into()));
-    assert_eq!(v3, TagValue::F64(0.0));
+    assert_eq!(divide_by_1000(&TagValue::Str("1000 2000".into())), 1.0);
+    assert_eq!(divide_by_1000(&TagValue::Str("-500 0 0".into())), -0.5);
+    assert_eq!(divide_by_1000(&TagValue::Str("0 0".into())), 0.0);
   }
 
   #[test]
-  fn round_to_3dp_print_conv_coerces_overlong_str() {
-    // Codex round-4 F1: OriginalFrameRate (Red.pm:131-135, format 2 =
-    // float, elem = 4) overlong directory entry ⇒ space-joined Str.
-    // Perl PrintConv: `int("23.976 30" * 1000 + 0.5) / 1000`
-    //     = int(23.976 * 1000 + 0.5) / 1000 = int(23976.5) / 1000
-    //     = 23976 / 1000 = 23.976.
-    let v = round_to_3dp_print_conv(&TagValue::Str("23.976 30".into()));
-    assert_eq!(v, TagValue::F64(23.976));
-    // Non-numeric Str ⇒ 0.0 (Perl `int("abc"*1000+0.5)/1000 == 0`).
-    let v2 = round_to_3dp_print_conv(&TagValue::Str("abc".into()));
-    assert_eq!(v2, TagValue::F64(0.0));
+  fn round_to_3dp_coerces_overlong_str() {
+    assert_eq!(round_to_3dp(&TagValue::Str("23.976 30".into())), 23.976);
+    assert_eq!(round_to_3dp(&TagValue::Str("abc".into())), 0.0);
   }
 
   #[test]
-  fn round_to_3dp_print_conv_zero_denom_rational_emits_perl_coercion() {
-    // Codex round-4 F2: RED1 FrameRate (Red.pm:166-170, rational32u at
-    // offset 0x3e) with `denominator == 0`.
-    //   `Rational::rational32(0, 0).exiftool_val_str()` ⇒ "undef"
-    //   Perl PrintConv: `int("undef" * 1000 + 0.5) / 1000 == 0`.
-    // Bundled-Perl oracle:
-    //   perl -e '$v="undef"; print int($v*1000+0.5)/1000'  → "0"
-    let v0 = round_to_3dp_print_conv(&TagValue::Rational(Rational::rational32(0, 0)));
-    assert_eq!(v0, TagValue::F64(0.0));
-    //   `Rational::rational32(N, 0)` for `N != 0` ⇒ "inf"
-    //   Perl: `int("inf"*1000+0.5)/1000 == Inf`.
-    // The Inf-to-JSON-null gap is the documented Phase-2 forward
-    // item #1 (engine-level serializer concern) — this helper's job is
-    // to faithfully propagate Perl's arithmetic result.
-    let v1 = round_to_3dp_print_conv(&TagValue::Rational(Rational::rational32(24000, 0)));
-    let inf = match v1 {
-      TagValue::F64(n) => n,
-      _ => panic!("expected F64, got {v1:?}"),
-    };
-    assert!(inf.is_infinite() && inf.is_sign_positive(), "got {inf}");
-  }
-
-  #[test]
-  fn round_to_3dp_print_conv_preserves_large_finite_floats() {
-    // Codex round-5 F1: Perl `int($x)` operates in NV space (double),
-    // not IV space (i64). A crafted RED `OriginalFrameRate` from a
-    // `float32` payload near `f32::MAX ≈ 3.4e38` reaches this branch
-    // as `TagValue::F64`. Perl keeps the value at ~3.4e38; an `as
-    // i64` cast in Rust would silently saturate to ~9.22e15.
-    //
-    // Bundled-Perl oracle (run interactively in the loop):
-    //   perl -e 'for my $v (3.40282346638529e38, 1e20, 1.844e19, -3.4e38) {
-    //              my $r = int($v * 1000 + 0.5) / 1000;
-    //              printf "%.10g -> %.10g\n", $v, $r;
-    //            }'
-    //   3.402823466e+38 -> 3.402823466e+38
-    //   1e+20           -> 1e+20
-    //   1.844e+19       -> 1.844e+19
-    //   -3.4e+38        -> -3.4e+38
-    let big = 3.40282346638529e38_f64; // ~ f32::MAX
-    let v = round_to_3dp_print_conv(&TagValue::F64(big));
-    // The Perl chain `int($v*1000+0.5)/1000` is exact for any double
-    // whose magnitude is so large that `* 1000.0` no longer changes
-    // any fraction-bit precision; the result is the input value back.
-    // Oracle: `printf "%.20g", int(3.402823466e38*1000+0.5)/1000` ⇒
-    // `3.4028234663852901093e+38` (identical to input).
-    assert_eq!(v, TagValue::F64(big));
-    // 1.844e19 (just above 2^63), would saturate to i64::MAX as i64.
-    // Perl preserves it; we now do too.
-    let v3 = round_to_3dp_print_conv(&TagValue::F64(1.844e19));
-    assert_eq!(v3, TagValue::F64(1.844e19));
-    // Large negative (would saturate to i64::MIN as i64).
-    let v4 = round_to_3dp_print_conv(&TagValue::F64(-3.4e38));
-    assert_eq!(v4, TagValue::F64(-3.4e38));
-    // Boundary near 2^63 (just below saturation under the old impl).
-    let v5 = round_to_3dp_print_conv(&TagValue::F64(9.0e15));
-    assert_eq!(v5, TagValue::F64(9.0e15));
-    // Near-boundary case where the i64 cast would lose precision
-    // (1e20 is too large for an i64 — Perl returns
-    // `99999999999999983616` ≡ `1e20.next_down()`, a one-ULP loss from
-    // the `* 1000.0` round-trip that lands on the SAME f64 value in
-    // Rust). Verify the two routes agree (no Codex-R5 saturation).
-    let v_1e20 = round_to_3dp_print_conv(&TagValue::F64(1e20));
-    let n = match v_1e20 {
-      TagValue::F64(n) => n,
-      _ => panic!("expected F64, got {v_1e20:?}"),
-    };
-    // The Perl-matching answer is ≈ 9.999999999999998e19 (a one-ULP
-    // loss from `1e20 * 1000.0 / 1000.0`). The pre-fix `as i64` path
-    // would emit ~9.22e15 (≈5 orders of magnitude smaller).
-    assert!(
-      (n - 1e20).abs() / 1e20 < 1e-15,
-      "got {n}, expected ≈ 1e20 (Perl: 99999999999999983616)"
+  fn round_to_3dp_zero_denom_rational_emits_perl_coercion() {
+    // Rational(0, 0).exiftool_val_str ⇒ "undef" ⇒ 0.0
+    assert_eq!(
+      round_to_3dp(&TagValue::Rational(Rational::rational32(0, 0))),
+      0.0
     );
+    // Rational(N, 0).exiftool_val_str ⇒ "inf" ⇒ Inf
+    let inf = round_to_3dp(&TagValue::Rational(Rational::rational32(24000, 0)));
+    assert!(inf.is_infinite() && inf.is_sign_positive());
   }
 
   #[test]
-  fn round_to_3dp_print_conv_negative_near_zero_normalizes_to_positive_zero() {
-    // Codex round-6 F1: a crafted RED `OriginalFrameRate` float in
-    // `(-0.0005, 0.0)` lands on a `scaled = f*1000+0.5` value in
-    // `(-1.0, 0.0)`; `f64::trunc()` returns **negative zero** in
-    // IEEE-754. Perl `int()` does not preserve the sign of zero
-    // (`int(-0.001*1000+0.5) == 0`, positive NV bits — verified via
-    // `Devel::Peek::Dump`). The result must serialize as `"0"`, not
-    // `"-0"`. Our impl normalizes via `scaled.trunc() + 0.0` which
-    // collapses `-0.0` to `+0.0` per IEEE addition rules.
-    //
-    // Bundled-Perl oracle:
-    //   perl -e 'no warnings "numeric";
-    //            for my $v (-0.001, -0.0001, -0.0004999, -0.00050) {
-    //              my $r = int($v * 1000 + 0.5) / 1000;
-    //              use Devel::Peek; Dump($r); print "---\n"; }'
-    //   ⇒ every result is NV = 0 (positive zero), prints as "0".
-    let v = round_to_3dp_print_conv(&TagValue::F64(-0.001));
-    let n = match v {
-      TagValue::F64(n) => n,
-      _ => panic!("expected F64, got {v:?}"),
-    };
+  fn round_to_3dp_preserves_large_finite_floats() {
+    let big = 3.40282346638529e38_f64;
+    assert_eq!(round_to_3dp(&TagValue::F64(big)), big);
+    assert_eq!(round_to_3dp(&TagValue::F64(1.844e19)), 1.844e19);
+    assert_eq!(round_to_3dp(&TagValue::F64(-3.4e38)), -3.4e38);
+    assert_eq!(round_to_3dp(&TagValue::F64(9.0e15)), 9.0e15);
+    let n = round_to_3dp(&TagValue::F64(1e20));
+    assert!((n - 1e20).abs() / 1e20 < 1e-15);
+  }
+
+  #[test]
+  fn round_to_3dp_negative_near_zero_normalizes_to_positive_zero() {
+    let n = round_to_3dp(&TagValue::F64(-0.001));
     assert_eq!(n, 0.0);
-    assert!(
-      !n.is_sign_negative(),
-      "expected positive zero, got negative zero (would JSON-emit -0)"
-    );
-    // Same shape for other inputs that hit the negative-near-zero
-    // path. -0.0004 ⇒ scaled = 0.1 ⇒ trunc = 0.0 (positive — no
-    // normalization needed). -0.0001 ⇒ scaled = 0.4 ⇒ trunc = 0.0
-    // (positive). -0.0005 ⇒ scaled = 0.0 ⇒ trunc = 0.0 (positive).
-    // -0.0006 ⇒ scaled = -0.1 ⇒ trunc = -0.0 (NEEDS the normalization).
+    assert!(!n.is_sign_negative());
     for v in [-0.0006_f64, -0.0009, -0.001, -0.0005001] {
-      let r = round_to_3dp_print_conv(&TagValue::F64(v));
-      let n = match r {
-        TagValue::F64(n) => n,
-        _ => panic!("expected F64, got {r:?}"),
-      };
-      assert_eq!(n, 0.0, "value {v}");
-      assert!(
-        !n.is_sign_negative(),
-        "value {v} produced negative zero (would JSON-emit -0)"
-      );
+      let n = round_to_3dp(&TagValue::F64(v));
+      assert_eq!(n, 0.0);
+      assert!(!n.is_sign_negative());
     }
-    // Sanity: negative inputs outside the (-0.0005, ?) zero-trunc band
-    // still produce the correct negative result (no spurious sign-flip).
-    let neg = round_to_3dp_print_conv(&TagValue::F64(-1.5));
-    assert_eq!(neg, TagValue::F64(-1.499)); // `int(-1.5*1000+0.5)/1000 = int(-1499.5)/1000 = -1499/1000`
-    let neg2 = round_to_3dp_print_conv(&TagValue::F64(-0.5));
-    assert_eq!(neg2, TagValue::F64(-0.499)); // `int(-499.5)/1000 = -499/1000`
+    assert_eq!(round_to_3dp(&TagValue::F64(-1.5)), -1.499);
+    assert_eq!(round_to_3dp(&TagValue::F64(-0.5)), -0.499);
   }
 
   #[test]
-  fn round_to_3dp_print_conv_handles_overflow_to_infinity() {
-    // Defensive: a finite `f` near `f64::MAX` whose `* 1000 + 0.5`
-    // overflows to ±Inf. Perl: `int(Inf+0.5)/1000 = Inf`. Our impl
-    // must not produce a NaN-or-other-anomaly; the post-multiply Inf
-    // is propagated, landing on Phase-2 forward item #1.
-    let near_max = f64::MAX / 100.0; // |f * 1000| overflows finite double range.
-    let v = round_to_3dp_print_conv(&TagValue::F64(near_max));
-    let n = match v {
-      TagValue::F64(n) => n,
-      _ => panic!("expected F64, got {v:?}"),
+  fn round_to_3dp_handles_overflow_to_infinity() {
+    let near_max = f64::MAX / 100.0;
+    let n = round_to_3dp(&TagValue::F64(near_max));
+    assert!(n.is_infinite() || n == near_max);
+  }
+
+  // ---- Typed Meta surface tests ------------------------------------------
+
+  #[test]
+  fn r3d_meta_default_is_empty() {
+    let m = R3dMeta::default();
+    assert_eq!(m.redcode_version(), None);
+    assert_eq!(m.image_width(), None);
+    assert!(m.directory_tag_order().is_empty());
+    assert!(m.warnings().is_empty());
+  }
+
+  #[test]
+  fn parse_borrowed_returns_meta_for_real_fixture() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
+    let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
+    let meta = parse_borrowed(&bytes)
+      .expect("ok")
+      .expect("real Red.r3d parses");
+    assert_eq!(meta.redcode_version(), Some(b'2'));
+    assert_eq!(meta.image_width(), Some(5120));
+    assert_eq!(meta.image_height(), Some(2560));
+    match meta.frame_rate() {
+      Some(FrameRate::F64(n)) => {
+        assert!((n - 24000.0 / 1001.0).abs() < 1e-12);
+      }
+      other => panic!("expected RED2 FrameRate::F64, got {other:?}"),
+    }
+    assert_eq!(meta.start_edge_code(), Some("01:49:54:11"));
+    assert_eq!(meta.serial_number(), Some("130-246-CE5"));
+    assert_eq!(meta.firmware_version(), Some("6.2.34"));
+    assert_eq!(meta.original_file_name(), Some("A106_C037_0118G5_002.R3D"));
+    assert_eq!(meta.f_number(), Some(4.9));
+    assert_eq!(meta.focus_distance(), Some(-0.001));
+    assert!(meta.warnings().is_empty());
+  }
+
+  #[test]
+  fn format_parser_trait_returns_meta_static() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
+    let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
+    let meta = <ProcessR3D as FormatParser>::parse(&ProcessR3D, &bytes)
+      .expect("ok")
+      .expect("real Red.r3d parses");
+    assert_eq!(meta.image_width(), Some(5120));
+    assert_eq!(meta.start_edge_code(), Some("01:49:54:11"));
+  }
+
+  #[test]
+  fn meta_sinker_emits_typed_tags_via_map_writer() {
+    use crate::sink::{MapTagWriter, MapValue};
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
+    let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
+    let meta = parse_borrowed(&bytes)
+      .expect("ok")
+      .expect("real Red.r3d parses");
+    // PrintConv ON.
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("Red", "RedcodeVersion").map(MapValue::as_str),
+      Some("2".to_string())
+    );
+    assert_eq!(
+      w.get("Red", "ImageWidth").map(MapValue::as_str),
+      Some("5120".to_string())
+    );
+    assert_eq!(
+      w.get("Red", "FrameRate").map(MapValue::as_str),
+      Some("23.976".to_string())
+    );
+    assert_eq!(
+      w.get("Red", "FocusDistance").map(MapValue::as_str),
+      Some("-0.001 m".to_string())
+    );
+    // PrintConv OFF (raw F64).
+    let mut w = MapTagWriter::new();
+    meta.sink(false, &mut w).unwrap();
+    let fr = w.get("Red", "FrameRate").unwrap();
+    let raw_f = match fr {
+      MapValue::F64(n) => *n,
+      other => panic!("expected F64 for FrameRate, got {other:?}"),
     };
-    // Either the value is preserved exactly (if `* 1000 + 0.5` stays
-    // finite due to floating-point absorbing the 0.5) or it became
-    // Inf (overflow). Both are consistent with the Perl chain; neither
-    // is the silent-saturation bug Codex R5 flagged.
-    assert!(n.is_infinite() || n == near_max, "got {n}");
+    assert!((raw_f - 24000.0 / 1001.0).abs() < 1e-6);
+    let fd = w.get("Red", "FocusDistance").unwrap();
+    let raw_fd = match fd {
+      MapValue::F64(n) => *n,
+      other => panic!("expected F64 for FocusDistance, got {other:?}"),
+    };
+    assert_eq!(raw_fd, -0.001);
   }
 }

--- a/src/parser_new.rs
+++ b/src/parser_new.rs
@@ -270,7 +270,18 @@ pub enum AnyParser {
   /// MOI (Phase E pilot — camcorder MOD info sidecar).
   #[cfg(feature = "moi")]
   Moi(crate::formats::moi::ProcessMoi),
-  // Phase F1 adds: Aac, Dv, Audible, Red.
+  /// AAC (Phase F1 — ADTS audio).
+  #[cfg(feature = "aac")]
+  Aac(crate::formats::aac::ProcessAac),
+  /// DV (Phase F1 — DV video stream).
+  #[cfg(feature = "dv")]
+  Dv(crate::formats::dv::ProcessDv),
+  /// Audible (AA) (Phase F1 — DRM'd audiobook).
+  #[cfg(feature = "audible")]
+  Aa(crate::formats::audible::ProcessAa),
+  /// Red R3D (Phase F1 — Redcode video).
+  #[cfg(feature = "red")]
+  R3D(crate::formats::red::ProcessR3D),
   // Phase F2 adds: Id3.
   // Phase F3 adds: Ape, Dsf, Aiff, Flac.
   // Phase F4 adds: Ogg, MpegAudio.
@@ -293,6 +304,21 @@ pub enum AnyMeta<'a> {
   /// MOI (Phase E pilot).
   #[cfg(feature = "moi")]
   Moi(crate::formats::moi::MoiMeta<'a>),
+  /// AAC (Phase F1).
+  #[cfg(feature = "aac")]
+  Aac(crate::formats::aac::AacMeta<'a>),
+  /// DV (Phase F1). Carries the [`crate::formats::dv::DvParseOutcome`]
+  /// because DV has TWO accept paths (unrecognized-profile warn vs.
+  /// full data); the closed-enum carry must distinguish them so the
+  /// sink can warn on the former without emitting DV:* tags.
+  #[cfg(feature = "dv")]
+  Dv(crate::formats::dv::DvParseOutcome<'a>),
+  /// Audible (AA) (Phase F1).
+  #[cfg(feature = "audible")]
+  Aa(crate::formats::audible::AaMeta<'a>),
+  /// Red R3D (Phase F1).
+  #[cfg(feature = "red")]
+  R3d(crate::formats::red::R3dMeta<'a>),
 }
 
 impl MetaSinker for AnyMeta<'_> {
@@ -306,6 +332,22 @@ impl MetaSinker for AnyMeta<'_> {
       }
       #[cfg(feature = "moi")]
       AnyMeta::Moi(m) => m.sink(print_conv, out),
+      #[cfg(feature = "aac")]
+      AnyMeta::Aac(m) => m.sink(print_conv, out),
+      #[cfg(feature = "dv")]
+      AnyMeta::Dv(o) => match o {
+        // DV.pm:188 — Warn + return 1 without DV:* tags. The bridge
+        // emits the warning at the legacy `OldFormatParser::process`
+        // entry; the sink path emits no tags for this variant.
+        crate::formats::dv::DvParseOutcome::UnrecognizedProfile => {
+          out.write_warning("Unrecognized DV profile")
+        }
+        crate::formats::dv::DvParseOutcome::Meta(m) => m.sink(print_conv, out),
+      },
+      #[cfg(feature = "audible")]
+      AnyMeta::Aa(m) => m.sink(print_conv, out),
+      #[cfg(feature = "red")]
+      AnyMeta::R3d(m) => m.sink(print_conv, out),
     }
   }
 }


### PR DESCRIPTION
PR #4 of 9 in stacked lib-first series. Builds on #20.

4 leaf formats migrated to typed Meta + MetaSinker. See commit message for details.

Verification:
- All AAC/DV/Audible/Red conformance fixtures byte-exact vs bundled `perl exiftool 13.58`.
- 4 gates green: `cargo build`, `cargo test --all-targets`, `cargo +stable fmt --all -- --check`, `RUSTFLAGS=-D warnings cargo build`.

Closes various agent-spawned conformance regressions. Tracker: `docs/tracking.md` (gitignored, local-only).