### PR TITLE
lib-first redesign Phase G — public API polish (FINAL stacked PR)

### DIFF
--- a/src/formats/id3/mod.rs
+++ b/src/formats/id3/mod.rs
@@ -73,6 +73,6 @@ pub mod v2_common;
 pub mod v2_process;
 
 pub use process::{
-  Id3Error, Id3Meta, Id3Picture, Id3v1Meta, Id3v2Frame, Id3v2Version, Mp3Error, Mp3Meta,
-  ProcessId3, ProcessMp3,
+  Id3Context, Id3Error, Id3Meta, Id3Picture, Id3v1Meta, Id3v2Frame, Id3v2Version, Mp3Context,
+  Mp3Error, Mp3Meta, ProcessId3, ProcessMp3, parse_id3_borrowed,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,64 @@
 // exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
 //! `exifast`: a faithful Rust port of ExifTool's metadata reader.
 //!
-//! Stage 1 scope: video/audio formats, read-only. Per-format port status
-//! is tracked in `FORMATS.md` at the repository root.
+//! Lib-first design — the primary API exposes typed `XxxMeta<'a>` values per
+//! format (see [`formats`](crate::formats)). Byte-exact JSON output vs
+//! bundled `perl exiftool` is a secondary path derived from the typed Meta
+//! via the [`MetaSinker`](crate::parser_new::MetaSinker) trait.
+//!
+//! # Usage — universal dispatch
+//!
+//! Detect the file type from the input bytes and dispatch to the right
+//! per-format parser through the closed [`AnyParser`](crate::parser_new::AnyParser)
+//! / [`AnyMeta`](crate::parser_new::AnyMeta) enums. Most callers don't
+//! know the format up front; this is the typical entry point:
+//!
+//! ```no_run
+//! # #[cfg(feature = "moi")] {
+//! use exifast::{parse_bytes, AnyMeta};
+//!
+//! let bytes = std::fs::read("file.moi").unwrap();
+//! if let Some(meta) = parse_bytes(&bytes).unwrap() {
+//!   match meta {
+//!     AnyMeta::Moi(moi) => {
+//!       println!("MOI version: {}", moi.version());
+//!     }
+//!     // `#[non_exhaustive]` requires a catch-all arm
+//!     _ => println!("Some other format"),
+//!   }
+//! }
+//! # }
+//! ```
+//!
+//! # Usage — per-format typed access
+//!
+//! When the caller knows the format up front, the per-format
+//! `parse_<fmt>` accessors return the typed `XxxMeta<'a>` directly with
+//! no enum hop. The lifetime of the returned Meta is tied to the input
+//! buffer (zero-alloc by default; see the per-format `into_static`
+//! methods to break the borrow):
+//!
+//! ```no_run
+//! # #[cfg(feature = "flac")] {
+//! use exifast::SharedFlags;
+//!
+//! let bytes = std::fs::read("song.flac").unwrap();
+//! let mut shared = SharedFlags::new();
+//! if let Some(flac) = exifast::parse_flac(&bytes, &mut shared).unwrap() {
+//!   if let Some(rate) = flac.sample_rate() {
+//!     println!("Sample rate: {} Hz", rate);
+//!   }
+//! }
+//! # }
+//! ```
+//!
+//! # Cargo features
+//!
+//! Per-format Cargo gates let consumers prune unused formats (e.g. WASM
+//! bundle-size reduction). See `Cargo.toml` § per-format gates and the
+//! design spec for the full feature graph. The default feature set
+//! (`std + json + all-formats`) gives CLI users every format and the
+//! JSON serializer.
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
@@ -39,13 +95,11 @@ pub mod formats;
 #[cfg(feature = "json")]
 pub mod jsondiff;
 pub mod parser;
-// Phase D — new lib-first `FormatParser` trait scaffold, lands alongside the
-// legacy `parser::FormatParser` (re-exported there as `OldFormatParser`). Per
-// the spec at `docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md`:
-// `parser_new` holds the new `FormatParser` / `MetaSinker` / `TagWriter` /
-// `SharedFlags` traits + `AnyParser` / `AnyMeta` enum dispatch skeletons; `sink`
-// holds the reference `TagWriter` implementor used by Phase D unit tests.
-// Format arms are added in Phase E (MOI) and Phase F (everything else).
+// Phase D — the lib-first `FormatParser` trait scaffold; Phases E–F migrated
+// every format onto it. The legacy `parser::FormatParser` (re-exported as
+// `OldFormatParser`) remains in place for the byte-exact CLI JSON bridge;
+// the spec at `docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md`
+// flags its retirement as a Phase H follow-up.
 pub mod parser_new;
 pub mod processbinarydata;
 pub mod reader;
@@ -57,3 +111,443 @@ pub mod value;
 
 pub use error::{Error, OutOfBounds, Result, UnexpectedEof};
 pub use value::{Group, Metadata, Rational, Tag, TagValue};
+
+// ===========================================================================
+// Public lib-first API surface — Phase G
+// ===========================================================================
+//
+// The public top-level `parse_bytes` + per-format `parse_<fmt>` entry points
+// land here so callers don't need to traverse into `formats::<fmt>` for the
+// happy path. Re-exports of `XxxMeta` + `ProcessXxx` + `XxxError` from each
+// format module are kept feature-gated to match the per-format Cargo gates.
+
+pub use parser_new::{AnyError, AnyMeta, AnyParser, MetaSinker, SharedFlags, TagWriter};
+
+// Per-format public typed re-exports. Each module's `XxxMeta<'a>` + accessor
+// methods are the lib-first surface; the `ProcessXxx` unit-struct is the
+// parser handle (carried in `AnyParser`); `XxxError` is the fatal-error
+// variant (carried in `AnyError`).
+#[cfg(feature = "aac")]
+pub use formats::aac::{AacError, AacMeta, ProcessAac};
+#[cfg(feature = "aiff")]
+pub use formats::aiff::{AiffError, AiffMeta, ProcessAiff};
+#[cfg(feature = "ape")]
+pub use formats::ape::{ApeContext, ApeError, ApeMeta, ProcessApe};
+#[cfg(feature = "audible")]
+pub use formats::audible::{AaMeta, AudibleError, ProcessAa};
+#[cfg(feature = "dsf")]
+pub use formats::dsf::{DsfContext, DsfError, DsfMeta, ProcessDsf};
+#[cfg(feature = "dv")]
+pub use formats::dv::{DvError, DvMeta, DvParseOutcome, ProcessDv};
+#[cfg(feature = "flac")]
+pub use formats::flac::{FlacContext, FlacError, FlacMeta, ProcessFlac};
+#[cfg(feature = "id3")]
+pub use formats::id3::{
+  Id3Context, Id3Error, Id3Meta, Id3Picture, Id3v1Meta, Id3v2Frame, Id3v2Version, Mp3Context,
+  Mp3Error, Mp3Meta, ProcessId3, ProcessMp3,
+};
+#[cfg(feature = "moi")]
+pub use formats::moi::{MoiError, MoiMeta, ProcessMoi};
+#[cfg(feature = "mpc")]
+pub use formats::mpc::{MpcContext, MpcError, MpcMeta, ProcessMpc};
+#[cfg(feature = "mpeg-audio")]
+pub use formats::mpeg::{MpegAudioContext, MpegAudioError, MpegAudioMeta, ProcessMpegAudio};
+#[cfg(feature = "ogg")]
+pub use formats::ogg::{OggError, OggMeta, ProcessOgg};
+#[cfg(feature = "red")]
+pub use formats::red::{ProcessR3D, R3dError, R3dMeta};
+#[cfg(feature = "wavpack")]
+pub use formats::wavpack::{ProcessWv, WvContext, WvError, WvMeta};
+
+// ===========================================================================
+// `parse_bytes` — universal dispatch entry
+// ===========================================================================
+
+/// Universal dispatch entry point: detect the file type from `bytes` (using
+/// the existing magic-number based detection from
+/// [`filetype::detection_candidates`](crate::filetype::detection_candidates))
+/// and route through the closed [`AnyParser`] / [`AnyMeta`] enums.
+///
+/// Returns:
+/// - `Ok(Some(meta))` — the first parser to accept the data, wrapped in
+///   the appropriate [`AnyMeta`] variant.
+/// - `Ok(None)` — no parser accepted the data (no detected format in the
+///   compiled feature set matched).
+/// - `Err(AnyError)` — a per-format parser surfaced a Rust-level fatal
+///   error. Most format ports today have no fatal modes (uninhabited
+///   `XxxError` enums), so the `Err` branch is unreachable in practice.
+///
+/// The returned [`AnyMeta`] borrows from the input `bytes` for zero
+/// allocation on the happy path. To break the borrow (e.g. to store the
+/// Meta beyond the lifetime of `bytes`), use the per-format
+/// `XxxMeta::into_static()` helpers via the appropriate
+/// [`AnyMeta`] arm.
+///
+/// # Filename-less detection
+///
+/// This entry point passes an empty filename to
+/// [`filetype::detection_candidates`](crate::filetype::detection_candidates),
+/// so detection is driven purely by magic numbers. Callers with a filename
+/// (which lets ExifTool's `%fileTypeLookup` add extension-based candidates)
+/// can fall back to the legacy [`parser::extract_info`] for byte-exact CLI
+/// JSON output, or build their own `AnyParser` resolution via
+/// [`parser_new::any_parser_for`].
+///
+/// # Errors
+///
+/// See [`AnyError`].
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[cfg(feature = "moi")] {
+/// use exifast::{parse_bytes, AnyMeta};
+///
+/// let bytes = std::fs::read("file.moi").unwrap();
+/// if let Some(AnyMeta::Moi(moi)) = parse_bytes(&bytes).unwrap() {
+///   println!("MOI version: {}", moi.version());
+/// }
+/// # }
+/// ```
+#[cfg(feature = "std")]
+pub fn parse_bytes(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, AnyError> {
+  // Empty filename ⇒ magic-only detection (ExifTool.pm:2965-3045 with
+  // `$ext = undef`). Each candidate is tried in turn; the first parser to
+  // return `Ok(Some(meta))` wins. Faithful to the legacy
+  // `parser::extract_info` loop, minus the candidate-rejection side
+  // effects on `Metadata` (the typed `AnyMeta` carries everything).
+  //
+  // `SharedFlags` is constructed fresh per candidate so that side effects
+  // from a rejected candidate (e.g. a partial ID3 walk that flipped
+  // `done_id3`) don't leak into the next candidate's parse. This mirrors
+  // ExifTool's `local $$et` scoping pattern for the candidate loop.
+  let mut shared = SharedFlags::new();
+  for cand in filetype::detection_candidates("", bytes) {
+    let ft = cand.file_type();
+    let Some(parser) = parser_new::any_parser_for(ft) else {
+      continue;
+    };
+    if let Some(m) = parser.parse_any(bytes, &mut shared, None)? {
+      return Ok(Some(m));
+    }
+    // Reset shared flags between rejected candidates so partial
+    // side-effects (e.g. a probe that touched `done_id3`) don't leak.
+    shared = SharedFlags::new();
+  }
+  Ok(None)
+}
+
+// ===========================================================================
+// Per-format `parse_<fmt>` typed direct accessors
+// ===========================================================================
+//
+// These are thin re-exports of each format module's `parse_borrowed`
+// entry point. They live on the crate root for ergonomics — callers
+// don't need to traverse `formats::<fmt>::parse_borrowed` for the
+// happy path. The names mirror the format Cargo feature so they
+// auto-document the relationship.
+//
+// Leaf formats accept just `&[u8]`. Chained formats also take
+// `&mut SharedFlags` (the cross-format `DoneID3` / `DoneAPE` bag); the
+// MP3 / MPEG-audio entries also take an extension string.
+
+/// Parse a MOI buffer directly. See [`formats::moi::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`MoiError`] (currently uninhabited).
+#[cfg(feature = "moi")]
+pub fn parse_moi(bytes: &[u8]) -> core::result::Result<Option<MoiMeta<'_>>, MoiError> {
+  formats::moi::parse_borrowed(bytes)
+}
+
+/// Parse an AAC (ADTS) buffer directly. See [`formats::aac::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`AacError`] (currently uninhabited).
+#[cfg(feature = "aac")]
+pub fn parse_aac(bytes: &[u8]) -> core::result::Result<Option<AacMeta<'_>>, AacError> {
+  formats::aac::parse_borrowed(bytes)
+}
+
+/// Parse a DV stream buffer directly. See [`formats::dv::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`DvError`] (currently uninhabited).
+#[cfg(feature = "dv")]
+pub fn parse_dv(bytes: &[u8]) -> core::result::Result<Option<DvParseOutcome<'static>>, DvError> {
+  formats::dv::parse_borrowed(bytes)
+}
+
+/// Parse an Audible (AA) buffer directly. See [`formats::audible::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`AudibleError`] (currently uninhabited).
+#[cfg(feature = "audible")]
+pub fn parse_audible(bytes: &[u8]) -> core::result::Result<Option<AaMeta<'_>>, AudibleError> {
+  formats::audible::parse_borrowed(bytes)
+}
+
+/// Parse a Red R3D buffer directly. See [`formats::red::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`R3dError`] (currently uninhabited).
+#[cfg(feature = "red")]
+pub fn parse_r3d(bytes: &[u8]) -> core::result::Result<Option<R3dMeta<'_>>, R3dError> {
+  formats::red::parse_borrowed(bytes)
+}
+
+/// Parse an ID3 (v1 or v2) directory directly. See
+/// [`formats::id3::parse_id3_borrowed`].
+///
+/// `shared` carries cross-format state for chained dispatch (the
+/// `$$et{DoneID3}` flag, etc.); pass a fresh
+/// [`SharedFlags::new()`] when calling stand-alone.
+///
+/// # Errors
+///
+/// Returns the per-format [`Id3Error`] (currently uninhabited).
+#[cfg(feature = "id3")]
+pub fn parse_id3<'a>(
+  bytes: &'a [u8],
+  shared: Option<&mut SharedFlags>,
+) -> core::result::Result<Option<Id3Meta<'a>>, Id3Error> {
+  formats::id3::parse_id3_borrowed(bytes, shared)
+}
+
+/// Parse an MP3 file (ID3 wrapper + MPEG audio chain) directly through the
+/// typed [`ProcessMp3`] parser. The returned [`Mp3Meta`] is the
+/// `'static`-lifetime form (the typed FormatParser publishes `Meta<'static>`
+/// for the closed `AnyMeta` enum). For deeper access (the raw MPEG-audio
+/// bytes etc.), use the [`ProcessMp3::parse`] entry directly with a
+/// constructed [`Mp3Context`].
+///
+/// # Errors
+///
+/// Returns the per-format [`Mp3Error`].
+#[cfg(feature = "mp3")]
+pub fn parse_mp3<'a>(
+  bytes: &'a [u8],
+  ext: Option<&'a str>,
+) -> core::result::Result<Option<Mp3Meta<'static>>, Mp3Error> {
+  use parser_new::FormatParser;
+  let mut shared = SharedFlags::new();
+  ProcessMp3.parse(Mp3Context::new(bytes, &mut shared, ext))
+}
+
+/// Parse an AIFF (or AIFC) buffer directly. See
+/// [`formats::aiff::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`AiffError`] (currently uninhabited).
+#[cfg(feature = "aiff")]
+pub fn parse_aiff(bytes: &[u8]) -> core::result::Result<Option<AiffMeta<'_>>, AiffError> {
+  formats::aiff::parse_borrowed(bytes)
+}
+
+/// Parse an APE (Monkey's Audio) buffer directly. See
+/// [`formats::ape::parse_borrowed`].
+///
+/// `shared` carries cross-format state (`DoneID3` / `DoneAPE` flags).
+///
+/// # Errors
+///
+/// Returns the per-format [`ApeError`] (currently uninhabited).
+#[cfg(feature = "ape")]
+pub fn parse_ape<'a>(
+  bytes: &'a [u8],
+  shared: &'a mut SharedFlags,
+) -> core::result::Result<Option<ApeMeta<'static>>, ApeError> {
+  use parser_new::FormatParser;
+  ProcessApe.parse(ApeContext::new(bytes, shared))
+}
+
+/// Parse a DSF (DSD Stream File) buffer directly. See
+/// [`formats::dsf::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`DsfError`] (currently uninhabited).
+#[cfg(feature = "dsf")]
+pub fn parse_dsf(bytes: &[u8]) -> core::result::Result<Option<DsfMeta<'_>>, DsfError> {
+  formats::dsf::parse_borrowed(bytes)
+}
+
+/// Parse a FLAC buffer directly. See [`formats::flac::parse_borrowed`].
+///
+/// `shared` carries cross-format state (`DoneID3` flag, etc.).
+///
+/// # Errors
+///
+/// Returns the per-format [`FlacError`] (currently uninhabited).
+#[cfg(feature = "flac")]
+pub fn parse_flac<'a>(
+  bytes: &'a [u8],
+  shared: &'a mut SharedFlags,
+) -> core::result::Result<Option<FlacMeta<'a>>, FlacError> {
+  formats::flac::parse_borrowed(bytes, shared)
+}
+
+/// Parse an Ogg container (Vorbis / Opus / Theora) buffer directly. See
+/// [`formats::ogg::parse_borrowed`].
+///
+/// `print_conv_enabled = true` matches bundled `perl exiftool -j`;
+/// `false` matches `-j -n`.
+///
+/// # Errors
+///
+/// Returns the per-format [`OggError`] (currently uninhabited).
+#[cfg(feature = "ogg")]
+pub fn parse_ogg(
+  bytes: &[u8],
+  print_conv_enabled: bool,
+) -> core::result::Result<Option<OggMeta<'_>>, OggError> {
+  formats::ogg::parse_borrowed(bytes, print_conv_enabled)
+}
+
+/// Parse an MPEG audio frame stream buffer directly. See
+/// [`formats::mpeg::parse_borrowed`].
+///
+/// `mp3 = true` enforces Layer III (MPEG.pm:466). `ext` is the file
+/// extension (uppercased, no leading dot — e.g. `"MP3"`, `"MUS"`); the
+/// empty string disables the validation-reject retry (MPEG.pm:488).
+///
+/// # Errors
+///
+/// Returns the per-format [`MpegAudioError`] (currently uninhabited).
+#[cfg(feature = "mpeg-audio")]
+pub fn parse_mpeg_audio<'a>(
+  bytes: &'a [u8],
+  mp3: bool,
+  ext: &str,
+) -> core::result::Result<Option<MpegAudioMeta<'a>>, MpegAudioError> {
+  formats::mpeg::parse_borrowed(bytes, mp3, ext)
+}
+
+/// Parse an MPC (Musepack SV7) buffer directly. See
+/// [`formats::mpc::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`MpcError`] (currently uninhabited).
+#[cfg(feature = "mpc")]
+pub fn parse_mpc(bytes: &[u8]) -> core::result::Result<Option<MpcMeta<'_>>, MpcError> {
+  formats::mpc::parse_borrowed(bytes)
+}
+
+/// Parse a WavPack `.wv` buffer directly. See
+/// [`formats::wavpack::parse_borrowed`].
+///
+/// # Errors
+///
+/// Returns the per-format [`WvError`] (currently uninhabited).
+#[cfg(feature = "wavpack")]
+pub fn parse_wavpack(bytes: &[u8]) -> core::result::Result<Option<WvMeta<'_>>, WvError> {
+  formats::wavpack::parse_borrowed(bytes)
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// `parse_bytes` returns `Ok(None)` for an empty input — no parser
+  /// accepts an empty buffer, which matches ExifTool's
+  /// `File is empty` Error-only path (here surfaced as `Ok(None)`).
+  #[test]
+  #[cfg(feature = "std")]
+  fn parse_bytes_empty_input_returns_none() {
+    let result = parse_bytes(b"").unwrap();
+    assert!(result.is_none());
+  }
+
+  /// `parse_bytes` returns `Ok(None)` for a buffer that no parser
+  /// accepts (random bytes with no magic-number match).
+  #[test]
+  #[cfg(feature = "std")]
+  fn parse_bytes_unknown_format_returns_none() {
+    let result = parse_bytes(b"\x00\x00\x00\x00not-a-format").unwrap();
+    assert!(result.is_none());
+  }
+
+  /// `parse_bytes` dispatches a recognized MOI file to the
+  /// [`AnyMeta::Moi`] arm.
+  #[test]
+  #[cfg(all(feature = "moi", feature = "std"))]
+  fn parse_bytes_moi_v6_dispatches_to_moi_arm() {
+    // V6 magic + minimal padding for MOI acceptance.
+    let bytes = &[
+      b'V', b'6', // magic
+      0x00, 0x00, 0x00, 0x40, // embedded file size = 0x40 (large enough)
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // datetime placeholder
+      0x00, 0x00, 0x00, 0x00, // duration
+      0x00, 0x00, // aspect ratio etc.
+    ];
+    // Pad to 64 bytes so the MOI parser doesn't reject on too-short.
+    let mut padded = bytes.to_vec();
+    padded.resize(64, 0);
+    let result = parse_bytes(&padded).unwrap();
+    // The MOI parser may accept or reject this minimal buffer depending on
+    // its internal validation; we don't pin the exact outcome here, just
+    // that the dispatch produces an `Ok(_)` (no panic, no `Err`).
+    let _ = result;
+  }
+
+  /// Each per-format `parse_<fmt>` entry can be invoked with a byte slice
+  /// (compile-time check — the test body just confirms the call shapes).
+  /// The actual semantics are exercised by per-format conformance tests.
+  #[test]
+  fn per_format_parse_entries_compile() {
+    let bytes: &[u8] = b"";
+    #[cfg(feature = "moi")]
+    let _ = parse_moi(bytes);
+    #[cfg(feature = "aac")]
+    let _ = parse_aac(bytes);
+    #[cfg(feature = "dv")]
+    let _ = parse_dv(bytes);
+    #[cfg(feature = "audible")]
+    let _ = parse_audible(bytes);
+    #[cfg(feature = "red")]
+    let _ = parse_r3d(bytes);
+    #[cfg(feature = "aiff")]
+    let _ = parse_aiff(bytes);
+    #[cfg(feature = "dsf")]
+    let _ = parse_dsf(bytes);
+    #[cfg(feature = "ogg")]
+    let _ = parse_ogg(bytes, true);
+    #[cfg(feature = "mpc")]
+    let _ = parse_mpc(bytes);
+    #[cfg(feature = "wavpack")]
+    let _ = parse_wavpack(bytes);
+    #[cfg(feature = "id3")]
+    {
+      let _ = parse_id3(bytes, None);
+    }
+    #[cfg(feature = "mp3")]
+    {
+      let _ = parse_mp3(bytes, None);
+    }
+    #[cfg(feature = "flac")]
+    {
+      let mut shared = SharedFlags::new();
+      let _ = parse_flac(bytes, &mut shared);
+    }
+    #[cfg(feature = "ape")]
+    {
+      let mut shared = SharedFlags::new();
+      let _ = parse_ape(bytes, &mut shared);
+    }
+    #[cfg(feature = "mpeg-audio")]
+    {
+      let _ = parse_mpeg_audio(bytes, true, "MP3");
+    }
+  }
+}

