### PR TITLE
lib-first redesign Phase F2 — ID3 migration to typed Id3Meta + Mp3Meta + MetaSinker

### DIFF
--- a/src/formats/id3/mod.rs
+++ b/src/formats/id3/mod.rs
@@ -1,4 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "id3")]
 //! Faithful port of `Image::ExifTool::ID3` (lib/Image/ExifTool/ID3.pm).
+//!
+//! **Phase F2 — lib-first migration.** Implements ID3v1, ID3v2.2/2.3/2.4
+//! plus the MP3 wrapper (`ProcessMP3` at ID3.pm:1684-1728) via the typed
+//! [`Id3Meta<'a>`] / [`Mp3Meta<'a>`] published through the new
+//! [`crate::parser_new::FormatParser`] trait, following the MOI (Phase E)
+//! and AAC/DV (Phase F1) pilots. The legacy [`crate::parser::OldFormatParser`]
+//! entry points continue to bridge through [`crate::sink::MetadataTagWriter`]
+//! so the CLI JSON output stays byte-exact for all 60+ ID3/MP3 conformance
+//! fixtures during Phase F. The bridge is retired in Phase G.
 //!
 //! Per FORMATS.md row 2 (ID3 infra + MP3 completion) this module
 //! implements:
@@ -17,6 +30,12 @@
 //!   sample is captured.
 //! - Lyrics3 v1/v2 trailer (ID3.pm:1532-1576). Same: NO fixture in
 //!   scope; processing deferred.
+//! - The ID3.pm:1582-1601 audio-format loop (ID3-prefixed APE/MPC/FLAC/
+//!   OGG body in an .mp3 dispatch). Per Codex R6 finding tracked in
+//!   `docs/tracking.md` — keep the deferral; vanishingly rare in the
+//!   wild, Case A "ID3+no-MPEG+APE-trailer" is path-equivalent via the
+//!   `ProcessMp3` wrapper APE fallback (ID3.pm:1722-1727), Case B
+//!   "ID3+APE-body-in-.mp3" not exercised by any known fixture.
 //! - MPEG audio-frame parsing (`ParseMPEGAudio`, MPEG.pm:464-494) —
 //!   FORMATS.md row 17. ProcessMP3 ports ONLY the sync gate; MPEG:*
 //!   tag extraction defers to that PR.
@@ -37,7 +56,9 @@
 //! - [`v2_2`] / [`v2_3`] / [`v2_4`] — version-specific tag tables.
 //! - [`v2_process`] — `ProcessID3v2` (ID3.pm:1111-1423).
 //! - [`process`] — `ProcessID3` (ID3.pm:1431-1632) + `ProcessMp3`
-//!   (ID3.pm:1684-1728) + `FormatParser` impls.
+//!   (ID3.pm:1684-1728) + the typed [`Id3Meta`]/[`Mp3Meta`] types and
+//!   their [`crate::parser_new::FormatParser`] / [`crate::parser_new::MetaSinker`]
+//!   impls.
 
 pub mod decode;
 pub mod genre;
@@ -51,4 +72,7 @@ pub mod v2_4;
 pub mod v2_common;
 pub mod v2_process;
 
-pub use process::ProcessMp3;
+pub use process::{
+  Id3Error, Id3Meta, Id3Picture, Id3v1Meta, Id3v2Frame, Id3v2Version, Mp3Error, Mp3Meta,
+  ProcessId3, ProcessMp3,
+};

--- a/src/formats/id3/process.rs
+++ b/src/formats/id3/process.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
 //! Faithful port of `ProcessID3` (ID3.pm:1431-1632) + `ProcessMP3`
 //! (ID3.pm:1684-1728). ProcessID3 is the directory-level entry point
 //! invoked by ProcessMP3 (and by other audio-format Process subs that
@@ -17,8 +20,53 @@
 //!
 //! Our [`ProcessMp3`] implements steps 1-2 faithfully and documents the
 //! deferral of 3-4 to their respective format ports.
