### PR TITLE
lib-first redesign Phase F5 — composite migrations (MPC + WavPack)

### DIFF
--- a/src/formats/mpc.rs
+++ b/src/formats/mpc.rs
@@ -1,10 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "mpc")]
 //! Faithful port of `Image::ExifTool::MPC` (lib/Image/ExifTool/MPC.pm).
-//! PROCESS_PROC is `FLAC::ProcessBitStream` (MPC.pm:22) → `crate::bitstream`.
+//! PROCESS_PROC is `FLAC::ProcessBitStream` (MPC.pm:22) → [`crate::bitstream`].
+//!
+//! **Phase F5 — lib-first migration.** This format follows the MOI (Phase E)
+//! and AAC/DV (Phase F1) pattern: a typed [`MpcMeta<'a>`] is produced by the
+//! new [`crate::parser_new::FormatParser`] trait; the legacy
+//! [`crate::parser::OldFormatParser`] entry point bridges through
+//! [`crate::sink::MetadataTagWriter`] so CLI JSON output stays byte-exact
+//! during the per-format crawl. The bridge is retired in Phase G.
+//!
+//! ## Chained-format role
+//!
+//! Unlike the F1 leaves (AAC/DV — single-format, no chained sub-blocks),
+//! MPC is a chained format (MPC.pm:84-87, 111-113):
+//!
+//! 1. **Leading ID3** — `unless ($$et{DoneID3}) { ProcessID3 ... and return 1; }`
+//!    (MPC.pm:84-87). The bundled audio-loop (ID3.pm:1582-1601) recursively
+//!    re-enters ProcessMPC with `DoneID3` set when ID3 detects a prefix; our
+//!    flattened single-pass model runs ID3 first, then the MP+ header from
+//!    the post-ID3 offset (mirrors APE.pm:122-127 / [`crate::formats::ape`]'s
+//!    APE-style flatten).
+//! 2. **APE trailer** — `Image::ExifTool::APE::ProcessAPE(...)` (MPC.pm:111-113).
+//!    Always invoked after the MP+ header, even on the non-SV7 warning arm;
+//!    bundled returns 1 regardless (void context, MPC.pm:113-115).
+//!
+//! Phase F5 spec: ID3 and APE are dispatched at the legacy [`OldFormatParser`]
+//! interface (the parallel F2 ID3 / F3 APE agents own the typed `Id3Meta` /
+//! `ApeMeta`). The typed [`MpcMeta<'a>`] carries [`Option<&'a [u8]>`] byte
+//! placeholders for the ID3-prefix and APE-trailer slices so a future
+//! F5-integration pass can compose them with the typed `Id3Meta`/`ApeMeta`.
+//!
+//! ## %MPC::Main table (MPC.pm:21-72)
+//!
+//! Bit fields walked by `process_bit_stream` (MPC.pm:22 `PROCESS_PROC =>
+//! \&Image::ExifTool::FLAC::ProcessBitStream`) on the 32-byte MP+ header
+//! with byte order `'II'` (MPC.pm:98).
+//!
+//! | Bit range  | Tag                  | PrintConv                    |
+//! |-----------|----------------------|------------------------------|
+//! | 032-063   | TotalFrames          | none                         |
+//! | 080-081   | SampleRate           | hash (0/1/2/3 ⇒ Hz numbers)  |
+//! | 084-087   | Quality              | hash (1..15, sparse strings) |
+//! | 088-093   | MaxBand              | none                         |
+//! | 096-111   | ReplayGainTrackPeak  | none                         |
+//! | 112-127   | ReplayGainTrackGain  | none                         |
+//! | 128-143   | ReplayGainAlbumPeak  | none                         |
+//! | 144-159   | ReplayGainAlbumGain  | none                         |
+//! | 179       | FastSeek             | hash (0/1 ⇒ No/Yes)          |
+//! | 191       | Gapless              | hash (0/1 ⇒ No/Yes)          |
+//! | 216-223   | EncoderVersion       | func (`$val =~ s/(\d)(\d)(\d)$/$1.$2.$3/`) |
 
 use crate::{
+  bitstream::{BitOrder, process_bit_stream},
+  parser::{OldFormatParser, ParseContext},
+  parser_new::{FormatParser, MetaSinker, SharedFlags, TagWriter, parser_sealed},
+  sink::MetadataTagWriter,
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
-  value::TagValue,
+  value::{Metadata, TagValue},
 };
+
+// ===========================================================================
+// `%MPC::Main` tag table (MPC.pm:21-72)
+//
+// Retained so the [`process_bit_stream`] engine (and the [`OldFormatParser`]
+// bridge below) can drive the same FLAC::ProcessBitStream PROCESS_PROC as
+// bundled Perl. The typed [`MpcMeta`] holds the raw bit-field scalars
+// (post-bit-stream, pre-PrintConv); PrintConv is applied at emit time by
+// [`MetaSinker::sink`] to mirror ExifTool's `$$self{OPTIONS}{PrintConv}`
+// toggle (ExifTool.pm:5710).
+// ===========================================================================
 
 // MPC.pm:28 — TotalFrames (Bit032-063 = 32-bit integer): no PrintConv.
 static TOTAL_FRAMES: TagDef = TagDef::new("TotalFrames", "MPC", ValueConv::None, PrintConv::None);
@@ -210,90 +277,744 @@ pub const MPC_BIT_KEYS: &[&str] = &[
   "Bit216-223", // EncoderVersion     (MPC.pm:68)
 ];
 
-/// MPC parser (faithful `ProcessMPC`, MPC.pm:79-116).
-pub struct ProcessMpc;
+// ===========================================================================
+// Typed Meta — `MpcMeta<'a>`
+// ===========================================================================
 