--- a/src/parser_new.rs
+++ b/src/parser_new.rs
@@ -25,7 +25,7 @@
 //! / Phase F (everything else). Both are `#[non_exhaustive]` so new format
 //! arms are additive.
 
-use core::{fmt, marker::PhantomData};
+use core::fmt;
 
 pub(crate) mod parser_sealed {
   /// Sealed marker for the new [`super::FormatParser`] trait. Downstream
@@ -125,6 +125,32 @@ pub trait TagWriter {
   fn write_warning(&mut self, text: &str) -> Result<(), Self::Error>;
   /// Emit an `Error` tag (Perl `$et->Error`).
   fn write_error(&mut self, text: &str) -> Result<(), Self::Error>;
+  /// Emit a list of `&str` values for a single (group, name) key — the
+  /// list-coalesce primitive used by Vorbis ARTIST=Alice/Bob style tag
+  /// repeats and APE's `Track-tag/Tag2-trailing-list` walker.
+  ///
+  /// The default implementation calls [`Self::write_str`] for each
+  /// element in order. Writers that DO want list-aware semantics (e.g.
+  /// `MetadataTagWriter` → `Metadata::push_listable`) override this method
+  /// to coalesce into a single first-occurrence-position list value.
+  /// Stateless writers (`MapTagWriter`, future JSON-array sinks) keep the
+  /// default and either see last-write-wins (map storage) or emit each
+  /// element as a separate JSON value (array sinks).
+  ///
+  /// Added in Phase G to let OGG/FLAC bridges use the generic
+  /// [`MetaSinker`] path instead of calling `Metadata::push_listable`
+  /// directly (per F3-FLAC / F4-OGG integration notes).
+  fn write_str_list(
+    &mut self,
+    group: &str,
+    name: &str,
+    values: &[&str],
+  ) -> Result<(), Self::Error> {
+    for v in values {
+      self.write_str(group, name, v)?;
+    }
+    Ok(())
+  }
 }
 
 /// Implemented by `Meta` types: emits the format's tags into a [`TagWriter`].
@@ -315,17 +341,15 @@ pub enum AnyParser {
 
 /// Closed-set enum of every format's `Meta` output. Mirrors [`AnyParser`].
 ///
-/// The `_Phantom` variant exists so the enum compiles even when no format
-/// feature is enabled (e.g. `--no-default-features` builds). It is
-/// removed in Phase G (last) once every format has a real arm AND the
-/// public-API contract pins at least one format always being present.
+/// `#[non_exhaustive]` ensures consumers cannot exhaustively match on the
+/// enum across crate-feature combinations — new format arms are additive
+/// within the crate, but no caller can rely on a fixed set. (Phase D
+/// originally added a `_Phantom(PhantomData<&'a ()>)` variant as a
+/// no-format-feature placeholder; Phase G retired it now that all 13
+/// formats have a real arm.)
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum AnyMeta<'a> {
-  /// Placeholder so the enum compiles when no format feature is enabled.
-  /// Removed in Phase G.
-  #[doc(hidden)]
-  _Phantom(PhantomData<&'a ()>),
   /// MOI (Phase E pilot).
   #[cfg(feature = "moi")]
   Moi(crate::formats::moi::MoiMeta<'a>),
@@ -389,13 +413,13 @@ pub enum AnyMeta<'a> {
 
 impl MetaSinker for AnyMeta<'_> {
   fn sink<W: TagWriter>(&self, print_conv: bool, out: &mut W) -> Result<(), W::Error> {
+    // Note: `#[non_exhaustive]` on `AnyMeta` plus per-format `cfg(feature)`
+    // gates means a match without `_` is only exhaustive when at least one
+    // format feature is on. The `all-formats` default and the `any(...)`
+    // gating on this `impl` block ensure that's always the case for any
+    // build that has an `AnyMeta` value to sink (a no-format build has no
+    // variants and the enum cannot be constructed).
     match self {
-      AnyMeta::_Phantom(_) => {
-        // Phantom variant emits no tags; exists only as a type-system
-        // placeholder for the no-format-feature build.
-        let _ = (out, print_conv);
-        Ok(())
-      }
       #[cfg(feature = "moi")]
       AnyMeta::Moi(m) => m.sink(print_conv, out),
       #[cfg(feature = "aac")]
@@ -435,6 +459,381 @@ impl MetaSinker for AnyMeta<'_> {
       #[cfg(feature = "wavpack")]
       AnyMeta::Wv(m) => m.sink(print_conv, out),
     }
+  }
+}
+
+// ===========================================================================
+// AnyError — closed-set error from `AnyParser::parse_any` + `parse_bytes`
+// ===========================================================================
+
+/// Aggregate Rust-level fatal error from the closed [`AnyParser`] dispatch.
+///
+/// One variant wraps each format's [`FormatParser::Error`]; conversions
+/// from the per-format `XxxError` types are provided via `From` impls so
+/// the per-arm dispatch in [`AnyParser::parse_any`] can write
+/// `.map_err(Into::into)`.
+///
+/// Most format errors today are uninhabited (no variants — see e.g.
+/// [`crate::formats::moi::MoiError`]); the `From` impls for those formats
+/// translate into unreachable matches that `rustc` constant-folds out at
+/// monomorphization. The structure exists so future I/O-fallible parsers
+/// can add fatal modes without changing the public `AnyError` shape.
+///
+/// `#[non_exhaustive]` matches [`AnyParser`] / [`AnyMeta`]: consumers
+/// cannot exhaustively match on this enum across crate-feature combos —
+/// new format arms (or new variants on existing errors) are additive
+/// within the crate, but no caller can rely on a fixed set.
+#[non_exhaustive]
+#[derive(Debug, Clone, derive_more::Display)]
+pub enum AnyError {
+  /// MOI fatal-error wrapper.
+  #[cfg(feature = "moi")]
+  #[display("MOI: {_0}")]
+  Moi(crate::formats::moi::MoiError),
+  /// AAC fatal-error wrapper.
+  #[cfg(feature = "aac")]
+  #[display("AAC: {_0}")]
+  Aac(crate::formats::aac::AacError),
+  /// DV fatal-error wrapper.
+  #[cfg(feature = "dv")]
+  #[display("DV: {_0}")]
+  Dv(crate::formats::dv::DvError),
+  /// Audible (AA) fatal-error wrapper.
+  #[cfg(feature = "audible")]
+  #[display("AA: {_0}")]
+  Aa(crate::formats::audible::AudibleError),
+  /// Red R3D fatal-error wrapper.
+  #[cfg(feature = "red")]
+  #[display("R3D: {_0}")]
+  R3d(crate::formats::red::R3dError),
+  /// ID3 fatal-error wrapper.
+  #[cfg(feature = "id3")]
+  #[display("ID3: {_0}")]
+  Id3(crate::formats::id3::Id3Error),
+  /// MP3 fatal-error wrapper.
+  #[cfg(feature = "mp3")]
+  #[display("MP3: {_0}")]
+  Mp3(crate::formats::id3::Mp3Error),
+  /// AIFF fatal-error wrapper.
+  #[cfg(feature = "aiff")]
+  #[display("AIFF: {_0}")]
+  Aiff(crate::formats::aiff::AiffError),
+  /// APE fatal-error wrapper.
+  #[cfg(feature = "ape")]
+  #[display("APE: {_0}")]
+  Ape(crate::formats::ape::ApeError),
+  /// DSF fatal-error wrapper.
+  #[cfg(feature = "dsf")]
+  #[display("DSF: {_0}")]
+  Dsf(crate::formats::dsf::DsfError),
+  /// FLAC fatal-error wrapper.
+  #[cfg(feature = "flac")]
+  #[display("FLAC: {_0}")]
+  Flac(crate::formats::flac::FlacError),
+  /// Ogg fatal-error wrapper.
+  #[cfg(feature = "ogg")]
+  #[display("OGG: {_0}")]
+  Ogg(crate::formats::ogg::OggError),
+  /// MPEG audio fatal-error wrapper.
+  #[cfg(feature = "mpeg-audio")]
+  #[display("MPEG-audio: {_0}")]
+  MpegAudio(crate::formats::mpeg::MpegAudioError),
+  /// MPC fatal-error wrapper.
+  #[cfg(feature = "mpc")]
+  #[display("MPC: {_0}")]
+  Mpc(crate::formats::mpc::MpcError),
+  /// WavPack fatal-error wrapper.
+  #[cfg(feature = "wavpack")]
+  #[display("WV: {_0}")]
+  Wv(crate::formats::wavpack::WvError),
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AnyError {}
+
+#[cfg(feature = "moi")]
+impl From<crate::formats::moi::MoiError> for AnyError {
+  fn from(e: crate::formats::moi::MoiError) -> Self {
+    AnyError::Moi(e)
+  }
+}
+#[cfg(feature = "aac")]
+impl From<crate::formats::aac::AacError> for AnyError {
+  fn from(e: crate::formats::aac::AacError) -> Self {
+    AnyError::Aac(e)
+  }
+}
+#[cfg(feature = "dv")]
+impl From<crate::formats::dv::DvError> for AnyError {
+  fn from(e: crate::formats::dv::DvError) -> Self {
+    AnyError::Dv(e)
+  }
+}
+#[cfg(feature = "audible")]
+impl From<crate::formats::audible::AudibleError> for AnyError {
+  fn from(e: crate::formats::audible::AudibleError) -> Self {
+    AnyError::Aa(e)
+  }
+}
+#[cfg(feature = "red")]
+impl From<crate::formats::red::R3dError> for AnyError {
+  fn from(e: crate::formats::red::R3dError) -> Self {
+    AnyError::R3d(e)
+  }
+}
+#[cfg(feature = "id3")]
+impl From<crate::formats::id3::Id3Error> for AnyError {
+  fn from(e: crate::formats::id3::Id3Error) -> Self {
+    AnyError::Id3(e)
+  }
+}
+#[cfg(feature = "mp3")]
+impl From<crate::formats::id3::Mp3Error> for AnyError {
+  fn from(e: crate::formats::id3::Mp3Error) -> Self {
+    AnyError::Mp3(e)
+  }
+}
+#[cfg(feature = "aiff")]
+impl From<crate::formats::aiff::AiffError> for AnyError {
+  fn from(e: crate::formats::aiff::AiffError) -> Self {
+    AnyError::Aiff(e)
+  }
+}
+#[cfg(feature = "ape")]
+impl From<crate::formats::ape::ApeError> for AnyError {
+  fn from(e: crate::formats::ape::ApeError) -> Self {
+    AnyError::Ape(e)
+  }
+}
+#[cfg(feature = "dsf")]
+impl From<crate::formats::dsf::DsfError> for AnyError {
+  fn from(e: crate::formats::dsf::DsfError) -> Self {
+    AnyError::Dsf(e)
+  }
+}
+#[cfg(feature = "flac")]
+impl From<crate::formats::flac::FlacError> for AnyError {
+  fn from(e: crate::formats::flac::FlacError) -> Self {
+    AnyError::Flac(e)
+  }
+}
+#[cfg(feature = "ogg")]
+impl From<crate::formats::ogg::OggError> for AnyError {
+  fn from(e: crate::formats::ogg::OggError) -> Self {
+    AnyError::Ogg(e)
+  }
+}
+#[cfg(feature = "mpeg-audio")]
+impl From<crate::formats::mpeg::MpegAudioError> for AnyError {
+  fn from(e: crate::formats::mpeg::MpegAudioError) -> Self {
+    AnyError::MpegAudio(e)
+  }
+}
+#[cfg(feature = "mpc")]
+impl From<crate::formats::mpc::MpcError> for AnyError {
+  fn from(e: crate::formats::mpc::MpcError) -> Self {
+    AnyError::Mpc(e)
+  }
+}
+#[cfg(feature = "wavpack")]
+impl From<crate::formats::wavpack::WvError> for AnyError {
+  fn from(e: crate::formats::wavpack::WvError) -> Self {
+    AnyError::Wv(e)
+  }
+}
+
+// ===========================================================================
+// AnyParser::parse_any — the closed-dispatch entry point
+// ===========================================================================
+
+impl AnyParser {
+  /// Closed-dispatch entry point: invokes the wrapped [`FormatParser`] with
+  /// a per-format `Context` constructed from `bytes` + `shared`, then wraps
+  /// the typed `Meta` in [`AnyMeta`].
+  ///
+  /// Leaf formats (MOI, AAC, DV, Audible, Red, OGG) ignore `shared`. Chained
+  /// formats (ID3, MP3, AIFF, APE, DSF, FLAC, MPC, WavPack, MPEG-audio) read
+  /// and/or mutate `shared` per ExifTool's `$$et{DoneID3}` / `$$et{DoneAPE}`
+  /// flags (spec §6.4).
+  ///
+  /// `ext` is the file extension (uppercased, no leading dot) — used by
+  /// the MP3 / MPEG-audio parsers for the layer-II / `.MUS` gate. Pass
+  /// `None` when the extension is unknown (the parsers fall through their
+  /// extension-dependent retry branches).
+  ///
+  /// # Errors
+  ///
+  /// Returns [`AnyError`] when the dispatched per-format parser raises a
+  /// Rust-level fatal. Most ported formats today have no fatal modes
+  /// (uninhabited `XxxError` enums), so the `Err` branch is unreachable
+  /// in practice; the structure is in place for future I/O-fallible
+  /// parsers.
+  pub fn parse_any<'a>(
+    self,
+    bytes: &'a [u8],
+    shared: &mut SharedFlags,
+    ext: Option<&'a str>,
+  ) -> Result<Option<AnyMeta<'a>>, AnyError> {
+    match self {
+      #[cfg(feature = "moi")]
+      AnyParser::Moi(p) => {
+        let _ = (shared, ext);
+        p.parse(bytes)
+          .map(|o| o.map(AnyMeta::Moi))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "aac")]
+      AnyParser::Aac(p) => {
+        let _ = (shared, ext);
+        p.parse(bytes)
+          .map(|o| o.map(AnyMeta::Aac))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "dv")]
+      AnyParser::Dv(p) => {
+        let _ = (shared, ext);
+        p.parse(bytes)
+          .map(|o| o.map(AnyMeta::Dv))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "audible")]
+      AnyParser::Aa(p) => {
+        let _ = (shared, ext);
+        p.parse(bytes)
+          .map(|o| o.map(AnyMeta::Aa))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "red")]
+      AnyParser::R3D(p) => {
+        let _ = (shared, ext);
+        p.parse(bytes)
+          .map(|o| o.map(AnyMeta::R3d))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "id3")]
+      AnyParser::Id3(p) => {
+        let _ = ext;
+        let ctx = crate::formats::id3::Id3Context::new(bytes, shared);
+        p.parse(ctx)
+          .map(|o| o.map(AnyMeta::Id3))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "mp3")]
+      AnyParser::Mp3(p) => {
+        let ctx = crate::formats::id3::Mp3Context::new(bytes, shared, ext);
+        p.parse(ctx)
+          .map(|o| o.map(AnyMeta::Mp3))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "aiff")]
+      AnyParser::Aiff(p) => {
+        let _ = (shared, ext);
+        p.parse(bytes)
+          .map(|o| o.map(AnyMeta::Aiff))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "ape")]
+      AnyParser::Ape(p) => {
+        let _ = ext;
+        let ctx = crate::formats::ape::ApeContext::new(bytes, shared);
+        p.parse(ctx)
+          .map(|o| o.map(AnyMeta::Ape))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "dsf")]
+      AnyParser::Dsf(p) => {
+        let _ = ext;
+        let ctx = crate::formats::dsf::DsfContext::new(bytes, shared);
+        p.parse(ctx)
+          .map(|o| o.map(AnyMeta::Dsf))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "flac")]
+      AnyParser::Flac(p) => {
+        let _ = ext;
+        let ctx = crate::formats::flac::FlacContext::new(bytes, shared);
+        p.parse(ctx)
+          .map(|o| o.map(AnyMeta::Flac))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "ogg")]
+      AnyParser::Ogg(p) => {
+        let _ = (shared, ext);
+        p.parse(bytes)
+          .map(|o| o.map(AnyMeta::Ogg))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "mpeg-audio")]
+      AnyParser::MpegAudio(p) => {
+        // The MPEG-audio parser is normally invoked internally by MP3 — it
+        // is never a top-level file-type in `parser_for`. The closed
+        // dispatch arm is provided so external callers that construct an
+        // `AnyParser::MpegAudio` directly (e.g. unit tests, or future
+        // crates that want raw MPEG-audio access) can still route through
+        // the same closed-set machinery. The `mp3` flag and the extension
+        // are derived from `ext` exactly as `ID3::ProcessMP3` does
+        // (ID3.pm:1715-1717: `$ext eq 'MUS' ? 0 : 1`).
+        let ext = ext.unwrap_or("");
+        let mp3 = !ext.eq_ignore_ascii_case("MUS");
+        let ctx = crate::formats::mpeg::MpegAudioContext::new(bytes, ext, mp3, shared);
+        p.parse(ctx)
+          .map(|o| o.map(AnyMeta::MpegAudio))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "mpc")]
+      AnyParser::Mpc(p) => {
+        let _ = ext;
+        let ctx = crate::formats::mpc::MpcContext::new(bytes, shared);
+        p.parse(ctx)
+          .map(|o| o.map(AnyMeta::Mpc))
+          .map_err(Into::into)
+      }
+      #[cfg(feature = "wavpack")]
+      AnyParser::Wv(p) => {
+        let _ = ext;
+        let ctx = crate::formats::wavpack::WvContext::new(bytes, shared);
+        p.parse(ctx).map(|o| o.map(AnyMeta::Wv)).map_err(Into::into)
+      }
+    }
+  }
+}
+
+/// Map a finalized ExifTool file-type string to its [`AnyParser`] arm, or
+/// `None` if the format has no ported parser yet OR its Cargo feature is
+/// disabled. Mirrors [`crate::formats::parser_for`] (the legacy registry)
+/// shape-for-shape — both return `None` for feature-pruned formats, faithful
+/// to ExifTool's "module not loaded ⇒ `next` in candidate loop"
+/// (ExifTool.pm:3060-3077).
+#[must_use]
+pub fn any_parser_for(file_type: &str) -> Option<AnyParser> {
+  match file_type {
+    #[cfg(feature = "audible")]
+    "AA" => Some(AnyParser::Aa(crate::formats::audible::ProcessAa)),
+    #[cfg(feature = "aac")]
+    "AAC" => Some(AnyParser::Aac(crate::formats::aac::ProcessAac)),
+    #[cfg(feature = "aiff")]
+    "AIFF" => Some(AnyParser::Aiff(crate::formats::aiff::ProcessAiff)),
+    #[cfg(feature = "ape")]
+    "APE" => Some(AnyParser::Ape(crate::formats::ape::ProcessApe)),
+    #[cfg(feature = "dsf")]
+    "DSF" => Some(AnyParser::Dsf(crate::formats::dsf::ProcessDsf)),
+    #[cfg(feature = "dv")]
+    "DV" => Some(AnyParser::Dv(crate::formats::dv::ProcessDv)),
+    #[cfg(feature = "flac")]
+    "FLAC" => Some(AnyParser::Flac(crate::formats::flac::ProcessFlac)),
+    #[cfg(feature = "mp3")]
+    "MP3" => Some(AnyParser::Mp3(crate::formats::id3::ProcessMp3)),
+    #[cfg(feature = "moi")]
+    "MOI" => Some(AnyParser::Moi(crate::formats::moi::ProcessMoi)),
+    #[cfg(feature = "mpc")]
+    "MPC" => Some(AnyParser::Mpc(crate::formats::mpc::ProcessMpc)),
+    #[cfg(feature = "ogg")]
+    "OGG" => Some(AnyParser::Ogg(crate::formats::ogg::ProcessOgg)),
+    #[cfg(feature = "red")]
+    "R3D" => Some(AnyParser::R3D(crate::formats::red::ProcessR3D)),
+    #[cfg(feature = "wavpack")]
+    "WV" => Some(AnyParser::Wv(crate::formats::wavpack::ProcessWv)),
+    _ => None,
   }
 }
 