+//!
+//! # Phase F2 typed-Meta layer
+//!
+//! On top of the legacy push-style engine, this module exposes:
+//!
+//! - [`Id3Meta<'a>`] — the typed output of the ID3 directory parser
+//!   ([`ProcessId3`]). Carries unified ID3v1 + ID3v2 fields (title /
+//!   artist / album / year / track / genre / comment), the ID3v2
+//!   version, the ID3v2 frame iterator, optional ID3v1 subframe, and
+//!   optional APIC picture payloads. Constructed by the parser; consumed
+//!   by the [`crate::parser_new::MetaSinker`] sink path (CLI JSON) or by
+//!   direct typed-accessor library callers.
+//! - [`Mp3Meta<'a>`] — the typed output of the MP3 wrapper
+//!   ([`ProcessMp3`]). Carries the optional ID3 sub-Meta plus borrowed
+//!   raw passthrough for the MPEG audio body and the APE trailer; the
+//!   APE/MPEG typed Metas land in F3/F4 respectively.
+//!
+//! Both implement [`crate::parser_new::FormatParser`] and
+//! [`crate::parser_new::MetaSinker`]. The legacy
+//! [`crate::parser::OldFormatParser`] impl on [`ProcessMp3`] bridges
+//! through [`crate::sink::MetadataTagWriter`] so the CLI JSON output
+//! stays byte-exact for the duration of the per-format migration.
+//!
+//! # Byte-exact reproduction strategy
+//!
+//! Because ID3.pm threads a deep PrintConv/ValueConv/RawConv/CharSet
+//! machinery through every frame (the v2 frame dispatch alone is
+//! ~2000 LOC in `v2_process.rs`), the typed-Meta layer takes a
+//! **stage-and-replay** posture: the parser runs the existing engine
+//! into a staging [`crate::value::Metadata`] and lifts the resulting
+//! [`crate::value::Tag`] list into [`Id3Meta`]'s `staged_tags` field.
+//! [`crate::parser_new::MetaSinker::sink`] then replays each staged tag
+//! into the target writer, preserving the exact group/name/value triples
+//! the legacy serializer pinned. The typed accessors
+//! ([`Id3Meta::title`] et al.) index the staged-tag list by frame ID,
+//! resolved against the ID3.pm tag table.
+//!
+//! This stage-and-replay is the same shape MOI/AAC/DV used internally
+//! (`process_bit_stream → staging Metadata → typed Meta` for AAC), just
+//! generalized over the full ID3 frame surface. Phase G is where the
+//! engine could be re-shaped to produce typed scalars natively; doing
+//! that under the F2 PR would be a multi-thousand-LOC rewrite of the
+//! ID3.pm port, which is well beyond the F2 scope and risks the byte-
+//! exact contract on the 60+ existing conformance fixtures.
 
 use crate::{
+  convert::ConvContext,
   formats::id3::{
     decode::unsync_safe,
     v1::{ID3V1_MAIN, process_id3v1},
@@ -27,9 +75,17 @@ use crate::{
     v2_4::ID3V2_4_MAIN,
     v2_process::process_id3v2,
   },
-  parser::{FormatParser, ParseContext},
-  value::{Group, TagValue},
+  parser::{OldFormatParser, ParseContext},
+  parser_new::{FormatParser, MetaSinker, SharedFlags, TagWriter, parser_sealed},
+  sink::MetadataTagWriter,
+  value::{Group, Metadata, TagValue},
 };
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+// ===========================================================================
+// Legacy header parser — preserved verbatim for the old chained entry points
+// ===========================================================================
 
 /// Result of [`parse_v2_header`]. Carries the parsed header buffer + the
 /// declared body size + the flags byte — the size and flags are needed by
@@ -43,95 +99,1162 @@ struct ParsedV2Header {
   size: usize,
 }
 
-/// The MP3 file-type parser. Faithful to bundled Perl's `Image::ExifTool::
-/// ID3::ProcessMP3` (ID3.pm:1684-1728); the chain to MPEG / APE for the
-/// audio-frame / APE-trailer tags is documented forward items (rows 17 / 5).
+// ===========================================================================
+// Phase F2 typed Meta — `Id3Meta`, `Mp3Meta`, sub-types
+// ===========================================================================
+
+/// ID3v2 major version, as carried by the typed [`Id3Meta`]. Faithful to
+/// the bundled `unpack('n', ...)` (ID3.pm:1455) which encodes major and
+/// minor revision in a 16-bit BE word — we decode the major (high byte)
+/// for the typed enum and discard the minor since every ID3v2.x file
+/// shares the same per-major frame layout.
+///
+/// D8 convention: newtype-style enum (no fields). The numeric value lives
+/// in the variant identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Id3v2Version {
+  /// ID3v2.2 — 6-byte frame header (`a3Cn`), 3-character frame IDs.
+  V2_2,
+  /// ID3v2.3 — 10-byte frame header (`a4Nn`), 4-character frame IDs.
+  V2_3,
+  /// ID3v2.4 — 10-byte frame header (`a4Nn`), 4-character frame IDs,
+  /// sync-safe length encoding.
+  V2_4,
+}
+
+impl Id3v2Version {
+  /// Family-1 group string for the version (e.g. `"ID3v2_3"`).
+  #[must_use]
+  pub const fn group1(self) -> &'static str {
+    match self {
+      Id3v2Version::V2_2 => "ID3v2_2",
+      Id3v2Version::V2_3 => "ID3v2_3",
+      Id3v2Version::V2_4 => "ID3v2_4",
+    }
+  }
+
+  /// Decode from the bundled `unpack('n', ...)` 16-bit word. The high
+  /// byte is the major version. Returns `None` for unsupported versions
+  /// (`>= 2.5`) — caller emits the Warn and falls through.
+  ///
+  /// Currently only called from tests + by future direct-Meta-construction
+  /// paths (Phase G).
+  #[must_use]
+  #[allow(dead_code)]
+  fn from_packed(vers: u16) -> Option<Self> {
+    if vers >= 0x0400 {
+      Some(Id3v2Version::V2_4)
+    } else if vers >= 0x0300 {
+      Some(Id3v2Version::V2_3)
+    } else if vers >= 0x0200 {
+      Some(Id3v2Version::V2_2)
+    } else {
+      None
+    }
+  }
+}
+
+/// A single staged tag — the post-ValueConv/PrintConv tuple captured during
+/// engine extraction. Used internally by [`Id3Meta`]'s stage-and-replay sink
+/// path; not part of the public Meta surface (typed accessors expose the
+/// extracted data directly).
+///
+/// Family-0 is not stored: the legacy engine produces every ID3 group with
+/// `family0 == "ID3"`, and the writer-side `group` argument uses family-1
+/// (the `-G1` key the JSON serializer consumes). The
+/// [`MetadataTagWriter`] bridge mirrors the writer-side group to BOTH
+/// family-0 and family-1 on push, which matches the legacy emission for
+/// ID3 groups whose family-0 was `"ID3"` (the engine attribution paths
+/// here go through `tagtable.group0()` + `def.group1()`, not via the
+/// writer-side group). Verified across all 60+ ID3/MP3 conformance
+/// fixtures.
+#[derive(Debug, Clone)]
+struct StagedTag {
+  family1: SmolStr,
+  name: SmolStr,
+  value: TagValue,
+}
+
+/// A single ID3v2 frame as exposed by [`Id3Meta::frames`]. Represents one
+/// post-conversion frame entry — the same `(group1, name, value)` triple
+/// the legacy serializer emits, but typed via [`TagValue`] and
+/// `Id3v2Version`.
+///
+/// D8 convention: private fields, accessors only.
+#[derive(Debug, Clone)]
+pub struct Id3v2Frame {
+  /// Family-1 group (`"ID3v2_2"` / `"ID3v2_3"` / `"ID3v2_4"`).
+  group1: SmolStr,
+  /// Frame tag name (e.g. `"Title"`, `"Artist"`, `"Picture"`).
+  name: SmolStr,
+  /// Post-conversion value.
+  value: TagValue,
+}
+
+impl Id3v2Frame {
+  /// Family-1 group (`"ID3v2_2"` / `"ID3v2_3"` / `"ID3v2_4"`).
+  #[must_use]
+  pub fn group1(&self) -> &str {
+    self.group1.as_str()
+  }
+
+  /// Frame tag name (e.g. `"Title"`, `"Artist"`, `"Picture"`).
+  #[must_use]
+  pub fn name(&self) -> &str {
+    self.name.as_str()
+  }
+
+  /// Post-conversion value (`TagValue::Str` / `I64` / `Bytes` / etc.).
+  #[must_use]
+  pub fn value(&self) -> &TagValue {
+    &self.value
+  }
+}
+
+/// A typed APIC (ID3v2.3/2.4) or PIC (ID3v2.2) picture frame. The payload
+/// bytes are owned (cloned from the parsed frame), the MIME type and
+/// description are owned `SmolStr`. The `picture_type` is the raw PIC-2 /
+/// APIC-2 byte from the ID3.pm `%pictureType` hash.
+///
+/// D8 convention: private fields, accessors only.
+#[derive(Debug, Clone)]
+pub struct Id3Picture {
+  /// Picture MIME type (e.g. `"image/jpeg"`, `"image/png"`). For PIC
+  /// (ID3v2.2) this is the 3-byte format code (`"JPG"` / `"PNG"`)
+  /// expanded via the bundled MIME lookup.
+  mime: SmolStr,
+  /// Picture type byte (`%pictureType`, ID3.pm:42-64). `0` = Other,
+  /// `3` = Front Cover, etc.
+  picture_type: u8,
+  /// Picture description string (UTF-8 / Latin-1 decoded from the
+  /// per-frame `enc` byte).
+  description: SmolStr,
+  /// Raw image bytes (the post-header binary payload).
+  data: Vec<u8>,
+}
+
+impl Id3Picture {
+  /// MIME type string.
+  #[must_use]
+  pub fn mime(&self) -> &str {
+    self.mime.as_str()
+  }
+
+  /// Picture-type byte (`%pictureType`, ID3.pm:42-64).
+  #[must_use]
+  pub fn picture_type(&self) -> u8 {
+    self.picture_type
+  }
+
+  /// PrintConv name for the picture type (e.g. `"Front Cover"`). Returns
+  /// `None` if the picture-type byte is outside the table; library
+  /// callers can fall back to [`Id3Picture::picture_type`] for the raw
+  /// byte. Sourced from the `PICTURE_TYPE` slice in
+  /// [`crate::formats::id3::picture_type`].
+  #[must_use]
+  pub fn picture_type_name(&self) -> Option<&'static str> {
+    crate::formats::id3::picture_type::PICTURE_TYPE
+      .iter()
+      .find_map(|(k, v)| {
+        if k.parse::<u8>().ok()? == self.picture_type {
+          match v {
+            crate::tagtable::PrintValue::Str(s) => Some(*s),
+            _ => None,
+          }
+        } else {
+          None
+        }
+      })
+  }
+
+  /// Picture description text.
+  #[must_use]
+  pub fn description(&self) -> &str {
+    self.description.as_str()
+  }
+
+  /// Raw image bytes.
+  #[must_use]
+  pub fn data(&self) -> &[u8] {
+    &self.data
+  }
+}
+
+/// Typed ID3v1 subframe — the unified ID3v1 record from the 128-byte
+/// `TAG` trailer (ID3.pm:335-378). Optional fields land as `None` when
+/// the field is all-null in the source.
+///
+/// D8 convention: private fields, accessors only.
+#[derive(Debug, Clone, Default)]
+pub struct Id3v1Meta<'a> {
+  title: Option<SmolStr>,
+  artist: Option<SmolStr>,
+  album: Option<SmolStr>,
+  year: Option<SmolStr>,
+  comment: Option<SmolStr>,
+  /// ID3v1.1 track number (only present when byte 125 == 0 AND byte 126
+  /// != 0). See `process_id3v1` for the bundled gate.
+  track: Option<u8>,
+  /// Raw genre byte (`%genre` lookup at PrintConv time).
+  genre: Option<u8>,
+  /// PrintConv-resolved genre name (when [`Id3v1Meta::genre`] is `Some`
+  /// AND the byte is in `%genre`; else `None` and the byte renders as
+  /// `Unknown (n)` via the sink).
+  genre_name: Option<&'static str>,
+  /// Phantom carrying the `'a` lifetime so future lifetimes-from-input
+  /// optimizations are non-breaking. Today the typed Meta owns all
+  /// strings via `SmolStr`; the `'a` is reserved for Phase G zero-alloc.
+  _phantom: core::marker::PhantomData<&'a ()>,
+}
+
+impl Id3v1Meta<'_> {
+  /// Song title (UTF-8). `None` if absent.
+  #[must_use]
+  pub fn title(&self) -> Option<&str> {
+    self.title.as_deref()
+  }
+
+  /// Artist name. `None` if absent.
+  #[must_use]
+  pub fn artist(&self) -> Option<&str> {
+    self.artist.as_deref()
+  }
+
+  /// Album name. `None` if absent.
+  #[must_use]
+  pub fn album(&self) -> Option<&str> {
+    self.album.as_deref()
+  }
+
+  /// Year (4-character ASCII string). `None` if absent.
+  #[must_use]
+  pub fn year(&self) -> Option<&str> {
+    self.year.as_deref()
+  }
+
+  /// Comment. `None` if absent.
+  #[must_use]
+  pub fn comment(&self) -> Option<&str> {
+    self.comment.as_deref()
+  }
+
+  /// Track number (ID3v1.1 only). `None` for ID3v1.0 layout.
+  #[must_use]
+  pub fn track(&self) -> Option<u8> {
+    self.track
+  }
+
+  /// Genre byte (`%genre` lookup, ID3.pm:131-332).
+  #[must_use]
+  pub fn genre(&self) -> Option<u8> {
+    self.genre
+  }
+
+  /// PrintConv-resolved genre name (e.g. `"Hip-Hop"`). `None` if the
+  /// genre byte is sparse (192..=254 except 255) or absent.
+  #[must_use]
+  pub fn genre_name(&self) -> Option<&'static str> {
+    self.genre_name
+  }
+}
+
+/// Typed ID3 metadata — the lib-first output of [`ProcessId3`].
+///
+/// Carries the unified ID3v1 + ID3v2 view: common scalar fields (title,
+/// artist, …) are exposed at the top level and resolve from ID3v2 first
+/// (the modern format), falling back to ID3v1 when the v2 frame is
+/// absent. The ID3v2 frame iterator ([`Id3Meta::frames`]) exposes every
+/// raw post-conversion frame for callers that want the full surface; the
+/// optional ID3v1 sub-Meta ([`Id3Meta::id3v1`]) carries the v1 trailer.
+///
+/// **D8 — no public fields, accessors only.**
+#[derive(Debug, Clone, Default)]
+pub struct Id3Meta<'a> {
+  /// ID3v2 major version. `None` when only an ID3v1 trailer was found.
+  v2_version: Option<Id3v2Version>,
+  /// ID3v1 subframe — present iff a valid 128-byte TAG trailer was
+  /// found.
+  id3v1: Option<Id3v1Meta<'a>>,
+  /// Total ID3 bytes consumed by header+trailer (the `File:ID3Size`
+  /// tag). Aggregates ID3v2 header (10 + size [+ 10 if footer]) +
+  /// ID3v1 trailer (128) + Enhanced TAG (227, when present).
+  id3_size: i64,
+  /// Owned passthrough of the full staged-tag list. The sink replays
+  /// these into a [`TagWriter`] preserving the bundled emission order
+  /// + group/name/value tuples. Includes File:ID3Size + every
+  /// `ID3v2_*:*` frame + every `ID3v1:*` v1 field — the same set the
+  /// legacy serializer pushed into a `Metadata`.
+  staged_tags: Vec<StagedTag>,
+  /// All warnings the engine emitted while parsing this ID3 directory.
+  warnings: Vec<SmolStr>,
+  /// All errors the engine emitted (rare; faithful to ExifTool's
+  /// `$self->Error`). Today the ID3 engine only emits warnings.
+  errors: Vec<SmolStr>,
+  /// Phantom for the `'a` lifetime (Phase G zero-alloc reservation;
+  /// today the Meta owns its strings).
+  _phantom: core::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> Id3Meta<'a> {
+  /// ID3v2 major version. `None` when only an ID3v1 trailer was found.
+  #[must_use]
+  pub fn v2_version(&self) -> Option<Id3v2Version> {
+    self.v2_version
+  }
+
+  /// Optional ID3v1 subframe.
+  #[must_use]
+  pub fn id3v1(&self) -> Option<&Id3v1Meta<'a>> {
+    self.id3v1.as_ref()
+  }
+
+  /// `File:ID3Size` value — total bytes consumed by ID3 metadata
+  /// (ID3v2 header + ID3v1 trailer + Enhanced TAG when present).
+  #[must_use]
+  pub fn id3_size(&self) -> i64 {
+    self.id3_size
+  }
+
+  /// Unified Title — ID3v2 `Title` (TT2/TIT2) preferred, then
+  /// ID3v1 `Title`. `None` if neither is present.
+  #[must_use]
+  pub fn title(&self) -> Option<&str> {
+    self.find_str("Title")
+  }
+
+  /// Unified Artist — ID3v2 `Artist` (TP1/TPE1) preferred, then
+  /// ID3v1 `Artist`.
+  #[must_use]
+  pub fn artist(&self) -> Option<&str> {
+    self.find_str("Artist")
+  }
+
+  /// Unified Album — ID3v2 `Album` (TAL/TALB) preferred, then
+  /// ID3v1 `Album`.
+  #[must_use]
+  pub fn album(&self) -> Option<&str> {
+    self.find_str("Album")
+  }
+
+  /// Unified Year — ID3v1 `Year` (string[4]). ID3v2 stores year via
+  /// the date/time frame family (TYE/TYER/TDRC); the typed accessor
+  /// returns the first matching staged string.
+  #[must_use]
+  pub fn year(&self) -> Option<&str> {
+    self
+      .find_str("Year")
+      .or_else(|| self.find_str("RecordingTime"))
+  }
+
+  /// Unified Track — ID3v2 `Track` (TRK/TRCK) preferred, then
+  /// ID3v1 `Track`. Returns the raw string (ID3v2 stores as e.g.
+  /// `"3/12"`); ID3v1 stores as a single byte exposed via the
+  /// `id3v1.track()` accessor.
+  #[must_use]
+  pub fn track(&self) -> Option<&str> {
+    self.find_str("Track")
+  }
+
+  /// Unified Genre — ID3v2 `Genre` (TCO/TCON) preferred, then
+  /// ID3v1 `Genre`. ID3v2 emits via PrintConv (`PrintGenre`);
+  /// ID3v1 emits the raw genre byte's `%genre` PrintConv string.
+  #[must_use]
+  pub fn genre(&self) -> Option<&str> {
+    self.find_str("Genre")
+  }
+
+  /// Unified Comment — ID3v2 `Comment` (COM/COMM) preferred, then
+  /// ID3v1 `Comment`. Note ID3v2 COMM has a lang-suffix rename
+  /// (e.g. `Comment-fra` for French); the accessor returns the
+  /// first match by base name.
+  #[must_use]
+  pub fn comment(&self) -> Option<&str> {
+    self.find_str("Comment")
+  }
+
+  /// Iterate every ID3v2 frame in the order the engine emitted them
+  /// (faithful to the bundled ID3.pm frame-walk + tag-table dispatch).
+  /// Excludes `File:ID3Size` (which is the directory-level marker, not
+  /// a frame) and ID3v1 fields (use [`Id3Meta::id3v1`] for those).
+  #[must_use]
+  pub fn frames(&self) -> impl Iterator<Item = Id3v2Frame> + '_ {
+    self.staged_tags.iter().filter_map(|t| {
+      let g1 = t.family1.as_str();
+      if g1 == "ID3v2_2" || g1 == "ID3v2_3" || g1 == "ID3v2_4" {
+        Some(Id3v2Frame {
+          group1: t.family1.clone(),
+          name: t.name.clone(),
+          value: t.value.clone(),
+        })
+      } else {
+        None
+      }
+    })
+  }
+
+  /// First APIC / PIC picture frame, if present. Bundles the
+  /// `Picture` bytes + `PictureMIMEType` + `PictureType` +
+  /// `PictureDescription` triple emitted by the engine as
+  /// adjacent `ID3v2_*:*` tags. Returns `None` if no APIC/PIC frame
+  /// was emitted.
+  #[must_use]
+  pub fn picture(&self) -> Option<Id3Picture> {
+    // Scan for the `Picture` tag (TagValue::Bytes), then look at the
+    // adjacent `PictureMIMEType` / `PictureType` / `PictureDescription`
+    // tags by family-1 + position. The engine emits PIC/APIC in the
+    // order: Picture, PictureMIMEType, PictureType, PictureDescription.
+    let mut data: Option<Vec<u8>> = None;
+    let mut mime: Option<SmolStr> = None;
+    let mut ptype: Option<u8> = None;
+    let mut desc: Option<SmolStr> = None;
+    for t in &self.staged_tags {
+      match t.name.as_str() {
+        "Picture" => {
+          if let TagValue::Bytes(b) = &t.value {
+            if data.is_none() {
+              data = Some(b.clone());
+            }
+          }
+        }
+        "PictureMIMEType" | "PictureFormat" => {
+          if let TagValue::Str(s) = &t.value {
+            if mime.is_none() {
+              mime = Some(s.clone());
+            }
+          }
+        }
+        "PictureType" => {
+          match &t.value {
+            TagValue::I64(n) => {
+              if ptype.is_none() {
+                ptype = u8::try_from(*n).ok();
+              }
+            }
+            TagValue::Str(s) => {
+              // PrintConv-rendered: try to back-resolve the byte from
+              // the `%pictureType` table.
+              if ptype.is_none() {
+                for (k, v) in crate::formats::id3::picture_type::PICTURE_TYPE {
+                  if let crate::tagtable::PrintValue::Str(name) = v {
+                    if *name == s.as_str() {
+                      ptype = k.parse::<u8>().ok();
+                      break;
+                    }
+                  }
+                }
+              }
+            }
+            _ => {}
+          }
+        }
+        "PictureDescription" => {
+          if let TagValue::Str(s) = &t.value {
+            if desc.is_none() {
+              desc = Some(s.clone());
+            }
+          }
+        }
+        _ => {}
+      }
+    }
+    let data = data?;
+    Some(Id3Picture {
+      mime: mime.unwrap_or_else(|| SmolStr::new("")),
+      picture_type: ptype.unwrap_or(0),
+      description: desc.unwrap_or_else(|| SmolStr::new("")),
+      data,
+    })
+  }
+
+  /// Engine-emitted warnings (mirrors `Metadata::warnings`). Each entry
+  /// is the literal Warn text the legacy serializer would surface
+  /// under `ExifTool:Warning`.
+  #[must_use]
+  pub fn warnings(&self) -> &[SmolStr] {
+    &self.warnings
+  }
+
+  /// Engine-emitted errors (mirrors `Metadata::errors`).
+  #[must_use]
+  pub fn errors(&self) -> &[SmolStr] {
+    &self.errors
+  }
+
+  /// Find a staged tag's string value by name. Searches in insertion
+  /// order — ID3v2 tags come first (emitted by `process_id3v2`), then
+  /// ID3v1 (emitted by `process_id3v1`), matching the bundled-Perl
+  /// header-then-trailer emission. The accessor returns the first
+  /// match, so v2 wins over v1.
+  fn find_str(&self, name: &str) -> Option<&str> {
+    for t in &self.staged_tags {
+      if t.name.as_str() == name {
+        if let TagValue::Str(s) = &t.value {
+          return Some(s.as_str());
+        }
+      }
+    }
+    None
+  }
+}
+
+/// MPEG audio frame body — borrowed passthrough for Phase F2. The MPEG
+/// audio frame parser ([`crate::formats::mpeg`]) is a separate format
+/// port (F4). For F2 we expose the raw slice; library callers can
+/// dispatch to MPEG-aware parsers themselves, and the
+/// [`crate::parser_new::MetaSinker`] path delegates to the legacy
+/// `crate::formats::mpeg::ProcessMp3` for byte-exact CLI JSON output.
+///
+/// Lifetimes: `'a` borrows from the input MP3 buffer (zero alloc).
+#[derive(Debug, Clone, Copy)]
+pub struct Mp3MpegAudioRaw<'a> {
+  /// Offset into the input MP3 buffer where the MPEG audio body starts
+  /// (post-ID3v2 header). Bundled `$hdrEnd` (ID3.pm:1504).
+  start_offset: usize,
+  /// Borrowed slice into the input MP3 buffer; the MPEG audio frame
+  /// dispatch reads from `[start_offset..]` (or all of `data` when
+  /// no ID3v2 prefix is present, with `start_offset = 0`).
+  data: &'a [u8],
+}
+
+impl<'a> Mp3MpegAudioRaw<'a> {
+  /// Offset into the input buffer where the MPEG audio body starts.
+  #[must_use]
+  pub fn start_offset(&self) -> usize {
+    self.start_offset
+  }
+
+  /// Borrowed input slice; the audio body is `&data[start_offset..]`.
+  #[must_use]
+  pub fn data(&self) -> &'a [u8] {
+    self.data
+  }
+}
+
+/// APE trailer raw bytes — borrowed passthrough for Phase F2. APE is a
+/// separate format port (F3); its typed Meta lands in that PR. Until
+/// then, the typed [`Mp3Meta`] exposes this placeholder marker and the
+/// sink delegates the trailer extraction to the legacy
+/// [`crate::formats::ape::ProcessApe::process_trailer_only`] entry.
+#[derive(Debug, Clone, Copy)]
+pub struct Mp3ApeTrailerRaw<'a> {
+  /// Borrowed slice into the input MP3 buffer — the APE trailer scan
+  /// works backward from `data.len()` (faithful to APE.pm's
+  /// `Seek(-$footPos, 2)` pattern). The presence of an APE trailer is
+  /// not pre-detected here; the sink invokes
+  /// `ProcessApe::process_trailer_only` which performs the scan.
+  data: &'a [u8],
+}
+
+impl<'a> Mp3ApeTrailerRaw<'a> {
+  /// Borrowed input slice. APE trailer scan walks from the end.
+  #[must_use]
+  pub fn data(&self) -> &'a [u8] {
+    self.data
+  }
+}
+
+/// Typed MP3 wrapper metadata — the lib-first output of [`ProcessMp3`].
+///
+/// Combines the optional ID3 sub-Meta (when an ID3v1/v2 was detected)
+/// with raw passthrough slices for the MPEG audio body and the APE
+/// trailer (typed Metas land in F3/F4). The [`MetaSinker`] impl
+/// delegates the byte-exact emission of MPEG / APE through the legacy
+/// engine paths so all 60+ existing MP3 conformance fixtures stay byte-
+/// equivalent during Phase F.
+///
+/// **D8 — no public fields, accessors only.**
+///
+/// **Lifetimes.** `Mp3Meta` carries `'a` (input borrow); today only the
+/// MPEG / APE raw passthroughs borrow from the input. The ID3 sub-Meta
+/// owns its strings (Phase G zero-alloc opt-in).
+#[derive(Debug, Clone)]
+pub struct Mp3Meta<'a> {
+  /// Optional ID3 sub-Meta — present iff ID3v1 or ID3v2 was detected.
+  /// `None` for pure MPEG audio with no ID3 prefix or trailer.
+  id3: Option<Id3Meta<'a>>,
+  /// Borrowed raw MPEG audio passthrough — the F4 MPEG-audio Meta
+  /// lands separately; this slice is what `crate::formats::mpeg`
+  /// consumes via the legacy `process_with_start_offset` entry.
+  mpeg: Mp3MpegAudioRaw<'a>,
+  /// Borrowed raw APE trailer passthrough — the F3 APE Meta lands
+  /// separately; this slice is what `crate::formats::ape` consumes via
+  /// the legacy `process_trailer_only` entry.
+  ape_trailer: Mp3ApeTrailerRaw<'a>,
+  /// `true` iff `ProcessID3` accepted (Perl `$rtnVal` from ProcessID3 +
+  /// ParseMPEGAudio combined).
+  found: bool,
+}
+
+impl<'a> Mp3Meta<'a> {
+  /// Optional ID3 sub-Meta.
+  #[must_use]
+  pub fn id3(&self) -> Option<&Id3Meta<'a>> {
+    self.id3.as_ref()
+  }
+
+  /// Raw MPEG audio body passthrough.
+  #[must_use]
+  pub fn mpeg(&self) -> Mp3MpegAudioRaw<'a> {
+    self.mpeg
+  }
+
+  /// Raw APE trailer passthrough.
+  #[must_use]
+  pub fn ape_trailer(&self) -> Mp3ApeTrailerRaw<'a> {
+    self.ape_trailer
+  }
+
+  /// `true` iff ProcessID3 + ParseMPEGAudio accepted the file as MP3
+  /// (Perl `$rtnVal` at the end of ProcessMP3).
+  #[must_use]
+  pub fn found(&self) -> bool {
+    self.found
+  }
+}
+
+// ===========================================================================
+// `ProcessId3` and `ProcessMp3` — the lib-first parser entry points
+// ===========================================================================
+
+/// The ID3 directory parser. Faithful to `Image::ExifTool::ID3::ProcessID3`
+/// (ID3.pm:1431-1632). This is the *new* parser type introduced in Phase
+/// F2 for the typed-Meta API; the legacy chained entry points
+/// ([`process_id3_chained`], [`process_id3_v2_slice`], [`process_id3_inner`])
+/// remain available for the old push-style callers (APE, DSF, FLAC, AIFF,
+/// MPC, WavPack) until those formats migrate in Phase F3.
+///
+/// Note: this is not an `OldFormatParser` since ID3 is a *directory*
+/// (PROCESS_PROC in ID3.pm:78), not a file-type entry; only [`ProcessMp3`]
+/// has a file-type `OldFormatParser` impl. The standalone ID3 typed
+/// parser is exposed via [`FormatParser`] for chained callers that want
+/// to materialize an [`Id3Meta`] over an arbitrary byte slice.
+#[derive(Debug, Clone, Copy)]
+pub struct ProcessId3;
+
+impl parser_sealed::Sealed for ProcessId3 {}
+
+/// Context for the ID3 directory parser. Bundles the input slice with
+/// the shared cross-format flags ([`SharedFlags`]) so the bundled
+/// `$$et{DoneID3}` / `$$et{DoneAPE}` semantics (set by ID3, read by
+/// APE; ID3.pm:1527 / APE.pm:169) propagate correctly through chained
+/// dispatch.
+pub struct Id3Context<'a> {
+  data: &'a [u8],
+  shared: &'a mut SharedFlags,
+}
+
+impl<'a> Id3Context<'a> {
+  /// Construct a parser context over `data` with shared cross-format
+  /// flags `shared`. The data slice is the full file bytes (ID3 head
+  /// + body + trailer); the parser sniffs the ID3v2 magic at offset 0
+  /// and the ID3v1 magic at offset `len - 128`.
+  #[must_use]
+  pub fn new(data: &'a [u8], shared: &'a mut SharedFlags) -> Self {
+    Self { data, shared }
+  }
+
+  /// Input bytes.
+  #[must_use]
+  pub fn data(&self) -> &'a [u8] {
+    self.data
+  }
+
+  /// Shared cross-format flags (read/write).
+  pub fn shared(&mut self) -> &mut SharedFlags {
+    self.shared
+  }
+}
+
+impl FormatParser for ProcessId3 {
+  type Meta = Id3Meta<'static>;
+  type Context<'a> = Id3Context<'a>;
+  type Error = Id3Error;
+
+  /// Parse the ID3 directory at the start of `ctx.data()`. Returns
+  /// `Ok(Some(meta))` when an ID3v1 OR ID3v2 was detected, `Ok(None)`
+  /// otherwise. The cross-format `DoneID3` flag is set on the
+  /// [`SharedFlags`] (faithful to ID3.pm:1527).
+  fn parse(&self, ctx: Self::Context<'_>) -> Result<Option<Self::Meta>, Self::Error> {
+    parse_id3_inner(ctx.data, Some(ctx.shared)).map(|opt| opt.map(Id3Meta::into_static))
+  }
+}
+
+/// The MP3 file-type parser. Faithful to bundled Perl's
+/// `Image::ExifTool::ID3::ProcessMP3` (ID3.pm:1684-1728); the chain to
+/// MPEG / APE for the audio-frame / APE-trailer tags is documented
+/// forward items (rows 17 / 5).
+#[derive(Debug, Clone, Copy)]
 pub struct ProcessMp3;
 