-impl crate::parser::FormatParser for ProcessMpc {
-  fn process(&self, ctx: &mut crate::parser::ParseContext<'_>) -> bool {
-    // MPC.pm:84-87 `unless ($$et{DoneID3}) { ProcessID3 ... and return 1 }`.
-    // Phase-2 DEFERRED to PR #6 (ID3): on a real MPC file that BEGINS with an
-    // ID3v2 magic (`ID3...`), ProcessID3 would consume the ID3v2 leading
-    // block, advance `$raf`, then dispatch the audio module from inside ID3
-    // (ID3.pm:1580-1601 `foreach $type (@audioFormats) { ... }`), and return
-    // 1 — at which point ProcessMPC returns 1 immediately. On a file WITHOUT
-    // ID3v2 leading bytes (the in-scope input set here), ProcessID3 reads 3
-    // bytes, finds no `^ID3` match (ID3.pm:1452), and returns 0 — at which
-    // point this `unless` block is a no-op. Inputs in this PR's scope are
-    // exactly the no-ID3 case: a pure SV7 MP+ file or a non-SV7 MP+ file.
-    //
-    // No `Warn` here is faithful: Perl's `ProcessID3` is silent in the
-    // no-ID3 case (it does NOT warn for "no ID3 found"; it simply returns 0).
-    // Re-derive the actual integration when the ID3 port lands.
+/// SV7 header bit-field scalars (MPC.pm:21-72), post-bit-stream extraction
+/// and pre-PrintConv. The bit-stream walker
+/// ([`process_bit_stream`]) emits these as `TagValue::I64`; the typed
+/// values here are the lifted primitives with the smallest faithful width
+/// (e.g. 32-bit `TotalFrames`, 16-bit `ReplayGain*`, 8-bit `EncoderVersion`).
+///
+/// PrintConv (`%SampleRate`, `%Quality`, `%FastSeek/Gapless`,
+/// [`encoder_version_print`]) is applied at emit time by [`MetaSinker::sink`]
+/// — `print_conv=true` ⇒ formatted strings or substituted numbers; `false` ⇒
+/// the raw scalars here as JSON numbers.
+///
+/// **D8 — no public fields, accessors only.** Construct only via the parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MpcSv7Header {
+  /// Bit032-063 — `TotalFrames` raw u32 (MPC.pm:28).
+  total_frames: u32,
+  /// Bit080-081 — `SampleRate` raw index (0..=3, MPC.pm:29-37).
+  /// PrintConv hash maps 0⇒44100, 1⇒48000, 2⇒37800, 3⇒32000.
+  sample_rate_index: u8,
+  /// Bit084-087 — `Quality` raw index (1..=15, MPC.pm:38-54). The PrintConv
+  /// hash is sparse (no entries for 2/3/4); fall-through emits the generic
+  /// `Unknown (N)` form (ExifTool.pm:3622).
+  quality_index: u8,
+  /// Bit088-093 — `MaxBand` raw 6-bit integer (MPC.pm:55).
+  max_band: u8,
+  /// Bit096-111 — `ReplayGainTrackPeak` raw u16 (MPC.pm:56).
+  replay_gain_track_peak: u16,
+  /// Bit112-127 — `ReplayGainTrackGain` raw u16 (MPC.pm:57).
+  replay_gain_track_gain: u16,
+  /// Bit128-143 — `ReplayGainAlbumPeak` raw u16 (MPC.pm:58).
+  replay_gain_album_peak: u16,
+  /// Bit144-159 — `ReplayGainAlbumGain` raw u16 (MPC.pm:59).
+  replay_gain_album_gain: u16,
+  /// Bit179 — `FastSeek` raw 1-bit (MPC.pm:60-63).
+  fast_seek: u8,
+  /// Bit191 — `Gapless` raw 1-bit (MPC.pm:64-67).
+  gapless: u8,
+  /// Bit216-223 — `EncoderVersion` raw 8-bit (MPC.pm:68-71). PrintConv runs
+  /// `$val =~ s/(\d)(\d)(\d)$/$1.$2.$3/` — `115` ⇒ `"1.1.5"`.
+  encoder_version: u8,
+}
 
-    // MPC.pm:92 `$raf->Read($buff,32) == 32 and $buff =~ /^MP\+(.)/s or return 0`.
-    // Copy the 32-byte header out of the borrowed `ctx.data()` so the upcoming
-    // `&mut ctx` (set_file_type + bit-stream call) does not conflict with
-    // `$buff`; `hdr` IS Perl `$buff`. Stack-allocated copy is panic-free.
-    let hdr: [u8; 32] = {
-      let data = ctx.data();
-      if data.len() < 32 {
-        return false; // short read ⇒ Perl `$raf->Read != 32` ⇒ return 0
-      }
-      let mut h = [0u8; 32];
-      h.copy_from_slice(&data[..32]);
-      h
-    };
-    if &hdr[..3] != b"MP+" {
-      return false; // magic mismatch ⇒ Perl regex no-match ⇒ return 0
+impl MpcSv7Header {
+  /// `TotalFrames` raw u32 (MPC.pm:28).
+  #[must_use]
+  pub const fn total_frames(&self) -> u32 {
+    self.total_frames
+  }
+  /// `SampleRate` raw index (0..=3, MPC.pm:29-37). Use
+  /// [`Self::sample_rate_hz`] for the PrintConv-mapped Hz number.
+  #[must_use]
+  pub const fn sample_rate_index(&self) -> u8 {
+    self.sample_rate_index
+  }
+  /// `SampleRate` in Hz from the MPC.pm:31-36 PrintConv hash. `None` if the
+  /// raw index is off-table (unreachable: bit field is 2-bit, all 4 values
+  /// are mapped).
+  #[must_use]
+  pub const fn sample_rate_hz(&self) -> Option<u32> {
+    match self.sample_rate_index {
+      0 => Some(44100), // MPC.pm:32
+      1 => Some(48000), // MPC.pm:33
+      2 => Some(37800), // MPC.pm:34
+      3 => Some(32000), // MPC.pm:35
+      _ => None,        // unreachable for a 2-bit index
     }
-    // MPC.pm:93 `my $vers = ord($1) & 0x0f` — low nibble of byte 3.
-    let vers = hdr[3] & 0x0f;
-    // MPC.pm:94 `$et->SetFileType()` — no-arg ⇒ detected file type ("MPC").
-    // Called AFTER magic passes, BEFORE the version dispatch, so the non-SV7
-    // branch still emits the File:* triplet alongside the Warning.
-    ctx.set_file_type(None, None, None);
-    let print_conv_enabled = ctx.print_conv_enabled();
-
-    // MPC.pm:97-106 — SV7 path: ProcessDirectory(MPC::Main) over the 32-byte
-    // header, byte order 'II' (MPC.pm:98). `Options('Verbose')` (MPC.pm:100)
-    // is faithfully deferred (no Verbose option on the read path).
-    if vers == 0x07 {
-      crate::bitstream::process_bit_stream(
-        &hdr,
-        crate::bitstream::BitOrder::Ii, // MPC.pm:98 SetByteOrder('II') — little-endian
-        MPC_BIT_KEYS,
-        &MPC_MAIN,
-        ctx.metadata(),
-        print_conv_enabled,
-      );
-    } else {
-      // MPC.pm:107-109 `$et->Warn('Audio info currently not extracted from
-      // this version MPC file')`. Verbatim string.
-      ctx
-        .metadata()
-        .push_warning("Audio info currently not extracted from this version MPC file");
+  }
+  /// `Quality` raw index (1..=15, MPC.pm:38-54).
+  #[must_use]
+  pub const fn quality_index(&self) -> u8 {
+    self.quality_index
+  }
+  /// `Quality` PrintConv string (MPC.pm:38-54). `None` on a hash miss
+  /// (raw 0, 2, 3, 4 — sparse keys); the legacy bridge then emits the
+  /// generic `Unknown (N)` fallback (ExifTool.pm:3622).
+  #[must_use]
+  pub const fn quality_name(&self) -> Option<&'static str> {
+    match self.quality_index {
+      1 => Some("Unstable/Experimental"),
+      5 => Some("0"),
+      6 => Some("1"),
+      7 => Some("2 (Telephone)"),
+      8 => Some("3 (Thumb)"),
+      9 => Some("4 (Radio)"),
+      10 => Some("5 (Standard)"),
+      11 => Some("6 (Xtreme)"),
+      12 => Some("7 (Insane)"),
+      13 => Some("8 (BrainDead)"),
+      14 => Some("9"),
+      15 => Some("10"),
+      _ => None,
     }
-
-    // MPC.pm:111-113 `require Image::ExifTool::APE; ProcessAPE($et, $dirInfo)`.
-    // Phase-2 DEFERRED to the APE port: on a file WITH an APE trailer,
-    // ProcessAPE seeks to the file end, reads the APE trailer, and pushes
-    // `APE:*` tags. On a file WITHOUT an APE trailer (the in-scope inputs
-    // here), ProcessAPE seeks to end-32 bytes, reads 32 bytes, finds no
-    // "APETAGEX" magic at the trailer position (APE.pm:128-133), and returns
-    // 0 with no warning. Re-derive the actual integration when the APE port
-    // lands; until then the no-APE case is byte-exact.
-
-    true // MPC.pm:115 `return 1`
+  }
+  /// `MaxBand` raw 6-bit (MPC.pm:55).
+  #[must_use]
+  pub const fn max_band(&self) -> u8 {
+    self.max_band
+  }
+  /// `ReplayGainTrackPeak` raw u16 (MPC.pm:56).
+  #[must_use]
+  pub const fn replay_gain_track_peak(&self) -> u16 {
+    self.replay_gain_track_peak
+  }
+  /// `ReplayGainTrackGain` raw u16 (MPC.pm:57).
+  #[must_use]
+  pub const fn replay_gain_track_gain(&self) -> u16 {
+    self.replay_gain_track_gain
+  }
+  /// `ReplayGainAlbumPeak` raw u16 (MPC.pm:58).
+  #[must_use]
+  pub const fn replay_gain_album_peak(&self) -> u16 {
+    self.replay_gain_album_peak
+  }
+  /// `ReplayGainAlbumGain` raw u16 (MPC.pm:59).
+  #[must_use]
+  pub const fn replay_gain_album_gain(&self) -> u16 {
+    self.replay_gain_album_gain
+  }
+  /// `FastSeek` raw 1-bit (MPC.pm:60-63). `true` ⇒ "Yes".
+  #[must_use]
+  pub const fn fast_seek(&self) -> bool {
+    self.fast_seek != 0
+  }
+  /// `Gapless` raw 1-bit (MPC.pm:64-67). `true` ⇒ "Yes".
+  #[must_use]
+  pub const fn gapless(&self) -> bool {
+    self.gapless != 0
+  }
+  /// `EncoderVersion` raw byte (MPC.pm:68-71). Use
+  /// [`Self::encoder_version_str`] for the dotted PrintConv form.
+  #[must_use]
+  pub const fn encoder_version(&self) -> u8 {
+    self.encoder_version
   }
 }
+
+/// Typed MPC metadata — the lib-first output of [`ProcessMpc`].
+///
+/// Holds the typed bit-field scalars from the SV7 header (when present) +
+/// the version-specific warning string (when the MP+ version is anything
+/// other than SV7, MPC.pm:107-109). PrintConv (hash + func) is applied at
+/// emit time by [`MetaSinker::sink`] to mirror ExifTool's
+/// `$$self{OPTIONS}{PrintConv}` toggle (ExifTool.pm:5710).
+///
+/// ## Chained sub-blocks
+///
+/// MPC dispatches both ID3 (MPC.pm:84-87) and APE (MPC.pm:111-113). Phase F5
+/// spec: the typed [`Id3Meta`] / [`ApeMeta`] land in the parallel F2 / F3
+/// agents; F5's MPC migration captures their input byte slices as
+/// `Option<&'a [u8]>` placeholders so a future F5-integration pass can
+/// compose them with the typed sub-format Metas. The legacy bridge below
+/// dispatches both via [`OldFormatParser`], so the byte-exact CLI output is
+/// preserved through Phase F.
+///
+/// **D8 — no public fields, accessors only.**
+///
+/// **Lifetimes.** `'a` is held for the ID3/APE byte placeholders that
+/// borrow from the input slice; the SV7 header is owned primitives.
+#[derive(Debug, Clone, Copy)]
+pub struct MpcMeta<'a> {
+  /// MP+ version low nibble (MPC.pm:93 `ord($1) & 0x0f`). The SV7 bit
+  /// walker only runs when `version == 0x07`; other versions trigger the
+  /// MPC.pm:107-109 warning arm.
+  version: u8,
+  /// SV7 header fields (MPC.pm:21-72). `Some` iff the MP+ version low
+  /// nibble is `0x07`; `None` for the non-SV7 warning arm
+  /// (MPC.pm:107-109).
+  sv7_header: Option<MpcSv7Header>,
+  /// Whether the non-SV7 warning (MPC.pm:108 `'Audio info currently not
+  /// extracted from this version MPC file'`) should be emitted.
+  warn_unsupported_version: bool,
+  /// **Phase F5 placeholder.** Byte slice of any ID3-prefix block seen
+  /// BEFORE the MP+ magic (MPC.pm:84-87). The legacy bridge dispatches it
+  /// through [`crate::formats::id3::process::process_id3_chained`]; the
+  /// typed `Id3Meta` from the parallel F2 agent will eventually consume
+  /// this slice (Phase F5-integration). Today: always `None` — F5 does NOT
+  /// pre-scan for ID3 (the bridge calls ID3 directly on `ctx.data()`).
+  id3_prefix: Option<&'a [u8]>,
+  /// **Phase F5 placeholder.** Byte slice of any APE trailer block seen
+  /// AFTER the MP+ header (MPC.pm:111-113). The legacy bridge dispatches
+  /// it through [`crate::formats::ape::ProcessApe::process_trailer_only`];
+  /// the typed `ApeMeta` from the parallel F3 agent will eventually
+  /// consume this slice. Today: always `None` for the same reason as
+  /// `id3_prefix`.
+  ape_trailer: Option<&'a [u8]>,
+}
+
+impl<'a> MpcMeta<'a> {
+  /// MP+ version low nibble (MPC.pm:93). `0x07` ⇒ SV7 path; anything else
+  /// ⇒ warning arm (MPC.pm:107-109).
+  #[must_use]
+  pub const fn version(&self) -> u8 {
+    self.version
+  }
+  /// SV7 header fields, present iff [`Self::version`] returned `0x07`.
+  #[must_use]
+  pub const fn sv7_header(&self) -> Option<&MpcSv7Header> {
+    self.sv7_header.as_ref()
+  }
+  /// `true` if the MPC.pm:108 warning (`'Audio info currently not extracted
+  /// from this version MPC file'`) should be emitted.
+  #[must_use]
+  pub const fn warn_unsupported_version(&self) -> bool {
+    self.warn_unsupported_version
+  }
+  /// **Phase F5 placeholder.** ID3-prefix bytes (always `None` today; see
+  /// the field-level doc).
+  #[must_use]
+  pub const fn id3_prefix(&self) -> Option<&'a [u8]> {
+    self.id3_prefix
+  }
+  /// **Phase F5 placeholder.** APE-trailer bytes (always `None` today; see
+  /// the field-level doc).
+  #[must_use]
+  pub const fn ape_trailer(&self) -> Option<&'a [u8]> {
+    self.ape_trailer
+  }
+}
+
+// ===========================================================================
+// `MpcContext<'a>` — per-format input view for chained dispatch
+// ===========================================================================
+
+/// Per-format input view for [`ProcessMpc`]. Wraps the input bytes and a
+/// mutable [`SharedFlags`] handle, faithful to spec §6.4: "Leaves (MOI,
+/// AAC, DV, Audible) take just `&'a [u8]`; chained formats (ID3 → APE,
+/// APE → ID3, MPC → ID3 + APE, …) wrap `&'a [u8]` + `&'a mut SharedFlags`."
+///
+/// MPC chains BOTH ID3 (MPC.pm:84-87) and APE (MPC.pm:111-113), so it
+/// carries the SharedFlags. The Phase F5 typed [`ProcessMpc::parse`] does
+/// NOT itself dispatch to ID3/APE (those typed parsers land in the parallel
+/// F2/F3 agents and the F5-integration composes them); the field is in the
+/// surface for forward compatibility.
+///
+/// D8: PRIVATE fields, accessors only.
+#[derive(Debug)]
+pub struct MpcContext<'a> {
+  data: &'a [u8],
+  // Held for cross-format chained dispatch. F5's typed `parse` does not
+  // mutate the shared flags directly — they're threaded so a future
+  // F5-integration pass can chain into typed `Id3Meta` / `ApeMeta`.
+  #[allow(dead_code)]
+  shared: &'a mut SharedFlags,
+}
+
+impl<'a> MpcContext<'a> {
+  /// Construct a chained-MPC context with the input bytes and a mutable
+  /// [`SharedFlags`] handle.
+  #[must_use]
+  pub fn new(data: &'a [u8], shared: &'a mut SharedFlags) -> Self {
+    Self { data, shared }
+  }
+  /// Borrow the input bytes.
+  #[must_use]
+  pub const fn data(&self) -> &'a [u8] {
+    self.data
+  }
+  /// Borrow the cross-format shared flags. Phase G integration will use
+  /// this to thread `done_id3` / `done_ape` updates from typed `Id3Meta` /
+  /// `ApeMeta` runs.
+  pub fn shared(&mut self) -> &mut SharedFlags {
+    self.shared
+  }
+}
+
+// ===========================================================================
+// `ProcessMpc` — the lib-first parser
+// ===========================================================================
+
+/// MPC parser (faithful `ProcessMPC`, MPC.pm:79-116).
+#[derive(Debug, Clone, Copy)]
+pub struct ProcessMpc;
+
+impl parser_sealed::Sealed for ProcessMpc {}
+
+impl FormatParser for ProcessMpc {
+  /// Typed Meta. The `<'static>` shape is the [`crate::parser_new::AnyMeta`]-
+  /// compatible form; the lib-first direct entry [`parse_borrowed`] keeps
+  /// the borrow-from-input lifetime.
+  type Meta = MpcMeta<'static>;
+  /// Chained-format Context: `data + SharedFlags`. See [`MpcContext`].
+  type Context<'a> = MpcContext<'a>;
+  /// Rust-level fatal error (currently none — every bad input is `Ok(None)`).
+  type Error = MpcError;
+
+  /// Parse an MPC file's bytes into a typed [`MpcMeta`], or `None` if the
+  /// buffer is not a valid MP+ stream (short read or wrong magic; MPC.pm:92).
+  ///
+  /// **Phase F5 scope.** Reads the 32-byte MP+ header, validates the magic
+  /// (MPC.pm:92), and extracts the SV7 bit-fields when `vers == 0x07`. The
+  /// chained ID3 (MPC.pm:84-87) and APE (MPC.pm:111-113) dispatches are
+  /// deferred to the legacy [`OldFormatParser`] bridge (the parallel F2/F3
+  /// agents own typed `Id3Meta` / `ApeMeta`).
+  fn parse(&self, ctx: Self::Context<'_>) -> Result<Option<Self::Meta>, MpcError> {
+    parse_inner(ctx.data()).map(|opt| opt.map(MpcMeta::into_static))
+  }
+}
+
+/// Lib-first direct entry. Same as [`FormatParser::parse`] but returns an
+/// [`MpcMeta`] that borrows from the input buffer (for the F5 placeholder
+/// byte slices; the SV7 header is owned).
+///
+/// # Errors
+///
+/// Returns `Err` for Rust-level fatal modes (none today; reserved for
+/// future I/O wrappers).
+pub fn parse_borrowed(data: &[u8]) -> Result<Option<MpcMeta<'_>>, MpcError> {
+  parse_inner(data)
+}
+
+/// Inner parser — produces a borrow-from-input [`MpcMeta`]. The trait's
+/// `Meta = MpcMeta<'static>` shape forces an [`MpcMeta::into_static`]
+/// upgrade for the closed [`crate::parser_new::AnyMeta`] enum (Phase E
+/// `into_static` pragma per `docs/tracking.md` 2026-05-21 entry); the
+/// placeholders [`MpcMeta::id3_prefix`] / [`MpcMeta::ape_trailer`] are
+/// always `None` in F5, so the upgrade is a trivial reborrow.
+fn parse_inner(data: &[u8]) -> Result<Option<MpcMeta<'_>>, MpcError> {
+  // MPC.pm:92 `$raf->Read($buff,32) == 32 and $buff =~ /^MP\+(.)/s or return 0`.
+  if data.len() < 32 {
+    return Ok(None); // short read ⇒ Perl `$raf->Read != 32` ⇒ return 0
+  }
+  let hdr = &data[..32];
+  if &hdr[..3] != b"MP+" {
+    return Ok(None); // magic mismatch ⇒ Perl regex no-match ⇒ return 0
+  }
+  // MPC.pm:93 `my $vers = ord($1) & 0x0f` — low nibble of byte 3.
+  let version = hdr[3] & 0x0f;
+
+  // MPC.pm:97-106 — SV7 path: ProcessDirectory(MPC::Main) over the 32-byte
+  // header, byte order 'II' (MPC.pm:98). `Options('Verbose')` (MPC.pm:100)
+  // is faithfully deferred (no Verbose option on the read path).
+  let (sv7_header, warn_unsupported_version) = if version == 0x07 {
+    (Some(extract_sv7_header(hdr)), false)
+  } else {
+    // MPC.pm:107-109 `$et->Warn('Audio info currently not extracted from
+    // this version MPC file')`.
+    (None, true)
+  };
+
+  Ok(Some(MpcMeta {
+    version,
+    sv7_header,
+    warn_unsupported_version,
+    // F5 placeholders — see field docs on `MpcMeta`.
+    id3_prefix: None,
+    ape_trailer: None,
+  }))
+}
+
+/// Extract the SV7 bit-fields from the 32-byte MP+ header. Reuses
+/// [`process_bit_stream`] (the shared FLAC::ProcessBitStream engine) for
+/// byte-exact extraction faithful to MPC.pm:22, then lifts the emitted
+/// `TagValue::I64` scalars into typed primitives on [`MpcSv7Header`].
+///
+/// The bit-stream walker pushes into a side [`Metadata`] (`print_conv=false`
+/// so the staged values are post-ValueConv raw scalars — `ValueConv::None`
+/// for every MPC field, so these are the literal bit-extracted integers).
+/// [`MetaSinker::sink`] applies PrintConv at emit time.
+fn extract_sv7_header(hdr: &[u8]) -> MpcSv7Header {
+  // Staging Metadata captures the bit-stream walker's emissions. The walker
+  // always emits `TagValue::I64` for these ≤ 32-bit fields (see the AAC
+  // pilot — same pattern), so the lift is a direct `as` cast.
+  let mut staging = Metadata::new("mpc-staging");
+  process_bit_stream(
+    hdr,
+    BitOrder::Ii, // MPC.pm:98 SetByteOrder('II') — little-endian
+    MPC_BIT_KEYS,
+    &MPC_MAIN,
+    &mut staging,
+    /* print_conv_enabled */ false,
+  );
+
+  // Defaults are 0 for every field — the bit-stream walker hits every key
+  // for a well-formed 32-byte header; on a short buffer the walker breaks
+  // early via FLAC.pm:177 `last if $i2 >= $dirLen`. The 32-byte gate above
+  // ensures the full walk in production; the defaults guard against
+  // pathological inputs.
+  let mut h = MpcSv7Header {
+    total_frames: 0,
+    sample_rate_index: 0,
+    quality_index: 0,
+    max_band: 0,
+    replay_gain_track_peak: 0,
+    replay_gain_track_gain: 0,
+    replay_gain_album_peak: 0,
+    replay_gain_album_gain: 0,
+    fast_seek: 0,
+    gapless: 0,
+    encoder_version: 0,
+  };
+  for tag in staging.tags() {
+    let TagValue::I64(n) = tag.value() else {
+      continue; // unreachable for these fields under print_conv=false
+    };
+    let n = *n;
+    match tag.name() {
+      "TotalFrames" => h.total_frames = n as u32,
+      "SampleRate" => h.sample_rate_index = n as u8,
+      "Quality" => h.quality_index = n as u8,
+      "MaxBand" => h.max_band = n as u8,
+      "ReplayGainTrackPeak" => h.replay_gain_track_peak = n as u16,
+      "ReplayGainTrackGain" => h.replay_gain_track_gain = n as u16,
+      "ReplayGainAlbumPeak" => h.replay_gain_album_peak = n as u16,
+      "ReplayGainAlbumGain" => h.replay_gain_album_gain = n as u16,
+      "FastSeek" => h.fast_seek = n as u8,
+      "Gapless" => h.gapless = n as u8,
+      "EncoderVersion" => h.encoder_version = n as u8,
+      _ => {}
+    }
+  }
+  h
+}
+
+// ===========================================================================
+// `MpcMeta::into_static`
+// ===========================================================================
+
+impl MpcMeta<'_> {
+  /// Promote a borrow-from-input [`MpcMeta`] into an owned
+  /// `MpcMeta<'static>`. Phase E `into_static` pragma: the trait
+  /// [`FormatParser::Meta`] is `MpcMeta<'static>` for [`crate::parser_new::
+  /// AnyMeta`] compatibility, but the lib-first direct path keeps the
+  /// borrow-from-input lifetime via [`parse_borrowed`].
+  ///
+  /// In F5 the `id3_prefix` / `ape_trailer` placeholders are ALWAYS `None`
+  /// (the typed parser does not pre-scan ID3/APE; the legacy bridge runs
+  /// those via [`OldFormatParser`]). The `into_static` upgrade is therefore
+  /// a trivial reborrow with no `Box::leak` (unlike MOI / AAC). When the
+  /// F5-integration pass starts threading typed `Id3Meta` / `ApeMeta` into
+  /// `MpcMeta`, this `into_static` will need to materialize the byte
+  /// slices — that's a Phase G concern (see spec §7's `<'a>` GAT note).
+  fn into_static(self) -> MpcMeta<'static> {
+    MpcMeta {
+      version: self.version,
+      sv7_header: self.sv7_header,
+      warn_unsupported_version: self.warn_unsupported_version,
+      // F5: placeholders are always `None`, so the lifetime upgrade is a
+      // direct `None: Option<&'static [u8]>` rebrand. When the F5-
+      // integration pass starts populating these from the typed
+      // `Id3Meta` / `ApeMeta`, the upgrade will need `Box::leak` or a
+      // full `'a` GAT thread-through (Phase G).
+      id3_prefix: None,
+      ape_trailer: None,
+    }
+  }
+}
+
+// ===========================================================================
+// `MetaSinker` — typed Meta → TagWriter
+// ===========================================================================
+
+impl MetaSinker for MpcMeta<'_> {
+  /// Emit MPC tags into the writer in `%MPC::Main` walk order (MPC.pm:21-72:
+  /// TotalFrames, SampleRate, Quality, MaxBand, ReplayGain×4, FastSeek,
+  /// Gapless, EncoderVersion) — faithful to the bundled-Perl bit-stream
+  /// iteration order.
+  ///
+  /// `print_conv=true` ⇒ PrintConv formatted values (`-j` mode):
+  /// - `SampleRate` ⇒ Hz number from the hash (e.g. `44100`)
+  /// - `Quality` ⇒ named string from the hash (e.g. `"5 (Standard)"`)
+  /// - `FastSeek` / `Gapless` ⇒ `"No"` / `"Yes"`
+  /// - `EncoderVersion` ⇒ dotted string (e.g. `"1.1.5"`)
+  ///
+  /// `print_conv=false` ⇒ post-ValueConv raw scalars (`-n` mode): every
+  /// field emits its raw integer (sample_rate_index, quality_index, etc.).
+  ///
+  /// **Non-SV7 arm.** When [`MpcMeta::sv7_header`] is `None`
+  /// (MPC.pm:107-109), no MPC:* tags are emitted; the warning is pushed by
+  /// the legacy bridge or directly by a lib caller via
+  /// [`TagWriter::write_warning`] at the end of this fn.
+  fn sink<W: TagWriter>(&self, print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    const GROUP: &str = "MPC";
+
+    if let Some(h) = self.sv7_header.as_ref() {
+      // MPC.pm:28 — TotalFrames: no conversions, identical under -j and -n.
+      out.write_u64(GROUP, "TotalFrames", u64::from(h.total_frames))?;
+
+      // MPC.pm:29-37 — SampleRate. -j: hash hit yields the Hz integer
+      // (PrintValue::I64). -n: raw index.
+      if print_conv {
+        // sample_rate_hz() is always Some for a 2-bit index (all 4
+        // values mapped); fall through to raw if ever None.
+        match h.sample_rate_hz() {
+          Some(hz) => out.write_u64(GROUP, "SampleRate", u64::from(hz))?,
+          None => out.write_u64(GROUP, "SampleRate", u64::from(h.sample_rate_index))?,
+        }
+      } else {
+        out.write_u64(GROUP, "SampleRate", u64::from(h.sample_rate_index))?;
+      }
+
+      // MPC.pm:38-54 — Quality. -j: hash hit yields a PrintValue::Str
+      // (e.g. "5 (Standard)" for index 10); miss falls back to "Unknown
+      // (N)" (ExifTool.pm:3622 — the generic PrintConv hash-miss path).
+      // -n: raw index.
+      if print_conv {
+        if let Some(name) = h.quality_name() {
+          out.write_str(GROUP, "Quality", name)?;
+        } else {
+          let idx = h.quality_index;
+          out.write_fmt(GROUP, "Quality", |w| write!(w, "Unknown ({idx})"))?;
+        }
+      } else {
+        out.write_u64(GROUP, "Quality", u64::from(h.quality_index))?;
+      }
+
+      // MPC.pm:55 — MaxBand: no conversions.
+      out.write_u64(GROUP, "MaxBand", u64::from(h.max_band))?;
+
+      // MPC.pm:56-59 — ReplayGain×4: no conversions.
+      out.write_u64(
+        GROUP,
+        "ReplayGainTrackPeak",
+        u64::from(h.replay_gain_track_peak),
+      )?;
+      out.write_u64(
+        GROUP,
+        "ReplayGainTrackGain",
+        u64::from(h.replay_gain_track_gain),
+      )?;
+      out.write_u64(
+        GROUP,
+        "ReplayGainAlbumPeak",
+        u64::from(h.replay_gain_album_peak),
+      )?;
+      out.write_u64(
+        GROUP,
+        "ReplayGainAlbumGain",
+        u64::from(h.replay_gain_album_gain),
+      )?;
+
+      // MPC.pm:60-63 — FastSeek. -j: 0⇒"No", 1⇒"Yes". -n: raw 0/1.
+      if print_conv {
+        out.write_str(
+          GROUP,
+          "FastSeek",
+          if h.fast_seek != 0 { "Yes" } else { "No" },
+        )?;
+      } else {
+        out.write_u64(GROUP, "FastSeek", u64::from(h.fast_seek))?;
+      }
+
+      // MPC.pm:64-67 — Gapless. Same shape as FastSeek.
+      if print_conv {
+        out.write_str(GROUP, "Gapless", if h.gapless != 0 { "Yes" } else { "No" })?;
+      } else {
+        out.write_u64(GROUP, "Gapless", u64::from(h.gapless))?;
+      }
+
+      // MPC.pm:68-71 — EncoderVersion. -j: dotted via the substitution
+      // function (115 ⇒ "1.1.5"). -n: raw byte (115). The match path is
+      // unconditional for valid 3-digit numbers: every u8 ≥ 100 takes the
+      // match path; u8 < 100 (1- or 2-digit) takes the no-match path and
+      // emits the raw integer faithfully.
+      if print_conv {
+        // Stringify the raw u8 and apply the Perl `s/(\d)(\d)(\d)$/$1.$2.$3/`
+        // substitution. For raw byte n:
+        //   n >= 100 ⇒ 3 trailing digits ⇒ match ⇒ "head.lhs.mid.tail"
+        //   n < 100  ⇒ no match ⇒ emit raw integer
+        // (This mirrors `encoder_version_print` above with the I64 input.)
+        let n = u32::from(h.encoder_version);
+        let s = n.to_string();
+        let bytes = s.as_bytes();
+        if bytes.len() >= 3 && bytes[bytes.len() - 3..].iter().all(u8::is_ascii_digit) {
+          out.write_fmt(GROUP, "EncoderVersion", |w| {
+            let (head, tail) = s.split_at(s.len() - 3);
+            let tb = tail.as_bytes();
+            w.write_str(head)?;
+            w.write_char(tb[0] as char)?;
+            w.write_char('.')?;
+            w.write_char(tb[1] as char)?;
+            w.write_char('.')?;
+            w.write_char(tb[2] as char)?;
+            Ok(())
+          })?;
+        } else {
+          // No-match path: emit the raw integer faithfully (Perl `s///`
+          // leaves $val unchanged, preserving I64 typing — the JSON
+          // writer emits a bare number, NOT a quoted string).
+          out.write_u64(GROUP, "EncoderVersion", u64::from(h.encoder_version))?;
+        }
+      } else {
+        out.write_u64(GROUP, "EncoderVersion", u64::from(h.encoder_version))?;
+      }
+    }
+
+    // MPC.pm:107-109 — non-SV7 warning. Emit AFTER the (empty) tag block;
+    // bundled `perl exiftool -j -G1` surfaces `ExifTool:Warning` as the
+    // first non-File: entry (the serializer emits the warning at the front
+    // of the JSON object). Both [`MetadataTagWriter`] and lib callers
+    // (MapTagWriter) route this through [`TagWriter::write_warning`].
+    if self.warn_unsupported_version {
+      out.write_warning("Audio info currently not extracted from this version MPC file")?;
+    }
+    Ok(())
+  }
+}
+
+// ===========================================================================
+// `MpcError` — Rust-level fatal modes (currently none)
+// ===========================================================================
+
+/// Rust-level fatal modes for MPC parsing. Currently empty — every bad
+/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
+/// wrappers if streaming readers are added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpcError {}
+
+impl core::fmt::Display for MpcError {
+  fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match *self {}
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MpcError {}
+
+// ===========================================================================
+// Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+// ===========================================================================
+
+impl OldFormatParser for ProcessMpc {
+  /// Phase E–F migration bridge. Faithful to `ProcessMPC` (MPC.pm:79-116):
+  /// 1. **ID3 prefix dispatch** (MPC.pm:84-87) — `unless ($$et{DoneID3})
+  ///    { ProcessID3 ... and return 1; }`. Via the parallel F2 agent's
+  ///    [`crate::formats::id3::process::process_id3_chained`] entry. When
+  ///    ID3 finds a prefix, MPC continues at the post-ID3 offset (faithful
+  ///    APE-style flattened model — bundled's audio-loop recursion folds
+  ///    into a single pass). No-ID3 case is the in-scope MPC fixture set:
+  ///    `process_id3_chained` returns `found=false, hdr_end=0`.
+  /// 2. **MP+ magic gate + SV7/non-SV7 dispatch** (MPC.pm:92-109). On a
+  ///    short read or wrong magic ⇒ return 0 BEFORE SetFileType (faithful
+  ///    to the bundled `or return 0` at MPC.pm:92).
+  /// 3. **SetFileType** (MPC.pm:94) — no-arg, detected ("MPC"). Called
+  ///    AFTER magic passes, BEFORE the version dispatch (so the non-SV7
+  ///    warning arm still emits File:* alongside the Warning).
+  /// 4. **SV7 bit-stream walk** (MPC.pm:97-106) or **non-SV7 warning**
+  ///    (MPC.pm:107-109).
+  /// 5. **APE trailer** (MPC.pm:111-113) — `Image::ExifTool::APE::
+  ///    ProcessAPE(...)` via the parallel F3 agent's
+  ///    [`crate::formats::ape::ProcessApe::process_trailer_only`] entry
+  ///    (chained-from-typed-file path, APE.pm:165-237). Bundled is void-
+  ///    context; the result is discarded. APE.pm:131 `$$et{DoneAPE} = 1`
+  ///    happens inside, so subsequent chained parsers see DoneAPE set.
+  /// 6. **Return 1** (MPC.pm:115).
+  fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
+    // ----- (1) ID3 prefix dispatch (MPC.pm:84-87) --------------------------
+    // `unless ($$et{DoneID3}) { ProcessID3 ... and return 1; }`. Bundled's
+    // `and return 1` chains: a successful ProcessID3 makes MPC return 1
+    // immediately. The bundled audio-loop (ID3.pm:1582-1601) then recursively
+    // re-invokes ProcessMPC with DoneID3 set, which reads MP+ at $hdrEnd.
+    //
+    // Faithful flattened model (mirrors APE's APE.pm:122-127 chained
+    // ID3 dispatch in `src/formats/ape.rs`): run ID3 first, then continue
+    // MPC's own work at the post-ID3 offset. For the in-scope MPC fixtures
+    // (`MPC.mpc` / `sv8.mpc`) which have NO ID3 prefix, this returns
+    // `found=false, hdr_end=0` and is a no-op.
+    let id3 = if ctx.metadata().done_id3().is_none() {
+      crate::formats::id3::process::process_id3_chained(ctx)
+    } else {
+      crate::formats::id3::process::Id3ChainedResult::default()
+    };
+    let id3_found = id3.found();
+    let hdr_end = id3.hdr_end_offset();
+
+    // ----- (2) MP+ magic gate (MPC.pm:92) ----------------------------------
+    // Slice past any ID3v2 header. When `hdr_end == 0` (no ID3 prefix —
+    // the in-scope fixture case), the slice IS `ctx.data()` from offset 0.
+    // Codex R4 F1 fix mirror (from APE): `hdr_end` may exceed `data.len()`
+    // for truncated v2.4-footer files — saturate-to-empty.
+    let body = ctx.data().get(hdr_end..).unwrap_or(&[]);
+    let meta = match parse_inner(body) {
+      Ok(Some(m)) => m,
+      // Bundled `or return 0` (MPC.pm:92): no magic, no SetFileType, no
+      // tags. Two faithful outcomes:
+      //   (a) ID3 was found above ⇒ bundled `and return 1` semantics:
+      //       return TRUE so the engine treats the file as ID3-only.
+      //   (b) ID3 was NOT found ⇒ return FALSE so the candidate loop
+      //       tries the next type.
+      Ok(None) | Err(_) => return id3_found,
+    };
+
+    // ----- (3) SetFileType (MPC.pm:94) -------------------------------------
+    // `$et->SetFileType()` no-arg ⇒ detected file type ("MPC"). Pushes
+    // File:FileType / File:FileTypeExtension / File:MIMEType under
+    // ("File", "File") BEFORE the MPC:* tags (the bundled iteration order
+    // under `-j -G1`).
+    ctx.set_file_type(None, None, None);
+
+    // ----- (4) SV7 walk OR non-SV7 warning (MPC.pm:97-109) -----------------
+    // Bridge: typed `MpcMeta` ⇒ `Metadata` via the Phase E–F
+    // `MetadataTagWriter` adapter. The MetaSinker emits the SV7 tags + the
+    // optional warning in faithful order; the bridge writes them through
+    // `Metadata::push` / `push_warning`. `MetadataTagWriter::Error` is
+    // `Infallible` ⇒ the call cannot fail.
+    let print_conv = ctx.print_conv_enabled();
+    let mut bridge = MetadataTagWriter::new(ctx.metadata());
+    let _: Result<(), core::convert::Infallible> = meta.sink(print_conv, &mut bridge);
+
+    // ----- (5) APE trailer (MPC.pm:111-113) --------------------------------
+    // `require Image::ExifTool::APE; ProcessAPE(...)`. Bundled is void
+    // context (`ProcessAPE($et, $dirInfo)` with no `and`/`or` chain), so
+    // the result is discarded — MPC's final return is always 1 (MPC.pm:115).
+    //
+    // Use the chained `process_trailer_only` (APE.pm:165-237 — the
+    // `unless ($header)` block) because MPC has already typed the file at
+    // step (3). APE.pm:131 `$$et{DoneAPE} = 1` happens INSIDE the trailer-
+    // only entry, regardless of whether a trailer is found.
+    //
+    // For the in-scope MPC fixtures (32-byte files, no APE trailer), the
+    // trailer scan finds no `APETAGEX` magic at the trailer position and
+    // emits no APE tags / no warning — byte-exact to the prior MPC.rs
+    // which simply omitted the APE dispatch entirely.
+    let _ = crate::formats::ape::ProcessApe.process_trailer_only(ctx);
+
+    // ----- (6) Return 1 (MPC.pm:115) ---------------------------------------
+    true
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
   use super::*;
   use crate::{
-    parser::{FormatParser, ParseContext},
+    parser::{OldFormatParser, ParseContext},
+    parser_new::FormatParser,
+    sink::{MapTagWriter, MapValue},
     value::Metadata,
   };
+
+  // ---------- Tag table + bit-keys faithfulness --------------------------
 
   #[test]
   fn table_and_keys_are_faithful() {
@@ -397,6 +1118,8 @@ mod tests {
     assert_eq!(out_short, TagValue::Str("ab".into()));
   }
 
+  // ---------- Reject paths (Perl `return 0`) -----------------------------
+
   #[test]
   fn rejects_non_mpc_magic() {
     // MPC.pm:92 `... $buff =~ /^MP\+(.)/s or return 0` — magic mismatch
@@ -404,7 +1127,7 @@ mod tests {
     let mut m = Metadata::new("x.mpc");
     let data = [0u8; 32];
     let mut c = ParseContext::new(&data, "MPC", 0, "MPC", None, true, &mut m);
-    assert!(!ProcessMpc.process(&mut c));
+    assert!(!OldFormatParser::process(&ProcessMpc, &mut c));
     assert!(m.tags().is_empty());
   }
 
@@ -415,7 +1138,299 @@ mod tests {
     let mut m = Metadata::new("x.mpc");
     let data = b"MP+\x07\x00\x00\x00";
     let mut c = ParseContext::new(data, "MPC", 0, "MPC", None, true, &mut m);
-    assert!(!ProcessMpc.process(&mut c));
+    assert!(!OldFormatParser::process(&ProcessMpc, &mut c));
     assert!(m.tags().is_empty());
+  }
+
+  // ---------- Lib-first typed Meta surface --------------------------------
+
+  #[test]
+  fn parse_borrowed_rejects_short_buffer() {
+    assert!(parse_borrowed(&[]).unwrap().is_none());
+    assert!(parse_borrowed(b"MP+\x07").unwrap().is_none());
+  }
+
+  #[test]
+  fn parse_borrowed_rejects_non_mpc_magic() {
+    let data = [0u8; 32];
+    assert!(parse_borrowed(&data).unwrap().is_none());
+  }
+
+  #[test]
+  fn parse_borrowed_extracts_sv7_fixture_fields() {
+    // Real MPC.mpc fixture is 32 bytes starting `MP+\x07...`. Oracle SV7
+    // header from bundled `perl exiftool`:
+    //   TotalFrames=102, SampleRate=44100 (idx=0), Quality="5 (Standard)"
+    //   (idx=10), MaxBand=28, ReplayGain*=0, FastSeek=No (0), Gapless=Yes
+    //   (1), EncoderVersion="1.1.5" (raw=115).
+    let bytes = std::fs::read(
+      std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/MPC.mpc"),
+    )
+    .expect("read MPC.mpc fixture");
+    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    assert_eq!(meta.version(), 0x07);
+    let h = meta.sv7_header().expect("SV7 header present");
+    assert_eq!(h.total_frames(), 102);
+    assert_eq!(h.sample_rate_index(), 0);
+    assert_eq!(h.sample_rate_hz(), Some(44100));
+    assert_eq!(h.quality_index(), 10);
+    assert_eq!(h.quality_name(), Some("5 (Standard)"));
+    assert_eq!(h.max_band(), 28);
+    assert_eq!(h.replay_gain_track_peak(), 0);
+    assert_eq!(h.replay_gain_track_gain(), 0);
+    assert_eq!(h.replay_gain_album_peak(), 0);
+    assert_eq!(h.replay_gain_album_gain(), 0);
+    assert!(!h.fast_seek()); // 0 ⇒ No
+    assert!(h.gapless()); // 1 ⇒ Yes
+    assert_eq!(h.encoder_version(), 115);
+    assert!(!meta.warn_unsupported_version());
+    // F5 placeholders are always None.
+    assert!(meta.id3_prefix().is_none());
+    assert!(meta.ape_trailer().is_none());
+  }
+
+  #[test]
+  fn parse_borrowed_warns_on_non_sv7_version() {
+    // sv8.mpc fixture: `MP+\x08...` ⇒ version=8 ⇒ warning arm.
+    let bytes = std::fs::read(
+      std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sv8.mpc"),
+    )
+    .expect("read sv8.mpc fixture");
+    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    assert_eq!(meta.version(), 0x08);
+    assert!(meta.sv7_header().is_none());
+    assert!(meta.warn_unsupported_version());
+  }
+
+  #[test]
+  fn format_parser_trait_returns_meta_static() {
+    // Drive the trait via the chained-format Context.
+    let bytes = std::fs::read(
+      std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/MPC.mpc"),
+    )
+    .expect("read MPC.mpc fixture");
+    let mut shared = SharedFlags::new();
+    let ctx = MpcContext::new(&bytes, &mut shared);
+    let meta = <ProcessMpc as FormatParser>::parse(&ProcessMpc, ctx)
+      .expect("ok")
+      .expect("parsed");
+    let h = meta.sv7_header().expect("SV7 header");
+    assert_eq!(h.total_frames(), 102);
+    assert_eq!(h.encoder_version(), 115);
+  }
+
+  // ---------- MetaSinker: -j (PrintConv on) ------------------------------
+
+  #[test]
+  fn meta_sinker_emits_sv7_print_conv_strings() {
+    // Build an SV7 MpcMeta with the MPC.mpc fixture values; sink -j.
+    let h = MpcSv7Header {
+      total_frames: 102,
+      sample_rate_index: 0,
+      quality_index: 10,
+      max_band: 28,
+      replay_gain_track_peak: 0,
+      replay_gain_track_gain: 0,
+      replay_gain_album_peak: 0,
+      replay_gain_album_gain: 0,
+      fast_seek: 0,
+      gapless: 1,
+      encoder_version: 115,
+    };
+    let meta = MpcMeta {
+      version: 0x07,
+      sv7_header: Some(h),
+      warn_unsupported_version: false,
+      id3_prefix: None,
+      ape_trailer: None,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("MPC", "TotalFrames").map(MapValue::as_str),
+      Some("102".to_string())
+    );
+    // SampleRate -j: PrintConv hash hit ⇒ 44100 (number)
+    assert_eq!(
+      w.get("MPC", "SampleRate").map(MapValue::as_str),
+      Some("44100".to_string())
+    );
+    // Quality -j: hash hit ⇒ "5 (Standard)"
+    assert_eq!(
+      w.get("MPC", "Quality").map(MapValue::as_str),
+      Some("5 (Standard)".to_string())
+    );
+    assert_eq!(
+      w.get("MPC", "MaxBand").map(MapValue::as_str),
+      Some("28".to_string())
+    );
+    assert_eq!(
+      w.get("MPC", "FastSeek").map(MapValue::as_str),
+      Some("No".to_string())
+    );
+    assert_eq!(
+      w.get("MPC", "Gapless").map(MapValue::as_str),
+      Some("Yes".to_string())
+    );
+    // EncoderVersion -j: 115 ⇒ "1.1.5"
+    assert_eq!(
+      w.get("MPC", "EncoderVersion").map(MapValue::as_str),
+      Some("1.1.5".to_string())
+    );
+    // No warning when sv7_header is Some.
+    assert!(w.warnings().is_empty());
+  }
+
+  #[test]
+  fn meta_sinker_emits_sv7_print_conv_off_raw_scalars() {
+    let h = MpcSv7Header {
+      total_frames: 102,
+      sample_rate_index: 0,
+      quality_index: 10,
+      max_band: 28,
+      replay_gain_track_peak: 0,
+      replay_gain_track_gain: 0,
+      replay_gain_album_peak: 0,
+      replay_gain_album_gain: 0,
+      fast_seek: 0,
+      gapless: 1,
+      encoder_version: 115,
+    };
+    let meta = MpcMeta {
+      version: 0x07,
+      sv7_header: Some(h),
+      warn_unsupported_version: false,
+      id3_prefix: None,
+      ape_trailer: None,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(false, &mut w).unwrap();
+    // SampleRate -n: raw idx = 0
+    assert_eq!(
+      w.get("MPC", "SampleRate").map(MapValue::as_str),
+      Some("0".to_string())
+    );
+    // Quality -n: raw idx = 10
+    assert_eq!(
+      w.get("MPC", "Quality").map(MapValue::as_str),
+      Some("10".to_string())
+    );
+    // FastSeek -n: 0
+    assert_eq!(
+      w.get("MPC", "FastSeek").map(MapValue::as_str),
+      Some("0".to_string())
+    );
+    // Gapless -n: 1
+    assert_eq!(
+      w.get("MPC", "Gapless").map(MapValue::as_str),
+      Some("1".to_string())
+    );
+    // EncoderVersion -n: raw 115
+    assert_eq!(
+      w.get("MPC", "EncoderVersion").map(MapValue::as_str),
+      Some("115".to_string())
+    );
+  }
+
+  #[test]
+  fn meta_sinker_emits_warning_on_non_sv7() {
+    // sv8 path: sv7_header=None, warn_unsupported_version=true.
+    let meta = MpcMeta {
+      version: 0x08,
+      sv7_header: None,
+      warn_unsupported_version: true,
+      id3_prefix: None,
+      ape_trailer: None,
+    };
+    // -j
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    // No MPC:* tags emitted (sv7_header is None). `MapTagWriter::iter`
+    // only yields keyed (group, name, value) triples — warnings/errors
+    // live in their own accumulator (`MapTagWriter::warnings/errors`)
+    // and would not be returned here even if the sink had emitted them.
+    assert!(w.iter().all(|(g, _, _)| g != "MPC"));
+    // The warning is pushed through write_warning ⇒ MapTagWriter::warnings.
+    assert_eq!(
+      w.warnings(),
+      &["Audio info currently not extracted from this version MPC file"]
+    );
+    // -n: identical (no MPC:* tags, same warning).
+    let mut w = MapTagWriter::new();
+    meta.sink(false, &mut w).unwrap();
+    assert_eq!(
+      w.warnings(),
+      &["Audio info currently not extracted from this version MPC file"]
+    );
+  }
+
+  #[test]
+  fn meta_sinker_emits_quality_unknown_fallback() {
+    // Quality raw=2 (sparse — MPC.pm:38-54 has no key for 2) ⇒ -j must
+    // emit "Unknown (2)" per ExifTool.pm:3622. -n: raw 2.
+    let h = MpcSv7Header {
+      total_frames: 0,
+      sample_rate_index: 0,
+      quality_index: 2,
+      max_band: 0,
+      replay_gain_track_peak: 0,
+      replay_gain_track_gain: 0,
+      replay_gain_album_peak: 0,
+      replay_gain_album_gain: 0,
+      fast_seek: 0,
+      gapless: 0,
+      encoder_version: 0,
+    };
+    let meta = MpcMeta {
+      version: 0x07,
+      sv7_header: Some(h),
+      warn_unsupported_version: false,
+      id3_prefix: None,
+      ape_trailer: None,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("MPC", "Quality").map(MapValue::as_str),
+      Some("Unknown (2)".to_string())
+    );
+    let mut w = MapTagWriter::new();
+    meta.sink(false, &mut w).unwrap();
+    assert_eq!(
+      w.get("MPC", "Quality").map(MapValue::as_str),
+      Some("2".to_string())
+    );
+  }
+
+  #[test]
+  fn meta_sinker_encoder_version_lt_100_emits_raw() {
+    // No-match path: 2-digit value ⇒ Perl `s///` no-match ⇒ original
+    // I64 preserved. Both -j and -n emit the raw integer.
+    let h = MpcSv7Header {
+      total_frames: 0,
+      sample_rate_index: 0,
+      quality_index: 1,
+      max_band: 0,
+      replay_gain_track_peak: 0,
+      replay_gain_track_gain: 0,
+      replay_gain_album_peak: 0,
+      replay_gain_album_gain: 0,
+      fast_seek: 0,
+      gapless: 0,
+      encoder_version: 15, // 2-digit ⇒ no-match
+    };
+    let meta = MpcMeta {
+      version: 0x07,
+      sv7_header: Some(h),
+      warn_unsupported_version: false,
+      id3_prefix: None,
+      ape_trailer: None,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(true, &mut w).unwrap();
+    assert_eq!(
+      w.get("MPC", "EncoderVersion").map(MapValue::as_str),
+      Some("15".to_string())
+    );
   }
 }

--- a/src/formats/wavpack.rs
+++ b/src/formats/wavpack.rs
@@ -1,16 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "wavpack")]
 //! Faithful port of `Image::ExifTool::WavPack` (lib/Image/ExifTool/WavPack.pm).
-//! WavPack.pm is 144 lines: one tag table + one Process<Type> sub.
+//! WavPack.pm is 144 lines: one tag table + one `Process<Type>` sub.
 //!
-//! PROCESS_PROC is `ExifTool::ProcessBinaryData` (WavPack.pm:22) running over
-//! a 32-byte header. With `FORMAT => 'int32u'` (WavPack.pm:24) and ALL five
-//! tag IDs sharing the integer part `6` (`6.1`..`6.5`, WavPack.pm:31-73), every
-//! tag reads the SAME `int32u` at offset `6 * 4 = 24` and applies its own
-//! `Mask` (ExifTool.pm:10067-10068 `val = (val & mask) >> BitShift`,
-//! `BitShift` auto-derived from the trailing zero bits of `Mask`,
-//! ExifTool.pm:5905-5910). So a faithful Rust transliteration reads the
-//! single `int32u` once (big-endian, ExifTool global default 'MM',
-//! ExifTool.pm:5981 — `WavPack.pm` never calls `SetByteOrder`) and emits
-//! the 5 tags in numeric order (the Perl `sort` at ExifTool.pm:9907).
+//! **Phase F5 — lib-first migration.** Follows the MOI pilot (Phase E) +
+//! AAC / DV leaves (Phase F1) pattern: a typed [`WvMeta<'a>`] is produced
+//! by the new [`crate::parser_new::FormatParser`] trait; the legacy
+//! [`crate::parser::OldFormatParser`] entry point bridges through
+//! [`crate::sink::MetadataTagWriter`] so CLI JSON output stays byte-exact
+//! during the per-format crawl. The bridge is retired in Phase G.
+//!
+//! ## What WavPack is
+//!
+//! WavPack (`.wv` and `.wvp`) is a hybrid-lossless audio codec. Files
+//! start with a 32-byte block header beginning with the ASCII magic
+//! `wvpk` (WavPack.pm:88). All five exposed tags are sub-fields of the
+//! big-endian `int32u` flags word at byte offset 24 — extracted by mask
+//! + bit-shift (`%WavPack::Main`, WavPack.pm:21-74).
+//!
+//! PROCESS_PROC is `ExifTool::ProcessBinaryData` (WavPack.pm:22) running
+//! over the 32-byte header. With `FORMAT => 'int32u'` (WavPack.pm:24)
+//! and ALL five tag IDs sharing the integer part `6` (`6.1`..`6.5`,
+//! WavPack.pm:31-73), every tag reads the SAME `int32u` at offset
+//! `6 * 4 = 24` and applies its own `Mask` (ExifTool.pm:10067-10068
+//! `val = (val & mask) >> BitShift`, `BitShift` auto-derived from the
+//! trailing zero bits of `Mask`, ExifTool.pm:5905-5910). So a faithful
+//! Rust transliteration reads the single `int32u` once (big-endian,
+//! ExifTool global default 'MM', ExifTool.pm:5981 — `WavPack.pm` never
+//! calls `SetByteOrder`) and emits the 5 tags in numeric order (the Perl
+//! `sort` at ExifTool.pm:9907).
 //!
 //! Byte-order verified against the bundled `perl exiftool` oracle: an
 //! on-disk LE flags value `0x0480008d` produces BytesPerSample=1,
@@ -18,308 +38,875 @@
 //! SampleRate=48000 — exactly what `u32::from_be_bytes(...)` + the
 //! `%WavPack::Main` masks compute.
 //!
+//! ## Chained ID3 + APE (WavPack.pm:97-103)
+//!
 //! `ProcessWV` (WavPack.pm:80-105) also calls `RIFF::ProcessRIFF` and
 //! `APE::ProcessAPE` AFTER its own `ProcessBinaryData`, to extract any
-//! RIFF/ID3/APE trailer metadata. Per the orchestrator's WavPack scope
-//! both are **faithfully deferred** to the dedicated RIFF / ID3 / APE
-//! rows (FORMATS.md rows 2 / 5 / 22). The oracle confirms that on a
-//! native-wvpk fixture with NO RIFF / no ID3 / no APE trailer those two
-//! Perl calls emit zero tags / warnings — so the deferral is byte-exact
-//! for the fixtures shipped here.
+//! RIFF wrapper / ID3 / APE-trailer metadata. The bundled `ProcessAPE`
+//! ALSO calls `ProcessID3` internally (APE.pm:122-127) — so the WavPack
+//! chain effectively runs RIFF → ID3 → APE.
+//!
+//! **Scope.** The typed parser ([`ProcessWv::parse`]) produces a
+//! [`WvMeta`] that ONLY carries the WavPack-header tags AND
+//! borrow-from-input `Option<&'a [u8]>` placeholders denoting the byte
+//! ranges where ID3 / APE trailers may live (the whole input buffer,
+//! since both legacy formats scan the entire file). Actually parsing
+//! those trailers is delegated to the legacy `OldFormatParser` bridge,
+//! which calls the existing chained entries
+//! `crate::formats::id3::process::process_id3_chained` +
+//! `crate::formats::ape::ProcessApe::process_trailer_only` (the same
+//! APIs APE.pm uses internally). The bundled `perl
+//! exiftool` oracle on the committed WavPack fixtures (`WavPack.wv` /
+//! `WavPack_adversarial.wv` — native `wvpk....` 32-byte header, no
+//! RIFF wrapper, no ID3, no APE trailer) emits exactly the File:* +
+//! 5 WavPack-header tags; the RIFF / ID3 / APE delegations observably
+//! emit nothing for these fixtures, but the bridge still drives them
+//! for correctness on chained fixtures.
+//!
+//! **RIFF deferral.** The RIFF wrapper detection (WavPack.pm:97-99)
+//! remains a Phase-2 forward item — `RIFF::ProcessRIFF` is not ported
+//! yet; FORMATS.md row 22 will wire it. On the committed fixtures the
+//! deferral is observably no-op (no RIFF wrapper present).
+
+use core::convert::Infallible;
 
 use crate::{
-  parser::{FormatParser, ParseContext},
-  tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
-  value::{Group, TagValue},
+  parser::{OldFormatParser, ParseContext},
+  parser_new::{FormatParser, MetaSinker, SharedFlags, TagWriter, parser_sealed},
+  sink::MetadataTagWriter,
 };
 
-// BitShifts derived at const-eval from the Mask. Faithful to
-// ExifTool.pm:5905-5910:
-//   ++$bitShift until $mask & (1 << $bitShift);
-// i.e. BitShift = number of trailing zero bits of Mask. `trailing_zeros()`
-// is `const fn` on u32 (Rust ≥ 1.46) and total — no runtime cost, no panic
-// surface — so the *_SHIFT constants are derived from their *_MASK
-// constants. This makes the mask/shift invariant enforced by construction
-// (a mask change automatically updates the shift; no need to keep two
-// hand-edited constants in sync). The Perl loop algorithm and the
-// resulting shifts are byte-identical.
+// ===========================================================================
+// Mask + BitShift constants
+// ===========================================================================
+
+/// BitShift derivation. Faithful to ExifTool.pm:5905-5910:
+///   `++$bitShift until $mask & (1 << $bitShift);`
+/// i.e. `BitShift = number of trailing zero bits of Mask`. `trailing_zeros`
+/// is `const fn` on u32 and total — no runtime cost, no panic surface —
+/// so the `*_SHIFT` constants are derived from their `*_MASK` constants.
+/// This makes the mask/shift invariant enforced by construction (a mask
+/// change automatically updates the shift). The Perl loop algorithm and
+/// the resulting shifts are byte-identical.
 const fn bit_shift(mask: u32) -> u32 {
   mask.trailing_zeros()
 }
-const BYTES_PER_SAMPLE_MASK: u32 = 0x0000_0003; // WavPack.pm:33
+
+/// WavPack.pm:33 `Mask => 0x03` (BytesPerSample).
+const BYTES_PER_SAMPLE_MASK: u32 = 0x0000_0003;
 const BYTES_PER_SAMPLE_SHIFT: u32 = bit_shift(BYTES_PER_SAMPLE_MASK); // 0
-const AUDIO_TYPE_MASK: u32 = 0x0000_0004; // WavPack.pm:38
+/// WavPack.pm:38 `Mask => 0x04` (AudioType).
+const AUDIO_TYPE_MASK: u32 = 0x0000_0004;
 const AUDIO_TYPE_SHIFT: u32 = bit_shift(AUDIO_TYPE_MASK); // 2
-const COMPRESSION_MASK: u32 = 0x0000_0008; // WavPack.pm:43
+/// WavPack.pm:43 `Mask => 0x08` (Compression).
+const COMPRESSION_MASK: u32 = 0x0000_0008;
 const COMPRESSION_SHIFT: u32 = bit_shift(COMPRESSION_MASK); // 3
-const DATA_FORMAT_MASK: u32 = 0x0000_0080; // WavPack.pm:48
+/// WavPack.pm:48 `Mask => 0x80` (DataFormat).
+const DATA_FORMAT_MASK: u32 = 0x0000_0080;
 const DATA_FORMAT_SHIFT: u32 = bit_shift(DATA_FORMAT_MASK); // 7
-const SAMPLE_RATE_MASK: u32 = 0x0780_0000; // WavPack.pm:53
+/// WavPack.pm:53 `Mask => 0x07800000` (SampleRate).
+const SAMPLE_RATE_MASK: u32 = 0x0780_0000;
 const SAMPLE_RATE_SHIFT: u32 = bit_shift(SAMPLE_RATE_MASK); // 23
 
-/// WavPack.pm:33-35. `Mask => 0x03; ValueConv => '$val + 1'`. The raw
-/// 2-bit field is in `[0,3]`; the conv produces `[1,4]` bytes per sample
-/// (1 = 8-bit, 2 = 16-bit, 3 = 24-bit, 4 = 32-bit). PrintConv is absent,
-/// so the post-ValueConv integer is emitted directly under both `-j` and
-/// `-n` (bundled `perl exiftool` shows e.g. `"File:BytesPerSample": 1`).
-fn bytes_per_sample_conv(v: &TagValue) -> TagValue {
-  match v {
-    // Raw int from the bit-shift below ⇒ stays I64 after +1.
-    TagValue::I64(n) => TagValue::I64(n + 1),
-    // Defensive identity (should never happen on this path — the mask
-    // produces an I64).
-    other => other.clone(),
-  }
-}
-
-// WavPack.pm:31-35  BytesPerSample
-static BYTES_PER_SAMPLE: TagDef = TagDef::new(
-  "BytesPerSample",
-  "File",
-  ValueConv::Func(bytes_per_sample_conv),
-  PrintConv::None,
-);
-// WavPack.pm:36-40  AudioType
-static AUDIO_TYPE: TagDef = TagDef::new(
-  "AudioType",
-  "File",
-  ValueConv::None,
-  PrintConv::Hash(PrintConvHash::direct(&[
-    ("0", PrintValue::Str("Stereo")),
-    ("1", PrintValue::Str("Mono")),
-  ])),
-);
-// WavPack.pm:41-45  Compression
-static COMPRESSION: TagDef = TagDef::new(
-  "Compression",
-  "File",
-  ValueConv::None,
-  PrintConv::Hash(PrintConvHash::direct(&[
-    ("0", PrintValue::Str("Lossless")),
-    ("1", PrintValue::Str("Hybrid")),
-  ])),
-);
-// WavPack.pm:46-50  DataFormat
-static DATA_FORMAT: TagDef = TagDef::new(
-  "DataFormat",
-  "File",
-  ValueConv::None,
-  PrintConv::Hash(PrintConvHash::direct(&[
-    ("0", PrintValue::Str("Integer")),
-    ("1", PrintValue::Str("Floating Point")),
-  ])),
-);
-// WavPack.pm:51-73  SampleRate. The Perl table is `# (NC)` (not committed)
-// with index 15 ⇒ 'Custom'; faithful by-value. Numeric entries serialize
-// as JSON numbers (PrintValue::I64), `Custom` as a string.
-static SAMPLE_RATE: TagDef = TagDef::new(
-  "SampleRate",
-  "File",
-  ValueConv::None,
-  PrintConv::Hash(PrintConvHash::direct(&[
-    ("0", PrintValue::I64(6000)),
-    ("1", PrintValue::I64(8000)),
-    ("2", PrintValue::I64(9600)),
-    ("3", PrintValue::I64(11025)),
-    ("4", PrintValue::I64(12000)),
-    ("5", PrintValue::I64(16000)),
-    ("6", PrintValue::I64(22050)),
-    ("7", PrintValue::I64(24000)),
-    ("8", PrintValue::I64(32000)),
-    ("9", PrintValue::I64(44100)),
-    ("10", PrintValue::I64(48000)),
-    ("11", PrintValue::I64(64000)),
-    ("12", PrintValue::I64(88200)),
-    ("13", PrintValue::I64(96000)),
-    ("14", PrintValue::I64(192000)),
-    ("15", PrintValue::Str("Custom")),
-  ])),
-);
-
-fn wavpack_get(id: TagId) -> Option<&'static TagDef> {
-  match id {
-    TagId::Str("BytesPerSample") => Some(&BYTES_PER_SAMPLE),
-    TagId::Str("AudioType") => Some(&AUDIO_TYPE),
-    TagId::Str("Compression") => Some(&COMPRESSION),
-    TagId::Str("DataFormat") => Some(&DATA_FORMAT),
-    TagId::Str("SampleRate") => Some(&SAMPLE_RATE),
+/// WavPack.pm:55-72 `SampleRate` PrintConv hash — indices 0..=14 are
+/// known integer rates; index 15 is the string `"Custom"`. Looked up at
+/// emit time (PrintConv-on) and via the typed accessor
+/// [`WvMeta::sample_rate_hz`].
+///
+/// Returns `None` only for indices ≥ 16 which are unreachable from a
+/// 4-bit mask (`0x07800000 >> 23 = 0..=15`). Kept as `None` for total
+/// safety rather than asserting.
+#[must_use]
+const fn sample_rate_lookup(index: u8) -> Option<SampleRate> {
+  match index {
+    0 => Some(SampleRate::Hz(6000)),
+    1 => Some(SampleRate::Hz(8000)),
+    2 => Some(SampleRate::Hz(9600)),
+    3 => Some(SampleRate::Hz(11025)),
+    4 => Some(SampleRate::Hz(12000)),
+    5 => Some(SampleRate::Hz(16000)),
+    6 => Some(SampleRate::Hz(22050)),
+    7 => Some(SampleRate::Hz(24000)),
+    8 => Some(SampleRate::Hz(32000)),
+    9 => Some(SampleRate::Hz(44100)),
+    10 => Some(SampleRate::Hz(48000)),
+    11 => Some(SampleRate::Hz(64000)),
+    12 => Some(SampleRate::Hz(88200)),
+    13 => Some(SampleRate::Hz(96000)),
+    14 => Some(SampleRate::Hz(192000)),
+    15 => Some(SampleRate::Custom),
     _ => None,
   }
 }
 
-/// `%WavPack::Main` (WavPack.pm:21). family-0 group "File"
-/// (`GROUPS => { 0 => 'File', 1 => 'File', 2 => 'Audio' }`, WavPack.pm:23);
-/// `-G1` ⇒ "File:" prefix. The family-2 'Audio' is not emitted under
-/// `-G1`. Keyed by **String** TagIds (Perl tag IDs are `6.1`..`6.5`; we
-/// pre-resolve them to the equivalent named keys at the call site since
-/// every tag shares `int(index) = 6` and thus the same byte window).
-pub static WAVPACK_MAIN: TagTable = TagTable::new("File", wavpack_get);
+// ===========================================================================
+// Typed enums
+// ===========================================================================
 
-/// WavPack parser (faithful `ProcessWV`, WavPack.pm:80-105).
+/// `AudioType` PrintConv (WavPack.pm:39): 0 ⇒ "Stereo", 1 ⇒ "Mono".
+///
+/// D8: newtype-style enum — no fields on variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioType {
+  /// WavPack.pm:39 — raw 0 ⇒ "Stereo".
+  Stereo,
+  /// WavPack.pm:39 — raw 1 ⇒ "Mono".
+  Mono,
+}
+
+impl AudioType {
+  /// Decode the raw bit (already mask + shift extracted) — 0 or 1.
+  #[must_use]
+  pub const fn from_raw(b: u8) -> AudioType {
+    if b == 0 {
+      AudioType::Stereo
+    } else {
+      AudioType::Mono
+    }
+  }
+
+  /// The on-disk raw bit (0 = Stereo, 1 = Mono). Used by the `-n` raw
+  /// emission path.
+  #[must_use]
+  pub const fn raw(self) -> u8 {
+    match self {
+      AudioType::Stereo => 0,
+      AudioType::Mono => 1,
+    }
+  }
+
+  /// WavPack.pm:39 PrintConv string.
+  #[must_use]
+  pub const fn print_conv(self) -> &'static str {
+    match self {
+      AudioType::Stereo => "Stereo",
+      AudioType::Mono => "Mono",
+    }
+  }
+}
+
+/// `Compression` PrintConv (WavPack.pm:44): 0 ⇒ "Lossless", 1 ⇒ "Hybrid".
+///
+/// D8: newtype-style enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Compression {
+  /// WavPack.pm:44 — raw 0 ⇒ "Lossless".
+  Lossless,
+  /// WavPack.pm:44 — raw 1 ⇒ "Hybrid".
+  Hybrid,
+}
+
+impl Compression {
+  /// Decode the raw bit (already mask + shift extracted) — 0 or 1.
+  #[must_use]
+  pub const fn from_raw(b: u8) -> Compression {
+    if b == 0 {
+      Compression::Lossless
+    } else {
+      Compression::Hybrid
+    }
+  }
+
+  /// The on-disk raw bit (0 = Lossless, 1 = Hybrid).
+  #[must_use]
+  pub const fn raw(self) -> u8 {
+    match self {
+      Compression::Lossless => 0,
+      Compression::Hybrid => 1,
+    }
+  }
+
+  /// WavPack.pm:44 PrintConv string.
+  #[must_use]
+  pub const fn print_conv(self) -> &'static str {
+    match self {
+      Compression::Lossless => "Lossless",
+      Compression::Hybrid => "Hybrid",
+    }
+  }
+}
+
+/// `DataFormat` PrintConv (WavPack.pm:49): 0 ⇒ "Integer", 1 ⇒ "Floating Point".
+///
+/// D8: newtype-style enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataFormat {
+  /// WavPack.pm:49 — raw 0 ⇒ "Integer".
+  Integer,
+  /// WavPack.pm:49 — raw 1 ⇒ "Floating Point".
+  FloatingPoint,
+}
+
+impl DataFormat {
+  /// Decode the raw bit (already mask + shift extracted) — 0 or 1.
+  #[must_use]
+  pub const fn from_raw(b: u8) -> DataFormat {
+    if b == 0 {
+      DataFormat::Integer
+    } else {
+      DataFormat::FloatingPoint
+    }
+  }
+
+  /// The on-disk raw bit (0 = Integer, 1 = FloatingPoint).
+  #[must_use]
+  pub const fn raw(self) -> u8 {
+    match self {
+      DataFormat::Integer => 0,
+      DataFormat::FloatingPoint => 1,
+    }
+  }
+
+  /// WavPack.pm:49 PrintConv string.
+  #[must_use]
+  pub const fn print_conv(self) -> &'static str {
+    match self {
+      DataFormat::Integer => "Integer",
+      DataFormat::FloatingPoint => "Floating Point",
+    }
+  }
+}
+
+/// `SampleRate` PrintConv decoded shape (WavPack.pm:55-72). Indices
+/// 0..=14 map to known integer rates; index 15 is the `"Custom"` string.
+///
+/// D8: newtype-style enum — the `Hz` variant payload is the post-PrintConv
+/// numeric rate, NOT the raw 4-bit index (`raw_index` is preserved
+/// separately on [`WvMeta`] for `-n` emission).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SampleRate {
+  /// WavPack.pm:55-71 — known sample rate in Hz (e.g. `48000`).
+  Hz(u32),
+  /// WavPack.pm:72 — index 15 ⇒ `"Custom"` (sample rate not encoded in
+  /// the header; the rate is "custom" / out-of-table).
+  Custom,
+}
+
+// ===========================================================================
+// Typed Meta — `WvMeta<'a>`
+// ===========================================================================
+
+/// Typed WavPack metadata — the lib-first output of [`ProcessWv`].
+///
+/// Carries the five `%WavPack::Main` header tags (post-mask, post-shift,
+/// post-ValueConv) and two borrow-from-input `Option<&'a [u8]>` placeholders
+/// for ID3 / APE trailers. The placeholders denote the byte ranges where
+/// the legacy chained parsers can scan; actually invoking them lives in
+/// the [`OldFormatParser`] bridge for byte-exact CLI conformance during
+/// Phase F5–G.
+///
+/// **D8 — no public fields, accessors only.** Construct only via
+/// [`ProcessWv::parse`].
+///
+/// **Lifetimes.** `'a` is held for the ID3 / APE byte-range slices. The
+/// WavPack-header fields are owned primitives (no allocation). On the
+/// no-chained-trailer case (the committed fixtures) both byte-range
+/// fields are `None`-tied to the input but contain the unsliced buffer
+/// so a future lib-first ID3 / APE typed parser can scan them.
+///
+/// ## Library usage
+///
+/// ```ignore
+/// use exifast::parser_new::{FormatParser, SharedFlags};
+/// use exifast::formats::wavpack::{ProcessWv, WvContext};
+///
+/// let bytes = std::fs::read("file.wv")?;
+/// let mut shared = SharedFlags::new();
+/// let ctx = WvContext::new(&bytes, &mut shared);
+/// if let Some(wv) = ProcessWv.parse(ctx)? {
+///   println!("BytesPerSample: {}", wv.bytes_per_sample());
+///   println!("AudioType: {}", wv.audio_type().print_conv());
+///   if let Some(rate) = wv.sample_rate_hz() {
+///     println!("SampleRate: {rate} Hz");
+///   } else {
+///     println!("SampleRate: Custom");
+///   }
+/// }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct WvMeta<'a> {
+  /// WavPack.pm:31-35 BytesPerSample — `Mask => 0x03; ValueConv => '$val + 1'`.
+  /// Raw 2-bit field ∈ [0, 3] ⇒ post-ValueConv [1, 4] bytes per sample
+  /// (1 = 8-bit, 2 = 16-bit, 3 = 24-bit, 4 = 32-bit). PrintConv is None,
+  /// so the post-ValueConv integer is emitted directly under both `-j`
+  /// and `-n`.
+  bytes_per_sample: u8,
+  /// WavPack.pm:36-40 AudioType — `Mask => 0x04`. Raw bit ∈ [0, 1];
+  /// PrintConv hash 0 ⇒ "Stereo", 1 ⇒ "Mono".
+  audio_type: AudioType,
+  /// WavPack.pm:41-45 Compression — `Mask => 0x08`. Raw bit ∈ [0, 1];
+  /// PrintConv hash 0 ⇒ "Lossless", 1 ⇒ "Hybrid".
+  compression: Compression,
+  /// WavPack.pm:46-50 DataFormat — `Mask => 0x80`. Raw bit ∈ [0, 1];
+  /// PrintConv hash 0 ⇒ "Integer", 1 ⇒ "Floating Point".
+  data_format: DataFormat,
+  /// WavPack.pm:51-73 SampleRate — `Mask => 0x07800000`. Raw 4-bit index
+  /// ∈ [0, 15]; PrintConv hash 0..=14 = numeric rates, 15 = "Custom".
+  /// Preserved typed via [`SampleRate`] (decoded form for ergonomic
+  /// access; the original raw index is stored alongside for `-n` byte-
+  /// exact emission).
+  sample_rate: SampleRate,
+  /// Raw 4-bit `SampleRate` index ∈ [0, 15] preserved alongside the
+  /// decoded [`SampleRate`] for `-n` raw emission. (WavPack.pm:53 mask =
+  /// 0x07800000, shift = 23 ⇒ raw value is the bundled `int($val)` that
+  /// `perl exiftool -n` emits as a bare JSON number.)
+  sample_rate_raw_index: u8,
+  /// Byte range for the legacy `RIFF::ProcessRIFF` / `ID3::ProcessID3` /
+  /// `APE::ProcessAPE` chained scan (WavPack.pm:96-103). Carries
+  /// `Some(&data)` — the full input buffer — on the typed parse so a
+  /// future lib-first ID3 typed parser can pick up the range without a
+  /// re-read; `None` is reserved for a future "stop-after-header" mode.
+  /// Today the `OldFormatParser` bridge does the actual chained parsing.
+  id3_apetrailer_scan: Option<&'a [u8]>,
+}
+
+impl<'a> WvMeta<'a> {
+  /// WavPack.pm:31-35 — `BytesPerSample` post-ValueConv (1..=4).
+  #[must_use]
+  pub fn bytes_per_sample(&self) -> u8 {
+    self.bytes_per_sample
+  }
+
+  /// WavPack.pm:36-40 — `AudioType` decoded enum.
+  #[must_use]
+  pub fn audio_type(&self) -> AudioType {
+    self.audio_type
+  }
+
+  /// WavPack.pm:41-45 — `Compression` decoded enum.
+  #[must_use]
+  pub fn compression(&self) -> Compression {
+    self.compression
+  }
+
+  /// WavPack.pm:46-50 — `DataFormat` decoded enum.
+  #[must_use]
+  pub fn data_format(&self) -> DataFormat {
+    self.data_format
+  }
+
+  /// WavPack.pm:51-73 — `SampleRate` typed decoded form (`Hz(u32)` or
+  /// `Custom`).
+  #[must_use]
+  pub fn sample_rate(&self) -> SampleRate {
+    self.sample_rate
+  }
+
+  /// `SampleRate` as `u32` Hz when known; `None` for the `"Custom"`
+  /// index 15. Convenience accessor for callers that want a numeric
+  /// rate or nothing.
+  #[must_use]
+  pub fn sample_rate_hz(&self) -> Option<u32> {
+    match self.sample_rate {
+      SampleRate::Hz(n) => Some(n),
+      SampleRate::Custom => None,
+    }
+  }
+
+  /// Raw 4-bit `SampleRate` index ∈ [0, 15]. Equivalent to the bundled
+  /// `perl exiftool -n` numeric output for `File:SampleRate` (which
+  /// emits the pre-PrintConv raw mask value).
+  #[must_use]
+  pub fn sample_rate_raw_index(&self) -> u8 {
+    self.sample_rate_raw_index
+  }
+
+  /// Byte range where the chained ID3 / APE-trailer scan runs. `Some`
+  /// borrows from the input buffer; today's lib-first parse always sets
+  /// this to the full buffer. The `OldFormatParser` bridge consumes it
+  /// through the existing chained entries
+  /// `crate::formats::id3::process::process_id3_chained` +
+  /// `crate::formats::ape::ProcessApe::process_trailer_only`.
+  #[must_use]
+  pub fn id3_ape_scan_range(&self) -> Option<&'a [u8]> {
+    self.id3_apetrailer_scan
+  }
+}
+
+// ===========================================================================
+// `WvContext<'a>` — per-format input view
+// ===========================================================================
+
+/// Per-format input view for [`ProcessWv`]. Wraps the input bytes plus
+/// a `&mut SharedFlags` for the cross-format chain (ID3 → APE flags).
+/// Spec §6.4 — chained-format `Context<'a>` is a struct, not a bare
+/// `&'a [u8]`.
+///
+/// The shared flags are reserved for the lib-first typed ID3 / APE
+/// parsers (Phase F2 / F3 work in parallel agents). Today the
+/// [`OldFormatParser`] bridge still drives ID3 / APE via the legacy
+/// `Metadata` flags ([`crate::value::Metadata::set_done_id3`] /
+/// [`crate::value::Metadata::set_done_ape`]); when the typed-ID3 /
+/// typed-APE typed parsers land they'll read/write
+/// [`SharedFlags::done_id3`] / [`SharedFlags::done_ape`] instead. The
+/// `&mut SharedFlags` carry is the seam.
+///
+/// D8: no public fields; constructor + accessors only.
+pub struct WvContext<'a> {
+  /// The full WavPack file bytes — typically the entire input buffer.
+  data: &'a [u8],
+  /// Mutable cross-format flags. Reserved for the typed ID3 / APE
+  /// parsers (Phase F2 / F3) — today's lib-first WavPack parse does
+  /// not flip these; the legacy bridge uses the [`crate::value::Metadata`]
+  /// counterparts instead.
+  shared: &'a mut SharedFlags,
+}
+
+impl<'a> WvContext<'a> {
+  /// Build a context wrapping `data` and a borrowed `shared` flags
+  /// table. The flags are not mutated by the lib-first parse today;
+  /// see the type-level docs for the Phase F2 / F3 plan.
+  pub fn new(data: &'a [u8], shared: &'a mut SharedFlags) -> Self {
+    Self { data, shared }
+  }
+
+  /// View the input bytes.
+  #[must_use]
+  pub fn data(&self) -> &'a [u8] {
+    self.data
+  }
+
+  /// Read-only view of the shared flags. The mutable borrow is exposed
+  /// via [`Self::shared_mut`] for the typed ID3 / APE parsers (Phase F2 /
+  /// F3) once they migrate.
+  #[must_use]
+  pub fn shared(&self) -> &SharedFlags {
+    self.shared
+  }
+
+  /// Mutable view of the shared flags (reserved for typed chained
+  /// parsers; today's WavPack parse leaves them untouched).
+  pub fn shared_mut(&mut self) -> &mut SharedFlags {
+    self.shared
+  }
+}
+
+// ===========================================================================
+// `ProcessWv` — the lib-first parser
+// ===========================================================================
+
+/// WavPack parser — faithful port of `Image::ExifTool::WavPack::ProcessWV`
+/// (WavPack.pm:80-105).
+#[derive(Debug, Clone, Copy)]
 pub struct ProcessWv;
 