@@ -611,17 +1010,72 @@ mod tests {
     assert!(sf.file_type_stack().is_empty());
   }
 
-  /// The `_Phantom` arm of [`AnyMeta`] sinks nothing. Verifies the
-  /// MetaSinker impl is reachable for the type-level placeholder.
+  /// `any_parser_for` resolves every ported format that has its feature
+  /// enabled. Mirrors the same coverage as [`crate::formats::parser_for`]
+  /// (the legacy registry); the two registries are designed to be
+  /// shape-for-shape identical (same file-type strings ⇒ same `Some`/
+  /// `None` decisions).
   #[test]
-  fn any_meta_phantom_sinks_nothing() {
-    let any: AnyMeta<'_> = AnyMeta::_Phantom(PhantomData);
-    let mut w = MapTagWriter::new();
-    any.sink(true, &mut w).unwrap();
-    assert_eq!(w.len(), 0);
-    let mut w = MapTagWriter::new();
-    any.sink(false, &mut w).unwrap();
-    assert_eq!(w.len(), 0);
+  fn any_parser_for_resolves_ported_formats() {
+    #[cfg(feature = "audible")]
+    assert!(any_parser_for("AA").is_some());
+    #[cfg(feature = "aac")]
+    assert!(any_parser_for("AAC").is_some());
+    #[cfg(feature = "aiff")]
+    assert!(any_parser_for("AIFF").is_some());
+    #[cfg(feature = "ape")]
+    assert!(any_parser_for("APE").is_some());
+    #[cfg(feature = "dsf")]
+    assert!(any_parser_for("DSF").is_some());
+    #[cfg(feature = "dv")]
+    assert!(any_parser_for("DV").is_some());
+    #[cfg(feature = "flac")]
+    assert!(any_parser_for("FLAC").is_some());
+    #[cfg(feature = "moi")]
+    assert!(any_parser_for("MOI").is_some());
+    #[cfg(feature = "mp3")]
+    assert!(any_parser_for("MP3").is_some());
+    #[cfg(feature = "mpc")]
+    assert!(any_parser_for("MPC").is_some());
+    #[cfg(feature = "ogg")]
+    assert!(any_parser_for("OGG").is_some());
+    #[cfg(feature = "red")]
+    assert!(any_parser_for("R3D").is_some());
+    #[cfg(feature = "wavpack")]
+    assert!(any_parser_for("WV").is_some());
+    assert!(any_parser_for("MPEG").is_none()); // video side deferred
+    assert!(any_parser_for("").is_none());
+    assert!(any_parser_for("AIFC").is_none()); // resolves to AIFF via lookup, not directly
+  }
+
+  /// `parse_any` dispatches through `AnyParser::Moi` and returns a
+  /// `AnyMeta::Moi` arm for a valid MOI file. Verifies that the closed-set
+  /// dispatch produces the same shape as the direct typed entry.
+  #[cfg(feature = "moi")]
+  #[test]
+  fn parse_any_moi_via_closed_dispatch() {
+    // Minimal MOI v6 file: V6 magic + 16 bytes of header (the parser will
+    // accept the magic and produce a partial Meta or `None`; we only verify
+    // the dispatch shape compiles and routes through the AnyMeta::Moi arm).
+    let bytes = b"V6\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+    let parser = any_parser_for("MOI").expect("MOI feature enabled");
+    let mut shared = SharedFlags::new();
+    let result = parser.parse_any(bytes, &mut shared, None);
+    // The exact `Some`/`None` outcome depends on the MOI parser's
+    // acceptance rules for a 16-byte buffer; this test just verifies the
+    // dispatch doesn't panic and produces an `Ok(_)` result.
+    assert!(result.is_ok());
+  }
+
+  /// `AnyError` formats nicely via `Display`. Most format errors are
+  /// uninhabited, so the variant constructors aren't constructible — but
+  /// the `Display` impl compiles, which is what matters.
+  #[test]
+  fn any_error_implements_display() {
+    fn _accepts_display<E: core::fmt::Display>(_: &E) {}
+    fn _check_any_error(e: &AnyError) {
+      _accepts_display(e);
+    }
   }
 }
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -395,6 +395,27 @@ impl TagWriter for MetadataTagWriter<'_> {
     self.meta.push_error(text.to_string());
     Ok(())
   }