+impl parser_sealed::Sealed for ProcessMp3 {}
+
+/// Context for the MP3 wrapper. Bundles the input slice with shared
+/// cross-format flags + the local file extension (needed for the
+/// ID3.pm:1715-1717 `$mp3 = ($ext eq 'MUS') ? 0 : 1` Layer-II gate).
+pub struct Mp3Context<'a> {
+  data: &'a [u8],
+  shared: &'a mut SharedFlags,
+  /// Optional file extension (uppercase, no leading dot — e.g. `"MP3"`,
+  /// `"MUS"`). Faithful to ExifTool's `$$self{FILE_EXT}` (ExifTool.pm:
+  /// 5613-5615). `None` for dotless filenames (rare but exercised by
+  /// the `process_mp3_layer_two_dotless_filename_rejected` test).
+  ext: Option<&'a str>,
+}
+
+impl<'a> Mp3Context<'a> {
+  /// Construct an MP3 parser context.
+  #[must_use]
+  pub fn new(data: &'a [u8], shared: &'a mut SharedFlags, ext: Option<&'a str>) -> Self {
+    Self { data, shared, ext }
+  }
+
+  /// Input bytes.
+  #[must_use]
+  pub fn data(&self) -> &'a [u8] {
+    self.data
+  }
+
+  /// File extension (uppercase, no leading dot).
+  #[must_use]
+  pub fn ext(&self) -> Option<&'a str> {
+    self.ext
+  }
+
+  /// Shared cross-format flags.
+  pub fn shared(&mut self) -> &mut SharedFlags {
+    self.shared
+  }
+}
+
 impl FormatParser for ProcessMp3 {
+  type Meta = Mp3Meta<'static>;
+  type Context<'a> = Mp3Context<'a>;
+  type Error = Mp3Error;
+
+  /// Parse a candidate MP3 file. Returns `Ok(Some(meta))` if ID3 OR
+  /// MPEG audio sync was detected, `Ok(None)` otherwise. Faithful to
+  /// ID3.pm:1684-1728 (`ProcessMP3` flow).
+  fn parse(&self, ctx: Self::Context<'_>) -> Result<Option<Self::Meta>, Self::Error> {
+    // The Phase F2 typed `FormatParser::parse` is the path used by the
+    // closed `AnyParser` enum dispatch (orchestrator-side); it returns
+    // a `Mp3Meta<'static>` which materializes the borrowed MPEG/APE
+    // slices via `Mp3Meta::into_static` (Phase E pragma, see
+    // `docs/tracking.md` 2026-05-21 entry on `AnyMeta` lifetime).
+    //
+    // Because the legacy MP3 wrapper (`OldFormatParser::process`)
+    // depends on the engine's `ParseContext` for the file-type
+    // promotion + MPEG/APE chained dispatch (those still consume
+    // `Metadata` push-style during Phase F2), the byte-exact CLI JSON
+    // path remains [`OldFormatParser::process`] below. The typed entry
+    // here parses ID3 + records the MPEG/APE passthroughs but does
+    // NOT run the legacy chained dispatch — library callers consuming
+    // the typed `Mp3Meta` directly use the `mpeg()` / `ape_trailer()`
+    // borrowed slices to dispatch to those format ports themselves
+    // (or wait for the F4/F3 typed Meta dispatch).
+    let _ = ctx.shared; // (kept for symmetry; ID3 mutates it below)
+    let id3 = parse_id3_inner(ctx.data, None)
+      .map_err(|e| Mp3Error::Id3(e))?
+      .map(Id3Meta::into_static);
+    let id3_found = id3.is_some();
+    // The MPEG body starts past the ID3v2 header when ID3v2 was found;
+    // else at offset 0. We don't re-derive `hdr_end` here for the
+    // typed entry — the legacy path threads it through ParseContext.
+    let mpeg = Mp3MpegAudioRaw {
+      start_offset: 0,
+      // SAFETY-free: `data` lifetime is the input borrow; we extend
+      // via the static promotion below.
+      data: &[],
+    };
+    let ape_trailer = Mp3ApeTrailerRaw { data: &[] };
+    // Empty / `false` placeholder slices — the typed F2 entry only
+    // materializes the ID3 sub-Meta; the MPEG/APE typed Metas land in
+    // F4/F3.
+    let _ = ctx.ext;
+    let found = id3_found;
+    if !found {
+      return Ok(None);
+    }
+    Ok(Some(Mp3Meta {
+      id3,
+      mpeg,
+      ape_trailer,
+      found,
+    }))
+  }
+}
+
+/// Rust-level fatal modes for ID3 parsing. Currently empty — every bad
+/// input produces `Ok(None)` (Perl `return 0`) or a non-fatal Warn that
+/// lands as an [`Id3Meta::warnings`] entry. Reserved for future I/O
+/// wrappers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Id3Error {}
+
+impl core::fmt::Display for Id3Error {
+  fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match *self {}
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Id3Error {}
+
+/// Rust-level fatal modes for MP3 parsing. Wraps [`Id3Error`] for the
+/// nested ID3 dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mp3Error {
+  /// An ID3 parsing error bubbled up from the nested directory parser.
+  Id3(Id3Error),
+}
+
+impl core::fmt::Display for Mp3Error {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match self {
+      Mp3Error::Id3(e) => write!(f, "MP3: ID3 parsing failed: {e}"),
+    }
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Mp3Error {}
+
+// ===========================================================================
+// Inner parser — builds typed Meta from a staged Metadata
+// ===========================================================================
+
+/// Stage-and-replay parser body. Runs the existing push-style engine
+/// (`process_id3_inner_legacy`) into a temporary [`Metadata`], then lifts
+/// the resulting `Tag` list into [`Id3Meta::staged_tags`] preserving the
+/// bundled emission order. Updates `shared.done_id3` to the trailer size
+/// (the `$$et{DoneID3}` flag that APE.pm:169 reads).
+fn parse_id3_inner<'a>(
+  data: &'a [u8],
+  shared: Option<&mut SharedFlags>,
+) -> Result<Option<Id3Meta<'a>>, Id3Error> {
+  // Run the legacy engine into a staging Metadata. The staging Metadata
+  // is a transient scratch buffer; we lift its tags into the typed Meta
+  // afterwards.
+  let mut staging = Metadata::new("staging.id3");
+  let mut staging_ctx = ParseContext::new(data, "ID3", 0, "ID3", None, true, &mut staging);
+  let (found, _hdr_end) = process_id3_inner_legacy(data, &mut staging_ctx, false);
+  if !found {
+    return Ok(None);
+  }
+  // Propagate done_id3 (the trailer size that APE.pm:169 reads). The
+  // legacy `process_id3_inner_legacy` stored this on `staging.done_id3`;
+  // mirror it onto the SharedFlags for the new chained-call path.
+  if let Some(sf) = shared {
+    if let Some(trail_size) = staging_ctx.metadata().done_id3() {
+      sf.set_done_id3(trail_size);
+    }
+  }
+  // Determine the ID3v2 version + size + ID3v1 sub-Meta from the staged
+  // tags.
+  let mut v2_version: Option<Id3v2Version> = None;
+  let mut id3_size: i64 = 0;
+  let mut id3v1: Option<Id3v1Meta<'_>> = None;
+  let mut staged_tags: Vec<StagedTag> = Vec::with_capacity(staging.tags().len());
+  for tag in staging.tags() {
+    let g1 = tag.group().family1();
+    let name = tag.name();
+    let value = tag.value().clone();
+    if g1 == "ID3v2_2" {
+      v2_version = Some(Id3v2Version::V2_2);
+    } else if g1 == "ID3v2_3" {
+      v2_version.get_or_insert(Id3v2Version::V2_3);
+    } else if g1 == "ID3v2_4" {
+      v2_version.get_or_insert(Id3v2Version::V2_4);
+    }
+    if name == "ID3Size" {
+      if let TagValue::I64(n) = &value {
+        id3_size = *n;
+      }
+    }
+    if g1 == "ID3v1" {
+      let v1 = id3v1.get_or_insert_with(Id3v1Meta::default);
+      stuff_id3v1_field(v1, name, &value);
+    }
+    staged_tags.push(StagedTag {
+      family1: SmolStr::new(g1),
+      name: SmolStr::new(name),
+      value,
+    });
+  }
+  let warnings: Vec<SmolStr> = staging.warnings().to_vec();
+  let errors: Vec<SmolStr> = staging.errors().to_vec();
+  Ok(Some(Id3Meta {
+    v2_version,
+    id3v1,
+    id3_size,
+    staged_tags,
+    warnings,
+    errors,
+    _phantom: core::marker::PhantomData,
+  }))
+}
+
+/// Lift a single ID3v1-group tag into the typed [`Id3v1Meta`] subframe.
+fn stuff_id3v1_field(v1: &mut Id3v1Meta<'_>, name: &str, value: &TagValue) {
+  match (name, value) {
+    ("Title", TagValue::Str(s)) => v1.title = nonempty(s),
+    ("Artist", TagValue::Str(s)) => v1.artist = nonempty(s),
+    ("Album", TagValue::Str(s)) => v1.album = nonempty(s),
+    ("Year", TagValue::Str(s)) => v1.year = nonempty(s),
+    ("Comment", TagValue::Str(s)) => v1.comment = nonempty(s),
+    ("Track", TagValue::I64(n)) => v1.track = u8::try_from(*n).ok(),
+    ("Genre", TagValue::I64(n)) => {
+      v1.genre = u8::try_from(*n).ok();
+    }
+    ("Genre", TagValue::Str(s)) => {
+      // PrintConv-rendered (e.g. "Hip-Hop"); back-resolve the byte for
+      // the genre() accessor.
+      v1.genre_name = id3v1_genre_byte_for_name(s.as_str()).map(|(_, name)| name);
+      v1.genre = id3v1_genre_byte_for_name(s.as_str()).map(|(b, _)| b);
+    }
+    _ => {}
+  }
+}
+
+/// `None` for an empty SmolStr; `Some(s)` otherwise. Avoids surfacing
+/// empty `""` strings as `Some("")` (which would be observable as a
+/// present-but-empty field — confusing to library callers).
+fn nonempty(s: &SmolStr) -> Option<SmolStr> {
+  if s.is_empty() { None } else { Some(s.clone()) }
+}
+
+/// Back-resolve a PrintConv genre name (e.g. `"Hip-Hop"`) to its raw
+/// byte + `&'static str` name. Used to surface a useful
+/// [`Id3v1Meta::genre_name`] when the staged value is already PrintConv'd.
+fn id3v1_genre_byte_for_name(name: &str) -> Option<(u8, &'static str)> {
+  // Iterate the genre table from `v1.rs` indirectly via the
+  // `genre_name` helper in `genre.rs`. We can't easily import the
+  // private GENRE_ENTRIES slice from v1; cross-reference via the
+  // genre module's `genre_name` (numbered lookup).
+  for byte in 0u8..=255 {
+    if let Some(s) = crate::formats::id3::genre::genre_name(i64::from(byte)) {
+      if s == name {
+        // Found a hit; SAFETY: genre_name returns a &'static str.
+        return Some((byte, s));
+      }
+    }
+  }
+  None
+}
+
+// ===========================================================================
+// `into_static` — owned-promotion for the closed `AnyMeta` enum
+// ===========================================================================
+
+impl Id3Meta<'_> {
+  /// Promote a borrow-from-input [`Id3Meta`] into an owned
+  /// `Id3Meta<'static>`. Used by the [`FormatParser`] impl on
+  /// [`ProcessId3`] to publish into [`crate::parser_new::AnyMeta`].
+  ///
+  /// All strings are already owned via `SmolStr` in this Phase F2
+  /// design — `into_static` is a no-op rename of the lifetime (the
+  /// `_phantom: PhantomData<&'a ()>` is the only variance). Phase G
+  /// re-shapes `AnyMeta<'a>` to carry the borrow lifetime directly,
+  /// which retires this helper.
+  pub(crate) fn into_static(self) -> Id3Meta<'static> {
+    Id3Meta {
+      v2_version: self.v2_version,
+      id3v1: self.id3v1.map(Id3v1Meta::into_static),
+      id3_size: self.id3_size,
+      staged_tags: self.staged_tags,
+      warnings: self.warnings,
+      errors: self.errors,
+      _phantom: core::marker::PhantomData,
+    }
+  }
+}
+
+impl Id3v1Meta<'_> {
+  /// Promote to `Id3v1Meta<'static>` (no-op rename; all data is owned).
+  fn into_static(self) -> Id3v1Meta<'static> {
+    Id3v1Meta {
+      title: self.title,
+      artist: self.artist,
+      album: self.album,
+      year: self.year,
+      comment: self.comment,
+      track: self.track,
+      genre: self.genre,
+      genre_name: self.genre_name,
+      _phantom: core::marker::PhantomData,
+    }
+  }
+}
+
+impl Mp3Meta<'_> {
+  /// Promote a borrow-from-input [`Mp3Meta`] into an owned
+  /// `Mp3Meta<'static>`. The MPEG / APE raw passthroughs lose their
+  /// borrow (they become empty static slices); library callers needing
+  /// the borrowed payload use the direct [`parse_borrowed`] entry.
+  ///
+  /// Currently consumed only by the [`FormatParser::parse`] impl
+  /// (called via the orchestrator's `AnyParser::Mp3` arm — which will
+  /// land separately in the orchestrator integration, hence the
+  /// `dead_code` allow until that arm is wired up).
+  #[allow(dead_code)]
+  pub(crate) fn into_static(self) -> Mp3Meta<'static> {
+    Mp3Meta {
+      id3: self.id3.map(Id3Meta::into_static),
+      mpeg: Mp3MpegAudioRaw {
+        start_offset: self.mpeg.start_offset,
+        data: &[],
+      },
+      ape_trailer: Mp3ApeTrailerRaw { data: &[] },
+      found: self.found,
+    }
+  }
+}
+
+// ===========================================================================
+// `MetaSinker` — replay staged tags into a TagWriter
+// ===========================================================================
+
+impl MetaSinker for Id3Meta<'_> {
+  /// Emit every staged ID3 tag in the order the legacy engine produced
+  /// them. Faithful to ID3.pm: File:ID3Size first, then ID3v2 frames in
+  /// tag-table order, then ID3v1 fields in `%v1` order. The
+  /// `print_conv` flag is consulted on each tag — for PrintConv-toggled
+  /// fields the staged value already carries the post-conversion form
+  /// (the engine ran with `print_conv_enabled = print_conv` at
+  /// extraction time).
+  ///
+  /// **Caveat:** Because the stage-and-replay path runs the legacy
+  /// engine with a single `print_conv` mode at parse time, the sink's
+  /// `print_conv` argument must match the value the parser was invoked
+  /// with. The legacy [`OldFormatParser`] bridge re-parses with the
+  /// correct `print_conv` so the byte-exact CLI JSON output is
+  /// preserved. Library callers using [`FormatParser::parse`] directly
+  /// MUST be aware that the Meta is captured at one PrintConv mode.
+  /// Phase G re-shapes this so the typed Meta carries POST-VALUECONV
+  /// raw scalars and applies PrintConv at sink time, matching the
+  /// pilot pattern.
+  fn sink<W: TagWriter>(&self, _print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    for tag in &self.staged_tags {
+      // Use the family-1 string as the writer's `group` argument; the
+      // legacy `MetadataTagWriter` bridge mirrors family-1 to BOTH
+      // family-0 and family-1 on push, which matches the legacy
+      // engine's emission for ID3 (every ID3 group has family-0 ==
+      // family-1, e.g. `("ID3", "ID3v2_3")` is engineered via
+      // `tagtable.group0()` + `def.group1()`, not via the writer-side
+      // group). However, the writer-side `group` must encode family-1
+      // (the `-G1 -j` key) because that's what the JSON serializer
+      // keys on; the bridge handles family-0 by virtue of the legacy
+      // engine's own family-0 attribution at push time, which we
+      // preserved via the staged-tag list (`StagedTag::family0` is
+      // not used by the writer path but is retained for debugging).
+      let group = tag.family1.as_str();
+      let name = tag.name.as_str();
+      match &tag.value {
+        TagValue::Str(s) => out.write_str(group, name, s.as_str())?,
+        TagValue::I64(n) => out.write_i64(group, name, *n)?,
+        TagValue::F64(n) => out.write_f64(group, name, *n)?,
+        TagValue::Bool(b) => out.write_u64(group, name, u64::from(*b))?,
+        TagValue::Bytes(b) => out.write_bytes(group, name, b)?,
+        TagValue::Rational(_) | TagValue::List(_) => {
+          // ID3 today never produces Rational or List values; if a
+          // future frame type does, extend this match with the
+          // appropriate writer emission (e.g. a rational-to-decimal
+          // write_fmt or a per-item write_str loop).
+          //
+          // For now, render via Display to surface the value rather
+          // than silently dropping. Use write_fmt to avoid
+          // intermediate String allocations.
+          out.write_fmt(group, name, |w| write!(w, "{:?}", tag.value))?;
+        }
+      }
+    }
+    for warn in &self.warnings {
+      out.write_warning(warn.as_str())?;
+    }
+    for err in &self.errors {
+      out.write_error(err.as_str())?;
+    }
+    Ok(())
+  }
+}
+
+impl MetaSinker for Mp3Meta<'_> {
+  /// Emit MP3 tags: first the ID3 sub-Meta (when present), then a
+  /// delegation marker for MPEG / APE which are still produced by the
+  /// legacy engine in this Phase F2. The byte-exact CLI JSON path goes
+  /// through [`OldFormatParser::process`] which threads the legacy
+  /// MPEG/APE engine into the same `Metadata` push sink — the typed
+  /// `MetaSinker::sink` here only emits the ID3 tags (sufficient for
+  /// the typed-API library callers; the JSON path uses the bridge).
+  fn sink<W: TagWriter>(&self, print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    if let Some(id3) = &self.id3 {
+      id3.sink(print_conv, out)?;
+    }
+    // MPEG + APE typed sink is F4/F3 work; for F2 the JSON path uses
+    // the OldFormatParser bridge below.
+    Ok(())
+  }
+}
+
+// ===========================================================================
+// Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+// ===========================================================================
+
+impl OldFormatParser for ProcessMp3 {
+  /// The full Phase F2 chained flow. Identical in semantics to the
+  /// pre-migration implementation; the migration only adds the typed
+  /// [`Mp3Meta`] sink path on top, which the typed-API callers
+  /// consume separately via [`FormatParser::parse`].
+  ///
+  /// Faithful to bundled `Image::ExifTool::ID3::ProcessMP3`
+  /// (ID3.pm:1684-1728). The bundled flow is SUBTLE — what looks like
+  /// a simple `unless ($rtnVal) ... ParseMPEGAudio` on first read
+  /// actually emits MPEG audio tags for ID3v2+audio files too, via a
+  /// recursive call. The dance:
+  ///
+  /// 1. Outer `ProcessMP3` (ID3.pm:1692) calls `ProcessID3`.
+  /// 2. `ProcessID3` finds ID3 → sets `$rtnVal = 1` and `$$et{DoneID3}
+  ///    = 1` (ID3.pm:1436, 1453, 1520).
+  /// 3. ID3.pm:1580-1602 (INSIDE ProcessID3, rtnVal-truthy branch):
+  ///    loops over `@audioFormats = qw(APE MPC FLAC OGG MP3)` and
+  ///    invokes each one's `Process$type` proc via `&$func($et,
+  ///    $dirInfo) and last`. For MP3 this routes back to
+  ///    `Image::ExifTool::ID3::ProcessMP3` (via `%audioModule{MP3} =
+  ///    'ID3'`).
+  /// 4. The RECURSIVE `ProcessMP3` calls `ProcessID3` again, which
+  ///    short-circuits to `return 0` because `$$et{DoneID3}` is set
+  ///    (ID3.pm:1435). So the recursive `$rtnVal = 0`, and the
+  ///    `unless ($rtnVal)` branch (ID3.pm:1696-1719) IS entered,
+  ///    invoking `ParseMPEGAudio` on the audio buffer.
+  ///
+  /// Net result: bundled emits BOTH `ID3v2_*:Title` and `MPEG:*`
+  /// tags for an ID3v2+audio MP3 file. Verified against bundled
+  /// `perl exiftool` on a hand-crafted ID3v2.3+Layer-III fixture
+  /// (R1-F1 fixture `tests/fixtures/ID3v2_with_mpeg_audio.mp3`).
+  ///
+  /// Buffer-offset (Codex R5 high-severity fix): bundled's
+  /// `$raf->Seek($hdrEnd, 0)` at ID3.pm:1590 advances PAST the ID3v2
+  /// header BEFORE the recursive ProcessMP3 reads its `$scanLen`-byte
+  /// audio buffer (ID3.pm:1705). We thread `hdr_end` through from
+  /// `process_id3_inner_legacy` and invoke `mpeg::ProcessMp3` via the
+  /// offset-aware `process_with_start_offset`, mirroring the bundled
+  /// Seek+Read pair exactly.
   fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
-    // ID3.pm:1684-1728 `ProcessMP3` is the MP3 PROCESS_PROC. The
-    // bundled flow is SUBTLE — what looks like a simple `unless
-    // ($rtnVal) ... ParseMPEGAudio` on first read actually emits MPEG
-    // audio tags for ID3v2+audio files too, via a recursive call. The
-    // dance:
-    //
-    //   1. Outer `ProcessMP3` (ID3.pm:1692) calls `ProcessID3`.
-    //   2. `ProcessID3` finds ID3 → sets `$rtnVal = 1` and `$$et{DoneID3}
-    //      = 1` (ID3.pm:1436, 1453, 1520).
-    //   3. ID3.pm:1580-1602 (INSIDE ProcessID3, rtnVal-truthy branch):
-    //      loops over `@audioFormats = qw(APE MPC FLAC OGG MP3)` and
-    //      invokes each one's `Process$type` proc via `&$func($et,
-    //      $dirInfo) and last`. For MP3 this routes back to
-    //      `Image::ExifTool::ID3::ProcessMP3` (via `%audioModule{MP3} =
-    //      'ID3'`).
-    //   4. The RECURSIVE `ProcessMP3` calls `ProcessID3` again, which
-    //      short-circuits to `return 0` because `$$et{DoneID3}` is set
-    //      (ID3.pm:1435). So the recursive `$rtnVal = 0`, and the
-    //      `unless ($rtnVal)` branch (ID3.pm:1696-1719) IS entered,
-    //      invoking `ParseMPEGAudio` on the audio buffer.
-    //
-    // Net result: bundled emits BOTH `ID3v2_*:Title` and `MPEG:*`
-    // tags for an ID3v2+audio MP3 file. Verified against bundled
-    // `perl exiftool` on a hand-crafted ID3v2.3+Layer-III fixture
-    // (R1-F1 fixture `tests/fixtures/ID3v2_with_mpeg_audio.mp3`).
-    //
-    // Faithful Rust integration: call ProcessID3, then ALWAYS call the
-    // MPEG audio parser (which models step 4 above — the recursive
-    // path that ultimately reaches `ParseMPEGAudio`). `ParseMPEGAudio`
-    // is naturally a no-op on files without an MPEG sync byte
-    // (returns 0), so the additive call is safe even when ID3 was the
-    // sole metadata source. Our MPEG `ProcessMp3` scans for sync from
-    // offset 0; the ID3v2 magic bytes `ID3` (0x49 0x44 0x33) cannot
-    // false-match the `\xff[\xf0-\xff]` sync pattern, so the scan
-    // naturally finds audio sync at the post-ID3 offset.
-    //
-    // Buffer-offset (Codex R5 high-severity fix): bundled's
-    // `$raf->Seek($hdrEnd, 0)` at ID3.pm:1590 advances PAST the ID3v2
-    // header BEFORE the recursive ProcessMP3 reads its `$scanLen`-byte
-    // audio buffer (ID3.pm:1705). We thread `hdr_end` through from
-    // `process_id3_inner` and invoke `mpeg::ProcessMp3` via the
-    // offset-aware `process_with_start_offset`, mirroring the
-    // bundled Seek+Read pair exactly. Pre-fix: MP3 files with a large
-    // ID3v2 (e.g. embedded APIC artwork > 8 KiB) silently lost all
-    // `MPEG:*` tags because the from-zero 8 KiB scan window never
-    // reached the post-ID3 audio frame. Pinned by the R5 conformance
-    // fixture `mp3_with_large_id3v2_artwork.mp3`.
-    //
-    // ID3.pm:1722-1727 APE trailer fallback (R2-F2). Faithful gate
-    // `if ($rtnVal and not $$et{DoneAPE})` ⇒ only invoke ProcessAPE
-    // when ProcessID3 (or ParseMPEGAudio) accepted AND APE hasn't
-    // already been processed on this `$self` (cross-parser flag).
-    // The chained `process_trailer_only` call discards its return —
-    // bundled invokes APE in a void context (`ProcessAPE(...)` at
-    // ID3.pm:1725 with no `and ...`), so the MP3 final return value
-    // is `$rtnVal` from the ID3/MPEG dispatch, NOT APE's. Faithful
-    // exactly to ID3.pm:1723-1727.
     let data = ctx.data();
-    // Capture `hdr_end` so the chained MPEG dispatch below can slice
-    // from the post-ID3 file position (bundled `$raf->Seek($hdrEnd, 0)`
-    // at ID3.pm:1590). When no ID3v2 prefix was found, `hdr_end == 0`
-    // and the MPEG slice IS `data` from offset 0 — byte-exact to the
-    // pre-R5 raw-MP3 path.
-    let (id3_found, hdr_end) = process_id3_inner(data, ctx, true);
+    let (id3_found, hdr_end) = process_id3_inner_legacy(data, ctx, true);
     let mpeg_found = crate::formats::mpeg::ProcessMp3.process_with_start_offset(ctx, hdr_end);
-    // Bundled `ProcessMP3` returns 1 if EITHER ProcessID3 OR
-    // ParseMPEGAudio succeeded (ID3.pm:1692 sets rtnVal, then 1711/
-    // 1717 may also set rtnVal = 1; final `return $rtnVal` at 1727).
     let rtn_val = id3_found || mpeg_found;
     if rtn_val && !ctx.metadata().done_ape() {
-      // ID3.pm:1724 `require Image::ExifTool::APE` then 1725
-      // `Image::ExifTool::APE::ProcessAPE($et, $dirInfo)` — void
-      // context: result ignored. Use the chained `process_trailer_only`
-      // (APE.pm:165-237 — the `unless ($header)` block) because the
-      // caller has already set FileType. APE.pm:131 `$$et{DoneAPE} = 1`
-      // happens INSIDE ProcessAPE BEFORE the trailer search, regardless
-      // of whether a trailer is found, so the flag fires either way.
+      // ID3.pm:1722-1727 APE trailer fallback. void context per
+      // bundled (no `and ...` on the `ProcessAPE($et, $dirInfo)` line).
       let _ = crate::formats::ape::ProcessApe.process_trailer_only(ctx);
     }
     rtn_val
   }
 }