+impl parser_sealed::Sealed for ProcessWv {}
+
 impl FormatParser for ProcessWv {
+  /// Typed metadata output. The `'static` shape is required by the closed
+  /// [`crate::parser_new::AnyMeta`] enum (Phase E `into_static` pragma);
+  /// [`parse_borrowed`] exposes the borrow-from-input form for zero-alloc
+  /// callers.
+  type Meta = WvMeta<'static>;
+  /// Spec §6.4 — chained-format context is a struct wrapping `&[u8]` +
+  /// `&mut SharedFlags`.
+  type Context<'a> = WvContext<'a>;
+  /// Rust-level fatal error (none today; WavPack parsing has no I/O modes).
+  type Error = WvError;
+
+  /// Parse a WavPack file's bytes into a typed [`WvMeta`], or `None` if
+  /// the buffer is not a valid WavPack file (short read, bad magic, or
+  /// version-byte mismatch — WavPack.pm:87-88).
+  ///
+  /// Returns `Err` only for Rust-level fatal modes; the current port
+  /// has none (every bad input is `Ok(None)` per Perl's `return 0`).
+  fn parse(&self, ctx: Self::Context<'_>) -> Result<Option<Self::Meta>, WvError> {
+    Ok(parse_inner(ctx.data).map(WvMeta::into_static))
+  }
+}
+
+/// Lib-first direct entry. Same as [`FormatParser::parse`] but returns a
+/// [`WvMeta`] that borrows from the input buffer — zero allocation. The
+/// `FormatParser` trait signature uses `'static` for compatibility with
+/// the closed `AnyMeta` enum, which forces an `into_static` upgrade.
+///
+/// # Errors
+///
+/// Returns `Err` for Rust-level fatal modes (none today; reserved for
+/// future I/O wrappers).
+pub fn parse_borrowed(data: &[u8]) -> Result<Option<WvMeta<'_>>, WvError> {
+  Ok(parse_inner(data))
+}
+
+/// Inner parser — produces a borrow-from-input [`WvMeta`]. The trait's
+/// `Meta = WvMeta<'static>` shape forces a [`WvMeta::into_static`]
+/// upgrade for the closed [`crate::parser_new::AnyMeta`] enum.
+fn parse_inner(data: &[u8]) -> Option<WvMeta<'_>> {
+  // WavPack.pm:87 `return 0 unless $raf->Read($buff, 32) == 32`.
+  if data.len() < 32 {
+    return None;
+  }
+  // WavPack.pm:88 `return 0 unless $buff =~ /^wvpk.{4}[\x02\x10]\x04/s`.
+  //   bytes 0..4 == "wvpk"
+  //   bytes 4..8 = ckSize  (any value, `.{4}` consumes them)
+  //   byte 8 ∈ {0x02, 0x10}
+  //   byte 9 == 0x04
+  if &data[..4] != b"wvpk" {
+    return None;
+  }
+  if data[8] != 0x02 && data[8] != 0x10 {
+    return None;
+  }
+  if data[9] != 0x04 {
+    return None;
+  }
+
+  // WavPack.pm:91-95 `$et->ProcessBinaryData(\%dirInfo, GetTagTable(
+  // 'Image::ExifTool::WavPack::Main'))`. With `FORMAT=>'int32u'` and all
+  // five tag IDs sharing `int(index) = 6`, every tag's entry offset is
+  // `6 * 4 = 24` (ExifTool.pm:9946 `$entry = int($index) * $increment +
+  // $varSize`, $varSize stays 0 across the integer-keyed loop). The
+  // shared `int32u` is read with the current byte order (ExifTool.pm:
+  // 6239 `int32u => \&Get32u`); WavPack.pm never calls `SetByteOrder`,
+  // so the global default 'MM' (ExifTool.pm:5981) applies — big-endian.
+  //
+  // ExifTool byte-order-state quirk (verified against bundled
+  // `perl exiftool` 2026-05-20): `$currentByteOrder` is process-wide
+  // and `ExifTool::Init` (ExifTool.pm:4316-4365) does NOT reset it
+  // between files in a batch invocation. Other audio modules
+  // (FLAC.pm:256, APE.pm:140/173, MPC.pm:98) explicitly call
+  // `SetByteOrder('MM'|'II')`; WavPack.pm does not, so e.g.
+  // `perl exiftool le.tiff WavPack.wv` reads these flags as `II`
+  // (because the TIFF read flipped the global). Our port is faithful
+  // to the FRESH-PROCESS state — global default 'MM' — which is the
+  // §4 conformance bar (tools/gen_golden.sh invokes Perl once per
+  // file). exifast's library API is per-file (`extract_info` builds a
+  // fresh `Metadata` per call); no shared parser state exists across
+  // calls, so the Perl batch-mode leak is structurally invisible
+  // here. Threading byte-order state through `ParseContext` would be
+  // dead code today and is intentionally not done.
+  let flags = u32::from_be_bytes([data[24], data[25], data[26], data[27]]);
+
+  // Mask + shift, faithful to ExifTool.pm:10067-10068
+  // `val = (val & mask) >> shift`.
+  let bps_raw = ((flags & BYTES_PER_SAMPLE_MASK) >> BYTES_PER_SAMPLE_SHIFT) as u8;
+  // ValueConv `$val + 1` (WavPack.pm:34) ⇒ post-ValueConv ∈ [1, 4].
+  let bytes_per_sample = bps_raw + 1;
+
+  let at_raw = ((flags & AUDIO_TYPE_MASK) >> AUDIO_TYPE_SHIFT) as u8;
+  let audio_type = AudioType::from_raw(at_raw);
+
+  let comp_raw = ((flags & COMPRESSION_MASK) >> COMPRESSION_SHIFT) as u8;
+  let compression = Compression::from_raw(comp_raw);
+
+  let df_raw = ((flags & DATA_FORMAT_MASK) >> DATA_FORMAT_SHIFT) as u8;
+  let data_format = DataFormat::from_raw(df_raw);
+
+  let sr_raw = ((flags & SAMPLE_RATE_MASK) >> SAMPLE_RATE_SHIFT) as u8;
+  // sr_raw ∈ [0, 15] by construction (4-bit mask). The `expect` is
+  // defensive: `sample_rate_lookup` is total over [0, 15].
+  let sample_rate = sample_rate_lookup(sr_raw)
+    .expect("4-bit SampleRate index always resolves via sample_rate_lookup");
+
+  // Carry the full input as the chained-trailer scan range. WavPack.pm:
+  // 97-102 scans the WHOLE file (the Perl `$raf` is reset to offset 0
+  // by `Seek(0, 0)`) for RIFF wrapper / ID3 / APE trailers. The typed
+  // parse exposes the range; the legacy bridge invokes the chained
+  // parsers.
+  Some(WvMeta {
+    bytes_per_sample,
+    audio_type,
+    compression,
+    data_format,
+    sample_rate,
+    sample_rate_raw_index: sr_raw,
+    id3_apetrailer_scan: Some(data),
+  })
+}
+
+// ===========================================================================
+// `WvMeta::into_static` — owned promotion for the `AnyMeta` enum
+// ===========================================================================
+
+impl WvMeta<'_> {
+  /// Promote a borrow-from-input [`WvMeta`] into an owned `WvMeta<'static>`.
+  /// Used by the [`FormatParser`] impl to publish into
+  /// [`AnyMeta`](crate::parser_new::AnyMeta) — the closed `AnyMeta` enum
+  /// (spec §7) cannot carry a per-format lifetime parameter that's
+  /// different from `AnyMeta`'s own `'a`, and the simplest reconciliation
+  /// is to clear the only borrowed field (`id3_apetrailer_scan: Option<&'a
+  /// [u8]>`) and rebuild as `'static`.
+  ///
+  /// **Phase F5 pragma.** The chained-trailer scan range is meaningful
+  /// only when a lib-first ID3 / APE typed parser consumes it; today's
+  /// `AnyMeta` consumer is the JSON sinker which emits the 5 header
+  /// tags and delegates the chained scan to the legacy bridge. Dropping
+  /// the borrow to `None` here is observably equivalent to leaving it
+  /// set: no caller of `AnyMeta::Wv(meta).sink(...)` reads the range
+  /// (the sink path doesn't drive trailers). Phase G will retire this
+  /// by threading `WvMeta<'a>` through `AnyMeta<'a>` end-to-end.
+  fn into_static(self) -> WvMeta<'static> {
+    WvMeta {
+      bytes_per_sample: self.bytes_per_sample,
+      audio_type: self.audio_type,
+      compression: self.compression,
+      data_format: self.data_format,
+      sample_rate: self.sample_rate,
+      sample_rate_raw_index: self.sample_rate_raw_index,
+      // Drop the borrow on input; the JSON sink does not read this
+      // field. See the doc comment above for the Phase G remediation.
+      id3_apetrailer_scan: None,
+    }
+  }
+}
+
+// ===========================================================================
+// `MetaSinker` — typed Meta → TagWriter
+// ===========================================================================
+
+impl MetaSinker for WvMeta<'_> {
+  /// Emit WavPack tags into the writer in ExifTool numeric sort order
+  /// (WavPack.pm:31-73 → ExifTool.pm:9907 sorted-key walk): 6.1
+  /// BytesPerSample, 6.2 AudioType, 6.3 Compression, 6.4 DataFormat, 6.5
+  /// SampleRate. The family-0/-1 group is `"File"` (WavPack.pm:23
+  /// `GROUPS => { 0 => 'File', 1 => 'File', 2 => 'Audio' }`; `-G1` ⇒
+  /// `"File:"` prefix; the family-2 `'Audio'` is not emitted under `-G1`).
+  ///
+  /// `print_conv=true` ⇒ PrintConv strings (`-j` mode, e.g.
+  /// `"Mono"`/`"Lossless"`/`"Custom"`); `print_conv=false` ⇒ post-ValueConv
+  /// raw scalars (`-n` mode, e.g. `1`/`0`/`15`).
+  fn sink<W: TagWriter>(&self, print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    const GROUP: &str = "File";
+
+    // 6.1 BytesPerSample — post-ValueConv `+1` already applied at parse
+    // time. PrintConv is None, so the post-ValueConv integer is emitted
+    // directly under both -j and -n.
+    out.write_u64(GROUP, "BytesPerSample", u64::from(self.bytes_per_sample))?;
+
+    // 6.2 AudioType — -j: PrintConv string; -n: raw u8.
+    if print_conv {
+      out.write_str(GROUP, "AudioType", self.audio_type.print_conv())?;
+    } else {
+      out.write_u64(GROUP, "AudioType", u64::from(self.audio_type.raw()))?;
+    }
+
+    // 6.3 Compression — -j: PrintConv string; -n: raw u8.
+    if print_conv {
+      out.write_str(GROUP, "Compression", self.compression.print_conv())?;
+    } else {
+      out.write_u64(GROUP, "Compression", u64::from(self.compression.raw()))?;
+    }
+
+    // 6.4 DataFormat — -j: PrintConv string; -n: raw u8.
+    if print_conv {
+      out.write_str(GROUP, "DataFormat", self.data_format.print_conv())?;
+    } else {
+      out.write_u64(GROUP, "DataFormat", u64::from(self.data_format.raw()))?;
+    }
+
+    // 6.5 SampleRate — -j: PrintConv hash. Hash returns I64 for known
+    // rates (0..=14) ⇒ bare JSON number; Str("Custom") for index 15 ⇒
+    // quoted JSON string. -n: raw 4-bit index 0..=15 (bare number).
+    if print_conv {
+      match self.sample_rate {
+        SampleRate::Hz(n) => out.write_u64(GROUP, "SampleRate", u64::from(n))?,
+        SampleRate::Custom => out.write_str(GROUP, "SampleRate", "Custom")?,
+      }
+    } else {
+      out.write_u64(GROUP, "SampleRate", u64::from(self.sample_rate_raw_index))?;
+    }
+
+    Ok(())
+  }
+}
+
+// ===========================================================================
+// `WvError` — Rust-level fatal modes (currently none)
+// ===========================================================================
+
+/// Rust-level fatal modes for WavPack parsing. Currently empty — every
+/// bad input produces `Ok(None)` (Perl `return 0`). Reserved for future
+/// I/O wrappers if streaming readers are added.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WvError {}
+
+impl core::fmt::Display for WvError {
+  fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    match *self {}
+  }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for WvError {}
+
+// ===========================================================================
+// Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+// ===========================================================================
+
+impl OldFormatParser for ProcessWv {
+  /// Phase F5 migration bridge. Runs the new typed [`FormatParser::parse`]
+  /// and drives [`MetaSinker::sink`] through a [`MetadataTagWriter`] so
+  /// the CLI JSON output stays byte-exact during Phases F1–F5. Retired
+  /// in Phase G.
+  ///
+  /// Faithful order (WavPack.pm:87-104):
+  /// 1. Magic + version-byte gate (`return 0` on reject) — WavPack.pm:87-88.
+  /// 2. `SetFileType` — WavPack.pm:89.
+  /// 3. ProcessBinaryData over the WavPack::Main table — WavPack.pm:91-95.
+  ///    The five header tags emit in numeric-key sort order
+  ///    (ExifTool.pm:9907).
+  /// 4. `Seek(0, 0)` + `RIFF::ProcessRIFF` — WavPack.pm:97-99
+  ///    (Phase-2 forward item; RIFF parser not ported yet — observably
+  ///    no-op on the committed fixtures).
+  /// 5. APE-trailer chain: `APE::ProcessAPE` — WavPack.pm:100-102.
+  ///    Routes through `crate::formats::ape::ProcessApe::process_trailer_only`
+  ///    (the same entry the bundled audio loop uses recursively).
+  ///    `ProcessApe::process_trailer_only` ALSO sets `done_ape`
+  ///    (APE.pm:131); this matches the bundled flag-setting order. On
+  ///    the committed fixtures (no APE trailer present) this is
+  ///    observably no-op.
   fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
-    // Snapshot the 32-byte header out of `ctx.data()` so the immutable
-    // borrow ends before the upcoming `&mut ctx` (set_file_type /
-    // metadata) calls; `buff32` IS Perl `$buff` (the first 32 bytes of
-    // the file). Mirrors the AAC parser's `buff7` pattern.
-    let buff32: [u8; 32] = {
+    // Phase F5 bridge: extract the typed Meta from a fresh shared-flags
+    // workspace, then sink it back into the legacy `Metadata` plumbing.
+    // The lib-first `SharedFlags` is NOT the same store as the legacy
+    // `Metadata::done_id3` / `Metadata::done_ape`; the legacy chained
+    // parsers below read the latter, so we don't need to thread the
+    // former through here.
+    let meta_opt = {
       let data = ctx.data();
-      // WavPack.pm:87 `return 0 unless $raf->Read($buff, 32) == 32`.
-      if data.len() < 32 {
-        return false;
-      }
-      // WavPack.pm:88 `return 0 unless $buff =~ /^wvpk.{4}[\x02\x10]\x04/s`.
-      //   bytes 0..4 == "wvpk"
-      //   bytes 4..8 = ckSize  (any value, `.{4}` consumes them)
-      //   byte 8 ∈ {0x02, 0x10}
-      //   byte 9 == 0x04
-      if &data[..4] != b"wvpk" {
-        return false;
-      }
-      if data[8] != 0x02 && data[8] != 0x10 {
-        return false;
-      }
-      if data[9] != 0x04 {
-        return false;
-      }
-      // Explicit copy is panic-free (no try_into).
-      let mut out = [0u8; 32];
-      out.copy_from_slice(&data[..32]);
-      out
+      parse_inner(data)
+    };
+    let Some(meta) = meta_opt else {
+      return false; // WavPack.pm:87-88 reject — `return 0`.
     };
 
     // WavPack.pm:89 `$et->SetFileType()` — no-arg ⇒ detected file type ("WV").
     ctx.set_file_type(None, None, None);
-    let print_conv_enabled = ctx.print_conv_enabled();
+    let print_conv = ctx.print_conv_enabled();
 
-    // WavPack.pm:91-95 `$et->ProcessBinaryData(\%dirInfo, GetTagTable(
-    // 'Image::ExifTool::WavPack::Main'))`. With `FORMAT=>'int32u'` and all
-    // five tag IDs sharing `int(index) = 6`, every tag's entry offset is
-    // `6 * 4 = 24` (ExifTool.pm:9946 `$entry = int($index) * $increment +
-    // $varSize`, $varSize stays 0 across the integer-keyed loop). The
-    // shared `int32u` is read with the current byte order (ExifTool.pm:
-    // 6239 `int32u => \&Get32u`); WavPack.pm never calls `SetByteOrder`,
-    // so the global default 'MM' (ExifTool.pm:5981) applies — big-endian.
-    //
-    // ExifTool byte-order-state quirk (verified against bundled
-    // `perl exiftool` 2026-05-20): `$currentByteOrder` is process-wide
-    // and `ExifTool::Init` (ExifTool.pm:4316-4365) does NOT reset it
-    // between files in a batch invocation. Other audio modules
-    // (FLAC.pm:256, APE.pm:140/173, MPC.pm:98) explicitly call
-    // `SetByteOrder('MM'|'II')`; WavPack.pm does not, so e.g.
-    // `perl exiftool le.tiff WavPack.wv` reads these flags as `II`
-    // (because the TIFF read flipped the global). Our port is faithful
-    // to the FRESH-PROCESS state — global default 'MM' — which is the
-    // §4 conformance bar (tools/gen_golden.sh invokes Perl once per
-    // file). exifast's library API is per-file (`extract_info` builds a
-    // fresh `Metadata` per call); no shared parser state exists across
-    // calls, so the Perl batch-mode leak is structurally invisible
-    // here. Threading byte-order state through `ParseContext` would be
-    // dead code today and is intentionally not done.
-    let flags = u32::from_be_bytes([buff32[24], buff32[25], buff32[26], buff32[27]]);
-
-    // Faithful order: ExifTool.pm:9907 sorts integer-keyed tags
-    // numerically — 6.1, 6.2, 6.3, 6.4, 6.5 — and each loop iteration
-    // calls `FoundTag`. So the output sequence (after the File:* triplet
-    // from SetFileType above) is BytesPerSample, AudioType, Compression,
-    // DataFormat, SampleRate.
-    push_masked(
-      ctx,
-      &BYTES_PER_SAMPLE,
-      flags,
-      BYTES_PER_SAMPLE_MASK,
-      BYTES_PER_SAMPLE_SHIFT,
-      print_conv_enabled,
-    );
-    push_masked(
-      ctx,
-      &AUDIO_TYPE,
-      flags,
-      AUDIO_TYPE_MASK,
-      AUDIO_TYPE_SHIFT,
-      print_conv_enabled,
-    );
-    push_masked(
-      ctx,
-      &COMPRESSION,
-      flags,
-      COMPRESSION_MASK,
-      COMPRESSION_SHIFT,
-      print_conv_enabled,
-    );
-    push_masked(
-      ctx,
-      &DATA_FORMAT,
-      flags,
-      DATA_FORMAT_MASK,
-      DATA_FORMAT_SHIFT,
-      print_conv_enabled,
-    );
-    push_masked(
-      ctx,
-      &SAMPLE_RATE,
-      flags,
-      SAMPLE_RATE_MASK,
-      SAMPLE_RATE_SHIFT,
-      print_conv_enabled,
-    );
+    // WavPack.pm:91-95 — sink the 5 header tags through the typed Meta.
+    // Faithful to the ProcessBinaryData iteration order (numeric-key
+    // sort) and the PrintConv / ValueConv toggle.
+    {
+      let mut bridge = MetadataTagWriter::new(ctx.metadata());
+      let _: Result<(), Infallible> = meta.sink(print_conv, &mut bridge);
+    }
 
     // WavPack.pm:96-103: `RIFF::ProcessRIFF` + `APE::ProcessAPE` trailers.
     // ----------------------------------------------------------------
-    // Phase-2 forward (orchestrator scope: this PR is WavPack only).
-    // For a native-wvpk fixture with NO RIFF wrapper / ID3 / APE trailer
-    // both Perl calls are observably no-ops (bundled `perl exiftool` on
-    // tests/fixtures/WavPack.wv emits exactly the File:* + 5 WavPack
-    // tags — no RIFF::*, no ID3::*, no APE:*). The dedicated RIFF /
-    // ID3 / APE rows (FORMATS.md rows 22 / 2 / 5) will wire these
-    // delegations when they land; deferring them here is byte-exact
-    // against the fixtures we ship.
-    // ----------------------------------------------------------------
+    // WavPack.pm:97-99 `Seek(0, 0)` + `RIFF::ProcessRIFF` — RIFF parser
+    // not ported yet (FORMATS.md row 22 forward item). On the committed
+    // fixtures (no RIFF wrapper) this is observably no-op.
+    //
+    // WavPack.pm:100-103 `$$et{PATH}[-1] = 'APE'` then
+    // `APE::ProcessAPE($et, $dirInfo)`. The bundled `ProcessAPE` itself
+    // dispatches to `ProcessID3` first (APE.pm:122-127 — the embedded
+    // ID3 arm). We invoke
+    // [`crate::formats::ape::ProcessApe::process_trailer_only`], which
+    // is the same entry the bundled audio loop uses recursively for
+    // the "wrapper has already set FileType, just scan for trailer"
+    // case. That entry:
+    //   * does NOT re-run the embedded-ID3 dispatch (APE.pm:122-127);
+    //     the bundled WavPack.pm DOES (the WavPack-level ProcessAPE
+    //     call goes through APE.pm:119 which checks `unless ($$et{
+    //     DoneID3})`). We need to drive the ID3 detection separately
+    //     before the APE trailer.
+    //   * DOES set `done_ape` (APE.pm:131) and scan for the APE-tag
+    //     trailer at EOF / ID3v1-adjusted position.
+    //
+    // ID3 dispatch — bundled APE.pm:122-127 `unless ($$et{DoneID3}) {
+    // require Image::ExifTool::ID3; Image::ExifTool::ID3::ProcessID3(
+    // $et, $dirInfo) and return 1; }`. The `and return 1` only fires
+    // when ProcessID3 succeeds AND we're in APE's own entry; in the
+    // WavPack chain, after the WavPack header tags are already pushed,
+    // hitting `return 1` from inside the APE call just means APE bails
+    // out of its own MAC body scan — the WavPack-level `return 1`
+    // (WavPack.pm:104) is unaffected. We model this faithfully via the
+    // chained `process_id3_chained` entry.
+    if ctx.metadata().done_id3().is_none() {
+      let _ = crate::formats::id3::process::process_id3_chained(ctx);
+    }
+    let _ = crate::formats::ape::ProcessApe.process_trailer_only(ctx);
 
-    true // WavPack.pm:104 `return 1`
+    true // WavPack.pm:104 `return 1`.
   }
 }
 