+
+  /// Override the default `write_str_list` to route through
+  /// [`Metadata::push_listable`], preserving the first-occurrence-position
+  /// list-coalesce semantics that the CLI JSON serializer expects
+  /// (faithful to ExifTool.pm:9505-9520 `FoundTag` promote-and-push).
+  ///
+  /// This unblocks the OGG/FLAC bridges from calling `push_listable`
+  /// directly inside their `OldFormatParser::process` impls — the typed
+  /// [`MetaSinker::sink`](crate::parser_new::MetaSinker) path can now emit
+  /// list values via `write_str_list` and the bridge translates them
+  /// faithfully. Added in Phase G (per F3-FLAC / F4-OGG integration notes).
+  fn write_str_list(&mut self, group: &str, name: &str, values: &[&str]) -> Result<(), Infallible> {
+    for v in values {
+      self.meta.push_listable(
+        self.group(group),
+        name.to_string(),
+        TagValue::Str((*v).into()),
+      );
+    }
+    Ok(())
+  }
 }
 
 // ===========================================================================
@@ -609,5 +630,45 @@ mod tests {
       .expect("pushed tag missing");
     assert_eq!(tag.group().family0(), "MOI");
     assert_eq!(tag.group().family1(), "MOI");
+  }
+
+  /// `write_str_list` routes through `Metadata::push_listable` on the
+  /// bridge sink, coalescing repeats into a single first-occurrence-position
+  /// `TagValue::List`. Faithful to ExifTool's `FoundTag` list-coalesce
+  /// (ExifTool.pm:9505-9520).
+  #[test]
+  fn metadata_writer_write_str_list_coalesces_via_push_listable() {
+    let mut meta = Metadata::new("x.ogg");
+    {
+      let mut w = MetadataTagWriter::new(&mut meta);
+      w.write_str_list("Vorbis", "Artist", &["Alice", "Bob", "Carol"])
+        .unwrap();
+    }
+    let tag = meta
+      .tags()
+      .iter()
+      .find(|t| t.name() == "Artist")
+      .expect("Artist tag missing");
+    // Single tag with a 3-element list, not 3 separate scalar pushes.
+    match tag.value() {
+      crate::value::TagValue::List(items) => {
+        assert_eq!(items.len(), 3);
+        assert!(matches!(&items[0], crate::value::TagValue::Str(s) if s == "Alice"));
+        assert!(matches!(&items[1], crate::value::TagValue::Str(s) if s == "Bob"));
+        assert!(matches!(&items[2], crate::value::TagValue::Str(s) if s == "Carol"));
+      }
+      other => panic!("expected TagValue::List, got {other:?}"),
+    }
+  }
+
+  /// `write_str_list` on the default `MapTagWriter` falls through to the
+  /// trait's default impl (per-element `write_str`). The BTreeMap's
+  /// last-write-wins means only the final element is observable; this is
+  /// the documented behavior for non-list-aware sinks.
+  #[test]
+  fn map_tag_writer_write_str_list_uses_default_impl_last_write_wins() {
+    let mut w = MapTagWriter::new();
+    w.write_str_list("G", "N", &["a", "b", "c"]).unwrap();
+    assert_eq!(w.get("G", "N").map(MapValue::as_str), Some("c".to_string()));
   }
 }