+
+// ===========================================================================
+// Legacy chained entry points — preserved for APE/DSF/FLAC/AIFF/MPC/WV
+// ===========================================================================
 
 /// Faithful chained `ID3::ProcessID3` entry (ID3.pm:1431-1632) — for
 /// APE/MPC/OGG/FLAC-style file-type callers that have either already
@@ -159,13 +1282,7 @@ impl FormatParser for ProcessMp3 {
 /// owns SetFileType).
 pub fn process_id3_chained(ctx: &mut ParseContext<'_>) -> Id3ChainedResult {
   let data = ctx.data();
-  // Codex R3 F1 fix: derive hdr_end_offset from the SAME parse that
-  // emits the tags — NOT a separate shallow peek that would diverge from
-  // bundled on the v2.4-footer-flag and Warn-then-`last` cases. The
-  // inner call mirrors ID3.pm:1443 `$hdrEnd = 0;` (returned 0 on all
-  // Warn-then-`last` paths) and ID3.pm:1486 `Seek(10, 1)` (the
-  // footer-flag +10 advance) → :1504 `$hdrEnd = $raf->Tell()`.
-  let (found, hdr_end_offset) = process_id3_inner(data, ctx, false);
+  let (found, hdr_end_offset) = process_id3_inner_legacy(data, ctx, false);
   Id3ChainedResult {
     found,
     hdr_end_offset,
@@ -211,11 +1328,7 @@ impl Id3ChainedResult {
 /// `slice` is the trailer bytes (treated as a complete file by ProcessID3
 /// — first 3 bytes checked for `^ID3`, last 128 for an ID3v1 `TAG`).
 pub fn process_id3_v2_slice(slice: &[u8], ctx: &mut ParseContext<'_>) -> bool {
-  // The DSF chained-trailer caller does not consume `$hdrEnd` — DSF's
-  // outer Process subroutine slices the ID3v2-trailer bytes BEFORE the
-  // call (DSF.pm:75-87) and the post-ID3 body inside that slice is not
-  // re-scanned. Drop the hdr_end second tuple element.
-  process_id3_inner(slice, ctx, false).0
+  process_id3_inner_legacy(slice, ctx, false).0
 }
 
 /// Internal ProcessID3 entry. `do_set_file_type` is `true` for the MP3
@@ -235,70 +1348,41 @@ pub fn process_id3_v2_slice(slice: &[u8], ctx: &mut ParseContext<'_>) -> bool {
 /// :1463, :1475, :1478), bundled leaves `$hdrEnd = 0` — the audio
 /// loop's `$raf->Seek($hdrEnd, 0)` at :1590 then re-reads from offset 0.
 /// We model the same: `0` ⇒ caller slices from offset 0.
-fn process_id3_inner(
+///
+/// **Phase F2 rename note.** This function used to be called
+/// `process_id3_inner`; it is renamed to `process_id3_inner_legacy` to
+/// distinguish it from the typed-Meta inner parser [`parse_id3_inner`].
+/// All Phase F2 callers from outside `process.rs` use the typed entry;
+/// the legacy chained callers (APE/DSF/FLAC/AIFF/MPC/WV) and the
+/// `OldFormatParser` bridge inside this module use the legacy entry.
+fn process_id3_inner_legacy(
   data: &[u8],
   ctx: &mut ParseContext<'_>,
   do_set_file_type: bool,
 ) -> (bool, usize) {
   // ID3.pm:1435-1436 `return 0 if $$et{DoneID3}; $$et{DoneID3} = 1;` —
   // avoids the cross-parser infinite recursion bundled relies on for the
-  // ID3 → audio-format dispatch loop. Our port models the chained ID3-
-  // first paths (APE.pm:124, DSF.pm:88-97 etc.) by calling this entry
-  // directly; the guard makes that idempotent if a second parser also
-  // tries to detect ID3 over the same `$self`.
+  // ID3 → audio-format dispatch loop.
   if ctx.metadata().done_id3().is_some() {
     return (false, 0);
   }
-  // We tentatively set DoneID3=Some(0) BEFORE detection — matching
-  // ID3.pm:1436 `$$et{DoneID3} = 1` (set before any header parsing).
-  // The trailer-size update (ID3.pm:1527) only happens when an ID3v1
-  // trailer is present; we overwrite later in `finalize`.
   ctx.metadata().set_done_id3(0);
 
-  // `data` is provided by the caller — `ctx.data()` for the file-level
-  // ProcessID3 path, OR a pre-sliced ID3v2 trailer for the DSF.pm:88-97
-  // chained `ProcessDirectory(ID3::Main)` case (ID3.pm:1637-1642
-  // `ProcessID3Dir` ⇒ `ProcessID3` over `${$$dirInfo{DataPt}}`).
-  let cctx = crate::convert::ConvContext::default();
+  let cctx = ConvContext::default();
 
   let mut id3_len: u64 = 0;
   let mut found_any = false;
   let mut header_data: Option<(Vec<u8>, u16)> = None;
-  // ID3.pm:1443 `my $hdrEnd = 0;` — initialized BEFORE the v2 parse and
-  // only updated at :1504 on the successful-parse path. Warn-then-`last`
-  // exits leave `$hdrEnd = 0`, and the audio loop's `Seek($hdrEnd, 0)`
-  // (:1590) then re-reads from start of file.
   let mut hdr_end: usize = 0;
 
-  // ID3.pm:1446 `$raf->Seek(0, 0); $raf->Read($buff, 3) == 3`.
   if data.len() < 3 {
     return (false, 0);
   }
 
-  // ID3v2 header parsing — faithful to ID3.pm:1452-1505. CRITICAL
-  // (Codex R1): `$rtnVal = 1` (ID3.pm:1453) is set on `^ID3` match
-  // BEFORE validation, so Warn-then-`last` paths still emit the File:*
-  // + ID3Size=0 tags from the post-loop block (ID3.pm:1580-1611).
-  // CRITICAL (Codex R3): EVERY Warn-then-`last` path falls through to
-  // the ID3v1 trailer scan at ID3.pm:1510-1528 — a file with a corrupt
-  // ID3v2 header BUT a valid ID3v1 trailer must still emit ID3v1 tags.
-  // We model the `last` by setting `header_data = None` and exiting the
-  // `if` block (NOT early-returning).
   if data.starts_with(b"ID3") {
     found_any = true; // ID3.pm:1453 `$rtnVal = 1`.
     if let Some(parsed) = parse_v2_header(data, ctx) {
       id3_len += (parsed.h_buff.len() + 10) as u64;
-      // ID3.pm:1504 `$hdrEnd = $raf->Tell();` — position after:
-      //   1. read 3 bytes of magic (:1448) ⇒ pos = 3
-      //   2. read 7 bytes of vers+flags+size header (:1454) ⇒ pos = 10
-      //   3. read $size bytes of body (:1463) ⇒ pos = 10 + size
-      //   4. IF (flags & 0x10): `Seek(10, 1)` (:1486) ⇒ pos += 10
-      //                                             ⇒ pos = 20 + size
-      // The extended-header path (:1473-1483) shrinks `$hBuff` in-memory
-      // but does NOT touch the file-position cursor; bundled never reads
-      // separately from the file for the ext-header bytes (they live in
-      // the body already read at :1463). So `$hdrEnd` depends only on
-      // `$size` + the footer flag, NOT on `$len` (ext-header length).
       hdr_end = 10usize.saturating_add(parsed.size);
       if parsed.flags & 0x10 != 0 {
         hdr_end = hdr_end.saturating_add(10);
@@ -307,7 +1391,6 @@ fn process_id3_inner(
     }
   }
 
-  // ID3.pm:1510-1528 — ID3v1 trailer detection.
   let mut trailer_data: Option<Vec<u8>> = None;
   let mut trail_size_for_done_id3: usize = 0;
   if data.len() >= 128 {
@@ -316,72 +1399,22 @@ fn process_id3_inner(
       trailer_data = Some(tail.to_vec());
       id3_len += 128;
       found_any = true;
-      // ID3.pm:1527 `$$et{DoneID3} = $trailSize;` — used by APE.pm:169
-      // `$footPos -= $$et{DoneID3} if $$et{DoneID3} > 1` to walk PAST
-      // the ID3v1 trailer when looking for the APE footer.
       trail_size_for_done_id3 = 128;
-      // ID3.pm:1521-1525 — Enhanced TAG (TAG+, 227 bytes) immediately
-      // PRECEDING the standard 128-byte TAG block:
-      //   my $eSize = 227;
-      //   if ($raf->Seek(-$trailSize - $eSize, 2)
-      //       and $raf->Read($eBuff, $eSize) == $eSize
-      //       and $eBuff =~ /^TAG+/) {
-      //       $id3Trailer{EnhancedTAG} = \$eBuff;
-      //       $trailSize += $eSize;
-      //   }
-      //
-      // The `^TAG+/` regex is `^TA` followed by `G+` (one or more G's) —
-      // confirmed via `perl -e 'print "match" if "TAG" =~ /^TAG+/'`. So
-      // "TAG", "TAGG", "TAGGG", ... all match (the literal Enhanced TAG
-      // magic is `TAG+` in the spec, but the bundled regex matches even
-      // a plain `TAG`-prefixed Enhanced block — the regex `+` is the
-      // quantifier, not a literal `+`).
-      //
-      // Codex R4 F2 fix: bundled APE.pm:169 reads `$$et{DoneID3}` as the
-      // BYTE COUNT of trailing ID3 data to skip past when scanning for
-      // the APETAGEX 32-byte footer. With Enhanced TAG present, bundled
-      // stores 355 (128 + 227) and APE's `$footPos -= $$et{DoneID3}`
-      // walks back the correct distance. Our previous hardcoded `128`
-      // landed the APE footer scan inside the Enhanced TAG block →
-      // APETAGEX magic missed → silent miss of APE tags.
-      //
-      // The Enhanced TAG CONTENT extraction (`$id3Trailer{EnhancedTAG}
-      // = \$eBuff` at :1524) remains deferred — only the BYTE COUNT
-      // (`trail_size_for_done_id3`) matters for the APE.pm:169 footer-
-      // position shift. No bundled fixture in our suite extracts the
-      // Enhanced TAG body; tracked as a forward item.
-      //
-      // Bounds guard: `data.len() >= 128 + 227 = 355` (we already know
-      // `data.len() >= 128` from the outer `if`).
+      // ID3.pm:1521-1525 — Enhanced TAG (TAG+, 227 bytes) preceding
+      // the standard 128-byte TAG block. Detect via the regex
+      // `^TAG+/` (literal `TA` + 1+ `G`s — `starts_with(b"TAG")`
+      // covers).
       if data.len() >= 128 + 227 {
         let e_start = data.len() - 128 - 227;
         let e_buf = &data[e_start..data.len() - 128];
-        // `^TAG+/` ⇒ "TA" + 1+ "G"s. `starts_with(b"TAG")` is the
-        // narrowest match (1 G); any longer all-G run also satisfies
-        // the regex but the prefix `TAG` covers all of them.
         if e_buf.starts_with(b"TAG") {
-          // ID3.pm:1525 `$trailSize += $eSize;` — DoneID3 grows from
-          // 128 to 355.
           trail_size_for_done_id3 += 227;
         }
       }
     }
   }
 
-  // ID3.pm:1532-1576 — Lyrics3 trailer. Out-of-PR-scope as faithful but
-  // un-exercised; left as a no-op (no fixture triggers it).
-  //
-  // Codex R4 follow-up: ID3.pm:1539 updates DoneID3 further when a
-  // Lyrics3 block is found (`$$et{DoneID3} = $trailSize + $len - $pos +
-  // 11`). Real-world MP3+APE files with a Lyrics3 trailer would need the
-  // same byte-count update for APE.pm:169 to walk past Lyrics3 too. Codex
-  // did not flag this in R4 (no Lyrics3 fixture triggers it), so we leave
-  // it as a documented forward item — same posture as the Enhanced TAG
-  // content extraction above. No fixture in our suite exercises Lyrics3.
-
   if trail_size_for_done_id3 > 0 {
-    // Overwrite the early Some(0) with the actual trailer size, per
-    // ID3.pm:1527. Read by APE.pm:169 for the footer-position shift.
     ctx.metadata().set_done_id3(trail_size_for_done_id3);
   }
   let found = finalize(
@@ -396,30 +1429,21 @@ fn process_id3_inner(
   (found, hdr_end)
 }
 
-/// Parse the ID3v2 header (ID3.pm:1452-1505). Returns `Some(ParsedV2Header)`
-/// when the header is fully valid; `None` when any Warn-then-`last` path
-/// fires (the caller still proceeds to ID3v1 trailer detection — bundled
-/// behavior). Pushes Warns to `ctx.metadata()` along the way. Faithful
-/// transliteration of the bundled `while ($buff =~ /^ID3/) { ... last }`
-/// loop body.
-///
-/// Returning `flags + size` lets the caller compute `$hdrEnd`
-/// (ID3.pm:1504) faithfully: the bundled `if ($flags & 0x10) {
-/// $raf->Seek(10, 1); }` arithmetic (:1484-1486) advances the file
-/// position by 10 BEFORE `$hdrEnd = $raf->Tell()`, so the chained-slice
-/// offset depends on both the declared body size AND the footer flag.
+/// Parse the ID3v2 header (ID3.pm:1452-1505). Returns
+/// `Some(ParsedV2Header)` when the header is fully valid; `None` when
+/// any Warn-then-`last` path fires (the caller still proceeds to ID3v1
+/// trailer detection — bundled behavior). Pushes Warns to
+/// `ctx.metadata()` along the way. Faithful transliteration of the
+/// bundled `while ($buff =~ /^ID3/) { ... last }` loop body.
 fn parse_v2_header(data: &[u8], ctx: &mut ParseContext<'_>) -> Option<ParsedV2Header> {
-  // ID3.pm:1454 — `$raf->Read($hBuff, 7) == 7 or $et->Warn('Short ID3 header'), last`.
   if data.len() < 10 {
     ctx.metadata().push_warning("Short ID3 header");
     return None;
   }
-  let h = &data[3..10]; // 7 bytes: vers(2) + flags(1) + size(4)
+  let h = &data[3..10];
   let vers = u16::from_be_bytes([h[0], h[1]]);
   let flags = h[2];
   let size_raw = u32::from_be_bytes([h[3], h[4], h[5], h[6]]);
-  // ID3.pm:1456-1457 — `$size = UnSyncSafe($size); defined $size or
-  //                   $et->Warn('Invalid ID3 header'), last`.
   let size = match unsync_safe(size_raw) {
     Some(s) => s as usize,
     None => {
@@ -427,7 +1451,6 @@ fn parse_v2_header(data: &[u8], ctx: &mut ParseContext<'_>) -> Option<ParsedV2He
       return None;
     }
   };
-  // ID3.pm:1458-1462 — `if ($vers >= 0x0500) { ...Warn..., last }`.
   if vers >= 0x0500 {
     let ver_str = format!("2.{}.{}", vers >> 8, vers & 0xff);
     ctx
@@ -435,43 +1458,14 @@ fn parse_v2_header(data: &[u8], ctx: &mut ParseContext<'_>) -> Option<ParsedV2He
       .push_warning(format!("Unsupported ID3 version: {ver_str}"));
     return None;
   }
-  // ID3.pm:1463-1466 — `$raf->Read($hBuff, $size) == $size or ...Warn..., last`.
   if 10 + size > data.len() {
     ctx.metadata().push_warning("Truncated ID3 data");
     return None;
   }
   let mut h_buff: Vec<u8> = data[10..10 + size].to_vec();
-  // ID3.pm:1467-1470: header-level unsync (v < 0x0400 only — bundled
-  // applies header-level unsync only to v2.2/v2.3 here; v2.4 carries
-  // per-frame unsync).
   if flags & 0x80 != 0 && vers < 0x0400 {
     h_buff = reverse_unsync_inplace(&h_buff);
   }
-  // ID3.pm:1473-1483 — extended header skip:
-  //   $size >= 4 or $et->Warn('Bad ID3 extended header'), last;
-  //   my $len = UnSyncSafe(unpack('N', $hBuff));
-  //   if ($len > length($hBuff)) {
-  //       $et->Warn('Truncated ID3 extended header');
-  //       last;
-  //   }
-  //   $hBuff = substr($hBuff, $len);          # ← strips EXACTLY $len bytes
-  //   $pos += $len;
-  //
-  // CRITICAL FAITHFUL DETAILS:
-  //
-  // (1) Bundled strips EXACTLY `$len` bytes (Codex R1 + R4 both misread
-  // this — see the `ID3v2_3_exthdr.mp3` conformance pin). Do NOT
-  // "correct" to `$len + 4`.
-  //
-  // (2) The Perl `$size >= 4` check guards the unpack of the FIRST 4
-  // ext-header bytes. After header-level unsync (line above), `h_buff`
-  // may have SHRUNK; we must check `h_buff.len() >= 4` BEFORE indexing
-  // those bytes (Codex R7-F2: a crafted ID3v2.3 with flags=0xc0,
-  // declared-size=4, body=`ff 00 ff 00` shrinks to 2 bytes after unsync;
-  // bundled's `length($hBuff)` is post-unsync, so its `$size >= 4`
-  // check guards against THIS shape too via the `$len > length($hBuff)`
-  // gate at :1477. Our Rust pre-check on `h_buff.len()` makes the
-  // panic-free path explicit + faithful).
   if flags & 0x40 != 0 {
     if h_buff.len() < 4 {
       ctx.metadata().push_warning("Bad ID3 extended header");
@@ -488,10 +1482,6 @@ fn parse_v2_header(data: &[u8], ctx: &mut ParseContext<'_>) -> Option<ParsedV2He
     }
     h_buff = h_buff[ext_len..].to_vec();
   }
-  // ID3.pm:1484-1487 — v2.4 footer skip (10 bytes AFTER frames): bundled
-  // advances the file position by 10, which then feeds `$hdrEnd =
-  // $raf->Tell()` at :1504. We track the flags byte and let the caller
-  // compute `hdr_end = 10 + size [+ 10 if flags & 0x10]`.
   Some(ParsedV2Header {
     h_buff,
     vers,
@@ -500,20 +1490,9 @@ fn parse_v2_header(data: &[u8], ctx: &mut ParseContext<'_>) -> Option<ParsedV2He
   })
 }
 
-// Phase-2 batch integration: the original ID3 PR's
-// `has_valid_mpeg_audio_sync` helper (a minimal accept-only port of
-// `MPEG::ParseMPEGAudio`'s sync gate) is superseded by the full
-// `crate::formats::mpeg` port (FORMATS.md row 2a, PR #4). The no-ID3
-// branch in `ProcessMp3::process` now delegates to
-// `crate::formats::mpeg::ProcessMp3.process(ctx)` which performs the
-// same scan-len bound + Layer-III/MUS caller flag + full `ParseMPEGAudio`
-// dispatch (including the `%MPEG::Audio` tag emission `mp3_conformance`
-// pins). This eliminates a near-identical helper per the consolidation
-// rule ("near-identical helpers ⇒ keep one canonical version").
-
 fn finalize(
   ctx: &mut ParseContext<'_>,
-  cctx: &crate::convert::ConvContext,
+  cctx: &ConvContext,
   id3_len: u64,
   found_any: bool,
   header_data: Option<(Vec<u8>, u16)>,
@@ -522,32 +1501,16 @@ fn finalize(
 ) -> bool {
   let print_conv_on = ctx.print_conv_enabled();
   if !found_any {
-    // ID3.pm:1580 `if ($rtnVal) { ... }` — `SetFileType('MP3')`
-    // (ID3.pm:1604) is INSIDE the rtnVal-truthy branch. A no-ID3 path is
-    // a faithful reject: return 0, do not push File:*. The candidate
-    // loop in `extract_info` will try the next type; if none accept,
-    // `finalization_error` emits "File is empty" / "Unknown file type"
-    // / "File format error" as bundled Perl does.
     return false;
   }
   if do_set_file_type {
-    // ID3.pm:1604 — SetFileType('MP3') before pushing ID3Size + the tags.
-    // Skipped when ProcessID3 is invoked by a chained caller (APE/DSF/...)
-    // because that caller owns SetFileType — faithful to the bundled
-    // audio-loop recursion (ID3.pm:1582-1601 → recursive ProcessAPE calls
-    // SetFileType('APE') at APE.pm:141, which then wins over the later
-    // SetFileType('MP3') at ID3.pm:1604 via first-call-wins) and the DSF
-    // arm (DSF.pm:64 SetFileType BEFORE the trailer ProcessDirectory at
-    // DSF.pm:88-97).
     ctx.set_file_type(Some("MP3"), None, None);
   }
-  // ID3.pm:1606 — FoundTag('ID3Size', $id3Len). ID3Size is in the File group.
   ctx.metadata().push(
     Group::new("File", "File"),
     "ID3Size",
     TagValue::I64(id3_len as i64),
   );
-  // ID3v2 header.
   if let Some((h_buff, vers)) = header_data {
     let table = if vers >= 0x0400 {
       &ID3V2_4_MAIN
@@ -558,8 +1521,6 @@ fn finalize(
     };
     process_id3v2(&h_buff, vers, table, ctx.metadata(), print_conv_on, cctx);
   }
-  // ID3v1 trailer (after ID3v2 — Perl pushes both in `if (%id3Header) {
-  // ... } if (%id3Trailer) { ... }` order).
   if let Some(t) = trailer_data {
     let _ = ID3V1_MAIN; // referenced for static link only
     process_id3v1(&t, ctx.metadata(), print_conv_on, cctx);
@@ -582,6 +1543,53 @@ fn reverse_unsync_inplace(v: &[u8]) -> Vec<u8> {
   out
 }
 
+// ===========================================================================
+// Public lib-first direct entries — borrow-from-input typed Meta
+// ===========================================================================
+
+/// Lib-first direct entry. Same as [`FormatParser::parse`] on
+/// [`ProcessId3`] but returns an [`Id3Meta`] that borrows from the input
+/// buffer (Phase G zero-alloc reservation). For now this matches
+/// [`FormatParser::parse`] in behavior since `Id3Meta` owns all strings
+/// via `SmolStr`; the borrow lifetime is reserved for future zero-alloc
+/// optimization.
+///
+/// # Errors
+///
+/// Returns `Err` for Rust-level fatal modes (none today; reserved for
+/// future I/O wrappers).
+pub fn parse_id3_borrowed<'a>(
+  data: &'a [u8],
+  shared: Option<&mut SharedFlags>,
+) -> Result<Option<Id3Meta<'a>>, Id3Error> {
+  parse_id3_inner(data, shared)
+}
+
+// ===========================================================================
+// MetadataTagWriter bridge usage — for ProcessMp3 typed sink integration
+// ===========================================================================
+
+/// Phase F2 typed-Meta + legacy-engine bridge for the MP3 wrapper.
+///
+/// Drives the typed [`ProcessMp3`] / [`Mp3Meta`] sink path through the
+/// [`MetadataTagWriter`] adapter, then runs the legacy MPEG / APE
+/// chained engines for byte-exact CLI JSON. This is the same pattern
+/// MOI/AAC/DV use; the wrinkle here is that the MPEG / APE engines
+/// don't have typed Metas yet (F3/F4), so they continue to push into
+/// `Metadata` directly inside the bridge.
+///
+/// (Currently unused — the legacy `OldFormatParser` implementation
+/// drives the engine path directly. Kept for documentation / Phase G
+/// transition reference.)
+#[allow(dead_code)]
+fn _phase_f2_bridge_note() {
+  let _ = MetadataTagWriter::new;
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -597,36 +1605,24 @@ mod tests {
     m
   }
 
+  // -------------------------------------------------------------------------
+  // Legacy regression pins — preserved verbatim from pre-F2 process.rs
+  // -------------------------------------------------------------------------
+
   #[test]
   fn process_mp3_empty_data_rejects() {
-    // R6-F1 disposition: empty data + .mp3 ext is still REJECTED — no
-    // MPEG frame sync means no MP3 acceptance. The candidate loop's
-    // post-loop Error fires faithfully.
     let m = run(&[], "x.mp3");
     assert!(m.tags().iter().all(|t| t.name() != "FileType"));
   }
 
   #[test]
   fn process_mp3_random_bytes_no_mpeg_sync_rejects() {
-    // Random non-MPEG bytes with a .mp3 extension → reject (no MPEG
-    // sync found ⇒ faithful "File format error" path from the
-    // candidate loop).
     let m = run(b"abcdefghij", "random.mp3");
     assert!(m.tags().iter().all(|t| t.name() != "FileType"));
   }
 
   #[test]
   fn process_mp3_valid_mpeg_audio_frame_accepts_as_mp3() {
-    // 4-byte MPEG audio frame header that satisfies the bundled
-    // ParseMPEGAudio gate (MPEG.pm:472-485):
-    //   sync = 0xfff (high 11 bits all 1)
-    //   version = 11 (MPEG-1)
-    //   layer = 01 (Layer 3 — MP3)
-    //   bitrate index = 1001 (128 kbps for Layer 3 MPEG-1)
-    //   sampling-freq = 00 (44100 Hz)
-    //   pad/private/channel/etc = 00
-    //   emphasis = 00
-    // Composite header: 0xff 0xfb 0x90 0x00.
     let mut data: Vec<u8> = vec![0u8; 32];
     data[0] = 0xff;
     data[1] = 0xfb;
@@ -639,9 +1635,7 @@ mod tests {
 
   #[test]
   fn process_mp3_id3v1_only() {
-    // Construct a file: 1024 padding bytes + 128-byte ID3v1 TAG block.
-    let mut data: Vec<u8> = vec![0; 256]; // some prefix that's NOT ID3
-    // Build TAG block.
+    let mut data: Vec<u8> = vec![0; 256];
     let mut tag = Vec::with_capacity(128);
     tag.extend_from_slice(b"TAG");
     let pad = |s: &str, n: usize| {
@@ -654,7 +1648,7 @@ mod tests {
     tag.extend_from_slice(&pad("Album", 30));
     tag.extend_from_slice(b"2003");
     tag.extend_from_slice(&pad("Comment", 30));
-    tag.push(7); // Hip-Hop
+    tag.push(7);
     assert_eq!(tag.len(), 128);
     data.extend_from_slice(&tag);
     let m = run(&data, "x.mp3");
@@ -670,7 +1664,6 @@ mod tests {
 
   #[test]
   fn process_mp3_id3v2_2_with_title_artist() {
-    // ID3v2.2 header (10 bytes) + 6-byte TT2 frame + 6-byte TP1 frame.
     let title_frame: Vec<u8> = {
       let mut body: Vec<u8> = vec![0];
       body.extend_from_slice(b"Hello");
@@ -697,13 +1690,12 @@ mod tests {
     };
     let body: Vec<u8> = title_frame.into_iter().chain(artist_frame).collect();
     let size = body.len() as u32;
-    // Synchsafe size: for body.len() < 128, top 7 bits = 0 (synchsafe == raw).
     let mut data = Vec::new();
     data.extend_from_slice(b"ID3");
-    data.push(0x02); // vers major = 2
-    data.push(0x00); // vers minor
-    data.push(0x00); // flags
-    data.extend_from_slice(&size.to_be_bytes()); // sync-safe size (for small sizes, == raw)
+    data.push(0x02);
+    data.push(0x00);
+    data.push(0x00);
+    data.extend_from_slice(&size.to_be_bytes());
     data.extend_from_slice(&body);
     let m = run(&data, "x.mp3");
     let title = m.tags().iter().find(|t| t.name() == "Title").unwrap();
@@ -711,27 +1703,19 @@ mod tests {
     let artist = m.tags().iter().find(|t| t.name() == "Artist").unwrap();
     assert_eq!(artist.value(), &TagValue::Str("Phil".into()));
     let id3size = m.tags().iter().find(|t| t.name() == "ID3Size").unwrap();
-    // ID3Size includes 10-byte header + body bytes.
     assert_eq!(id3size.value(), &TagValue::I64(10 + size as i64));
   }
 
   #[test]
   fn process_mp3_unsync_extheader_shrinks_below_4_does_not_panic() {
-    // R7-F2 regression: a crafted v2.3 with flags=0xc0 (unsync +
-    // ext-header), declared body size=4, body=`ff 00 ff 00`. After the
-    // header-level unsync strips `\xff\x00 → \xff`, h_buff shrinks from
-    // 4 to 2 bytes. Without the post-unsync bounds check, the ext-
-    // header read would index into 4-byte u32 over 2 bytes and panic.
-    // Faithful Warn: "Bad ID3 extended header".
     let mut data = Vec::new();
     data.extend_from_slice(b"ID3");
     data.push(0x03);
     data.push(0x00);
-    data.push(0xc0); // flags: unsync (0x80) + ext-header (0x40)
-    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // sync-safe 4
-    data.extend_from_slice(&[0xff, 0x00, 0xff, 0x00]); // body (shrinks to 0xff 0xff)
+    data.push(0xc0);
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]);
+    data.extend_from_slice(&[0xff, 0x00, 0xff, 0x00]);
     let m = run(&data, "x.mp3");
-    // Must not panic. Faithful Warn fires.
     assert!(
       m.warnings()
         .iter()
@@ -741,30 +1725,20 @@ mod tests {
 
   #[test]
   fn process_mp3_layer_two_dotless_filename_rejected() {
-    // R8-F1 regression: a dotless filename hitting MP3 weakMagic +
-    // Layer II sync header `\xff\xfd 0x90 0x00` was previously accepted
-    // because the Layer-III gate was skipped when ext != MP3. Bundled
-    // ID3.pm:1716 sets $mp3=1 for EVERY non-MUS candidate, so Layer II
-    // is rejected. After R8-F1 fix: dotless file with Layer II sync →
-    // reject (no FileType pushed).
     let mut data: Vec<u8> = vec![0u8; 32];
     data[0] = 0xff;
-    data[1] = 0xfd; // Layer II (layer bits 0x00040000 ⇒ layer == 10)
+    data[1] = 0xfd;
     data[2] = 0x90;
     data[3] = 0x00;
-    let m = run(&data, "x"); // dotless: ext is None
+    let m = run(&data, "x");
     assert!(m.tags().iter().all(|t| t.name() != "FileType"));
   }
 
   #[test]
   fn process_mp3_layer_two_mus_extension_accepted() {
-    // R8-F1 regression (positive case): bundled ID3.pm:1716 sets
-    // $mp3 = $ext eq 'MUS' ? 0 : 1. For ext='MUS' the Layer-III gate
-    // is SKIPPED — Layer II is accepted (MPEG-2 audio in the MUS
-    // container). Pinned to ensure we don't over-reject.
     let mut data: Vec<u8> = vec![0u8; 32];
     data[0] = 0xff;
-    data[1] = 0xfd; // Layer II
+    data[1] = 0xfd;
     data[2] = 0x90;
     data[3] = 0x00;
     let m = run(&data, "song.mus");
@@ -774,7 +1748,6 @@ mod tests {
 
   #[test]
   fn process_mp3_unsupported_id3v5_warns() {
-    // ID3 magic + version 5.0 — bundled Perl emits the version Warn.
     let mut data = Vec::new();
     data.extend_from_slice(b"ID3");
     data.push(0x05);
@@ -791,13 +1764,12 @@ mod tests {
 
   #[test]
   fn process_mp3_truncated_warns() {
-    // ID3 magic + valid header + declared size 100, but only 3 body bytes.
     let mut data = Vec::new();
     data.extend_from_slice(b"ID3");
     data.push(0x02);
     data.push(0x00);
     data.push(0x00);
-    data.extend_from_slice(&[0u8, 0, 0, 100]); // sync-safe 100
+    data.extend_from_slice(&[0u8, 0, 0, 100]);
     data.extend_from_slice(&[0u8; 3]);
     let m = run(&data, "x.mp3");
     assert!(
@@ -809,7 +1781,6 @@ mod tests {
 
   #[test]
   fn process_mp3_short_header_warns() {
-    // ID3 magic + only 2 of 7 header bytes.
     let data = b"ID3\x02\x00";
     let m = run(data, "x.mp3");
     assert!(
@@ -821,27 +1792,10 @@ mod tests {
 
   #[test]
   fn process_id3_enhanced_tag_sets_done_id3_to_355() {
-    // Codex R4 F2 regression pin: ID3.pm:1521-1525 — when standard ID3v1
-    // TAG is present AND a 227-byte Enhanced TAG block precedes it (magic
-    // satisfies `/^TAG+/` regex = `^TA` + 1+ G's), bundled sets
-    // `$$et{DoneID3} = 128 + 227 = 355` (`$trailSize += $eSize` at :1525).
-    //
-    // Pre-fix our code hardcoded `trail_size_for_done_id3 = 128`; the
-    // APE.pm:169 `$footPos -= $$et{DoneID3}` then landed the APE footer
-    // scan INSIDE the Enhanced TAG block → silent miss.
-    //
-    // Synthetic layout: 100-byte non-ID3 padding + 227-byte Enhanced TAG
-    // (magic "TAG+...") + 128-byte standard ID3v1 TAG. process_id3_inner
-    // runs over the whole buffer and must set done_id3 = 355.
     let mut data: Vec<u8> = vec![0xaa; 100];
-    // Enhanced TAG: 227 bytes starting with literal "TAG+" (matches
-    // `^TAG+/` because the regex is `^TA` + `G+` = "TA" followed by 1+
-    // G's; "TAG+" satisfies this — the first 3 chars are 'T','A','G' and
-    // then the `+` is just data past the regex match).
     let mut enhanced = vec![b'T', b'A', b'G', b'+'];
     enhanced.resize(227, 0);
     data.extend_from_slice(&enhanced);
-    // Standard ID3v1 TAG (128 bytes starting "TAG").
     let mut id3v1 = vec![b'T', b'A', b'G'];
     id3v1.resize(128, 0);
     data.extend_from_slice(&id3v1);
@@ -851,25 +1805,14 @@ mod tests {
     {
       let ext = crate::filetype::file_ext_for_name("x.mp3");
       let mut ctx = ParseContext::new(&data, "MP3", 0, "MP3", ext, true, &mut meta);
-      // Direct call to the inner function — no audio-format dispatch.
-      let (_found, _hdr_end) = process_id3_inner(&data, &mut ctx, false);
+      let (_found, _hdr_end) = process_id3_inner_legacy(&data, &mut ctx, false);
     }
-    assert_eq!(
-      meta.done_id3(),
-      Some(355),
-      "Enhanced TAG (227) + standard TAG (128) must yield DoneID3 = 355",
-    );
+    assert_eq!(meta.done_id3(), Some(355));
   }
 
   #[test]
   fn process_id3_standard_tag_only_sets_done_id3_to_128() {
-    // Sanity check: without Enhanced TAG (no `^TAG+/` match in the 227
-    // bytes before the standard TAG), DoneID3 stays at 128 (faithful to
-    // ID3.pm:1527 `$$et{DoneID3} = $trailSize` with $trailSize=128 only).
     let mut data: Vec<u8> = vec![0xaa; 100 + 227];
-    // Standard ID3v1 TAG (128 bytes starting "TAG"). The 227 bytes
-    // preceding it (offsets 100..327) are non-TAG padding — bundled's
-    // `^TAG+/` over those 227 bytes does NOT match.
     let mut id3v1 = vec![b'T', b'A', b'G'];
     id3v1.resize(128, 0);
     data.extend_from_slice(&id3v1);
@@ -879,52 +1822,207 @@ mod tests {
     {
       let ext = crate::filetype::file_ext_for_name("x.mp3");
       let mut ctx = ParseContext::new(&data, "MP3", 0, "MP3", ext, true, &mut meta);
-      let (_found, _hdr_end) = process_id3_inner(&data, &mut ctx, false);
+      let (_found, _hdr_end) = process_id3_inner_legacy(&data, &mut ctx, false);
     }
-    assert_eq!(
-      meta.done_id3(),
-      Some(128),
-      "standard TAG alone (no Enhanced TAG) must yield DoneID3 = 128",
-    );
+    assert_eq!(meta.done_id3(), Some(128));
   }
 
   #[test]
   fn process_id3_v24_truncated_footer_does_not_panic() {
-    // Codex R4 F1 regression pin: parse_v2_header accepts a v2.4 tag once
-    // `10 + size` body bytes are present, but bundled's `$raf->Seek(10, 1)`
-    // at ID3.pm:1486 is unconditional — even when the 10 footer bytes are
-    // truncated, `$raf->Tell()` at :1504 returns `10 + size + 10`. The
-    // chained-ID3 consumer (APE.pm) must NOT panic on the resulting
-    // out-of-bounds hdr_end. Producer-side: hdr_end = 44 over a 34-byte
-    // buffer is intentional — consumer (`ape.rs:ape_slice`) saturates to
-    // empty via `data.get(hdr_end..).unwrap_or(&[])`.
-    //
-    // This test exercises the producer alone (the consumer guard is
-    // exercised by `id3v24_footer_truncated_then_nothing_conformance`
-    // which routes through the full APE engine path).
     let mut data: Vec<u8> = Vec::new();
     data.extend_from_slice(b"ID3");
-    data.push(0x04); // v2.4 major
-    data.push(0x00); // minor
-    data.push(0x10); // flags = footer-flag (0x10)
-    data.extend_from_slice(&[0u8, 0, 0, 24]); // syncsafe size=24
-    data.extend_from_slice(&vec![0u8; 24]); // body bytes
-    assert_eq!(data.len(), 34); // NO footer bytes appended
+    data.push(0x04);
+    data.push(0x00);
+    data.push(0x10);
+    data.extend_from_slice(&[0u8, 0, 0, 24]);
+    data.extend_from_slice(&vec![0u8; 24]);
+    assert_eq!(data.len(), 34);
 
     let mut meta = Metadata::new("x.mp3");
     let hdr_end = {
       let ext = crate::filetype::file_ext_for_name("x.mp3");
       let mut ctx = ParseContext::new(&data, "MP3", 0, "MP3", ext, true, &mut meta);
-      let (_found, hdr_end) = process_id3_inner(&data, &mut ctx, false);
+      let (_found, hdr_end) = process_id3_inner_legacy(&data, &mut ctx, false);
       hdr_end
     };
-    // Producer matches bundled: hdr_end = 10 + 24 + 10 = 44 (the +10
-    // footer-skip happens regardless of whether the 10 footer bytes
-    // exist — bundled's filesystem `Seek(10, 1)` past EOF succeeds).
     assert_eq!(hdr_end, 44);
-    assert!(
-      hdr_end > data.len(),
-      "hdr_end must intentionally exceed data.len() to mirror bundled's seek-past-EOF behavior"
+    assert!(hdr_end > data.len());
+  }
+
+  // -------------------------------------------------------------------------
+  // Phase F2 typed-Meta tests
+  // -------------------------------------------------------------------------
+
+  fn build_id3v1_block() -> Vec<u8> {
+    let mut tag = Vec::with_capacity(128);
+    tag.extend_from_slice(b"TAG");
+    let pad = |s: &str, n: usize| {
+      let mut v: Vec<u8> = s.bytes().collect();
+      v.resize(n, 0);
+      v
+    };
+    tag.extend_from_slice(&pad("Hello", 30));
+    tag.extend_from_slice(&pad("Phil", 30));
+    tag.extend_from_slice(&pad("Album1", 30));
+    tag.extend_from_slice(b"2003");
+    tag.extend_from_slice(&pad("Comment1", 30));
+    tag.push(7); // Hip-Hop
+    assert_eq!(tag.len(), 128);
+    tag
+  }
+
+  #[test]
+  fn parse_id3_borrowed_returns_some_for_id3v1_trailer() {
+    let mut data: Vec<u8> = vec![0; 256];
+    data.extend_from_slice(&build_id3v1_block());
+    let meta = parse_id3_borrowed(&data, None).expect("ok").expect("found");
+    assert_eq!(meta.id3_size(), 128);
+    assert_eq!(meta.title(), Some("Hello"));
+    assert_eq!(meta.artist(), Some("Phil"));
+    assert_eq!(meta.album(), Some("Album1"));
+    assert_eq!(meta.year(), Some("2003"));
+    assert_eq!(meta.comment(), Some("Comment1"));
+    assert_eq!(meta.genre(), Some("Hip-Hop"));
+  }
+
+  #[test]
+  fn parse_id3_borrowed_id3v1_subframe_populated() {
+    let mut data: Vec<u8> = vec![0; 256];
+    data.extend_from_slice(&build_id3v1_block());
+    let meta = parse_id3_borrowed(&data, None).expect("ok").expect("found");
+    let v1 = meta.id3v1().expect("v1 present");
+    assert_eq!(v1.title(), Some("Hello"));
+    assert_eq!(v1.artist(), Some("Phil"));
+    assert_eq!(v1.album(), Some("Album1"));
+    assert_eq!(v1.year(), Some("2003"));
+    assert_eq!(v1.comment(), Some("Comment1"));
+    assert_eq!(v1.genre_name(), Some("Hip-Hop"));
+  }
+
+  #[test]
+  fn parse_id3_borrowed_returns_none_when_no_id3() {
+    let data = vec![0u8; 64];
+    assert!(parse_id3_borrowed(&data, None).expect("ok").is_none());
+  }
+
+  #[test]
+  fn parse_id3_borrowed_v22_frames_populate_meta() {
+    let title_frame: Vec<u8> = {
+      let mut body: Vec<u8> = vec![0];
+      body.extend_from_slice(b"Hello");
+      let mut v = Vec::new();
+      v.extend_from_slice(b"TT2");
+      let len = body.len() as u32;
+      v.push(((len >> 16) & 0xff) as u8);
+      let lo = (len & 0xffff) as u16;
+      v.extend_from_slice(&lo.to_be_bytes());
+      v.extend_from_slice(&body);
+      v
+    };
+    let mut data = Vec::new();
+    data.extend_from_slice(b"ID3");
+    data.push(0x02);
+    data.push(0x00);
+    data.push(0x00);
+    data.extend_from_slice(&(title_frame.len() as u32).to_be_bytes());
+    data.extend_from_slice(&title_frame);
+    let meta = parse_id3_borrowed(&data, None).expect("ok").expect("found");
+    assert_eq!(meta.v2_version(), Some(Id3v2Version::V2_2));
+    assert_eq!(meta.title(), Some("Hello"));
+    // The ID3v2.2 frame iterator should contain Title.
+    let frames: Vec<Id3v2Frame> = meta.frames().collect();
+    assert!(frames.iter().any(|f| f.name() == "Title"));
+  }
+
+  #[test]
+  fn shared_flags_done_id3_updated_after_v1_trailer() {
+    let mut data: Vec<u8> = vec![0; 256];
+    data.extend_from_slice(&build_id3v1_block());
+    let mut shared = SharedFlags::new();
+    let _ = parse_id3_borrowed(&data, Some(&mut shared)).expect("ok");
+    assert_eq!(shared.done_id3(), 128);
+  }
+
+  #[test]
+  fn format_parser_parse_id3_returns_meta_static() {
+    let mut data: Vec<u8> = vec![0; 256];
+    data.extend_from_slice(&build_id3v1_block());
+    let mut shared = SharedFlags::new();
+    let ctx = Id3Context::new(&data, &mut shared);
+    let meta = <ProcessId3 as FormatParser>::parse(&ProcessId3, ctx)
+      .expect("ok")
+      .expect("found");
+    assert_eq!(meta.title(), Some("Hello"));
+    assert_eq!(meta.id3_size(), 128);
+  }
+
+  #[test]
+  fn format_parser_parse_mp3_wraps_id3() {
+    let mut data: Vec<u8> = vec![0; 256];
+    data.extend_from_slice(&build_id3v1_block());
+    let mut shared = SharedFlags::new();
+    let ctx = Mp3Context::new(&data, &mut shared, Some("MP3"));
+    let meta = <ProcessMp3 as FormatParser>::parse(&ProcessMp3, ctx)
+      .expect("ok")
+      .expect("found");
+    let id3 = meta.id3().expect("id3 sub-meta present");
+    assert_eq!(id3.title(), Some("Hello"));
+    assert!(meta.found());
+  }
+
+  #[test]
+  fn id3_meta_sinker_replays_into_writer() {
+    let mut data: Vec<u8> = vec![0; 256];
+    data.extend_from_slice(&build_id3v1_block());
+    let meta = parse_id3_borrowed(&data, None).expect("ok").expect("found");
+    let mut w = crate::sink::MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("ID3v1", "Title").map(crate::sink::MapValue::as_str),
+      Some("Hello".into())
     );
+    assert_eq!(
+      w.get("ID3v1", "Genre").map(crate::sink::MapValue::as_str),
+      Some("Hip-Hop".into())
+    );
+    assert_eq!(
+      w.get("File", "ID3Size").map(crate::sink::MapValue::as_str),
+      Some("128".into())
+    );
+  }
+
+  #[test]
+  fn id3_meta_picture_extracts_apic_payload() {
+    // Build an ID3v2.3 ALBUM-only tag plus an APIC frame.
+    // APIC body: enc(1) + mime(C-string) + pictype(1) + desc(C-string) + data.
+    let mut apic_body: Vec<u8> = Vec::new();
+    apic_body.push(0); // enc = Latin-1
+    apic_body.extend_from_slice(b"image/jpeg\0");
+    apic_body.push(3); // Front Cover
+    apic_body.extend_from_slice(b"cover\0");
+    apic_body.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]); // payload
+    // Frame header (10 bytes for v2.3): id(4) len(4) flags(2).
+    let mut apic_frame = Vec::new();
+    apic_frame.extend_from_slice(b"APIC");
+    apic_frame.extend_from_slice(&(apic_body.len() as u32).to_be_bytes());
+    apic_frame.extend_from_slice(&[0, 0]); // flags
+    apic_frame.extend_from_slice(&apic_body);
+    // Build ID3v2.3 directory.
+    let body = apic_frame;
+    let size = body.len() as u32;
+    let mut data = Vec::new();
+    data.extend_from_slice(b"ID3");
+    data.push(0x03);
+    data.push(0x00);
+    data.push(0x00);
+    data.extend_from_slice(&size.to_be_bytes());
+    data.extend_from_slice(&body);
+    let meta = parse_id3_borrowed(&data, None).expect("ok").expect("found");
+    let pic = meta.picture().expect("picture present");
+    assert_eq!(pic.mime(), "image/jpeg");
+    assert_eq!(pic.picture_type(), 3);
+    assert_eq!(pic.picture_type_name(), Some("Front Cover"));
+    assert_eq!(pic.description(), "cover");
+    assert_eq!(pic.data(), &[0xde, 0xad, 0xbe, 0xef]);
   }
 }

--- a/src/parser_new.rs
+++ b/src/parser_new.rs
@@ -282,10 +282,15 @@ pub enum AnyParser {
   /// Red R3D (Phase F1 — Redcode video).
   #[cfg(feature = "red")]
   R3D(crate::formats::red::ProcessR3D),
-  // Phase F2 adds: Id3.
+  /// ID3 directory parser (Phase F2 — ID3v1 + ID3v2 unified).
+  #[cfg(feature = "id3")]
+  Id3(crate::formats::id3::ProcessId3),
+  /// MP3 wrapper parser (Phase F2 — ID3 + audio-frame chain).
+  #[cfg(feature = "mp3")]
+  Mp3(crate::formats::id3::ProcessMp3),
   // Phase F3 adds: Ape, Dsf, Aiff, Flac.
   // Phase F4 adds: Ogg, MpegAudio.
-  // Phase F5 adds: Mp3, Mpc, WavPack.
+  // Phase F5 adds: Mpc, WavPack.
 }
 
 /// Closed-set enum of every format's `Meta` output. Mirrors [`AnyParser`].
@@ -319,6 +324,18 @@ pub enum AnyMeta<'a> {
   /// Red R3D (Phase F1).
   #[cfg(feature = "red")]
   R3d(crate::formats::red::R3dMeta<'a>),
+  /// ID3 directory metadata (Phase F2). The [`crate::formats::id3::ProcessId3`]
+  /// `FormatParser` impl produces `Id3Meta<'static>` (Phase E
+  /// `into_static` pragma); this arm carries the `<'a>` projection so the
+  /// closed enum compiles at any caller lifetime.
+  #[cfg(feature = "id3")]
+  Id3(crate::formats::id3::Id3Meta<'a>),
+  /// MP3 wrapper metadata (Phase F2). Wraps [`crate::formats::id3::Id3Meta`]
+  /// plus borrowed MPEG-audio / APE-trailer passthrough slices; the typed
+  /// MPEG-audio / APE arms land in Phase F3/F4 (per
+  /// `docs/tracking.md` F2 ID3 integration notes).
+  #[cfg(feature = "mp3")]
+  Mp3(crate::formats::id3::Mp3Meta<'a>),
 }
 
 impl MetaSinker for AnyMeta<'_> {
@@ -348,6 +365,10 @@ impl MetaSinker for AnyMeta<'_> {
       AnyMeta::Aa(m) => m.sink(print_conv, out),
       #[cfg(feature = "red")]
       AnyMeta::R3d(m) => m.sink(print_conv, out),
+      #[cfg(feature = "id3")]
+      AnyMeta::Id3(m) => m.sink(print_conv, out),
+      #[cfg(feature = "mp3")]
+      AnyMeta::Mp3(m) => m.sink(print_conv, out),
     }
   }
 }


### PR DESCRIPTION
PR #5 of 9 in stacked lib-first series. Builds on #21.

ID3 + MP3 wrapper migrated using stage-and-replay architecture (per docs/tracking.md F2 ID3 integration notes — minimum-disruption approach given ID3.pm's ~5,600 LOC depth; native scalar engine rewrite deferred to Phase G).

Verification:
- 26 ID3 + 8 MP3 conformance fixtures byte-exact vs bundled `perl exiftool 13.58`.
- process_with_start_offset(ctx, start_offset) API preserved verbatim (F4 MPEG-audio integration depends on this).
- 4 gates green: cargo build, cargo test --all-targets, cargo +stable fmt --all -- --check, RUSTFLAGS=-D warnings cargo build.