-/// Emit one masked sub-field of the int32u flags word. Mirrors
-/// `ProcessBinaryData`'s mask/shift step (ExifTool.pm:10067-10068):
-///   `val = (val & mask) >> shift`
-/// then runs the def's ValueConv / PrintConv pipeline via `convert::apply`
-/// and pushes the resulting tag (faithful `FoundTag`,
-/// ExifTool.pm:5648-ish) into the parser's value sink. `shift` is the
-/// pre-computed `BitShift` (from the module-level `bit_shift` helper);
-/// the parameter is named `shift` to avoid shadowing the helper at the
-/// call site.
-fn push_masked(
-  ctx: &mut ParseContext<'_>,
-  def: &'static TagDef,
-  flags: u32,
-  mask: u32,
-  shift: u32,
-  print_conv_enabled: bool,
-) {
-  let raw_u = (flags & mask) >> shift;
-  // The largest possible raw value after masking is 0x0F (SampleRate's
-  // 4-bit field) — fits in i64 trivially. Every WavPack ProcessBinaryData
-  // raw is non-negative and ≤ 15, so i64 is exact and matches the Perl
-  // scalar's UV path.
-  let raw = TagValue::I64(i64::from(raw_u));
-  let out = crate::convert::apply(def, &raw, print_conv_enabled);
-  ctx.metadata().push(
-    Group::new(WAVPACK_MAIN.group0(), def.group1()),
-    def.name(),
-    out,
-  );
-}
+// ===========================================================================
+// Tests
+// ===========================================================================
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::value::Metadata;
+  use crate::{
+    sink::{MapTagWriter, MapValue},
+    value::{Metadata, TagValue},
+  };
 