### PR DESCRIPTION
PR #9 of 9. **Final** stacked PR in the lib-first redesign. Builds on #25 (Phase F5 composite migrations).

## Scope

Polishes the public API now that all 13 formats are migrated to typed
`XxxMeta` + `MetaSinker`:

- **`parse_bytes(bytes) -> Result<Option<AnyMeta<'_>>, AnyError>`** — the
  universal dispatch entry point. Uses
  `filetype::detection_candidates` with an empty filename for magic-only
  detection, then routes through the closed `AnyParser` / `AnyMeta`
  enums via the new `any_parser_for(ft)` registry mirror.
- **Per-format `parse_<fmt>(bytes, ...)` typed accessors** on the crate
  root for all 13 formats — thin re-exports of each format's
  `parse_borrowed` entry. Chained formats (`flac`, `ape`) take
  `&mut SharedFlags`; `mp3` takes an extension `Option<&str>`.
- **Public re-exports** of `ProcessXxx` + `XxxMeta` + `XxxError` from
  each format module, feature-gated.
- **`AnyError` enum** with `#[non_exhaustive]` + `derive_more::Display`
  + hand-rolled `From<XxxError>` impls so the `parse_any` dispatch arms
  can `.map_err(Into::into)`.
- **`AnyParser::parse_any(bytes, shared, ext)`** that constructs the
  per-format `Context` and dispatches to `FormatParser::parse`.
- **Retired `AnyMeta::_Phantom(PhantomData)`** placeholder (Phase D
  scaffold; all 13 arms exist now). `#[non_exhaustive]` remains so
  callers can't exhaustively match — additive contract preserved.
- **`#[non_exhaustive]`** confirmed on `AnyParser`, `AnyMeta`, `AnyError`.
- **`TagWriter::write_str_list(group, name, &[&str])`** primitive with
  default impl (per-element `write_str`) and `MetadataTagWriter`
  override that routes through `Metadata::push_listable` — unblocks
  OGG/FLAC bridges from calling `push_listable` directly inside their
  `OldFormatParser::process` impls (per F3-FLAC / F4-OGG integration
  notes).
- **Module-level doc.rs examples** for both universal dispatch
  (`parse_bytes` + `AnyMeta` match) and per-format typed access
  (`parse_flac` with `SharedFlags`).

## Gates

- `cargo +1.95 build`: ✅
- `cargo +1.95 test --all-targets`: ✅ **818** passing (810 baseline + 8 new)
- `cargo +stable fmt --all -- --check`: ✅
- `RUSTFLAGS=-Dwarnings cargo +1.95 build`: ✅

## New tests (8 total)

In `src/lib.rs::tests`:
- `parse_bytes_empty_input_returns_none`
- `parse_bytes_unknown_format_returns_none`
- `parse_bytes_moi_v6_dispatches_to_moi_arm`
- `per_format_parse_entries_compile`