-  /// Build a 32-byte wvpk header with the given LE flags word. All other
-  /// fields use deterministic values; only the flags drive WavPack's tags.
+  // -------------------------------------------------------------------------
+  // Mask + shift derivation
+  // -------------------------------------------------------------------------
+
+  #[test]
+  fn bit_shifts_pin_to_perl_table() {
+    // ExifTool.pm:5905-5910: BitShift = trailing zeros of Mask.
+    assert_eq!(BYTES_PER_SAMPLE_MASK, 0x0000_0003);
+    assert_eq!(AUDIO_TYPE_MASK, 0x0000_0004);
+    assert_eq!(COMPRESSION_MASK, 0x0000_0008);
+    assert_eq!(DATA_FORMAT_MASK, 0x0000_0080);
+    assert_eq!(SAMPLE_RATE_MASK, 0x0780_0000);
+    assert_eq!(BYTES_PER_SAMPLE_SHIFT, 0);
+    assert_eq!(AUDIO_TYPE_SHIFT, 2);
+    assert_eq!(COMPRESSION_SHIFT, 3);
+    assert_eq!(DATA_FORMAT_SHIFT, 7);
+    assert_eq!(SAMPLE_RATE_SHIFT, 23);
+  }
+
+  #[test]
+  fn sample_rate_lookup_table_is_faithful() {
+    // WavPack.pm:55-72 — 0..=14 known rates, 15 = Custom.
+    assert_eq!(sample_rate_lookup(0), Some(SampleRate::Hz(6000)));
+    assert_eq!(sample_rate_lookup(9), Some(SampleRate::Hz(44100)));
+    assert_eq!(sample_rate_lookup(10), Some(SampleRate::Hz(48000)));
+    assert_eq!(sample_rate_lookup(14), Some(SampleRate::Hz(192000)));
+    assert_eq!(sample_rate_lookup(15), Some(SampleRate::Custom));
+    // Unreachable from a 4-bit mask, but kept total for safety.
+    assert_eq!(sample_rate_lookup(16), None);
+  }
+
+  // -------------------------------------------------------------------------
+  // Typed enums
+  // -------------------------------------------------------------------------
+
+  #[test]
+  fn audio_type_round_trip() {
+    assert_eq!(AudioType::from_raw(0), AudioType::Stereo);
+    assert_eq!(AudioType::from_raw(1), AudioType::Mono);
+    assert_eq!(AudioType::Stereo.raw(), 0);
+    assert_eq!(AudioType::Mono.raw(), 1);
+    assert_eq!(AudioType::Stereo.print_conv(), "Stereo");
+    assert_eq!(AudioType::Mono.print_conv(), "Mono");
+  }
+
+  #[test]
+  fn compression_round_trip() {
+    assert_eq!(Compression::from_raw(0), Compression::Lossless);
+    assert_eq!(Compression::from_raw(1), Compression::Hybrid);
+    assert_eq!(Compression::Lossless.raw(), 0);
+    assert_eq!(Compression::Hybrid.raw(), 1);
+    assert_eq!(Compression::Lossless.print_conv(), "Lossless");
+    assert_eq!(Compression::Hybrid.print_conv(), "Hybrid");
+  }
+
+  #[test]
+  fn data_format_round_trip() {
+    assert_eq!(DataFormat::from_raw(0), DataFormat::Integer);
+    assert_eq!(DataFormat::from_raw(1), DataFormat::FloatingPoint);
+    assert_eq!(DataFormat::Integer.raw(), 0);
+    assert_eq!(DataFormat::FloatingPoint.raw(), 1);
+    assert_eq!(DataFormat::Integer.print_conv(), "Integer");
+    assert_eq!(DataFormat::FloatingPoint.print_conv(), "Floating Point");
+  }
+
+  // -------------------------------------------------------------------------
+  // `parse_borrowed` — lib-first direct entry
+  // -------------------------------------------------------------------------
+
+  /// Build a 32-byte wvpk header with the given LE flags word. All
+  /// other fields use deterministic values; only the flags drive
+  /// WavPack's tags.
   fn header_with_flags(flags_le: u32) -> [u8; 32] {
     let mut h = [0u8; 32];
     h[0..4].copy_from_slice(b"wvpk");
@@ -337,200 +924,325 @@ mod tests {
   }
 
   #[test]
-  fn table_and_lookup_are_faithful() {
-    let g = WAVPACK_MAIN.get();
-    // The five WavPack tags resolve via TagId::Str (faithful to the
-    // way `wavpack_get` keys; the Perl IDs 6.1..6.5 collapse onto a
-    // single offset so we look them up by name).
-    assert_eq!(
-      g(TagId::Str("BytesPerSample")).unwrap().name(),
-      "BytesPerSample"
-    );
-    assert_eq!(g(TagId::Str("AudioType")).unwrap().name(), "AudioType");
-    assert_eq!(g(TagId::Str("Compression")).unwrap().name(), "Compression");
-    assert_eq!(g(TagId::Str("DataFormat")).unwrap().name(), "DataFormat");
-    assert_eq!(g(TagId::Str("SampleRate")).unwrap().name(), "SampleRate");
-    assert!(g(TagId::Str("Other")).is_none());
-    assert!(g(TagId::Int(0)).is_none());
-    assert_eq!(WAVPACK_MAIN.group0(), "File"); // WavPack.pm:23
-    // BitShift derivation: per ExifTool.pm:5905-5910 each shift = #
-    // trailing zero bits of the mask. Pinned to the exact integer values
-    // documented in the .pm so a mask-literal typo is caught even if the
-    // `bit_shift` helper is ever changed.
-    assert_eq!(BYTES_PER_SAMPLE_MASK, 0x0000_0003);
-    assert_eq!(AUDIO_TYPE_MASK, 0x0000_0004);
-    assert_eq!(COMPRESSION_MASK, 0x0000_0008);
-    assert_eq!(DATA_FORMAT_MASK, 0x0000_0080);
-    assert_eq!(SAMPLE_RATE_MASK, 0x0780_0000);
-    assert_eq!(BYTES_PER_SAMPLE_SHIFT, 0);
-    assert_eq!(AUDIO_TYPE_SHIFT, 2);
-    assert_eq!(COMPRESSION_SHIFT, 3);
-    assert_eq!(DATA_FORMAT_SHIFT, 7);
-    assert_eq!(SAMPLE_RATE_SHIFT, 23);
-    // ValueConv +1: BytesPerSample only.
-    assert!(BYTES_PER_SAMPLE.value_conv().is_func());
-    assert!(AUDIO_TYPE.value_conv().is_none());
-    // SampleRate PrintConv hash size is 16 (indices 0..=15).
-    match SAMPLE_RATE.print_conv() {
-      PrintConv::Hash(h) => assert_eq!(h.direct_entries().len(), 16),
-      _ => panic!("expected hash"),
-    }
+  fn parse_borrowed_extracts_fixture_flags() {
+    // Oracle pattern: on-disk LE flags `0x0480008d`. BE read of bytes
+    // 24..27 = 0x8d008004 ⇒
+    //   BytesPerSample raw=0 +1 = 1
+    //   AudioType raw=1 → Mono
+    //   Compression raw=0 → Lossless
+    //   DataFormat raw=0 → Integer
+    //   SampleRate raw=10 → Hz(48000)
+    let data = header_with_flags(0x0480_008d);
+    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    assert_eq!(meta.bytes_per_sample(), 1);
+    assert_eq!(meta.audio_type(), AudioType::Mono);
+    assert_eq!(meta.compression(), Compression::Lossless);
+    assert_eq!(meta.data_format(), DataFormat::Integer);
+    assert_eq!(meta.sample_rate(), SampleRate::Hz(48000));
+    assert_eq!(meta.sample_rate_hz(), Some(48000));
+    assert_eq!(meta.sample_rate_raw_index(), 10);
+    // The chained scan range is the FULL input buffer.
+    assert_eq!(meta.id3_ape_scan_range(), Some(data.as_slice()));
   }
 
   #[test]
-  fn rejects_short_header() {
-    let mut m = Metadata::new("WavPack.wv");
-    let data = vec![0u8; 16]; // < 32 bytes
-    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(!ProcessWv.process(&mut c));
-    assert!(m.tags().is_empty()); // no SetFileType run
+  fn parse_borrowed_adversarial_all_bits_set() {
+    // flags = 0xFFFFFFFF: every mask saturates.
+    //   BytesPerSample raw=3 → +1 = 4
+    //   AudioType raw=1 → Mono
+    //   Compression raw=1 → Hybrid
+    //   DataFormat raw=1 → FloatingPoint
+    //   SampleRate raw=15 → Custom
+    let data = header_with_flags(0xFFFF_FFFF);
+    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    assert_eq!(meta.bytes_per_sample(), 4);
+    assert_eq!(meta.audio_type(), AudioType::Mono);
+    assert_eq!(meta.compression(), Compression::Hybrid);
+    assert_eq!(meta.data_format(), DataFormat::FloatingPoint);
+    assert_eq!(meta.sample_rate(), SampleRate::Custom);
+    assert_eq!(meta.sample_rate_hz(), None);
+    assert_eq!(meta.sample_rate_raw_index(), 15);
   }
 
   #[test]
-  fn rejects_bad_magic() {
-    let mut m = Metadata::new("WavPack.wv");
+  fn parse_borrowed_rejects_short() {
+    assert!(parse_borrowed(&[]).unwrap().is_none());
+    assert!(parse_borrowed(&[0u8; 16]).unwrap().is_none());
+    assert!(parse_borrowed(&[0u8; 31]).unwrap().is_none());
+  }
+
+  #[test]
+  fn parse_borrowed_rejects_bad_magic() {
     let mut data = vec![0u8; 32];
-    // Wrong magic.
     data[..4].copy_from_slice(b"WVPK");
-    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(!ProcessWv.process(&mut c));
-    assert!(m.tags().is_empty());
+    assert!(parse_borrowed(&data).unwrap().is_none());
   }
 
   #[test]
-  fn rejects_bad_version_byte_8() {
-    // Byte 8 must be ∈ {0x02, 0x10}; any other rejects (WavPack.pm:88).
-    let mut m = Metadata::new("WavPack.wv");
+  fn parse_borrowed_rejects_bad_version_byte_8() {
     let mut data = vec![0u8; 32];
     data[..4].copy_from_slice(b"wvpk");
     data[8] = 0x05; // out of {0x02, 0x10}
     data[9] = 0x04;
-    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(!ProcessWv.process(&mut c));
-    assert!(m.tags().is_empty());
+    assert!(parse_borrowed(&data).unwrap().is_none());
   }
 
   #[test]
-  fn rejects_bad_version_byte_9() {
-    // Byte 9 must be 0x04; any other rejects.
-    let mut m = Metadata::new("WavPack.wv");
+  fn parse_borrowed_rejects_bad_version_byte_9() {
     let mut data = vec![0u8; 32];
     data[..4].copy_from_slice(b"wvpk");
     data[8] = 0x10;
     data[9] = 0x05; // not 0x04
+    assert!(parse_borrowed(&data).unwrap().is_none());
+  }
+
+  #[test]
+  fn parse_borrowed_accepts_version_byte_02() {
+    // Byte 8 == 0x02 is the other allowed version (WavPack.pm:88).
+    let mut data = header_with_flags(0);
+    data[8] = 0x02; // 0x0402
+    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    assert_eq!(meta.bytes_per_sample(), 1); // raw=0 +1
+  }
+
+  // -------------------------------------------------------------------------
+  // `FormatParser` trait + `WvContext`
+  // -------------------------------------------------------------------------
+
+  #[test]
+  fn format_parser_trait_returns_meta_static() {
+    let data = header_with_flags(0x0480_008d);
+    let mut shared = SharedFlags::new();
+    let ctx = WvContext::new(&data, &mut shared);
+    let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx)
+      .expect("ok")
+      .expect("parsed");
+    // Same field extraction as parse_borrowed; the only difference is
+    // the borrow on `id3_ape_scan_range` collapses to `None` after
+    // `into_static`.
+    assert_eq!(meta.bytes_per_sample(), 1);
+    assert_eq!(meta.audio_type(), AudioType::Mono);
+    assert_eq!(meta.sample_rate(), SampleRate::Hz(48000));
+    assert_eq!(meta.sample_rate_raw_index(), 10);
+    // `into_static` drops the borrow — see WvMeta::into_static doc.
+    assert!(meta.id3_ape_scan_range().is_none());
+  }
+
+  #[test]
+  fn format_parser_trait_rejects_bad_magic() {
+    let mut data = vec![0u8; 32];
+    data[..4].copy_from_slice(b"WVPK");
+    let mut shared = SharedFlags::new();
+    let ctx = WvContext::new(&data, &mut shared);
+    let result = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx).unwrap();
+    assert!(result.is_none());
+  }
+
+  #[test]
+  fn wv_context_exposes_shared_mut_for_chained_parsers() {
+    // Reserved-for-Phase-F2/F3 wiring smoke test — the lib-first parse
+    // does not actually flip shared flags today.
+    let data = header_with_flags(0);
+    let mut shared = SharedFlags::new();
+    {
+      let mut ctx = WvContext::new(&data, &mut shared);
+      assert_eq!(ctx.shared().done_id3(), 0);
+      ctx.shared_mut().set_done_id3(128);
+    }
+    assert_eq!(shared.done_id3(), 128);
+  }
+
+  // -------------------------------------------------------------------------
+  // `MetaSinker` — typed Meta → TagWriter (PrintConv on / off)
+  // -------------------------------------------------------------------------
+
+  fn collect(flags_le: u32, print_conv: bool) -> MapTagWriter {
+    let data = header_with_flags(flags_le);
+    let mut shared = SharedFlags::new();
+    let ctx = WvContext::new(&data, &mut shared);
+    let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx)
+      .unwrap()
+      .unwrap();
+    let mut w = MapTagWriter::new();
+    meta.sink(print_conv, &mut w).unwrap();
+    w
+  }
+
+  #[test]
+  fn sink_print_on_emits_fixture_strings() {
+    let w = collect(0x0480_008d, true);
+    let g = |n: &str| w.get("File", n).map(MapValue::as_str);
+    assert_eq!(g("BytesPerSample"), Some("1".into()));
+    assert_eq!(g("AudioType"), Some("Mono".into()));
+    assert_eq!(g("Compression"), Some("Lossless".into()));
+    assert_eq!(g("DataFormat"), Some("Integer".into()));
+    assert_eq!(g("SampleRate"), Some("48000".into()));
+  }
+
+  #[test]
+  fn sink_print_on_emits_adversarial_strings() {
+    let w = collect(0xFFFF_FFFF, true);
+    let g = |n: &str| w.get("File", n).map(MapValue::as_str);
+    assert_eq!(g("BytesPerSample"), Some("4".into()));
+    assert_eq!(g("AudioType"), Some("Mono".into()));
+    assert_eq!(g("Compression"), Some("Hybrid".into()));
+    assert_eq!(g("DataFormat"), Some("Floating Point".into()));
+    assert_eq!(g("SampleRate"), Some("Custom".into()));
+  }
+
+  #[test]
+  fn sink_print_off_emits_fixture_raw() {
+    let w = collect(0x0480_008d, false);
+    let g = |n: &str| w.get("File", n).map(MapValue::as_str);
+    assert_eq!(g("BytesPerSample"), Some("1".into())); // +1 applied
+    assert_eq!(g("AudioType"), Some("1".into()));
+    assert_eq!(g("Compression"), Some("0".into()));
+    assert_eq!(g("DataFormat"), Some("0".into()));
+    // SampleRate -n: raw 4-bit index (10), not the post-PrintConv 48000.
+    assert_eq!(g("SampleRate"), Some("10".into()));
+  }
+
+  #[test]
+  fn sink_print_off_emits_adversarial_raw() {
+    let w = collect(0xFFFF_FFFF, false);
+    let g = |n: &str| w.get("File", n).map(MapValue::as_str);
+    assert_eq!(g("BytesPerSample"), Some("4".into())); // raw=3 +1
+    assert_eq!(g("AudioType"), Some("1".into()));
+    assert_eq!(g("Compression"), Some("1".into()));
+    assert_eq!(g("DataFormat"), Some("1".into()));
+    assert_eq!(g("SampleRate"), Some("15".into())); // raw index 15
+  }
+
+  // -------------------------------------------------------------------------
+  // Legacy `OldFormatParser` bridge — preserves CLI byte-exact JSON
+  // -------------------------------------------------------------------------
+
+  fn run_bridge(data: &[u8], print_on: bool) -> Metadata {
+    let mut m = Metadata::new("WavPack.wv");
+    let mut c = ParseContext::new(data, "WV", 0, "WV", None, print_on, &mut m);
+    OldFormatParser::process(&ProcessWv, &mut c);
+    m
+  }
+
+  #[test]
+  fn bridge_fixture_round_trip_print_on() {
+    let data = header_with_flags(0x0480_008d);
+    let m = run_bridge(&data, true);
+    let by_name = |n: &str| {
+      m.tags()
+        .iter()
+        .find(|t| t.name() == n)
+        .map(|t| t.value().clone())
+    };
+    assert_eq!(by_name("FileType"), Some(TagValue::Str("WV".into())));
+    assert_eq!(by_name("BytesPerSample"), Some(TagValue::I64(1)));
+    assert_eq!(by_name("AudioType"), Some(TagValue::Str("Mono".into())));
+    assert_eq!(
+      by_name("Compression"),
+      Some(TagValue::Str("Lossless".into()))
+    );
+    assert_eq!(by_name("DataFormat"), Some(TagValue::Str("Integer".into())));
+    assert_eq!(by_name("SampleRate"), Some(TagValue::I64(48000)));
+  }
+
+  #[test]
+  fn bridge_fixture_round_trip_print_off() {
+    let data = header_with_flags(0x0480_008d);
+    let m = run_bridge(&data, false);
+    let by_name = |n: &str| {
+      m.tags()
+        .iter()
+        .find(|t| t.name() == n)
+        .map(|t| t.value().clone())
+    };
+    assert_eq!(by_name("BytesPerSample"), Some(TagValue::I64(1)));
+    assert_eq!(by_name("AudioType"), Some(TagValue::I64(1)));
+    assert_eq!(by_name("Compression"), Some(TagValue::I64(0)));
+    assert_eq!(by_name("DataFormat"), Some(TagValue::I64(0)));
+    assert_eq!(by_name("SampleRate"), Some(TagValue::I64(10)));
+  }
+
+  #[test]
+  fn bridge_adversarial_round_trip_print_on() {
+    let data = header_with_flags(0xFFFF_FFFF);
+    let m = run_bridge(&data, true);
+    let by_name = |n: &str| {
+      m.tags()
+        .iter()
+        .find(|t| t.name() == n)
+        .map(|t| t.value().clone())
+    };
+    assert_eq!(by_name("BytesPerSample"), Some(TagValue::I64(4)));
+    assert_eq!(by_name("AudioType"), Some(TagValue::Str("Mono".into())));
+    assert_eq!(by_name("Compression"), Some(TagValue::Str("Hybrid".into())));
+    assert_eq!(
+      by_name("DataFormat"),
+      Some(TagValue::Str("Floating Point".into()))
+    );
+    assert_eq!(by_name("SampleRate"), Some(TagValue::Str("Custom".into())));
+  }
+
+  #[test]
+  fn bridge_rejects_short() {
+    let mut m = Metadata::new("WavPack.wv");
+    let data = vec![0u8; 16];
     let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(!ProcessWv.process(&mut c));
+    assert!(!OldFormatParser::process(&ProcessWv, &mut c));
+    assert!(m.tags().is_empty()); // no SetFileType run
+  }
+
+  #[test]
+  fn bridge_rejects_bad_magic() {
+    let mut m = Metadata::new("WavPack.wv");
+    let mut data = vec![0u8; 32];
+    data[..4].copy_from_slice(b"WVPK");
+    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
+    assert!(!OldFormatParser::process(&ProcessWv, &mut c));
     assert!(m.tags().is_empty());
   }
 
   #[test]
-  fn accepts_version_02() {
-    // Byte 8 == 0x02 is the other allowed version (WavPack.pm:88).
+  fn bridge_rejects_bad_version_byte_8() {
     let mut m = Metadata::new("WavPack.wv");
-    let mut data = header_with_flags(0);
-    data[8] = 0x02; // 0x0402
+    let mut data = vec![0u8; 32];
+    data[..4].copy_from_slice(b"wvpk");
+    data[8] = 0x05;
+    data[9] = 0x04;
     let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(ProcessWv.process(&mut c));
-    // File:FileType=WV plus 5 WavPack tags.
+    assert!(!OldFormatParser::process(&ProcessWv, &mut c));
+    assert!(m.tags().is_empty());
+  }
+
+  #[test]
+  fn bridge_rejects_bad_version_byte_9() {
+    let mut m = Metadata::new("WavPack.wv");
+    let mut data = vec![0u8; 32];
+    data[..4].copy_from_slice(b"wvpk");
+    data[8] = 0x10;
+    data[9] = 0x05;
+    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
+    assert!(!OldFormatParser::process(&ProcessWv, &mut c));
+    assert!(m.tags().is_empty());
+  }
+
+  #[test]
+  fn bridge_accepts_version_byte_02() {
+    let mut data = header_with_flags(0);
+    data[8] = 0x02;
+    let m = run_bridge(&data, true);
     assert!(m.tags().iter().any(|t| t.name() == "FileType"));
     assert!(m.tags().iter().any(|t| t.name() == "BytesPerSample"));
   }
 
   #[test]
-  fn extracts_tags_from_oracle_pattern_print_on() {
-    // Mirrors the conformance fixture: on-disk LE flags 0x0480008d.
-    // BE read of bytes 24..27 = 0x8d008004; oracle-verified ⇒
-    //   BytesPerSample raw=0 +1 = 1
-    //   AudioType raw=1 → 'Mono'
-    //   Compression raw=0 → 'Lossless'
-    //   DataFormat raw=0 → 'Integer'
-    //   SampleRate raw=10 → 48000
-    let mut m = Metadata::new("WavPack.wv");
-    let data = header_with_flags(0x0480_008d);
-    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(ProcessWv.process(&mut c));
-    let get = |name: &str| {
-      m.tags()
-        .iter()
-        .find(|t| t.name() == name)
-        .map(|t| t.value().clone())
-    };
-    assert_eq!(get("BytesPerSample"), Some(TagValue::I64(1)));
-    assert_eq!(get("AudioType"), Some(TagValue::Str("Mono".into())));
-    assert_eq!(get("Compression"), Some(TagValue::Str("Lossless".into())));
-    assert_eq!(get("DataFormat"), Some(TagValue::Str("Integer".into())));
-    assert_eq!(get("SampleRate"), Some(TagValue::I64(48000)));
-  }
-
-  #[test]
-  fn extracts_tags_print_off() {
-    // `-n` (print_conv_enabled=false): ValueConv runs (BytesPerSample +1),
-    // PrintConv does NOT — the raw mask values are emitted directly as
-    // numbers (matches the oracle's "-n" snapshot).
-    let mut m = Metadata::new("WavPack.wv");
-    let data = header_with_flags(0x0480_008d);
-    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, false, &mut m);
-    assert!(ProcessWv.process(&mut c));
-    let get = |name: &str| {
-      m.tags()
-        .iter()
-        .find(|t| t.name() == name)
-        .map(|t| t.value().clone())
-    };
-    // ValueConv-only output (PrintConv hash lookups skipped).
-    assert_eq!(get("BytesPerSample"), Some(TagValue::I64(1))); // +1 applied
-    assert_eq!(get("AudioType"), Some(TagValue::I64(1)));
-    assert_eq!(get("Compression"), Some(TagValue::I64(0)));
-    assert_eq!(get("DataFormat"), Some(TagValue::I64(0)));
-    assert_eq!(get("SampleRate"), Some(TagValue::I64(10)));
-  }
-
-  #[test]
-  fn adversarial_all_bits_set() {
-    // flags = 0xFFFFFFFF: every mask saturates.
-    //   BytesPerSample raw=3 → +1 = 4
-    //   AudioType raw=1 → 'Mono'
-    //   Compression raw=1 → 'Hybrid'
-    //   DataFormat raw=1 → 'Floating Point'
-    //   SampleRate raw=15 → 'Custom'  (the only string entry, PrintValue::Str)
-    let mut m = Metadata::new("WavPack_adv.wv");
-    let data = header_with_flags(0xFFFF_FFFF);
-    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(ProcessWv.process(&mut c));
-    let get = |name: &str| {
-      m.tags()
-        .iter()
-        .find(|t| t.name() == name)
-        .map(|t| t.value().clone())
-    };
-    assert_eq!(get("BytesPerSample"), Some(TagValue::I64(4)));
-    assert_eq!(get("AudioType"), Some(TagValue::Str("Mono".into())));
-    assert_eq!(get("Compression"), Some(TagValue::Str("Hybrid".into())));
-    assert_eq!(
-      get("DataFormat"),
-      Some(TagValue::Str("Floating Point".into()))
-    );
-    assert_eq!(get("SampleRate"), Some(TagValue::Str("Custom".into())));
-    // Final File:FileType=WV from SetFileType.
-    assert_eq!(
-      m.tags()
-        .iter()
-        .find(|t| t.name() == "FileType")
-        .map(|t| t.value().clone()),
-      Some(TagValue::Str("WV".into()))
-    );
-  }
-
-  #[test]
-  fn tag_order_is_set_file_type_then_numeric() {
+  fn bridge_emits_tags_in_expected_order() {
     // ExifTool.pm:9907 numeric sort ⇒ 6.1, 6.2, 6.3, 6.4, 6.5. After
-    // SetFileType pushes the File:* triplet, the parser pushes the
-    // five WavPack tags in that order. Lock the order in.
-    let mut m = Metadata::new("WavPack.wv");
+    // SetFileType pushes the File:* triplet, the bridge sinks the 5
+    // WavPack tags in that order. The chained ID3 + APE trailer
+    // entries emit nothing on the fixture (no ID3 / no APE trailer).
     let data = header_with_flags(0x0480_008d);
-    let mut c = ParseContext::new(&data, "WV", 0, "WV", None, true, &mut m);
-    assert!(ProcessWv.process(&mut c));
-    let names: Vec<&str> = m.tags().iter().map(|t| t.name()).collect();
+    let m = run_bridge(&data, true);
+    let names: std::vec::Vec<&str> = m.tags().iter().map(|t| t.name()).collect();
     assert_eq!(
       names,
       vec![
@@ -544,5 +1256,15 @@ mod tests {
         "SampleRate",
       ]
     );
+  }
+
+  #[test]
+  fn bridge_marks_done_ape_after_running() {
+    // APE.pm:131 `$$et{DoneAPE} = 1` runs INSIDE `process_trailer_only`,
+    // regardless of whether an APE trailer is actually present. Pin
+    // that the WavPack chain drives the flag.
+    let data = header_with_flags(0x0480_008d);
+    let m = run_bridge(&data, true);
+    assert!(m.done_ape());
   }
 }

--- a/src/parser_new.rs
+++ b/src/parser_new.rs
@@ -25,8 +25,7 @@
 //! / Phase F (everything else). Both are `#[non_exhaustive]` so new format
 //! arms are additive.
 
-use core::fmt;
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 pub(crate) mod parser_sealed {
   /// Sealed marker for the new [`super::FormatParser`] trait. Downstream
@@ -306,7 +305,12 @@ pub enum AnyParser {
   /// MPEG audio (Phase F4 — MP3 / MP2 / MUS frame parser + Xing/LAME tail).
   #[cfg(feature = "mpeg-audio")]
   MpegAudio(crate::formats::mpeg::ProcessMpegAudio),
-  // Phase F5 adds: Mpc, WavPack.
+  /// MPC (Phase F5 — Musepack SV7/SV8 audio, chains ID3 + APE).
+  #[cfg(feature = "mpc")]
+  Mpc(crate::formats::mpc::ProcessMpc),
+  /// WavPack (Phase F5 — `.wv` / `.wvp` hybrid-lossless audio, chains ID3 + APE).
+  #[cfg(feature = "wavpack")]
+  Wv(crate::formats::wavpack::ProcessWv),
 }
 
 /// Closed-set enum of every format's `Meta` output. Mirrors [`AnyParser`].
@@ -375,6 +379,12 @@ pub enum AnyMeta<'a> {
   /// `MpegAudioMeta<'static>` by [`crate::formats::mpeg::ProcessMpegAudio`].
   #[cfg(feature = "mpeg-audio")]
   MpegAudio(crate::formats::mpeg::MpegAudioMeta<'a>),
+  /// MPC (Phase F5 — Musepack SV7/SV8 audio).
+  #[cfg(feature = "mpc")]
+  Mpc(crate::formats::mpc::MpcMeta<'a>),
+  /// WavPack (Phase F5 — `.wv` / `.wvp` hybrid-lossless audio).
+  #[cfg(feature = "wavpack")]
+  Wv(crate::formats::wavpack::WvMeta<'a>),
 }
 
 impl MetaSinker for AnyMeta<'_> {
@@ -420,6 +430,10 @@ impl MetaSinker for AnyMeta<'_> {
       AnyMeta::Ogg(m) => m.sink(print_conv, out),
       #[cfg(feature = "mpeg-audio")]
       AnyMeta::MpegAudio(m) => m.sink(print_conv, out),
+      #[cfg(feature = "mpc")]
+      AnyMeta::Mpc(m) => m.sink(print_conv, out),
+      #[cfg(feature = "wavpack")]
+      AnyMeta::Wv(m) => m.sink(print_conv, out),
     }
   }
 }


### PR DESCRIPTION
PR #8 of 9. Builds on #24. Last format-migration phase. All conformance fixtures byte-exact.