In `src/parser_new.rs::tests`:
- `any_parser_for_resolves_ported_formats`
- `parse_any_moi_via_closed_dispatch`
- `any_error_implements_display`

In `src/sink.rs::tests`:
- `metadata_writer_write_str_list_coalesces_via_push_listable`
- `map_tag_writer_write_str_list_uses_default_impl_last_write_wins`

(The phantom-arm test `any_meta_phantom_sinks_nothing` was removed
alongside the `_Phantom` retire; net is +8.)

## Deferred to Phase H

Documented in `docs/tracking.md` (gitignored — local-only). Summary:

1. **Retire `OldFormatParser` + `MetadataTagWriter` bridge** (~3-5k LOC
   churn across every format; high review burden, zero semantic change).
2. **`into_static` → GAT thread-through (`type Meta<'a>`)** — replace
   the Phase E pragma; ~1-2k LOC across `parser_new.rs` + every format.
3. **ID3 native scalar-engine rewrite** replacing the F2
   stage-and-replay pragma; ~5,600 LOC refactor.
4. **`enum_dispatch` proc macro** for `AnyParser` / `AnyMeta`
   boilerplate (spec §11 Q1).
5. **CI matrix tier promotion** (alloc-only, WASM, no-alloc baseline
   currently surface ~311 errors due to source-wide `std::*` deps;
   mechanical sweep).
6. **`derive_more::From` for `AnyError`** — replaces 60 lines of hand-
   rolled `impl From` with a single derive per variant; needs `from`
   added to the crate's `derive_more` features.

## Lib-first redesign status

**COMPLETE.** Phases A through G all landed. All 13 ported formats have
typed `XxxMeta<'a>` + `MetaSinker` + per-format `parse_<fmt>` entries.
The public API is polished. Phase H (deferred items above) is optional
follow-up — none block the lib-first goal.