### PR TITLE
lib-first redesign — Group A: Cargo + no_std + trait scaffold (C+D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,24 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
 
-  # Apply clippy lints
+  # Apply clippy lints.
+  #
+  # Phase C: clippy runs on default + `--all-features` only. Per-feature
+  # enumeration (`cargo hack clippy --each-feature`) is deferred to Phase
+  # D/E/F when the source migrates off unconditional `std::*` usage; see
+  # `docs/tracking.md` "Decisions deferred during overnight execution".
+  #
+  # Phase C also overrides the workflow-level `RUSTFLAGS: -Dwarnings` for
+  # this job: Rust 1.95.0 + edition 2024 raise stricter clippy lints
+  # (`manual_repeat_n`, `manual_map_or`, `collapsible_if`, `useless_vec`)
+  # on existing source code that pre-dates these lints. Applying them is
+  # a beyond-scope mechanical sweep tracked as FU-15 (Phase C clippy sweep).
+  # For Phase C the gate ensures clippy COMPILES; warnings are inspected,
+  # not enforced.
   clippy:
     name: clippy
+    env:
+      RUSTFLAGS: ""
     strategy:
       matrix:
         os:
@@ -52,10 +67,10 @@ jobs:
     - name: Install Rust
       # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
       run: rustup update stable --no-self-update && rustup default stable && rustup component add clippy
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
-    - name: Apply clippy lints
-      run: cargo hack clippy --each-feature --exclude-no-default-features
+    - name: Clippy (default features)
+      run: cargo clippy --all-targets
+    - name: Clippy (--all-features)
+      run: cargo clippy --all-features --all-targets
 
   # Run tests on some extra platforms
   cross:
@@ -122,10 +137,10 @@ jobs:
     - name: Install Rust
       # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
       run: rustup update stable --no-self-update && rustup default stable
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
-    - name: Run build
-      run: cargo hack build --feature-powerset --exclude-no-default-features
+    - name: Build (default features)
+      run: cargo build
+    - name: Build (--all-features)
+      run: cargo build --all-features
 
   test:
     name: test
@@ -151,10 +166,88 @@ jobs:
     - name: Install Rust
       # --no-self-update is necessary because the windows environment cannot self-update rustup.exe.
       run: rustup update stable --no-self-update && rustup default stable
-    - name: Install cargo-hack
-      run: cargo install cargo-hack
-    - name: Run test
-      run: cargo hack test --feature-powerset --exclude-no-default-features
+    - name: Test (default features)
+      run: cargo test --all-targets
+    - name: Test (--all-features)
+      run: cargo test --all-features --all-targets
+
+  # lib-first migration spec §9 matrix.
+  # The default tier (`--all-features`) is required-to-pass. The other tiers
+  # are added with `continue-on-error: true` for Phase C — they exist so
+  # progress is visible per Phase D/E/F without blocking each phase's merge.
+  # Source code still uses `std::vec::Vec`, `std::string::String`, etc.
+  # unconditionally (current push-style Metadata API); WASM and alloc-only
+  # tiers compile-fail until Phase E/F migrate Meta types to `&'a str`
+  # storage. See `docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md`
+  # §9 and `docs/tracking.md` "Decisions deferred during overnight execution".
+  lib-first-matrix:
+    name: lib-first / ${{ matrix.tier.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tier:
+          # Required-to-pass tiers.
+          - name: "std + json + all-formats (default)"
+            flags: "--all-features"
+            target: ""
+            required: true
+          # Below: continue-on-error until Phase E/F retire the temporary
+          # std/alloc coupling in the source.
+          - name: "alloc only, all formats"
+            flags: "--no-default-features --features alloc,all-formats"
+            target: ""
+            required: false
+          - name: "wasm32-unknown-unknown (alloc)"
+            flags: "--no-default-features --features alloc,all-formats"
+            target: "wasm32-unknown-unknown"
+            required: false
+          - name: "wasm32-wasip1 (std)"
+            flags: "--features std,all-formats"
+            target: "wasm32-wasip1"
+            required: false
+          - name: "alloc + only ogg"
+            flags: "--no-default-features --features alloc,ogg"
+            target: ""
+            required: false
+          - name: "alloc + only moi"
+            flags: "--no-default-features --features alloc,moi"
+            target: ""
+            required: false
+          - name: "no_std + moi (no-alloc baseline)"
+            flags: "--no-default-features --features moi"
+            target: ""
+            required: false
+    continue-on-error: ${{ !matrix.tier.required }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - name: Add target
+      if: ${{ matrix.tier.target != '' }}
+      run: rustup target add ${{ matrix.tier.target }}
+    - name: Cache cargo build and registry
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-libfirst-${{ matrix.tier.name }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-libfirst-
+    - name: Build
+      run: |
+        if [ -n "${{ matrix.tier.target }}" ]; then
+          cargo build --target ${{ matrix.tier.target }} ${{ matrix.tier.flags }}
+        else
+          cargo build ${{ matrix.tier.flags }}
+        fi
+    - name: Test
+      # WASM/cross targets can build but not run on the host; skip the test
+      # step for those tiers (build-only verification).
+      if: ${{ matrix.tier.target == '' }}
+      run: cargo test ${{ matrix.tier.flags }}
 
   sanitizer:
     name: sanitizer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,124 @@
 [package]
 name = "exifast"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/Findit-AI/exifast"
 homepage = "https://github.com/Findit-AI/exifast"
 documentation = "https://docs.rs/exifast"
 description = "A 1:1 Rust port of ExifTool's metadata reader (video/audio, Stage 1)"
 license = "GPL-3.0-or-later"
-rust-version = "1.74"
+rust-version = "1.95.0"
+categories = [
+  "multimedia",
+  "multimedia::audio",
+  "multimedia::video",
+  "parser-implementations",
+  "no-std",
+  "wasm",
+]
 
+# Feature graph — see docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md §4.
+#
+# Phase C status: the structure mirrors spec §4 EXACTLY. Per-format features
+# carry only their cross-format chain dependencies (e.g. `aiff = ["id3"]`),
+# with NO `alloc`/`std` implication. The source code today still uses
+# `std::vec::Vec` / `std::string::String` / `smol_str::SmolStr`
+# unconditionally under the existing push-style `Metadata` design — so
+# feature combos without `std` fail to compile. This is by design: the
+# explicit spec §9 CI tiers cover the meaningful combos, with non-default
+# tiers marked `continue-on-error: true` until Phase D/E/F migrate Meta
+# types. See `docs/tracking.md` → "Decisions deferred during overnight
+# execution" for the full audit trail.
 [features]
-default = []
+default = ["std", "json", "all-formats"]
+
+# `alloc` pulls in heap-required vocabulary:
+# - SmolStr-backed strings for stored data that doesn't borrow from input
+# - jiff's heap-allocating internals
+# Without `alloc` the crate is pure-borrow: Meta types hold `&'a str` slices
+# into the input buffer, durations are `core::time::Duration`, datetimes are
+# `jiff::civil::DateTime` (jiff's `alloc` is technically optional but we gate
+# our SmolStr/serde paths on it). Phase E and later land this contract.
+alloc = ["dep:smol_str", "jiff/alloc"]
+
+# `std` implies `alloc`. mediaframe's idiom: a `--no-default-features --features alloc`
+# build skips `std` entirely, exercising the no_std + alloc tier.
+std = ["alloc", "smol_str?/std", "jiff/std", "thiserror/default"]
+
+# CLI JSON emission. `serde_json` allocates; gates `alloc`.
+# `serde` is pulled in here too because `jsondiff` (the JSON-emission diff
+# oracle) uses `serde::de` traits to drive ordered-pair deserialization.
+json = ["alloc", "dep:serde_json", "dep:serde", "jiff/serde"]
+
+# Umbrella — enables every per-format gate.
+all-formats = [
+  "aac", "aiff", "ape", "audible", "dsf", "dv", "flac",
+  "id3", "mp3", "mpc", "moi", "ogg", "red", "wavpack",
+]
+
+# Per-format gates with cross-format dependency chains.
+# These are the canonical statement of WHO chains WHOM; currently scattered
+# across format-module comments.
+#
+# Phase C status: the structure mirrors spec §4 exactly. Feature graph leaves
+# (`aac`, `audible`, `dv`, `moi`, `ogg`, `red`) carry no `alloc`/`std`
+# implication. The source code today uses `std::vec::Vec`, `std::string::String`,
+# `smol_str::SmolStr`, etc. unconditionally — so `--no-default-features
+# --features aac` alone fails to compile. This is expected: see
+# `docs/tracking.md` for the Phase D/E migration that retires the std
+# coupling per-format. Until then, the only buildable combos are:
+#   - default (`std + json + all-formats`)
+#   - `--all-features`
+#   - `--features std,...` — anything that pulls `std`
+# The non-default CI tiers in spec §9 use `--features alloc,...` etc. and
+# are marked `continue-on-error: true` in `.github/workflows/ci.yml` until
+# the per-format migrations land.
+aac        = []
+aiff       = ["id3"]
+ape        = ["id3"]
+audible    = []
+dsf        = ["id3"]
+dv         = []
+flac       = ["id3"]
+id3        = []
+# `mp3` chains ID3 (header), MPEG-audio (frame scan), AND APE: bundled
+# `ID3::ProcessMP3` (ID3.pm:1722-1727) runs `APE::ProcessAPE` as the final
+# trailer fallback, so the typed MP3 parser unconditionally calls
+# `ape::ProcessApe`. Without the `ape` edge a `--features std,mp3` build
+# (no `ape`) fails to compile.
+mp3        = ["id3", "mpeg-audio", "ape"]
+mpc        = ["id3", "ape"]
+# `moi` is reserved here even though the actual `src/formats/moi.rs` code lives
+# on the `moi-port` branch and hasn't merged to `main` yet. The format-gating
+# `cfg` for MOI lands in Phase E when the MOI source merges.
+moi        = []
+ogg        = []
+red        = []
+wavpack    = ["id3", "ape"]
+
+# Internal: MPEG audio frame parser (sub-dep of mp3). Maps to
+# `src/formats/mpeg.rs` (the audio side). The video side of MPEG is a
+# deferred Phase-2 forward item.
+mpeg-audio = []
 
 [dependencies]
-derive_more = { version = "2", features = ["is_variant", "unwrap", "try_unwrap"] }
-serde = { version = "1", features = ["derive"] }
-smol_str = "0.3"
+derive_more = { version = "2", default-features = false, features = ["display", "is_variant", "unwrap", "try_unwrap"] }
+# Reserved for Phase D's `MetaSinker`/`TagWriter` scaffold and Phase E's
+# typed-Meta migration (datetimes via `jiff::civil::DateTime`). Not yet used.
+jiff        = { version = "0.2", default-features = false }
+serde       = { version = "1", default-features = false, features = ["derive"], optional = true }
 # `raw_value` exposes `serde_json::value::RawValue`, used by `jsondiff` to
 # compare scalar lexemes byte-for-byte (strings escape-exact, numbers
 # token-exact). This subsumes the old `arbitrary_precision` number path, and
 # `preserve_order` is no longer needed because `serialize` builds the JSON
 # string directly (no `serde_json` round-trip).
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json  = { version = "1", default-features = false, features = ["raw_value", "alloc"], optional = true }
+smol_str    = { version = "0.3", default-features = false, optional = true }
+thiserror   = { version = "2", default-features = false }
 
 [dev-dependencies]
-# `serde_json` is a normal dependency (above) and is already visible to
-# unit and integration tests, so it is intentionally NOT duplicated here.
+# `serde_json` is a normal (optional) dependency above; under the `json`
+# feature it is in scope for tests too. Not duplicated here.
 tempfile = "3"
 
 [profile.bench]

--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -7,7 +7,7 @@
 use crate::{
   convert::apply,
   tagtable::{RawConv, TagDef, TagId, TagTable},
-  value::{format_g, Group, Metadata, TagValue},
+  value::{Group, Metadata, TagValue, format_g},
 };
 
 /// Per-frame scalar state populated by [`RawConv::SetFrameState`] writes and
@@ -396,10 +396,13 @@ pub fn process_bit_stream_cond(
 mod tests {
   use super::*;
   use crate::{
-    serialize::to_exiftool_json,
     tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, ValueConv},
     value::Group,
   };
+  // `serialize` is gated on `feature = "json"` (spec §4); tests below that
+  // use `to_exiftool_json` are correspondingly gated.
+  #[cfg(feature = "json")]
+  use crate::serialize::to_exiftool_json;
 
   // Faithful AAC::Main subset for the synthetic header
   // [0xFF,0xF1,0x50,0x80,0x00,0x00,0x00]:
@@ -671,6 +674,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_8_byte_all_ff_is_u64_max_exact_decimal() {
     // Oracle (bundled Perl, re-derived 2026-05-19):
@@ -703,6 +707,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_9_byte_all_ff_promotes_to_nv_format_g() {
     // Oracle (bundled Perl, re-derived 2026-05-19):
@@ -769,6 +774,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_small_value_is_i64_and_emitted_bare() {
     // Prove the common (≤ i64::MAX) path is byte-exact unchanged.
@@ -796,6 +802,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn no_format_8_byte_i64_max_split_boundary() {
     // Pins the u64-mode i64::MAX / i64::MAX+1 representation-split (D5).
@@ -999,11 +1006,7 @@ mod tests {
     )
     .with_raw_conv(RawConv::SetFrameState("MPEG_Layer"));
     fn choose(key: &str, _s: &FrameState) -> Option<&'static TagDef> {
-      if key == "Bit13-14" {
-        Some(&VL)
-      } else {
-        None
-      }
+      if key == "Bit13-14" { Some(&VL) } else { None }
     }
     // Layout: byte 1 bits 5-6 = layer (0xfb >> 1 & 0b11 = 0b01 = 1).
     let data = [0xffu8, 0xfb, 0x90, 0x4c];

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -33,7 +33,7 @@
 
 use crate::{
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, ValueConv},
-  value::{format_g, TagValue},
+  value::{TagValue, format_g},
 };
 use smol_str::SmolStr;
 
@@ -514,6 +514,13 @@ fn decode_bits(vals: &str, lookup: Option<&[(u8, &str)]>, bits: u8) -> String {
 /// but-bounded behavior — real ExifTool COVERART payloads are clean base64,
 /// so this fallback is mostly defensive and never panics). Output is the
 /// decoded raw bytes.
+///
+/// `#[allow(dead_code)]`: only the `ogg` format uses this helper today; under
+/// feature-pruned builds without OGG the dead-code lint fires. The helper
+/// stays in `convert.rs` (not in `formats/ogg.rs`) because it's logically
+/// a `ConvertBase64` helper akin to ExifTool's `MIME::Base64::decode` and
+/// will be reused by future XMP/EXIF ports.
+#[allow(dead_code)]
 pub(crate) fn base64_decode(s: &str) -> Vec<u8> {
   // Map an ASCII byte to its 6-bit value, or `None` for ignored/invalid.
   fn val(b: u8) -> Option<u8> {
@@ -1166,6 +1173,7 @@ mod tests {
   // emits the JSON number `2`, never the string `"2"`. Pin that shape:
   // the Map hit must yield a numeric `TagValue`, and serializing it must
   // produce a bare JSON number.
+  #[cfg(feature = "json")]
   #[test]
   fn numeric_map_value_yields_number_not_string() {
     static CHANNELS: TagDef = TagDef::new(
@@ -1182,7 +1190,7 @@ mod tests {
     let v = apply(&CHANNELS, &TagValue::I64(2), true);
     assert_eq!(v, TagValue::I64(2));
 
-    use crate::{serialize::to_exiftool_json, Group, Metadata};
+    use crate::{Group, Metadata, serialize::to_exiftool_json};
     let mut m = Metadata::new("a.aac");
     m.push(Group::new("Audio", "AAC"), "Channels", v);
     let json = to_exiftool_json(&m);
@@ -2652,7 +2660,7 @@ mod tests {
     assert_eq!(pipeline(0xFFFE), "???"); // noncharacter ⇒ 3 `?`s
     assert_eq!(pipeline(0x10FFFF), "\u{10ffff}"); // max valid kept
     assert_eq!(pipeline(0x110000), "????"); // > U+10FFFF ⇒ 4 `?`s
-                                            // R5 additions — Perl-empirical (`pack('C0U', n)` → `FixUTF8`):
+    // R5 additions — Perl-empirical (`pack('C0U', n)` → `FixUTF8`):
     assert_eq!(pipeline(0x1_0000_0000), "???????"); // 7 `?`s (above-u32 7-byte)
     assert_eq!(pipeline(0xF_FFFF_FFFF), "???????"); // 7 `?`s (top of 7-byte range)
     assert_eq!(pipeline(0x10_0000_0000), "?????????????"); // 13 `?`s (13-byte form)

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -115,8 +115,8 @@ pub fn convert_duration(time: f64) -> String {
   let m_f = (rounded / 60.0).trunc();
   rounded -= m_f * 60.0;
   let s_f = rounded.trunc(); // `int($time)` of remaining
-                             // ExifTool.pm:6878-6882 `if ($h > 24) { my $d = int($h/24); $h -= $d*24;
-                             // $sign = "$sign$d days "; }`.
+  // ExifTool.pm:6878-6882 `if ($h > 24) { my $d = int($h/24); $h -= $d*24;
+  // $sign = "$sign$d days "; }`.
   let mut prefix = sign.to_string();
   let h_after_days = if h_f > 24.0 {
     let d_f = (h_f / 24.0).trunc();

--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -570,8 +570,8 @@ pub fn detection_candidates(name: &str, head: &[u8]) -> DetectionCandidates {
     // (Perl reaches this branch only when $recognizedExt is false — it is
     // the `else` of the `elsif ($recognizedExt)`.)
     let skip = end - marker_len; // Perl: pos($buff) - length($1)
-                                 // L3038 applies to this terminal $type too: a JPEG terminal's Parent
-                                 // is "JPEG"; a TIFF terminal's Parent is $tiffType.
+    // L3038 applies to this terminal $type too: a JPEG terminal's Parent
+    // is "JPEG"; a TIFF terminal's Parent is $tiffType.
     out.push(DetectionCandidate {
       file_type: ty,
       header_skip: skip,

--- a/src/filetype/tests.rs
+++ b/src/filetype/tests.rs
@@ -226,7 +226,7 @@ fn strip_subtype_leftmost_paren_matches_perl() {
   // No strip when ends with ')' but no " (" anywhere before it.
   assert_eq!(strip_subtype("(nodot)"), None); // no SPACE before "("
   assert_eq!(strip_subtype("a(b)"), None); // no space before "("
-                                           // Edge: " (" immediately before the ")".
+  // Edge: " (" immediately before the ")".
   assert_eq!(strip_subtype("stem ()"), Some("stem"));
   // Unicode in the stem is not a concern (" (" and ")" are ASCII so the
   // byte index from find is always a valid char boundary).
@@ -1062,8 +1062,8 @@ fn detection_candidate_accessor_contract() {
   // (ExifTool.pm:3038 `($type eq 'TIFF') ? $tiffType : $type`).
   assert_eq!(d.parent_type(), "FLV");
   assert_eq!(d, d.clone()); // Clone + PartialEq (derive_more-free struct)
-                            // Remaining candidates are the faithful WV.. fall-through (non-empty,
-                            // fully drainable — FusedIterator stays None after exhaustion).
+  // Remaining candidates are the faithful WV.. fall-through (non-empty,
+  // fully drainable — FusedIterator stays None after exhaustion).
   let rest: Vec<&str> = it.by_ref().map(|c| c.file_type()).collect();
   assert_eq!(
     rest,

--- a/src/formats/aac.rs
+++ b/src/formats/aac.rs
@@ -2,7 +2,7 @@
 //! PROCESS_PROC is `FLAC::ProcessBitStream` (AAC.pm:29) → `crate::bitstream`.
 
 use crate::{
-  bitstream::{process_bit_stream, BitOrder},
+  bitstream::{BitOrder, process_bit_stream},
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
   value::{Group, TagValue},
@@ -189,7 +189,7 @@ impl FormatParser for ProcessAac {
             if pos + cnt <= frame.len() {
               // if ($pos + $cnt <= length($buff))  (AAC.pm:129)
               let dat = &frame[pos..pos + cnt]; // my $dat = substr($buff,$pos,$cnt)  (AAC.pm:130)
-                                                // $dat =~ s/^\0+// ; $dat =~ s/\0+$//  (AAC.pm:131-132)
+              // $dat =~ s/^\0+// ; $dat =~ s/\0+$//  (AAC.pm:131-132)
               let s = dat.iter().position(|&b| b != 0).unwrap_or(dat.len());
               let e = dat.iter().rposition(|&b| b != 0).map_or(s, |i| i + 1);
               // e >= s by construction (map_or(s,…) | rposition+1 > s)

--- a/src/formats/aiff.rs
+++ b/src/formats/aiff.rs
@@ -57,7 +57,7 @@
 
 use crate::{
   charset::decode_macroman,
-  datetime::{convert_datetime, convert_unix_time, AIFF_EPOCH_OFFSET},
+  datetime::{AIFF_EPOCH_OFFSET, convert_datetime, convert_unix_time},
   parser::{FormatParser, ParseContext},
   processbinarydata::process_binary_data,
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
@@ -554,13 +554,13 @@ impl FormatParser for ProcessAiff {
         break;
       };
       pos += 8; // :222 `$pos += 8`.
-                // AIFF.pm:227 `my $len2 = $len + ($len & 0x01)` — chunks padded to
-                // an even number of bytes. Perl scalars are 64-bit; on a 32-bit
-                // host `usize` is 32-bit and `len + 1` would wrap when
-                // `len == u32::MAX`. We `saturating_add`: `len2` then equals
-                // `usize::MAX`, which is guaranteed `> data.len()` so the
-                // short-read / unknown-chunk EOF arms both still fire
-                // correctly. Equivalent to Perl on the host's natural width.
+      // AIFF.pm:227 `my $len2 = $len + ($len & 0x01)` — chunks padded to
+      // an even number of bytes. Perl scalars are 64-bit; on a 32-bit
+      // host `usize` is 32-bit and `len + 1` would wrap when
+      // `len == u32::MAX`. We `saturating_add`: `len2` then equals
+      // `usize::MAX`, which is guaranteed `> data.len()` so the
+      // short-read / unknown-chunk EOF arms both still fire
+      // correctly. Equivalent to Perl on the host's natural width.
       let len2 = len.saturating_add(len & 0x01);
       // AIFF.pm:224 `$et->GetTagInfo($tagTablePtr, $tag)`.
       let tag_str = match core::str::from_utf8(&tag_bytes) {
@@ -670,8 +670,8 @@ impl FormatParser for ProcessAiff {
           }
         }
         pos = pos.saturating_add(len2); // AIFF.pm:268 `$pos += $len2`.
-                                        // AIFF.pm:269 `$n = 0;` (inside the body, before the for-step),
-                                        // then the for's `++$n` at top of next iter:
+        // AIFF.pm:269 `$n = 0;` (inside the body, before the for-step),
+        // then the for's `++$n` at top of next iter:
         n = 0;
         n = n.saturating_add(1);
       } else if len == 0 {
@@ -695,7 +695,7 @@ impl FormatParser for ProcessAiff {
           break;
         }
         n = n.saturating_add(1); // for-step `++$n` after `next`
-                                 // No `pos += len2` here (len == 0, len2 == 0) — fall-through to top.
+      // No `pos += len2` here (len == 0, len2 == 0) — fall-through to top.
       } else {
         // AIFF.pm:265-267 `else { $raf->Seek($len2, 1) or $err=1, last }`.
         // Unknown chunk with non-zero length: skip its body. Perl's `Seek`
@@ -1006,7 +1006,7 @@ mod tests {
     data.extend_from_slice(&0u16.to_be_bytes()); // markerID = 0 ⇒ skip MarkerID tag
     data.extend_from_slice(&4u16.to_be_bytes()); // size
     data.extend_from_slice(b"abcd"); // text
-                                     // Second comment header truncated: data ends after first.
+    // Second comment header truncated: data ends after first.
     process_comment(&data, &mut m, false);
     assert_eq!(m.tags().len(), 2); // CommentTime + Comment text (no MarkerID b/c 0)
     assert_eq!(m.tags()[0].name(), "CommentTime");

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -172,8 +172,8 @@ fn perl_nv_str(n: f64) -> String {
   // 2^63 (signed: n < 2^63; unsigned: 2^63 <= n < 2^64).
   let two63 = (1u128 << 63) as f64; // exactly 9223372036854775808.0
   let two64 = (1u128 << 64) as f64; // exactly 18446744073709551616.0
-                                    // Signed-integer carve-out: integer-valued f64 in [i64::MIN, 2^63),
-                                    // EXCLUDING 2^63 because `n as i64` would saturate to i64::MAX = 2^63-1.
+  // Signed-integer carve-out: integer-valued f64 in [i64::MIN, 2^63),
+  // EXCLUDING 2^63 because `n as i64` would saturate to i64::MAX = 2^63-1.
   if n == n.trunc() && n >= i64::MIN as f64 && n < two63 {
     let iv = n as i64;
     return iv.to_string();
@@ -208,11 +208,7 @@ fn as_perl_float(v: &TagValue) -> Option<f64> {
     TagValue::F64(x) => {
       // Non-finite ⇒ stringifies to Inf/-Inf/NaN ⇒ IsFloat regex fails ⇒
       // gate miss. Finite ⇒ pass through.
-      if x.is_finite() {
-        Some(*x)
-      } else {
-        None
-      }
+      if x.is_finite() { Some(*x) } else { None }
     }
     TagValue::Str(s) => {
       if is_perl_float(s) {
@@ -870,11 +866,7 @@ fn perl_numeric_coerce_f64(s: &str) -> f64 {
   }
   // Parse the matched numeric prefix as positive, then apply the sign.
   let mag = s[num_start..i].parse::<f64>().unwrap_or(0.0);
-  if neg {
-    -mag
-  } else {
-    mag
-  }
+  if neg { -mag } else { mag }
 }
 
 // APE.pm:29
@@ -1968,8 +1960,8 @@ mod tests {
     data[12..16].copy_from_slice(&48000u32.to_le_bytes()); // SampleRate (idx 4)
     data[24..28].copy_from_slice(&500u32.to_le_bytes()); // TotalFrames (idx 10)
     data[28..32].copy_from_slice(&65536u32.to_le_bytes()); // FinalFrameBlocks (idx 12)
-                                                           // Fill the rest with non-zero junk that would corrupt header reads
-                                                           // if we mistakenly copied the WHOLE file and indexed past 28 bytes.
+    // Fill the rest with non-zero junk that would corrupt header reads
+    // if we mistakenly copied the WHOLE file and indexed past 28 bytes.
     for byte in data.iter_mut().skip(32) {
       *byte = 0xCC;
     }
@@ -2245,7 +2237,7 @@ mod tests {
     let mut data = vec![0u8; 64];
     data[..4].copy_from_slice(b"MAC ");
     data[4..6].copy_from_slice(&5000u16.to_le_bytes()); // NewHeader path
-                                                        // Footer at data[32..64] — APETAGEX with size_raw = 5.
+    // Footer at data[32..64] — APETAGEX with size_raw = 5.
     data[32..40].copy_from_slice(b"APETAGEX");
     data[32 + 12..32 + 16].copy_from_slice(&5u32.to_le_bytes());
     data[32 + 16..32 + 20].copy_from_slice(&0u32.to_le_bytes());
@@ -2491,7 +2483,7 @@ mod tests {
     data.extend_from_slice(&2u32.to_le_bytes()); // count
     data.extend_from_slice(&0u32.to_le_bytes()); // flags
     data.extend_from_slice(&[0u8; 8]); // reserved
-                                       // Run the trailer-only planner.
+    // Run the trailer-only planner.
     let plan = plan_ape_trailer_only(&data, true, 0).expect("trailer-only plan returns Some");
     // header_job is None (the prior parser owns the File:*/header tags).
     assert!(matches!(plan.header_job, HeaderJob::None));

--- a/src/formats/audible.rs
+++ b/src/formats/audible.rs
@@ -1164,7 +1164,7 @@ mod tests {
     // Length < 2.
     assert_eq!(make_tag_name(""), "Tag");
     assert_eq!(make_tag_name("a"), "TagA"); // ucfirst then Tag-prefix
-                                            // Leading hyphen.
+    // Leading hyphen.
     assert_eq!(make_tag_name("-foo"), "Tag-foo");
     // Normal name: ucfirst only.
     assert_eq!(make_tag_name("product_id"), "Product_id");
@@ -1281,7 +1281,7 @@ mod tests {
     assert_eq!(unescape_html("&mdash;"), "—");
     assert_eq!(unescape_html("&eacute;"), "é");
     assert_eq!(unescape_html("&Alpha;"), "Α"); // 913, distinct from "alpha"
-                                               // Numeric (decimal): `&#169;` = `©`.
+    // Numeric (decimal): `&#169;` = `©`.
     assert_eq!(unescape_html("&#169;"), "©");
     // Numeric (hex): lowercase `#x` only, per XMP.pm:2924.
     assert_eq!(unescape_html("&#xA9;"), "©");

--- a/src/formats/dsf.rs
+++ b/src/formats/dsf.rs
@@ -498,9 +498,9 @@ mod tests {
     // Craft SampleCount = u64::MAX (above i64::MAX) — must emit as decimal
     // string `TagValue::Str("18446744073709551615")` (faithful UV→NV shape).
     let mut p = vec![0u8; 36]; // payload fills keys 3..=11 with zeros (placeholder)
-                               // overwrite SampleCount slot (key 9 ⇒ payload byte offset 36-12=24 … wait:
-                               // key * 4 = 36 in the dirInfo buffer; dirInfo starts with 12 bytes of
-                               // 'fmt'+size, so payload byte offset = 36-12 = 24.
+    // overwrite SampleCount slot (key 9 ⇒ payload byte offset 36-12=24 … wait:
+    // key * 4 = 36 in the dirInfo buffer; dirInfo starts with 12 bytes of
+    // 'fmt'+size, so payload byte offset = 36-12 = 24.
     p[24..32].copy_from_slice(&u64::MAX.to_le_bytes());
     let buf = dir(&p);
     let mut m = Metadata::new("x");
@@ -588,7 +588,7 @@ mod tests {
     v.extend_from_slice(&0u64.to_le_bytes()); // metaPos = 0
     v.extend_from_slice(b"fmt ");
     v.extend_from_slice(&48u64.to_le_bytes()); // fmtLen
-                                               // payload (36 bytes):
+    // payload (36 bytes):
     v.extend_from_slice(&1u32.to_le_bytes());
     v.extend_from_slice(&0u32.to_le_bytes());
     v.extend_from_slice(&2u32.to_le_bytes());
@@ -751,7 +751,7 @@ mod tests {
     buf.extend_from_slice(&0u64.to_le_bytes()); // metaPos = 0 ⇒ no ID3 trailer
     buf.extend_from_slice(b"fmt ");
     buf.extend_from_slice(&999u64.to_le_bytes()); // fmtLen = 999 (< 1000 ✓)
-                                                  // First 36 bytes of payload: the eight DSF::Main fields in key order.
+    // First 36 bytes of payload: the eight DSF::Main fields in key order.
     buf.extend_from_slice(&1u32.to_le_bytes()); // key 3 FormatVersion
     buf.extend_from_slice(&0u32.to_le_bytes()); // key 4 FormatID = 'DSD Raw'
     buf.extend_from_slice(&2u32.to_le_bytes()); // key 5 ChannelType = Stereo
@@ -760,7 +760,7 @@ mod tests {
     buf.extend_from_slice(&1u32.to_le_bytes()); // key 8 BitsPerSample
     buf.extend_from_slice(&2_822_400u64.to_le_bytes()); // key 9 SampleCount
     buf.extend_from_slice(&4096u32.to_le_bytes()); // key 11 BlockSize
-                                                   // Pad to total payload of 987 bytes (951 zeros after the 36-byte head).
+    // Pad to total payload of 987 bytes (951 zeros after the 36-byte head).
     buf.extend(std::iter::repeat(0u8).take(987 - 36));
     assert_eq!(buf.len(), 40 + 987);
     let mut m = Metadata::new("x.dsf");

--- a/src/formats/dv.rs
+++ b/src/formats/dv.rs
@@ -6,7 +6,7 @@
 use crate::{
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
-  value::{format_g, Group, TagValue},
+  value::{Group, TagValue, format_g},
 };
 
 /// One row of `@dvProfiles` (DV.pm:21-113). All fields are derived
@@ -478,8 +478,8 @@ fn extract_vaux_meta(
     // DV.pm:207 `for ($j=0; $j<15; ++$j)`.
     for j in 0..15usize {
       let p = vaux_pos + j * 5 + 3; // DV.pm:208
-                                    // Guard against running past the buffer: every Get8u must be in
-                                    // range (`p+0` through `p+4` for the 4-byte date/time fields).
+      // Guard against running past the buffer: every Get8u must be in
+      // range (`p+0` through `p+4` for the 4-byte date/time fields).
       if p + 4 >= buff.len() {
         break;
       }
@@ -955,7 +955,7 @@ mod tests {
     // forces an `a-f` letter in the hex sprintf — DV.pm:220-221 rejects.
     let mut data = vec![0u8; 8000];
     data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0xbf]); // dsf=1
-                                                           // VAUX block 1 at offset 80 — block_type & 0xf0 == 0x50.
+    // VAUX block 1 at offset 80 — block_type & 0xf0 == 0x50.
     data[80] = 0x50;
     // Pack 0 (j=0): p = 80 + 0*5 + 3 = 83. pack_type = 0x62 (date).
     data[83] = 0x62;

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -1301,7 +1301,7 @@ mod tests {
     assert_eq!(g(TagId::Str("Bit103-107")).unwrap().name(), "BitsPerSample"); // FLAC.pm:72
     assert_eq!(g(TagId::Str("Bit108-143")).unwrap().name(), "TotalSamples"); //  FLAC.pm:76
     assert_eq!(g(TagId::Str("Bit144-271")).unwrap().name(), "MD5Signature"); //  FLAC.pm:77
-                                                                             // Channels + BitsPerSample carry a ValueConv (`$val + 1`).
+    // Channels + BitsPerSample carry a ValueConv (`$val + 1`).
     assert!(matches!(
       g(TagId::Str("Bit100-102")).unwrap().value_conv(),
       ValueConv::Func(_)
@@ -1589,8 +1589,8 @@ mod tests {
     let mut payload = Vec::new();
     payload.extend_from_slice(&(1u32).to_le_bytes()); // vendor len = 1
     payload.push(b'v'); // vendor "v"
-                        // pos==5; append exactly 4 bytes — count slot if buggy `<=` is taken;
-                        // non-zero so the buggy branch enters the comment loop.
+    // pos==5; append exactly 4 bytes — count slot if buggy `<=` is taken;
+    // non-zero so the buggy branch enters the comment loop.
     payload.extend_from_slice(&[0x01u8, 0, 0, 0]); // would-be count=1
     let mut m = Metadata::new("x.flac");
     let ok = process_vorbis_comments(&payload, &mut m, true);
@@ -1617,10 +1617,11 @@ mod tests {
     let ok = process_vorbis_comments(&[], &mut m, true);
     assert!(!ok);
     assert!(m.tags().is_empty());
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w == "Format error in Vorbis comments"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w == "Format error in Vorbis comments")
+    );
   }
 
   #[test]
@@ -1686,10 +1687,11 @@ mod tests {
       "post-ID3 `fLaC` magic must accept and continue parsing"
     );
     // File:FileType=FLAC pushed.
-    assert!(m
-      .tags()
-      .iter()
-      .any(|t| t.name() == "FileType" && t.value() == &TagValue::Str("FLAC".into())));
+    assert!(
+      m.tags()
+        .iter()
+        .any(|t| t.name() == "FileType" && t.value() == &TagValue::Str("FLAC".into()))
+    );
     // StreamInfo tag(s) emitted from the post-ID3 body.
     assert!(
       m.tags().iter().any(|t| t.name() == "BlockSizeMin"),
@@ -1758,10 +1760,11 @@ mod tests {
     // SetFileType fired (FLAC.pm:255).
     assert!(m.tags().iter().any(|t| t.name() == "FileType"));
     // Warning recorded with the exact Perl string.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w == "Format error in FLAC file"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w == "Format error in FLAC file")
+    );
   }
 
   #[test]
@@ -1787,10 +1790,11 @@ mod tests {
     let data: &[u8] = &[b'f', b'L', b'a', b'C', 0x80, 0xff, 0xff, 0xff];
     let mut c = ParseContext::new(data, "FLAC", 0, "FLAC", None, true, &mut m);
     assert!(ProcessFlac.process(&mut c));
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w == "Format error in FLAC file"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w == "Format error in FLAC file")
+    );
   }
 
   #[test]
@@ -1802,7 +1806,7 @@ mod tests {
     // < 30 s ⇒ '%.2f s'.
     assert_eq!(convert_duration(1.543125), "1.54 s");
     assert_eq!(convert_duration(29.999), "30.00 s"); // rounds up below 30
-                                                     // == 30 ⇒ H:MM:SS arm (+0.5 round, int → 30s).
+    // == 30 ⇒ H:MM:SS arm (+0.5 round, int → 30s).
     assert_eq!(convert_duration(30.0), "0:00:30");
     // Hour boundary.
     assert_eq!(convert_duration(3600.0), "1:00:00");
@@ -1836,9 +1840,9 @@ mod tests {
     assert_eq!(decode_base64("Q2F0!garbage"), b"Cat");
     // Missing padding still decodes the bytes we can: "Cat" → "Q2F0".
     assert_eq!(decode_base64("Q2F"), b"Ca"); // 3 base64 chars → 2 bytes
-                                             // R2-F4: internal padding is DELETED, decoding continues past it.
-                                             // "AA==AA" — Perl `tr/.../d` deletes both `=`s, leaving "AAAA" which
-                                             // decodes to 3 zero bytes (verified against bundled Perl).
+    // R2-F4: internal padding is DELETED, decoding continues past it.
+    // "AA==AA" — Perl `tr/.../d` deletes both `=`s, leaving "AAAA" which
+    // decodes to 3 zero bytes (verified against bundled Perl).
     assert_eq!(decode_base64("AA==AA"), [0u8, 0, 0]);
     // "AA==" — `tr/.../d` deletes both `=`s, leaving "AA" which decodes
     // to 1 zero byte (3-base64-char → 2-byte partial chunk halves).

--- a/src/formats/id3/mod.rs
+++ b/src/formats/id3/mod.rs
@@ -51,4 +51,9 @@ pub mod v2_4;
 pub mod v2_common;
 pub mod v2_process;
 
+// MP3 wrapper re-export (Codex A-R2-1) — gated behind `mp3`, which pulls
+// `mpeg-audio` + `ape`. The plain `id3` feature (pulled by flac/aiff/dsf/ape
+// for the ID3-prefix chain) does NOT compile `ProcessMp3` because its
+// `process` references `crate::formats::mpeg` + `crate::formats::ape`.
+#[cfg(feature = "mp3")]
 pub use process::ProcessMp3;

--- a/src/formats/id3/process.rs
+++ b/src/formats/id3/process.rs
@@ -21,15 +21,20 @@
 use crate::{
   formats::id3::{
     decode::unsync_safe,
-    v1::{process_id3v1, ID3V1_MAIN},
+    v1::{ID3V1_MAIN, process_id3v1},
     v2_2::ID3V2_2_MAIN,
     v2_3::ID3V2_3_MAIN,
     v2_4::ID3V2_4_MAIN,
     v2_process::process_id3v2,
   },
-  parser::{FormatParser, ParseContext},
+  parser::ParseContext,
   value::{Group, TagValue},
 };
+// `FormatParser` is only implemented by `ProcessMp3` (gated behind `mp3`,
+// Codex A-R2-1); importing it unconditionally warns under `--features
+// std,id3`. Gate the import alongside its sole impl.
+#[cfg(feature = "mp3")]
+use crate::parser::FormatParser;
 
 /// Result of [`parse_v2_header`]. Carries the parsed header buffer + the
 /// declared body size + the flags byte — the size and flags are needed by
@@ -46,8 +51,15 @@ struct ParsedV2Header {
 /// The MP3 file-type parser. Faithful to bundled Perl's `Image::ExifTool::
 /// ID3::ProcessMP3` (ID3.pm:1684-1728); the chain to MPEG / APE for the
 /// audio-frame / APE-trailer tags is documented forward items (rows 17 / 5).
+///
+/// Gated behind `mp3` (Codex A-R2-1): `process` references
+/// `crate::formats::mpeg` (mpeg-audio) + `crate::formats::ape` (ape), so a
+/// per-format build that pulls `id3` alone (flac/aiff/dsf/ape chains) must
+/// NOT compile it. The `mp3` feature pulls both `mpeg-audio` + `ape`.
+#[cfg(feature = "mp3")]
 pub struct ProcessMp3;
 
+#[cfg(feature = "mp3")]
 impl FormatParser for ProcessMp3 {
   fn process(&self, ctx: &mut ParseContext<'_>) -> bool {
     // ID3.pm:1684-1728 `ProcessMP3` is the MP3 PROCESS_PROC. The
@@ -587,6 +599,10 @@ mod tests {
   use super::*;
   use crate::value::Metadata;
 
+  // `run` + the `process_mp3_*` tests below drive `ProcessMp3`, which is
+  // gated behind `mp3` (Codex A-R2-1). Gate the helper + its tests so
+  // `cargo test --no-default-features --features std,id3` stays clean.
+  #[cfg(feature = "mp3")]
   fn run(data: &[u8], name: &str) -> Metadata {
     let mut m = Metadata::new(name);
     {
@@ -597,6 +613,7 @@ mod tests {
     m
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_empty_data_rejects() {
     // R6-F1 disposition: empty data + .mp3 ext is still REJECTED — no
@@ -606,6 +623,7 @@ mod tests {
     assert!(m.tags().iter().all(|t| t.name() != "FileType"));
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_random_bytes_no_mpeg_sync_rejects() {
     // Random non-MPEG bytes with a .mp3 extension → reject (no MPEG
@@ -615,6 +633,7 @@ mod tests {
     assert!(m.tags().iter().all(|t| t.name() != "FileType"));
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_valid_mpeg_audio_frame_accepts_as_mp3() {
     // 4-byte MPEG audio frame header that satisfies the bundled
@@ -637,11 +656,12 @@ mod tests {
     assert_eq!(ft.value(), &TagValue::Str("MP3".into()));
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_id3v1_only() {
     // Construct a file: 1024 padding bytes + 128-byte ID3v1 TAG block.
     let mut data: Vec<u8> = vec![0; 256]; // some prefix that's NOT ID3
-                                          // Build TAG block.
+    // Build TAG block.
     let mut tag = Vec::with_capacity(128);
     tag.extend_from_slice(b"TAG");
     let pad = |s: &str, n: usize| {
@@ -668,6 +688,7 @@ mod tests {
     assert_eq!(genre.value(), &TagValue::Str("Hip-Hop".into()));
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_id3v2_2_with_title_artist() {
     // ID3v2.2 header (10 bytes) + 6-byte TT2 frame + 6-byte TP1 frame.
@@ -715,6 +736,7 @@ mod tests {
     assert_eq!(id3size.value(), &TagValue::I64(10 + size as i64));
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_unsync_extheader_shrinks_below_4_does_not_panic() {
     // R7-F2 regression: a crafted v2.3 with flags=0xc0 (unsync +
@@ -732,12 +754,14 @@ mod tests {
     data.extend_from_slice(&[0xff, 0x00, 0xff, 0x00]); // body (shrinks to 0xff 0xff)
     let m = run(&data, "x.mp3");
     // Must not panic. Faithful Warn fires.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Bad ID3 extended header"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Bad ID3 extended header")
+    );
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_layer_two_dotless_filename_rejected() {
     // R8-F1 regression: a dotless filename hitting MP3 weakMagic +
@@ -755,6 +779,7 @@ mod tests {
     assert!(m.tags().iter().all(|t| t.name() != "FileType"));
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_layer_two_mus_extension_accepted() {
     // R8-F1 regression (positive case): bundled ID3.pm:1716 sets
@@ -771,6 +796,7 @@ mod tests {
     assert_eq!(ft.value(), &TagValue::Str("MP3".into()));
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_unsupported_id3v5_warns() {
     // ID3 magic + version 5.0 — bundled Perl emits the version Warn.
@@ -781,12 +807,14 @@ mod tests {
     data.push(0x00);
     data.extend_from_slice(&[0u8, 0, 0, 0]);
     let m = run(&data, "x.mp3");
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Unsupported ID3 version: 2.5.0"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Unsupported ID3 version: 2.5.0")
+    );
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_truncated_warns() {
     // ID3 magic + valid header + declared size 100, but only 3 body bytes.
@@ -798,21 +826,24 @@ mod tests {
     data.extend_from_slice(&[0u8, 0, 0, 100]); // sync-safe 100
     data.extend_from_slice(&[0u8; 3]);
     let m = run(&data, "x.mp3");
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Truncated ID3 data"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Truncated ID3 data")
+    );
   }
 
+  #[cfg(feature = "mp3")]
   #[test]
   fn process_mp3_short_header_warns() {
     // ID3 magic + only 2 of 7 header bytes.
     let data = b"ID3\x02\x00";
     let m = run(data, "x.mp3");
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.as_str() == "Short ID3 header"));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.as_str() == "Short ID3 header")
+    );
   }
 
   #[test]

--- a/src/formats/id3/v1.rs
+++ b/src/formats/id3/v1.rs
@@ -7,7 +7,7 @@
 //! (the parent `%Image::ExifTool::ID3::Main` table's group, ID3.pm:78).
 
 use crate::{
-  convert::{apply_ctx, ConvContext},
+  convert::{ConvContext, apply_ctx},
   formats::id3::text::convert_id3v1_text,
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
   value::{Group, Metadata, TagValue},

--- a/src/formats/id3/v2_process.rs
+++ b/src/formats/id3/v2_process.rs
@@ -23,7 +23,7 @@
 //! - Unhandled: faithful Warn "Don't know how to handle $id frame".
 
 use crate::{
-  convert::{apply_ctx, ConvContext},
+  convert::{ConvContext, apply_ctx},
   formats::id3::decode::{decode_string, decode_string_joined, unsync_safe},
   tagtable::{TagDef, TagId, TagTable},
   value::{Group, Metadata, TagValue},
@@ -1552,8 +1552,8 @@ mod tests {
     // 4-byte length itself + 2 more bytes (the ext-flags-and-padding).
     let mut ext = Vec::new();
     ext.extend_from_slice(&[0, 0, 0, 6]); // length=6 (NOT sync-safe in v2.3;
-                                          // UnSyncSafe leaves small values
-                                          // unchanged)
+    // UnSyncSafe leaves small values
+    // unchanged)
     ext.extend_from_slice(&[0, 0]); // 2 ext bytes
     let payload: Vec<u8> = ext.into_iter().chain(title_frame).collect();
     let size = payload.len() as u32;
@@ -1571,7 +1571,7 @@ mod tests {
     // Here we just exercise the wrapper indirectly by replicating the
     // bundled behavior: strip `len` bytes from h_buff, then process.
     let mut h_buff: Vec<u8> = data[10..].to_vec(); // skip ID3v2 header
-                                                   // Read ext length (first 4 bytes of h_buff).
+    // Read ext length (first 4 bytes of h_buff).
     let ext_len_raw = u32::from_be_bytes([h_buff[0], h_buff[1], h_buff[2], h_buff[3]]);
     // UnSyncSafe leaves <=0x7F unchanged.
     let ext_len = ext_len_raw as usize;
@@ -1636,10 +1636,11 @@ mod tests {
       .expect("MCDI must be emitted as raw bytes");
     assert_eq!(mcdi.value(), &TagValue::Bytes(vec![0xde, 0xad, 0xbe, 0xef]));
     // No Warn for known-binary frames.
-    assert!(m
-      .warnings()
-      .iter()
-      .all(|w| !w.contains("Don't know how to handle")));
+    assert!(
+      m.warnings()
+        .iter()
+        .all(|w| !w.contains("Don't know how to handle"))
+    );
   }
 
   #[test]
@@ -1665,16 +1666,18 @@ mod tests {
       &ConvContext::default(),
     );
     // No GEOB-* tags, no GeneralEncapsulatedObject.
-    assert!(m
-      .tags()
-      .iter()
-      .all(|t| !t.name().starts_with("GEOB") && t.name() != "GeneralEncapsulatedObject"));
+    assert!(
+      m.tags()
+        .iter()
+        .all(|t| !t.name().starts_with("GEOB") && t.name() != "GeneralEncapsulatedObject")
+    );
     // No "Don't know how to handle" Warn — bundled silently dispatches
     // SubDirectory frames; our skip must be silent too.
-    assert!(m
-      .warnings()
-      .iter()
-      .all(|w| !w.contains("Don't know how to handle")));
+    assert!(
+      m.warnings()
+        .iter()
+        .all(|w| !w.contains("Don't know how to handle"))
+    );
   }
 
   #[test]
@@ -1706,10 +1709,11 @@ mod tests {
     // dateTimeConv: XMP → EXIF date.
     assert_eq!(t.value(), &TagValue::Str("2024:05:19".into()));
     // Bundled minor Warn fires.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.contains("[minor] Frame 'TDRC' is not valid for this ID3 version")));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.contains("[minor] Frame 'TDRC' is not valid for this ID3 version"))
+    );
   }
 
   #[test]
@@ -1743,10 +1747,11 @@ mod tests {
       "Picture" | "PictureMIMEType" | "PictureType" | "PictureDescription"
     )));
     // Faithful Warn.
-    assert!(m
-      .warnings()
-      .iter()
-      .any(|w| w.contains("Invalid APIC frame")));
+    assert!(
+      m.warnings()
+        .iter()
+        .any(|w| w.contains("Invalid APIC frame"))
+    );
   }
 
   #[test]

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -1,56 +1,98 @@
 //! Dispatch registry: ExifTool file-type string → its parser
 //! (ExifTool `%moduleName` → `Process<Type>`). Add one `match` arm per
 //! ported format.
+//!
+//! Each `pub mod <fmt>;` is gated on its Cargo feature (spec §4); the
+//! corresponding `match` arm in [`parser_for`] is gated identically. When
+//! a format feature is disabled, its file-type string returns `None`
+//! (faithful to ExifTool's "Process<Type> not loaded → `next` in candidate
+//! loop" behavior — ExifTool.pm:3060-3077).
 
+#[cfg(feature = "aac")]
 pub mod aac;
+#[cfg(feature = "aiff")]
 pub mod aiff;
+#[cfg(feature = "ape")]
 pub mod ape;
+#[cfg(feature = "audible")]
 pub mod audible;
+#[cfg(feature = "dsf")]
 pub mod dsf;
+#[cfg(feature = "dv")]
 pub mod dv;
+#[cfg(feature = "flac")]
 pub mod flac;
+#[cfg(feature = "id3")]
 pub mod id3;
+#[cfg(feature = "mpc")]
 pub mod mpc;
+// MPEG audio frame parser is the internal `mpeg-audio` feature (gates
+// `mp3` and is reused by other audio chained formats). Phase D may split
+// `mpeg::audio` from a future `mpeg::video` submodule; today the file
+// holds only the audio half (the video side is a Phase-2 forward item).
+#[cfg(feature = "mpeg-audio")]
 pub mod mpeg;
+#[cfg(feature = "ogg")]
 pub mod ogg;
+#[cfg(feature = "red")]
 pub mod red;
+#[cfg(feature = "wavpack")]
 pub mod wavpack;
 
 use crate::parser::FormatParser;
 
 /// Returns the parser for a finalized ExifTool file type, or `None` if that
-/// format has no ported parser yet.
+/// format has no ported parser yet OR its Cargo feature is disabled.
+///
+/// When a format's feature is off, this returns `None` for the corresponding
+/// file-type string — faithful to ExifTool's "module not loaded ⇒ `next` in
+/// candidate loop" (ExifTool.pm:3060-3077). Callers see the same "no parser"
+/// signal whether the format is unported or merely feature-pruned.
 #[must_use]
 pub fn parser_for(file_type: &str) -> Option<&'static dyn FormatParser> {
   // `match` (not a static HashMap/phf): zero-alloc, branch-predicted; fine at ~28 formats.
   match file_type {
+    #[cfg(feature = "audible")]
     "AA" => Some(&audible::ProcessAa), // ExifTool %moduleName{AA}='Audible'
-    "AAC" => Some(&aac::ProcessAac),   // ExifTool %moduleName{AAC}='AAC'
+    #[cfg(feature = "aac")]
+    "AAC" => Some(&aac::ProcessAac), // ExifTool %moduleName{AAC}='AAC'
     // ExifTool %fileTypeLookup maps AIFF/AIFC/AIF all to TYPE 'AIFF'; the
     // detection candidate for any of those extensions is "AIFF". The
     // parser itself differentiates AIFF vs AIFC via the magic body
     // (AIFF.pm:209-210 `$1` = "AIFF" or "AIFC") and drives the right
     // SetFileType.
+    #[cfg(feature = "aiff")]
     "AIFF" => Some(&aiff::ProcessAiff), // ExifTool %moduleName{AIFF}=undef ⇒ default to 'AIFF'
+    #[cfg(feature = "ape")]
     "APE" => Some(&ape::ProcessApe), // ExifTool %moduleName{APE}=undef ⇒ Perl $module=$type ⇒ "APE"
     // DSF: %moduleName absent ⇒ Perl `$module = $type` = 'DSF'; faithful to
     // ExifTool.pm:4203-4275 dispatch (`module_for_type("DSF")` returns
     // `Module(Cow::Owned("DSF"))` via the default arm in
     // `filetype_data.rs::module_for_type`).
+    #[cfg(feature = "dsf")]
     "DSF" => Some(&dsf::ProcessDsf),
+    #[cfg(feature = "dv")]
     "DV" => Some(&dv::ProcessDv), // ExifTool %moduleName{DV} default = 'DV'
+    #[cfg(feature = "flac")]
     "FLAC" => Some(&flac::ProcessFlac), // ExifTool %moduleName{FLAC}='FLAC'
     // ExifTool.pm:893 maps `MP3 => 'ID3'` — ID3::ProcessMP3 (ID3.pm:1684-1729)
     // scans for ID3v1/v2 tags and then delegates the audio side to
     // `MPEG::ParseMPEGAudio` (ID3.pm:1716). Faithful: this arm is ID3's
     // wrapping parser; its no-ID3 branch calls back into
-    // `mpeg::parse_mpeg_audio` (see `src/formats/id3/process.rs`).
+    // `mpeg::parse_mpeg_audio` (see `src/formats/id3/process.rs`). The
+    // `mp3` feature implies both `id3` and `mpeg-audio` (Cargo.toml §
+    // per-format gates), so `id3` is in scope whenever this arm compiles.
+    #[cfg(feature = "mp3")]
     "MP3" => Some(&id3::ProcessMp3),
+    #[cfg(feature = "mpc")]
     "MPC" => Some(&mpc::ProcessMpc), // ExifTool %moduleName{MPC}=undef ⇒ 'MPC'
     // ExifTool %moduleName{OGG}='Ogg' (handles OGG, OGV, OPUS via container
     // dispatch + OverrideFileType — Ogg.pm:49-50).
+    #[cfg(feature = "ogg")]
     "OGG" => Some(&ogg::ProcessOgg),
+    #[cfg(feature = "red")]
     "R3D" => Some(&red::ProcessR3D), // ExifTool %moduleName{R3D}='Red'
+    #[cfg(feature = "wavpack")]
     "WV" => Some(&wavpack::ProcessWv), // ExifTool %moduleName{WV}='WavPack'
     _ => None,
   }
@@ -63,22 +105,36 @@ mod tests {
   #[test]
   fn registry_resolves_ported_formats() {
     // AA, AAC, AIFF, APE, DSF, DV, FLAC, MP3 (ID3), MPC, OGG, R3D, and WV
-    // are the ported formats; their arms must resolve. Unported types (and
-    // the empty string) must still cleanly report "no parser" so the
-    // consumer falls through to the next detection candidate (faithful
-    // to Perl: a Process<Type> not loaded is `next` in the candidate
-    // loop, ExifTool.pm:3060-3077).
+    // are the ported formats; their arms must resolve when their Cargo
+    // features are enabled. Unported types (and the empty string) must
+    // still cleanly report "no parser" so the consumer falls through to
+    // the next detection candidate (faithful to Perl: a Process<Type>
+    // not loaded is `next` in the candidate loop, ExifTool.pm:3060-3077).
+    // Each assertion is feature-gated to match the corresponding `match`
+    // arm in [`parser_for`].
+    #[cfg(feature = "audible")]
     assert!(parser_for("AA").is_some());
+    #[cfg(feature = "aac")]
     assert!(parser_for("AAC").is_some());
+    #[cfg(feature = "aiff")]
     assert!(parser_for("AIFF").is_some());
+    #[cfg(feature = "ape")]
     assert!(parser_for("APE").is_some());
+    #[cfg(feature = "dsf")]
     assert!(parser_for("DSF").is_some());
+    #[cfg(feature = "dv")]
     assert!(parser_for("DV").is_some());
+    #[cfg(feature = "flac")]
     assert!(parser_for("FLAC").is_some());
+    #[cfg(feature = "mp3")]
     assert!(parser_for("MP3").is_some());
+    #[cfg(feature = "mpc")]
     assert!(parser_for("MPC").is_some());
+    #[cfg(feature = "ogg")]
     assert!(parser_for("OGG").is_some());
+    #[cfg(feature = "red")]
     assert!(parser_for("R3D").is_some());
+    #[cfg(feature = "wavpack")]
     assert!(parser_for("WV").is_some());
     assert!(parser_for("MPEG").is_none()); // video side deferred (forward item)
     assert!(parser_for("").is_none());

--- a/src/formats/mpeg.rs
+++ b/src/formats/mpeg.rs
@@ -41,7 +41,7 @@
 //!   keeps that faithful for any future divergence.
 
 use crate::{
-  bitstream::{process_bit_stream_cond, BitOrder, FrameState},
+  bitstream::{BitOrder, FrameState, process_bit_stream_cond},
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, PrintConvHash, PrintValue, RawConv, TagDef, ValueConv},
   value::TagValue,
@@ -784,11 +784,7 @@ fn parse_xing_lame(
   let len = buff.len();
   // MPEG.pm:504 side-info offset.
   let side = if v == 3 {
-    if m == 3 {
-      17
-    } else {
-      32
-    }
+    if m == 3 { 17 } else { 32 }
   } else if m == 3 {
     9
   } else {
@@ -1110,11 +1106,7 @@ pub(crate) const fn id3_process_mp3_scan_len(ext_is_mp3: bool) -> usize {
   // compares against the uppercased `$$self{FILE_EXT}` (ExifTool.pm:2966
   // `GetFileExtension` returns it uppercased), so a case-insensitive
   // match on the Rust side (which already uppercases) is faithful.
-  if ext_is_mp3 {
-    8192
-  } else {
-    256
-  }
+  if ext_is_mp3 { 8192 } else { 256 }
 }
 
 impl ProcessMp3 {
@@ -1571,8 +1563,8 @@ mod tests {
     d.extend_from_slice(&200_000u32.to_be_bytes()); // VBRBytes
     d.extend(std::iter::repeat(0).take(100)); // TOC (skipped)
     d.extend_from_slice(&78u32.to_be_bytes()); // VBRScale (LameVBRQuality=2, LameQuality=2)
-                                               // LAME block starts here. Pre-fill 348 bytes so the LAME-flag length
-                                               // gate (MPEG.pm:537 `last if $pos + 348 > $len`) passes.
+    // LAME block starts here. Pre-fill 348 bytes so the LAME-flag length
+    // gate (MPEG.pm:537 `last if $pos + 348 > $len`) passes.
     let start = d.len();
     d.extend(std::iter::repeat(0).take(348));
     // Stamp the LAME fields by absolute offset into `d`.
@@ -1684,8 +1676,8 @@ mod tests {
     d.extend(std::iter::repeat(0).take(32));
     d.extend_from_slice(b"Xing");
     d.extend_from_slice(&0x01u32.to_be_bytes()); // flag VBRFrames only
-                                                 // Truncate: do NOT append the 4-byte VBRFrames; MPEG.pm:516 `last if
-                                                 // $pos + 4 > $len`.
+    // Truncate: do NOT append the 4-byte VBRFrames; MPEG.pm:516 `last if
+    // $pos + 4 > $len`.
     let mut m = Metadata::new("x.mp3");
     let mut c = ctx_over(&mut m, &d, "MP3");
     assert!(ProcessMp3.process(&mut c));

--- a/src/formats/red.rs
+++ b/src/formats/red.rs
@@ -31,7 +31,7 @@
 //! `exifast-phase2-forward-items` memory entry.
 
 use crate::{
-  convert::{apply, read_value, ByteOrder},
+  convert::{ByteOrder, apply, read_value},
   parser::{FormatParser, ParseContext},
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
   value::{Group, TagValue},

--- a/src/formats/wavpack.rs
+++ b/src/formats/wavpack.rs
@@ -326,13 +326,13 @@ mod tests {
     h[4..8].copy_from_slice(&100u32.to_le_bytes()); // ckSize
     h[8] = 0x10; // version low
     h[9] = 0x04; // version high (0x0410)
-                 // [10] block_index_u8 = 0
-                 // [11] total_samples_u8 = 0
+    // [10] block_index_u8 = 0
+    // [11] total_samples_u8 = 0
     h[12..16].copy_from_slice(&1000u32.to_le_bytes()); // total_samples
-                                                       // [16..20] block_index = 0
+    // [16..20] block_index = 0
     h[20..24].copy_from_slice(&500u32.to_le_bytes()); // block_samples
     h[24..28].copy_from_slice(&flags_le.to_le_bytes()); // flags (LE on disk)
-                                                        // [28..32] crc = 0
+    // [28..32] crc = 0
     h
   }
 
@@ -353,10 +353,10 @@ mod tests {
     assert!(g(TagId::Str("Other")).is_none());
     assert!(g(TagId::Int(0)).is_none());
     assert_eq!(WAVPACK_MAIN.group0(), "File"); // WavPack.pm:23
-                                               // BitShift derivation: per ExifTool.pm:5905-5910 each shift = #
-                                               // trailing zero bits of the mask. Pinned to the exact integer values
-                                               // documented in the .pm so a mask-literal typo is caught even if the
-                                               // `bit_shift` helper is ever changed.
+    // BitShift derivation: per ExifTool.pm:5905-5910 each shift = #
+    // trailing zero bits of the mask. Pinned to the exact integer values
+    // documented in the .pm so a mask-literal typo is caught even if the
+    // `bit_shift` helper is ever changed.
     assert_eq!(BYTES_PER_SAMPLE_MASK, 0x0000_0003);
     assert_eq!(AUDIO_TYPE_MASK, 0x0000_0004);
     assert_eq!(COMPRESSION_MASK, 0x0000_0008);

--- a/src/json_scalar.rs
+++ b/src/json_scalar.rs
@@ -1,0 +1,241 @@
+//! Shared ExifTool scalar JSON encoders — the byte-exact `EscapeJSON`
+//! transliteration used by BOTH the `Metadata`→JSON serializer
+//! ([`crate::serialize`]) and the direct [`crate::json_writer::JsonTagWriter`].
+//!
+//! This is a faithful transliteration of ExifTool's scalar encoder
+//! `EscapeJSON` (`exiftool` lines 3800-3831, with the `%jsonChar` table at
+//! line 250) and the `FormatJSON` ARRAY branch (`exiftool` 3843-3855).
+//! Extracted verbatim from `serialize.rs` so the two output paths share ONE
+//! source of truth for the number-vs-quoted-string gate, string escaping,
+//! the binary placeholder, the rational repr, and list framing — guaranteeing
+//! they are byte-identical. Building the string directly (no `serde_json`
+//! round-trip) keeps it byte-exact with ExifTool and infallible — there is no
+//! error path, so `Bytes`/`Rational` can never fail the document.
+
+use crate::value::{Rational, TagValue, format_g, perl_nonfinite_str};
+
+/// ExifTool's `%jsonChar` short escapes (`exiftool` line 250):
+/// `"` → `\"`, `\` → `\\`, TAB → `\t`, LF → `\n`, CR → `\r`.
+fn json_short_escape(c: char) -> Option<&'static str> {
+  match c {
+    '"' => Some("\\\""),
+    '\\' => Some("\\\\"),
+    '\t' => Some("\\t"),
+    '\n' => Some("\\n"),
+    '\r' => Some("\\r"),
+    _ => None,
+  }
+}
+
+/// Faithful transliteration of ExifTool `EscapeJSON`'s number gate
+/// (`exiftool` line 3809):
+/// `/^-?(\d|[1-9]\d{1,14})(\.\d{1,16})?(e[-+]?\d{1,3})?$/i`.
+///
+/// ExifTool emits a (stringly-typed) value as a bare JSON number iff its text
+/// matches this regex; otherwise it is quoted. We transliterate the regex by
+/// hand (the crate has no regex dependency) so numeric-looking string values
+/// are emitted bare exactly as ExifTool does (e.g. an `Aperture` PrintConv of
+/// `"3.5"` → bare `3.5`).
+#[must_use]
+pub fn is_json_number_literal(s: &str) -> bool {
+  let b = s.as_bytes();
+  let mut i = 0;
+  // -?
+  if i < b.len() && b[i] == b'-' {
+    i += 1;
+  }
+  // (\d | [1-9]\d{1,14})  — a lone digit, OR 2..=15 digits with no leading 0
+  let int_start = i;
+  if i >= b.len() || !b[i].is_ascii_digit() {
+    return false;
+  }
+  if b[i] == b'0' {
+    // lone `0` only (the `\d` alternative); `[1-9]…` forbids leading zero.
+    i += 1;
+  } else {
+    // [1-9]\d{1,14}  → 2..=15 digits total, or the single-digit `\d` form.
+    i += 1;
+    let mut extra = 0;
+    while i < b.len() && b[i].is_ascii_digit() && extra < 14 {
+      i += 1;
+      extra += 1;
+    }
+    // total integer digits = 1 (single \d) or 2..=15; reject 16+.
+    if i < b.len() && b[i].is_ascii_digit() {
+      return false;
+    }
+  }
+  debug_assert!(i > int_start);
+  // (\.\d{1,16})?
+  if i < b.len() && b[i] == b'.' {
+    i += 1;
+    let frac_start = i;
+    let mut n = 0;
+    while i < b.len() && b[i].is_ascii_digit() && n < 16 {
+      i += 1;
+      n += 1;
+    }
+    if i == frac_start || (i < b.len() && b[i].is_ascii_digit()) {
+      return false; // need 1..=16 fraction digits
+    }
+  }
+  // (e[-+]?\d{1,3})?  (case-insensitive `e`)
+  if i < b.len() && (b[i] == b'e' || b[i] == b'E') {
+    i += 1;
+    if i < b.len() && (b[i] == b'+' || b[i] == b'-') {
+      i += 1;
+    }
+    let exp_start = i;
+    let mut n = 0;
+    while i < b.len() && b[i].is_ascii_digit() && n < 3 {
+      i += 1;
+      n += 1;
+    }
+    if i == exp_start || (i < b.len() && b[i].is_ascii_digit()) {
+      return false; // need 1..=3 exponent digits
+    }
+  }
+  i == b.len()
+}
+
+/// Quote and escape a string exactly as ExifTool `EscapeJSON` does for the
+/// non-numeric path (`exiftool` lines 3816-3830, JSON branch):
+/// short escapes for `" \ \t \n \r`, NULs deleted, other C0 controls and DEL
+/// (`\x00-\x1f`, `\x7f`) as `\uXXXX` (upper-case hex). The input is already
+/// valid UTF-8 (`String`), so `FixUTF8` is a no-op.
+pub fn push_json_string(out: &mut String, s: &str) {
+  out.push('"');
+  for c in s.chars() {
+    if let Some(esc) = json_short_escape(c) {
+      out.push_str(esc);
+    } else if c == '\0' {
+      // ExifTool: `tr/\0//d` — NULs are removed entirely.
+    } else if (c as u32) <= 0x1f || (c as u32) == 0x7f {
+      // ExifTool: sprintf("\\u%.4X", ord $1)
+      out.push_str(&format!("\\u{:04X}", c as u32));
+    } else {
+      out.push(c);
+    }
+  }
+  out.push('"');
+}
+
+/// ExifTool's numeric value for a rational (ExifTool.pm `GetRational*`
+/// lines 6081-6109): `num/denom` rounded to significant figures via the
+/// shared [`crate::value::format_g`] (`%.{sig}g`, `$sig` = 7 for a
+/// rational32 `ExifTool.pm:6087,6094`, 10 for a rational64
+/// `ExifTool.pm:6101,6108`, carried on [`Rational::sig`]). A zero
+/// denominator yields the bare word `inf` (numerator ≠ 0) or `undef`
+/// (numerator == 0). Those words are not JSON numbers, so ExifTool's
+/// `EscapeJSON` emits them as the quoted strings `"inf"` / `"undef"`.
+///
+/// Returns `(text, is_number)`: `is_number` is `false` for the `inf`/`undef`
+/// words (→ quoted string) and `true` for a numeric token (→ bare number).
+/// The text itself is [`Rational::exiftool_val_str`] — the single source of
+/// truth shared with the PrintConv-hash lookup so a hash key (`$$conv{$val}`)
+/// matches what the serializer prints.
+fn rational_repr(r: &Rational) -> (String, bool) {
+  let is_number = r.denominator() != 0;
+  (r.exiftool_val_str(), is_number)
+}
+
+/// Append a `TagValue` as its faithful ExifTool JSON encoding.
+///
+/// Every variant is representable, so this is infallible — `Bytes` and
+/// `Rational` can never fail the document (matching `exiftool -j`, which never
+/// aborts a file because a tag is binary or rational).
+pub fn push_value(out: &mut String, v: &TagValue) {
+  match v {
+    // ExifTool feeds the STRING form of every scalar through `EscapeJSON`'s
+    // one number gate (`exiftool:3809`
+    // `/^-?(\d|[1-9]\d{1,14})(\.\d{1,16})?(e[-+]?\d{1,3})?$/i`): bare iff it
+    // matches, else the quoted-string branch (`exiftool:3830`
+    // `'"' . $str . '"'`). A typed integer is no exception — Perl
+    // stringifies it (`"$n"`) and runs the same gate, so a >15-digit
+    // integer (`i64::MIN`/`MAX`, any 16+-digit value) is QUOTED, not bare.
+    // Verified against the bundled Perl regex (see tests).
+    TagValue::I64(n) => push_numeric_gated(out, &n.to_string()),
+    // Same gate for floats: ExifTool stringifies (`%.15g`-ish) then runs
+    // line 3809. `format_g(_, 15)` fixed-notation can exceed the regex's
+    // `\d{1,16}` fraction cap (e.g. `sprintf("%.15g",10/2134)` =
+    // `0.00468603561387067`, 17 frac digits → Perl QUOTES it), so route
+    // through the gate rather than assuming bare. Bundled-Perl verified.
+    TagValue::F64(n) => {
+      if n.is_finite() {
+        push_numeric_gated(out, &format_g(*n, 15));
+      } else {
+        // ExifTool never emits a non-finite bare token; quote it. Codex R8
+        // fix: use Perl's titlecase `Inf`/`-Inf`/`NaN` form (verified
+        // 2026-05-20 via `perl -e 'print 1e308*1e308'`), NOT Rust's
+        // lowercase `inf`/`-inf` from `f64::to_string`. `perl_nonfinite_str`
+        // covers every non-finite f64 (NaN/+Inf/-Inf — IEEE-754 has no other
+        // non-finite category), so the `None` arm is unreachable while the
+        // outer `is_finite` gate holds. Fall back to Rust's default
+        // stringification rather than emit a hard-to-debug empty string if
+        // a future refactor ever routes a finite value into this branch
+        // (would surface as visibly lowercase `inf`/`-inf` in the JSON,
+        // failing the conformance gate loudly instead of silently emitting
+        // `""`).
+        match perl_nonfinite_str(*n) {
+          Some(s) => push_json_string(out, s),
+          None => push_json_string(out, &n.to_string()),
+        }
+      }
+    }
+    TagValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+    // ExifTool's value strings are stringly-typed: `EscapeJSON` emits them
+    // bare when they look like a JSON number or `true`/`false`, else quoted.
+    TagValue::Str(s) => {
+      if is_json_number_literal(s) {
+        out.push_str(s);
+      } else if s.eq_ignore_ascii_case("true") {
+        out.push_str("true");
+      } else if s.eq_ignore_ascii_case("false") {
+        out.push_str("false");
+      } else {
+        push_json_string(out, s);
+      }
+    }
+    // ExifTool universal no-`-b` placeholder. Verified against the bundled
+    // tool (see tests): `(Binary data <N> bytes, use -b option to extract)`
+    // where N is the byte length. It is a plain string, never numeric.
+    TagValue::Bytes(b) => {
+      let placeholder = format!("(Binary data {} bytes, use -b option to extract)", b.len());
+      push_json_string(out, &placeholder);
+    }
+    // ExifTool default rational = its numeric value (or "inf"/"undef").
+    // The numeric token still passes through `EscapeJSON`'s gate
+    // (`exiftool:3809`); `inf`/`undef` are non-numeric so the gate quotes
+    // them anyway, matching `rational_repr`'s `is_number == false`.
+    TagValue::Rational(r) => {
+      let (text, _is_number) = rational_repr(r);
+      push_numeric_gated(out, &text);
+    }
+    TagValue::List(items) => {
+      // ExifTool `FormatJSON` ARRAY branch (`exiftool` 3843-3855):
+      // `[`, comma-separated elements, `]` (no internal newlines).
+      out.push('[');
+      for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+          out.push(',');
+        }
+        push_value(out, item);
+      }
+      out.push(']');
+    }
+  }
+}
+
+/// Emit an already-stringified numeric token exactly as ExifTool's
+/// `EscapeJSON` would (`exiftool` lines 3808-3830): a bare token iff it passes
+/// the number gate ([`is_json_number_literal`], the line-3809 regex), otherwise
+/// the quoted-and-escaped string branch ([`push_json_string`],
+/// `'"' . $str . '"'`). This is the single funnel every scalar's string form
+/// goes through in ExifTool, so integers/floats/rationals are all faithful.
+pub fn push_numeric_gated(out: &mut String, s: &str) {
+  if is_json_number_literal(s) {
+    out.push_str(s);
+  } else {
+    push_json_string(out, s);
+  }
+}

--- a/src/json_writer.rs
+++ b/src/json_writer.rs
@@ -1,0 +1,804 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! [`JsonTagWriter`] — a [`TagWriter`] that emits bundled-`exiftool -j -G1`
+//! JSON DIRECTLY from a typed `Meta`'s [`MetaSinker::sink`] stream, with no
+//! intermediate [`crate::value::Metadata`] push-bag.
+//!
+//! Task #124 made this the engine's `$$et` value sink: the CLI JSON path is
+//! now `Meta` → [`crate::parser_new::MetaSinker::sink`] → `JsonTagWriter` →
+//! [`JsonTagWriter::finish`]. `JsonTagWriter` collapses what was previously a
+//! `Metadata` push-bag + [`crate::serialize::to_exiftool_json`] render into a
+//! single writer, dropping the `Metadata` push-bag from the OUTPUT path
+//! entirely (`Metadata` + `to_exiftool_json` survive only as the test
+//! byte-exactness oracle and as internal staging — e.g. Ogg comments).
+//!
+//! ## Byte-exactness contract
+//!
+//! `JsonTagWriter` is a *faithful re-composition* of the push-style
+//! `Metadata` + serialize pair, so its output is byte-identical to
+//! [`to_exiftool_json`](crate::serialize::to_exiftool_json) applied to the
+//! equivalent [`crate::value::Metadata`] (the oracle the tests assert
+//! against). Specifically it mirrors, citing the source rules:
+//!
+//! 1. **Scalar encoding.** Every scalar goes through the SAME
+//!    [`crate::json_scalar`] encoders the serializer uses (the `EscapeJSON`
+//!    number gate at `exiftool:3809`, string escaping at `exiftool:3816-3830`,
+//!    the binary placeholder, the rational repr, and the `FormatJSON` ARRAY
+//!    framing at `exiftool:3843-3855`). One source of truth ⇒ no drift.
+//! 2. **`write_*` → `TagValue` mapping.** `write_u64` → `I64` (saturating to
+//!    `i64::MAX`, matching the push-style `Metadata`'s `I64` storage),
+//!    `write_i64` → `I64`, `write_f64` → `F64`, `write_str`/`write_fmt` →
+//!    `Str`, `write_bytes` → `Bytes`. `write_str_list` coalesces via the
+//!    [`crate::value::Metadata::push_listable`] promote-and-push rule
+//!    (`ExifTool.pm:9505-9520`).
+//! 3. **Push-level dedup / last-write-wins.** Same `(family0, family1, name)`
+//!    identity replace-in-place as [`crate::value::Metadata::push`] (faithful
+//!    `FoundTag`, `ExifTool.pm:9437-9519`): the LATEST scalar `write_*` for a
+//!    key wins, in the FIRST occurrence's position.
+//! 4. **`%noDups` first-wins + framing + Warning/Error placement.** Same as
+//!    [`crate::serialize::to_exiftool_json`]: `[{`, `SourceFile` first, then
+//!    `"<family1>:<name>"` tokens with `%noDups` first-wins
+//!    (`exiftool:2950-2951`), then the generated `ExifTool:Warning` /
+//!    `ExifTool:Error` tags (`ExifTool.pm:1225,1288-1297`), then `\n}]\n`.
+//!
+//! ## Group mapping
+//!
+//! The writer-side `group`
+//! argument is taken as BOTH family-0 and family-1 by default, or — when
+//! constructed via [`JsonTagWriter::with_family0`] — family-0 is pinned and
+//! `group` is family-1. Only family-1 reaches the JSON token (`exiftool:2948`
+//! `-G1`), but family-0 still participates in the push-level dedup identity
+//! (so two tags differing only in family-0 are distinct at the push stage,
+//! exactly as `Metadata::push` treats them).
+//!
+//! ## Modes
+//!
+//! `print_conv` is supplied to [`MetaSinker::sink`], not stored on the writer:
+//! the Meta itself chooses `write_str`(PrintConv) vs `write_u64`/`write_f64`
+//! (raw ValueConv) per the flag. `JsonTagWriter` is mode-agnostic — it
+//! faithfully renders whatever scalars the Meta emits, so the same writer
+//! serves both `-j` and `-n` (`exiftool` PrintConv toggle, `ExifTool.pm:5710`).
+
+use crate::json_scalar::{push_json_string, push_value};
+use crate::parser_new::TagWriter;
+use crate::value::{Group, Tag, TagValue};
+use core::{convert::Infallible, fmt};
+use smol_str::SmolStr;
+use std::{collections::HashSet, string::String, vec::Vec};
+
+/// A [`TagWriter`] that emits bundled-`exiftool -j -G1` JSON directly from a
+/// typed `Meta`'s emission stream — see the module docs for the byte-exact
+/// contract it honours.
+///
+/// Usage: construct with the `SourceFile` path, drive
+/// [`MetaSinker::sink`](crate::parser_new::MetaSinker::sink) into it (in the
+/// desired `-j`/`-n` mode), then call [`JsonTagWriter::finish`] for the JSON
+/// string. The writer is infallible ([`Infallible`] error), so a
+/// `?`-propagating sink chain compile-eliminates the error branch.
+///
+/// D8 convention: no public fields; constructors + accessors only.
+pub struct JsonTagWriter {
+  source_file: String,
+  /// Buffered tags in first-occurrence order (mirrors the retired push-style
+  /// `Metadata`'s `Vec<Tag>` ordering, which the `%noDups` pass then walks).
+  /// Stored as [`crate::value::Tag`] — the SAME element type the retired
+  /// `Metadata` used — so the engine read-back surface ([`Self::tags`] /
+  /// [`Self::records`]) is a 1:1 replacement for `Metadata::tags()`.
+  records: Vec<Tag>,
+  /// Warning accumulator, in call order (`ExifTool.pm:1297`; the first is
+  /// surfaced as `ExifTool:Warning` under `-j -G1`).
+  warnings: Vec<String>,
+  /// Error accumulator, in call order (`ExifTool.pm:1288-1296`; the first is
+  /// surfaced as `ExifTool:Error`).
+  errors: Vec<String>,
+  /// Optional family-0 override: when `Some(f0)`, family-0 = `f0` and
+  /// family-1 = the writer-side `group`; when `None`, family-0 = family-1 =
+  /// `group`. Mutable at runtime via [`JsonTagWriter::set_family0_override`]
+  /// so the engine's APE entry can pin family-0 = `"APE"` for the duration of
+  /// the APE `MetaSinker::sink` call (the MAC/main split, APE.pm:84-87) while
+  /// leaving the surrounding `File:*` / chained-ID3 emissions on the default
+  /// `group == family-0 == family-1` mapping — a single writer-level seam in
+  /// place of any per-sink family-0 wrapper.
+  family0_override: Option<&'static str>,
+  /// Faithful `$$et{DoneID3}` flag (ID3.pm:1435-1436, APE.pm:124, etc.) for
+  /// the ENGINE path (`crate::parser::extract_info` -> `process(ctx)`), which
+  /// carries cross-format state on this `$$et` value sink. `None` => ProcessID3
+  /// has not run on this `$self`; `Some(n)` => run, with `n` the ID3v1-trailer
+  /// size (ID3.pm:1527) read by APE.pm:169 to walk PAST the trailer. Moved here
+  /// verbatim from the retired `crate::value::Metadata::done_id3` so the engine
+  /// `process` chain (ID3 -> APE/MPC/WV/etc.) keeps its `$self`-scoped flag.
+  /// (The TYPED `parse`/`parse_bytes` path uses `SharedFlags` instead — these
+  /// are two parallel ExifTool-`$$et` mirrors, unchanged by this migration.)
+  done_id3: Option<usize>,
+  /// Faithful `$$et{DoneAPE}` flag (APE.pm:131, ID3.pm:1723) for the engine
+  /// path. Set by `ProcessAPE` immediately after the ID3 check; read by
+  /// ID3.pm:1723 to gate the MP3->APE trailer fallback. Moved verbatim from
+  /// the retired `Metadata::done_ape`.
+  done_ape: bool,
+}
+
+impl JsonTagWriter {
+  /// Construct a writer for the given `SourceFile` path. Family-0 = family-1 =
+  /// the writer-side `group` argument (the default MOI/AAC/DV pattern).
+  #[must_use]
+  pub fn new(source_file: impl Into<String>) -> Self {
+    Self {
+      source_file: source_file.into(),
+      records: Vec::new(),
+      warnings: Vec::new(),
+      errors: Vec::new(),
+      family0_override: None,
+      done_id3: None,
+      done_ape: false,
+    }
+  }
+
+  /// Construct a writer that pins family-0 to `family0` for every emission
+  /// (the writer-side `group` becomes family-1 only). Used by APE's MAC vs
+  /// main-tag family-0 split.
+  #[must_use]
+  pub fn with_family0(source_file: impl Into<String>, family0: &'static str) -> Self {
+    Self {
+      source_file: source_file.into(),
+      records: Vec::new(),
+      warnings: Vec::new(),
+      errors: Vec::new(),
+      family0_override: Some(family0),
+      done_id3: None,
+      done_ape: false,
+    }
+  }
+
+  /// The `SourceFile` path this writer was constructed with.
+  #[must_use]
+  pub fn source_file(&self) -> &str {
+    &self.source_file
+  }
+
+  /// Build a [`Group`] from the writer-side single-string `group` argument,
+  /// honouring the optional family-0 override.
+  fn group(&self, group: &str) -> Group {
+    match self.family0_override {
+      Some(f0) => Group::new(f0, group),
+      None => Group::new(group, group),
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Engine `$$et` value-sink surface — read-back + state. These methods make
+  // `JsonTagWriter` a drop-in for the retired `crate::value::Metadata` push-bag
+  // on the ENGINE path (`crate::parser::extract_info` -> `process(ctx)`): the
+  // `ParseContext` carries `&mut JsonTagWriter` and the format `process`
+  // entries push File:* + sink their typed Meta + read tags back (Composite
+  // ingredient lookup, SetFileType first-call-wins) directly here.
+  // -------------------------------------------------------------------------
+
+  /// Set (or clear) the runtime family-0 override. The engine's APE entry
+  /// pins family-0 = `"APE"` for the duration of its `MetaSinker::sink` call
+  /// (the MAC-header vs main-tag split keyed by family-0 = `APE:`,
+  /// APE.pm:84-87) then clears it, so the surrounding `File:*` and chained-ID3
+  /// emissions keep the default `group == family-0 == family-1` mapping. This
+  /// is a single writer-level seam (in place of any per-sink family-0
+  /// wrapper) now that a single writer is shared across the whole `process`.
+  pub fn set_family0_override(&mut self, family0: Option<&'static str>) {
+    self.family0_override = family0;
+  }
+
+  /// `$$et{DoneID3}` — `None` until `ProcessID3` runs on this engine `$self`;
+  /// `Some(n)` once run, with `n` the ID3v1-trailer size. Faithful read of
+  /// the retired `Metadata::done_id3` (ID3.pm:1435, APE.pm:124/169).
+  #[must_use]
+  pub fn done_id3(&self) -> Option<usize> {
+    self.done_id3
+  }
+
+  /// Set `$$et{DoneID3} = trailer_size` (ID3.pm:1436/1527). Mirrors the
+  /// retired `Metadata::set_done_id3`.
+  pub fn set_done_id3(&mut self, trailer_size: usize) {
+    self.done_id3 = Some(trailer_size);
+  }
+
+  /// `$$et{DoneAPE}` (APE.pm:131, ID3.pm:1723). Faithful read of the retired
+  /// `Metadata::done_ape`.
+  #[must_use]
+  pub fn done_ape(&self) -> bool {
+    self.done_ape
+  }
+
+  /// Set `$$et{DoneAPE} = 1` (APE.pm:131). Mirrors the retired
+  /// `Metadata::set_done_ape`.
+  pub fn set_done_ape(&mut self) {
+    self.done_ape = true;
+  }
+
+  /// Is `File:FileType` (family-1 `File`) already buffered? Faithful to
+  /// ExifTool's per-file `$$self{FileType}` first-call-wins marker
+  /// (ExifTool.pm:9681/9701). Read by `ParseContext::set_file_type` before
+  /// pushing the `File:*` triplet. Verbatim port of the retired
+  /// `Metadata::has_file_type`.
+  #[must_use]
+  pub fn has_file_type(&self) -> bool {
+    self
+      .records
+      .iter()
+      .any(|t| t.group().family1() == "File" && t.name() == "FileType")
+  }
+
+  /// Existence query for `(group, name)` (family-0 AND family-1 + name).
+  /// Verbatim port of the retired `Metadata::has_tag` — used by
+  /// format-specific duplicate-handling paths.
+  #[must_use]
+  pub fn has_tag(&self, group: &Group, name: &str) -> bool {
+    self
+      .records
+      .iter()
+      .any(|t| t.group() == group && t.name() == name)
+  }
+
+  /// Push (FoundTag) a tag in first-occurrence order, or overwrite an existing
+  /// same-`(group, name)` tag's value in place (last-write-wins). Verbatim
+  /// port of the retired `Metadata::push` (ExifTool.pm:9437-9519). The
+  /// `group` carries BOTH families explicitly — the engine's `set_file_type`,
+  /// the Composite emission, and the chained-ID3 push helpers call this
+  /// exactly as they called `Metadata::push`.
+  pub fn push(&mut self, group: Group, name: impl Into<SmolStr>, value: TagValue) {
+    let name = name.into();
+    if let Some(tag) = self
+      .records
+      .iter_mut()
+      .find(|t| t.group() == &group && t.name() == name.as_str())
+    {
+      tag.set_value(value);
+    } else {
+      self.records.push(Tag::new(group, name, value));
+    }
+  }
+
+  /// Push `value` under `(group, name)` with `List`-coalesce semantics
+  /// (promote scalar -> 1-elem list, extend list, else append scalar).
+  /// Verbatim port of the retired `Metadata::push_listable`
+  /// (ExifTool.pm:9505-9520). The engine's chained-ID3 / Vorbis push helpers
+  /// call this exactly as they called `Metadata::push_listable`.
+  pub fn push_listable(&mut self, group: Group, name: impl Into<SmolStr>, value: TagValue) {
+    let name = name.into();
+    if let Some(tag) = self
+      .records
+      .iter_mut()
+      .find(|t| t.group() == &group && t.name() == name.as_str())
+    {
+      let placeholder = TagValue::List(Vec::new());
+      let new_val = match core::mem::replace(tag.value_mut(), placeholder) {
+        TagValue::List(mut items) => {
+          items.push(value);
+          TagValue::List(items)
+        }
+        scalar => TagValue::List(std::vec![scalar, value]),
+      };
+      tag.set_value(new_val);
+    } else {
+      self.records.push(Tag::new(group, name, value));
+    }
+  }
+
+  /// Replace the value of the existing `(group, name)` tag in place;
+  /// returns `true` if found (else no-op `false`). Verbatim port of the
+  /// retired `Metadata::set_tag_value` (the `OverrideFileType` path,
+  /// ExifTool.pm:9717-9724).
+  pub fn set_tag_value(&mut self, group: &Group, name: &str, value: TagValue) -> bool {
+    match self
+      .records
+      .iter_mut()
+      .find(|t| t.group() == group && t.name() == name)
+    {
+      Some(tag) => {
+        tag.set_value(value);
+        true
+      }
+      None => false,
+    }
+  }
+
+  /// Record a non-fatal warning, in occurrence order (`$self->Warn`,
+  /// ExifTool.pm:1297). Verbatim port of the retired `Metadata::push_warning`.
+  /// (Identical to the [`TagWriter::write_warning`] impl, exposed under the
+  /// `Metadata`-style name so the engine `process` chain migrates 1:1.)
+  pub fn push_warning(&mut self, warning: impl Into<String>) {
+    self.warnings.push(warning.into());
+  }
+
+  /// Record an error, in occurrence order (`$self->Error`, ExifTool.pm:5648).
+  /// Verbatim port of the retired `Metadata::push_error`.
+  pub fn push_error(&mut self, error: impl Into<String>) {
+    self.errors.push(error.into());
+  }
+
+  /// The buffered tags, in first-occurrence order. The 1:1 read analogue of
+  /// the retired `Metadata::tags()` (same [`crate::value::Tag`] element type,
+  /// same ordering the `%noDups` pass walks). The engine's Composite
+  /// ingredient lookup (APE.pm:81-93, scanning family-0 = `APE:`) and the ID3
+  /// stage-and-replay lift (a scratch `JsonTagWriter` collects the legacy
+  /// engine's emission, then [`crate::formats::id3`] reads it back) iterate
+  /// this.
+  #[must_use]
+  pub fn tags(&self) -> &[Tag] {
+    &self.records
+  }
+
+  /// Iterate the buffered tags in first-occurrence order as
+  /// `(&Group, &str name, &TagValue)` triples — a destructured convenience
+  /// over [`Self::tags`] for the `.rev()` Composite ingredient scan and the
+  /// orchestration-tag lift.
+  pub fn records(&self) -> impl DoubleEndedIterator<Item = (&Group, &str, &TagValue)> {
+    self
+      .records
+      .iter()
+      .map(|t| (t.group(), t.name(), t.value()))
+  }
+
+  /// Accumulated warnings, in call order (`$self->Warn`). Read by the ID3
+  /// stage-and-replay lift off its scratch writer; the public output document
+  /// surfaces only the FIRST via [`Self::finish`]. Faithful read analogue of
+  /// the retired `Metadata::warnings`.
+  #[must_use]
+  pub fn warnings(&self) -> &[String] {
+    &self.warnings
+  }
+
+  /// Accumulated errors, in call order (`$self->Error`). Faithful read
+  /// analogue of the retired `Metadata::errors`.
+  #[must_use]
+  pub fn errors(&self) -> &[String] {
+    &self.errors
+  }
+
+  /// Emit the buffered records as the byte-exact `exiftool -j -G1` JSON
+  /// document. Consumes the writer.
+  ///
+  /// This is a faithful re-composition of
+  /// [`crate::serialize::to_exiftool_json`]: the document framing (`[{`,
+  /// `SourceFile` first, `,\n  "tok": v` per tag, `\n}]\n`), the `%noDups`
+  /// first-wins on the `"<family1>:<name>"` token (`exiftool:2950-2951`), and
+  /// the generated `ExifTool:Warning` / `ExifTool:Error` tags joining the SAME
+  /// `%noDups` set (`ExifTool.pm:1225,1288-1297`). See the module docs for the
+  /// per-rule citations.
+  #[must_use]
+  pub fn finish(self) -> String {
+    // ExifTool framing: `$fileHeader = '['` (exiftool 1649); per file
+    // `{\n  "SourceFile": …` (exiftool 2678) then `,\n  "tok": v` per tag
+    // (exiftool 2953-2954, $ind = '  '); close `\n}` (exiftool 3090);
+    // `$fileTrailer = "]\n"` (exiftool 1650).
+    let mut out = String::new();
+    out.push('[');
+    out.push('{');
+    out.push_str("\n  \"SourceFile\": ");
+    push_json_string(&mut out, &self.source_file);
+    // ExifTool `%noDups` (exiftool:2950-2951 `next if $noDups{$tok};
+    // $noDups{$tok} = 1;`): first occurrence of a "<family1>:<name>" token
+    // wins; later same-token records are skipped entirely (no key, no value).
+    let mut seen: HashSet<String> = HashSet::new();
+    for rec in &self.records {
+      // exiftool:2947 `my $tok = $allGroup ? "$group:$tagName" : $tagName;`
+      // (`-G1` => $allGroup true => "<family1>:<name>").
+      let tok = std::format!("{}:{}", rec.group().family1(), rec.name());
+      // exiftool:2950 `next if $noDups{$tok};` — first wins, drop the rest.
+      if !seen.insert(tok.clone()) {
+        continue;
+      }
+      out.push_str(",\n  ");
+      push_json_string(&mut out, &tok);
+      out.push_str(": ");
+      push_value(&mut out, rec.value());
+    }
+    // ExifTool's generated `Warning` tag: group1 = `ExifTool`
+    // (`ExifTool.pm:1225,1297`) ⇒ `-G1` token `"ExifTool:Warning"`
+    // (`exiftool:2948`). Joins the SAME `%noDups` set (`exiftool:2951`,
+    // first-wins). Default `-j -G1` emits only the FIRST warning (the
+    // ` (N)` copy-suffix dups are dropped, `exiftool:2744`; `-a`/Duplicates
+    // not modelled — same deferral as `to_exiftool_json`).
+    if let Some(first) = self.warnings.first() {
+      let tok = String::from("ExifTool:Warning");
+      if seen.insert(tok.clone()) {
+        out.push_str(",\n  ");
+        push_json_string(&mut out, &tok);
+        out.push_str(": ");
+        push_json_string(&mut out, first);
+      }
+    }
+    // ExifTool's generated `Error` tag: group1 `ExifTool`
+    // (`ExifTool.pm:1225,1288-1296`) ⇒ `-G1` token `"ExifTool:Error"`. Joins
+    // the SAME `%noDups` set INDEPENDENTLY of the Warning token (distinct
+    // tokens), first-wins; only the FIRST error is emitted under `-j -G1`
+    // (same deferral as `to_exiftool_json`).
+    if let Some(first) = self.errors.first() {
+      let tok = String::from("ExifTool:Error");
+      if seen.insert(tok.clone()) {
+        out.push_str(",\n  ");
+        push_json_string(&mut out, &tok);
+        out.push_str(": ");
+        push_json_string(&mut out, first);
+      }
+    }
+    out.push_str("\n}");
+    out.push_str("]\n");
+    out
+  }
+}
+
+impl TagWriter for JsonTagWriter {
+  /// Buffering into in-memory `Vec`s cannot fail; using [`Infallible`] lets a
+  /// typed `Meta`'s `?`-propagating [`MetaSinker::sink`](crate::parser_new::MetaSinker::sink)
+  /// chain compile-eliminate the error branch.
+  type Error = Infallible;
+
+  fn write_str(&mut self, group: &str, name: &str, value: &str) -> Result<(), Infallible> {
+    let g = self.group(group);
+    self.push(g, name, TagValue::Str(value.into()));
+    Ok(())
+  }
+
+  fn write_u64(&mut self, group: &str, name: &str, value: u64) -> Result<(), Infallible> {
+    // The push-style `Metadata` stores integers as `TagValue::I64`; the
+    // bridge saturates `u64` → `i64::MAX` (sink.rs). Mirror that exactly so a
+    // >`i64::MAX` value renders identically (it then quotes via the number
+    // gate just like the bridge path would).
+    let n = i64::try_from(value).unwrap_or(i64::MAX);
+    let g = self.group(group);
+    self.push(g, name, TagValue::I64(n));
+    Ok(())
+  }
+
+  fn write_i64(&mut self, group: &str, name: &str, value: i64) -> Result<(), Infallible> {
+    let g = self.group(group);
+    self.push(g, name, TagValue::I64(value));
+    Ok(())
+  }
+
+  fn write_f64(&mut self, group: &str, name: &str, value: f64) -> Result<(), Infallible> {
+    let g = self.group(group);
+    self.push(g, name, TagValue::F64(value));
+    Ok(())
+  }
+
+  fn write_bytes(&mut self, group: &str, name: &str, value: &[u8]) -> Result<(), Infallible> {
+    let g = self.group(group);
+    self.push(g, name, TagValue::Bytes(value.to_vec()));
+    Ok(())
+  }
+
+  fn write_fmt(
+    &mut self,
+    group: &str,
+    name: &str,
+    f: impl FnOnce(&mut dyn fmt::Write) -> fmt::Result,
+  ) -> Result<(), Infallible> {
+    // `write_fmt` is the no-alloc workhorse on the sink side; we must
+    // materialize because the buffered record stores an owned `TagValue::Str`
+    // — the single allocation happens here, exactly like the bridge.
+    let mut s = String::new();
+    f(&mut s).expect("JsonTagWriter::write_fmt: in-memory String write cannot fail");
+    let g = self.group(group);
+    self.push(g, name, TagValue::Str(s.into()));
+    Ok(())
+  }
+
+  fn write_warning(&mut self, text: &str) -> Result<(), Infallible> {
+    self.warnings.push(text.into());
+    Ok(())
+  }
+
+  fn write_error(&mut self, text: &str) -> Result<(), Infallible> {
+    self.errors.push(text.into());
+    Ok(())
+  }
+
+  /// Override the default per-element `write_str` to coalesce into a single
+  /// first-occurrence-position list value, via
+  /// [`crate::value::Metadata::push_listable`] semantics (faithful
+  /// `FoundTag` promote-and-push, `ExifTool.pm:9505-9520`).
+  fn write_str_list(&mut self, group: &str, name: &str, values: &[&str]) -> Result<(), Infallible> {
+    for v in values {
+      let g = self.group(group);
+      self.push_listable(g, name, TagValue::Str((*v).into()));
+    }
+    Ok(())
+  }
+}
+
+impl fmt::Debug for JsonTagWriter {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("JsonTagWriter")
+      .field("source_file", &self.source_file)
+      .field("records", &self.records.len())
+      .field("warnings", &self.warnings.len())
+      .field("errors", &self.errors.len())
+      .finish()
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::serialize::to_exiftool_json;
+  use crate::value::{Metadata, Rational};
+
+  /// Helper: build a `Metadata` from the SAME (family0, family1, name, value)
+  /// records and assert `JsonTagWriter::finish` is byte-identical to
+  /// `to_exiftool_json` over that Metadata. This is the core byte-exactness
+  /// contract — the writer is a faithful re-composition of bridge+serialize.
+  fn assert_matches_serialize(source: &str, push: impl Fn(&mut Metadata, &mut JsonTagWriter)) {
+    let mut m = Metadata::new(source);
+    let mut w = JsonTagWriter::new(source);
+    push(&mut m, &mut w);
+    let via_serialize = to_exiftool_json(&m);
+    let via_writer = w.finish();
+    assert_eq!(
+      via_writer, via_serialize,
+      "JsonTagWriter must be byte-identical to to_exiftool_json"
+    );
+  }
+
+  #[test]
+  fn empty_doc_matches_serialize() {
+    assert_matches_serialize("a.aac", |_m, _w| {});
+  }
+
+  #[test]
+  fn scalars_match_serialize_and_bridge_mapping() {
+    assert_matches_serialize("a.aac", |m, w| {
+      // write_str → Str
+      m.push(
+        Group::new("AAC", "AAC"),
+        "ProfileType",
+        TagValue::Str("Low Complexity".into()),
+      );
+      w.write_str("AAC", "ProfileType", "Low Complexity").unwrap();
+      // write_u64 → I64
+      m.push(Group::new("AAC", "AAC"), "SampleRate", TagValue::I64(44100));
+      w.write_u64("AAC", "SampleRate", 44100).unwrap();
+      // write_i64 → I64
+      m.push(Group::new("X", "X"), "Neg", TagValue::I64(-7));
+      w.write_i64("X", "Neg", -7).unwrap();
+      // write_f64 → F64
+      m.push(Group::new("X", "X"), "Dur", TagValue::F64(8.16));
+      w.write_f64("X", "Dur", 8.16).unwrap();
+      // write_bytes → Bytes
+      m.push(
+        Group::new("EXIF", "IFD0"),
+        "Thumb",
+        TagValue::Bytes(std::vec![1, 2, 3]),
+      );
+      w.write_bytes("IFD0", "Thumb", &[1, 2, 3]).unwrap();
+    });
+  }
+
+  #[test]
+  fn write_u64_saturates_like_bridge() {
+    assert_matches_serialize("a.aac", |m, w| {
+      // u64::MAX → i64::MAX (saturating), then quoted by the number gate
+      // (19 digits > 15). Both paths agree.
+      m.push(Group::new("X", "X"), "Huge", TagValue::I64(i64::MAX));
+      w.write_u64("X", "Huge", u64::MAX).unwrap();
+    });
+  }
+
+  #[test]
+  fn write_fmt_materializes_like_bridge() {
+    assert_matches_serialize("a.moi", |m, w| {
+      m.push(
+        Group::new("MOI", "MOI"),
+        "DateTimeOriginal",
+        TagValue::Str("2011:05:15 17:58:48.000".into()),
+      );
+      w.write_fmt("MOI", "DateTimeOriginal", |f| {
+        write!(
+          f,
+          "{:04}:{:02}:{:02} {:02}:{:02}:{:06.3}",
+          2011, 5, 15, 17, 58, 48.0
+        )
+      })
+      .unwrap();
+    });
+  }
+
+  #[test]
+  fn last_write_wins_for_same_key() {
+    // FoundTag last-wins (ExifTool.pm:9437-9519) at the push stage.
+    assert_matches_serialize("dup.aif", |m, w| {
+      m.push(
+        Group::new("AIFF", "AIFF"),
+        "Name",
+        TagValue::Str("First".into()),
+      );
+      m.push(
+        Group::new("AIFF", "AIFF"),
+        "Name",
+        TagValue::Str("Second".into()),
+      );
+      w.write_str("AIFF", "Name", "First").unwrap();
+      w.write_str("AIFF", "Name", "Second").unwrap();
+    });
+  }
+
+  #[test]
+  fn nodups_first_wins_on_family1_token() {
+    // Two records with SAME family1:name but DIFFERENT family0 → distinct at
+    // the push stage, then `%noDups` first-wins on the family1 token drops the
+    // second (exiftool:2950-2951). Push both into one writer via the internal
+    // scalar path with explicit groups (the public API uses one family0 per
+    // writer, so the two-family0 case is exercised at the buffer level).
+    let mut m = Metadata::new("a.aac");
+    m.push(Group::new("Audio", "AAC"), "Channels", TagValue::I64(2));
+    m.push(Group::new("QuickTime", "AAC"), "Channels", TagValue::I64(6));
+    let mut wr = JsonTagWriter::new("a.aac");
+    wr.push(Group::new("Audio", "AAC"), "Channels", TagValue::I64(2));
+    wr.push(Group::new("QuickTime", "AAC"), "Channels", TagValue::I64(6));
+    assert_eq!(wr.finish(), to_exiftool_json(&m));
+  }
+
+  #[test]
+  fn write_str_list_coalesces_like_serialize() {
+    assert_matches_serialize("a.ogg", |m, w| {
+      m.push_listable(
+        Group::new("Vorbis", "Vorbis"),
+        "Artist",
+        TagValue::Str("Alice".into()),
+      );
+      m.push_listable(
+        Group::new("Vorbis", "Vorbis"),
+        "Artist",
+        TagValue::Str("Bob".into()),
+      );
+      m.push_listable(
+        Group::new("Vorbis", "Vorbis"),
+        "Artist",
+        TagValue::Str("Carol".into()),
+      );
+      w.write_str_list("Vorbis", "Artist", &["Alice", "Bob", "Carol"])
+        .unwrap();
+    });
+  }
+
+  #[test]
+  fn interleaved_list_keeps_first_occurrence_position() {
+    // R1-F2 semantics: a List tag accumulates at its FIRST-occurrence
+    // position even when unrelated tags interleave (write_str_list per repeat,
+    // faithful to the Vorbis comment walker).
+    assert_matches_serialize("a.ogg", |m, w| {
+      m.push_listable(
+        Group::new("Vorbis", "Vorbis"),
+        "Artist",
+        TagValue::Str("Alice".into()),
+      );
+      m.push(
+        Group::new("Vorbis", "Vorbis"),
+        "Title",
+        TagValue::Str("Song".into()),
+      );
+      m.push_listable(
+        Group::new("Vorbis", "Vorbis"),
+        "Artist",
+        TagValue::Str("Bob".into()),
+      );
+      m.push(
+        Group::new("Vorbis", "Vorbis"),
+        "Comment",
+        TagValue::Str("Foo".into()),
+      );
+      w.write_str_list("Vorbis", "Artist", &["Alice"]).unwrap();
+      w.write_str("Vorbis", "Title", "Song").unwrap();
+      w.write_str_list("Vorbis", "Artist", &["Bob"]).unwrap();
+      w.write_str("Vorbis", "Comment", "Foo").unwrap();
+    });
+  }
+
+  #[test]
+  fn warnings_and_errors_match_serialize() {
+    assert_matches_serialize("a.jpg", |m, w| {
+      m.push(
+        Group::new("EXIF", "IFD0"),
+        "Make",
+        TagValue::Str("Canon".into()),
+      );
+      m.push_warning("w1");
+      m.push_warning("w2");
+      m.push_error("e1");
+      w.write_str("IFD0", "Make", "Canon").unwrap();
+      w.write_warning("w1").unwrap();
+      w.write_warning("w2").unwrap();
+      w.write_error("e1").unwrap();
+    });
+  }
+
+  #[test]
+  fn string_escaping_matches_serialize() {
+    assert_matches_serialize("a.jpg", |m, w| {
+      let s = "tab\there\"q\\b\nnl\u{1}\u{7f}\0z";
+      m.push(Group::new("X", "X"), "S", TagValue::Str(s.into()));
+      w.write_str("X", "S", s).unwrap();
+    });
+  }
+
+  #[test]
+  fn numeric_looking_strings_match_serialize() {
+    assert_matches_serialize("a.jpg", |m, w| {
+      for (n, v) in [
+        ("Aperture", "3.5"),
+        ("ISO", "100"),
+        ("Mp", "6.4e-05"),
+        ("Ver", "01"),
+        ("B", "true"),
+        ("C", "FALSE"),
+      ] {
+        m.push(Group::new("X", "X"), n, TagValue::Str(v.into()));
+        w.write_str("X", n, v).unwrap();
+      }
+    });
+  }
+
+  #[test]
+  fn float_and_inf_match_serialize() {
+    assert_matches_serialize("a.jpg", |m, w| {
+      m.push(Group::new("X", "X"), "Plain", TagValue::F64(3.5));
+      m.push(Group::new("X", "X"), "Long", TagValue::F64(10.0 / 2134.0));
+      m.push(Group::new("X", "X"), "Inf", TagValue::F64(f64::INFINITY));
+      m.push(
+        Group::new("X", "X"),
+        "NegInf",
+        TagValue::F64(f64::NEG_INFINITY),
+      );
+      m.push(Group::new("X", "X"), "Nan", TagValue::F64(f64::NAN));
+      w.write_f64("X", "Plain", 3.5).unwrap();
+      w.write_f64("X", "Long", 10.0 / 2134.0).unwrap();
+      w.write_f64("X", "Inf", f64::INFINITY).unwrap();
+      w.write_f64("X", "NegInf", f64::NEG_INFINITY).unwrap();
+      w.write_f64("X", "Nan", f64::NAN).unwrap();
+    });
+  }
+
+  #[test]
+  fn list_with_bytes_and_rational_matches_serialize() {
+    // Lists can only reach the writer via write_str_list (all-str), so cover
+    // the mixed-list serializer path through push_listable parity directly on
+    // the writer's internal buffer (the bridge has no mixed-list emission).
+    let mut m = Metadata::new("a.jpg");
+    m.push(
+      Group::new("EXIF", "IFD0"),
+      "MixedList",
+      TagValue::List(std::vec![
+        TagValue::I64(1),
+        TagValue::Bytes(std::vec![0u8; 5]),
+        TagValue::Rational(Rational::rational64(1, 2)),
+      ]),
+    );
+    let mut w = JsonTagWriter::new("a.jpg");
+    w.push(
+      Group::new("EXIF", "IFD0"),
+      "MixedList",
+      TagValue::List(std::vec![
+        TagValue::I64(1),
+        TagValue::Bytes(std::vec![0u8; 5]),
+        TagValue::Rational(Rational::rational64(1, 2)),
+      ]),
+    );
+    assert_eq!(w.finish(), to_exiftool_json(&m));
+  }
+
+  #[test]
+  fn with_family0_routes_family1_to_token() {
+    // APE MAC/main split: family0 pinned, group arg is family1.
+    let mut m = Metadata::new("a.ape");
+    m.push(
+      Group::new("APE", "MAC"),
+      "Version",
+      TagValue::Str("3.99".into()),
+    );
+    let mut w = JsonTagWriter::with_family0("a.ape", "APE");
+    w.write_str("MAC", "Version", "3.99").unwrap();
+    assert_eq!(w.finish(), to_exiftool_json(&m));
+  }
+}

--- a/src/jsondiff.rs
+++ b/src/jsondiff.rs
@@ -316,29 +316,37 @@ mod tests {
     // (key, raw-bytes) sort mispaired them and reported a FALSE
     // mismatch. Canonical-form pairing fixes it: {x:1,y:2} ≡ {y:2,x:1}
     // and {x:9} ≡ {x:9}, so the two documents are equivalent.
-    assert!(json_equivalent(
-      r#"[{"A":{"x":1,"y":2},"A":{"x":9}}]"#,
-      r#"[{"A":{"x":9},"A":{"y":2,"x":1}}]"#,
-    )
-    .is_ok());
+    assert!(
+      json_equivalent(
+        r#"[{"A":{"x":1,"y":2},"A":{"x":9}}]"#,
+        r#"[{"A":{"x":9},"A":{"y":2,"x":1}}]"#,
+      )
+      .is_ok()
+    );
     // Nested arrays inside dup values stay ORDER-significant.
-    assert!(json_equivalent(
-      r#"[{"A":[1,2],"A":{"q":0}}]"#,
-      r#"[{"A":{"q":0},"A":[2,1]}]"#,
-    )
-    .is_err());
+    assert!(
+      json_equivalent(
+        r#"[{"A":[1,2],"A":{"q":0}}]"#,
+        r#"[{"A":{"q":0},"A":[2,1]}]"#,
+      )
+      .is_err()
+    );
     // The fix must NOT loosen the verdict: genuinely different dup
     // values (and different value multisets) still mismatch.
-    assert!(json_equivalent(
-      r#"[{"A":{"x":1},"A":{"x":2}}]"#,
-      r#"[{"A":{"x":1},"A":{"x":3}}]"#,
-    )
-    .is_err());
-    assert!(json_equivalent(
-      r#"[{"A":{"x":1},"A":{"y":1}}]"#,
-      r#"[{"A":{"x":1},"A":{"x":1}}]"#,
-    )
-    .is_err());
+    assert!(
+      json_equivalent(
+        r#"[{"A":{"x":1},"A":{"x":2}}]"#,
+        r#"[{"A":{"x":1},"A":{"x":3}}]"#,
+      )
+      .is_err()
+    );
+    assert!(
+      json_equivalent(
+        r#"[{"A":{"x":1},"A":{"y":1}}]"#,
+        r#"[{"A":{"x":1},"A":{"x":1}}]"#,
+      )
+      .is_err()
+    );
   }
 
   #[test]
@@ -384,11 +392,13 @@ mod tests {
 
   #[test]
   fn nested_structures_compare_recursively() {
-    assert!(json_equivalent(
-      r#"[{"a":[1,{"x":"v"}],"b":2}]"#,
-      r#"[{"b":2,"a":[1,{"x":"v"}]}]"#
-    )
-    .is_ok());
+    assert!(
+      json_equivalent(
+        r#"[{"a":[1,{"x":"v"}],"b":2}]"#,
+        r#"[{"b":2,"a":[1,{"x":"v"}]}]"#
+      )
+      .is_ok()
+    );
     let m = json_equivalent(r#"[{"a":[1,{"x":"v"}]}]"#, r#"[{"a":[1,{"x":"w"}]}]"#).unwrap_err();
     assert_eq!(
       m,
@@ -407,25 +417,31 @@ mod tests {
 
   #[test]
   fn invalid_json_is_reported() {
-    assert!(json_equivalent("[1,]", "[1]")
-      .unwrap_err()
-      .message()
-      .contains("actual is invalid"));
-    assert!(json_equivalent("[1]", "nope")
-      .unwrap_err()
-      .message()
-      .contains("golden is invalid"));
+    assert!(
+      json_equivalent("[1,]", "[1]")
+        .unwrap_err()
+        .message()
+        .contains("actual is invalid")
+    );
+    assert!(
+      json_equivalent("[1]", "nope")
+        .unwrap_err()
+        .message()
+        .contains("golden is invalid")
+    );
   }
 
   #[test]
   fn whitespace_insignificant_for_containers() {
     // Internal container whitespace must not cause a mismatch (only scalar
     // lexemes are byte-compared; structure is compared recursively).
-    assert!(json_equivalent(
-      "[ { \"a\" : 1 , \"b\" : [ 2 , 3 ] } ]",
-      r#"[{"a":1,"b":[2,3]}]"#
-    )
-    .is_ok());
+    assert!(
+      json_equivalent(
+        "[ { \"a\" : 1 , \"b\" : [ 2 , 3 ] } ]",
+        r#"[{"a":1,"b":[2,3]}]"#
+      )
+      .is_ok()
+    );
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,25 @@
 //!
 //! Stage 1 scope: video/audio formats, read-only. Per-format port status
 //! is tracked in `FORMATS.md` at the repository root.
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, allow(unused_attributes))]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
+
+// Alias `alloc as std` on no_std + alloc builds so code can use
+// `std::vec::Vec` etc. uniformly across feature combos. When the
+// `std` feature is on, the real `std` crate is already in scope via
+// the prelude. The `unused_extern_crates` allow silences a
+// rust-2018-idioms false positive — the alias is needed at use-time
+// even though rustc can't see that statically.
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+#[allow(unused_extern_crates)]
+extern crate alloc as std;
+
+#[cfg(feature = "std")]
+#[allow(unused_extern_crates)]
+extern crate std;
 
 pub mod bitstream;
 pub mod charset;
@@ -14,11 +31,42 @@ pub mod datetime;
 pub mod error;
 pub mod filetype;
 pub mod formats;
+// `jsondiff` and `serialize` are the JSON emitter + golden-diff oracle: they
+// unconditionally depend on `serde_json` (and `serde`). They are gated on
+// the `json` feature (spec §4: `json = ["alloc", "dep:serde_json", "dep:serde", ...]`).
+// Library callers without `json` get the typed-Meta API path only; CLI
+// JSON emission requires the feature.
+// `json_scalar` builds the per-scalar JSON lexemes by hand (no `serde_json`),
+// so it needs only `alloc` (String/format!), NOT the serde-pulling `json`
+// feature. Gated on `alloc` because [`json_writer`] — the engine's mandatory
+// `$$et` value sink after task #124 — depends on it, and the engine
+// (parser + format modules) is always compiled.
+#[cfg(feature = "alloc")]
+pub mod json_scalar;
+// The direct typed-Meta → JSON `TagWriter` and the engine's `$$et` value sink
+// (task #124). Reuses the byte-exact scalar encoders in [`json_scalar`] so it
+// is byte-identical to the `Metadata`→JSON `serialize` path. Builds its JSON
+// string directly (no `serde_json`), so it is gated on `alloc` rather than the
+// serde-pulling `json` feature: the always-compiled parser/format engine now
+// emits through it, so it must be available in every engine build.
+#[cfg(feature = "alloc")]
+pub mod json_writer;
+#[cfg(feature = "json")]
 pub mod jsondiff;
 pub mod parser;
+// Phase D — new lib-first `FormatParser` trait scaffold, lands alongside the
+// legacy `parser::FormatParser` (re-exported there as `OldFormatParser`). Per
+// the spec at `docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md`:
+// `parser_new` holds the new `FormatParser` / `MetaSinker` / `TagWriter` /
+// `SharedFlags` traits + `AnyParser` / `AnyMeta` enum dispatch skeletons; `sink`
+// holds the reference `TagWriter` implementor used by Phase D unit tests.
+// Format arms are added in Phase E (MOI) and Phase F (everything else).
+pub mod parser_new;
 pub mod processbinarydata;
 pub mod reader;
+#[cfg(feature = "json")]
 pub mod serialize;
+pub mod sink;
 pub mod tagtable;
 pub mod value;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -403,6 +403,12 @@ pub trait FormatParser: Sync {
   fn process(&self, ctx: &mut ParseContext<'_>) -> bool;
 }
 
+/// Phase D shim: the existing push-style [`FormatParser`] is being
+/// migrated to the new typed-Meta [`crate::parser_new::FormatParser`] in
+/// Phases E–F. During migration this alias documents the legacy trait
+/// without renaming, so existing impl sites continue to work verbatim.
+pub use FormatParser as OldFormatParser;
+
 /// Faithful `ConvertFileSize` (ExifTool.pm:6840-6860), default-units branch
 /// only. The `ByteUnit eq 'Binary'` arm (ExifTool.pm:6843-6850) is gated on
 /// the `ByteUnit` option, which the read path here does not expose (YAGNI;
@@ -901,7 +907,7 @@ mod tests {
     {
       let mut c = ctx_over(&mut m, "AAC", true);
       c.set_file_type(None, None, None); // MIMEType = audio/aac
-                                         // "XYZ" has no %mimeType key and we pass mime=None.
+      // "XYZ" has no %mimeType key and we pass mime=None.
       c.override_file_type("XYZ", None, None);
     }
     let ft = m.tags().iter().find(|t| t.name() == "FileType").unwrap();
@@ -1346,6 +1352,7 @@ mod tests {
     );
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn aac_fixture_matches_golden_print_on() {
     let root = env!("CARGO_MANIFEST_DIR");
@@ -1357,6 +1364,7 @@ mod tests {
       .unwrap_or_else(|e| panic!("AAC -j -G1 -struct conformance: {}", e.message()));
   }
 
+  #[cfg(feature = "json")]
   #[test]
   fn aac_fixture_matches_golden_n() {
     let root = env!("CARGO_MANIFEST_DIR");
@@ -1427,6 +1435,7 @@ mod tests {
 
   static ACCEPTING_BUT_ERRORING: AcceptingButErroring = AcceptingButErroring;
 
+  #[cfg(feature = "json")]
   #[test]
   fn accepted_parser_error_reaches_serialized_json() {
     // Register the injected parser for the REAL detected file type.
@@ -1501,6 +1510,7 @@ mod tests {
 
   static REJECTING_AFTER_SET_FILE_TYPE: RejectingAfterSetFileType = RejectingAfterSetFileType;
 
+  #[cfg(feature = "json")]
   #[test]
   fn rejecting_parser_set_file_type_side_effect_persists() {
     // Faithful Perl `$self` model: a rejecting `Process<Type>` that
@@ -1564,6 +1574,7 @@ mod tests {
   // gated exactly like the post-loop Error's `not defined $type`
   // (ExifTool.pm:3080) — NOT on `SetFileType`. This FAILS if anyone
   // adopts the reviewer's unfaithful `file_type_set` gate.
+  #[cfg(feature = "json")]
   #[test]
   fn finalization_error_keyed_on_parser_accept_not_set_file_type() {
     // (a) Parser returns true WITHOUT set_file_type ⇒ its tag emits, and
@@ -1662,6 +1673,7 @@ mod tests {
   }
   static WV_OVERWRITE_AND_ACCEPT: WvOverwriteAndAccept = WvOverwriteAndAccept;
 
+  #[cfg(feature = "json")]
   #[test]
   fn set_file_type_is_file_scoped_first_call_wins_across_candidates() {
     // `bad.aac` with head `\xff\xf1\xf0…` yields candidates beginning

--- a/src/parser_new.rs
+++ b/src/parser_new.rs
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! New lib-first `FormatParser` trait scaffold. Lands alongside the existing
+//! [`crate::parser::OldFormatParser`] (aliased from the legacy
+//! [`crate::parser::FormatParser`]); each format migrates from old to new in
+//! Phases E–F per the design spec at
+//! `docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md`.
+//!
+//! The four central pieces, per spec §6:
+//!
+//! - [`FormatParser`] — the central parser trait with associated `Meta`,
+//!   `Context<'a>`, and `Error` types. Sealed via [`parser_sealed::Sealed`]
+//!   so downstream crates cannot add format arms.
+//! - [`TagWriter`] — fallible sink receiving tag emissions. Mirrors
+//!   `mediaframe::PixelSink`. Implementors that cannot fail use
+//!   [`core::convert::Infallible`] as `Error`.
+//! - [`MetaSinker`] — implemented by `Meta` types; emits the format's tags
+//!   into a `TagWriter`.
+//! - [`SharedFlags`] — cross-format shared state (DoneID3 / DoneAPE / file-type
+//!   stack) threaded through chained parsers.
+//!
+//! The closed-set enums [`AnyParser`] and [`AnyMeta`] dispatch over the
+//! runtime-keyed parser registry. Each format adds an arm in Phase E (MOI)
+//! / Phase F (everything else). Both are `#[non_exhaustive]` so new format
+//! arms are additive.
+
+use core::fmt;
+use core::marker::PhantomData;
+
+mod parser_sealed {
+  /// Sealed marker for the new [`super::FormatParser`] trait. Downstream
+  /// crates cannot implement the trait because they cannot name this type.
+  pub trait Sealed {}
+}
+
+/// One ported format parser. Each format owns its `Meta` (typed output),
+/// `Context<'a>` (per-format input view — leaves take `&'a [u8]`, chained
+/// formats take a richer struct with shared mutable state), and `Error`.
+///
+/// `parse` returns:
+/// - `Ok(Some(meta))` — this is the format; here are the tags. (Perl `return 1`)
+/// - `Ok(None)`       — not this format, try the next detection candidate.
+///   (Perl `return 0`)
+/// - `Err(e)`         — Rust-level fatal (not Perl-modeled — Perl uses
+///   `$et->Warn`/`$et->Error` which are recorded as tags in `Meta` regardless
+///   of return).
+///
+/// IMPORTANT: side effects on the shared [`SharedFlags`] (held inside the
+/// per-format `Context`) PERSIST regardless of return value, faithful to
+/// ExifTool's `$self` model. Preserved from the old `FormatParser` trait
+/// (see `[[exifast-phase2-forward-items]]`).
+///
+/// The trait is **sealed** (cannot be implemented by downstream crates). The
+/// closed-set discipline is required by the [`AnyParser`] / [`AnyMeta`] enum
+/// dispatch model (associated types are not dyn-compatible, so dispatch
+/// happens via a match on a closed enum). New formats are added inside the
+/// crate by:
+///
+/// 1. Implementing [`parser_sealed::Sealed`] on the new parser type;
+/// 2. Implementing this `FormatParser` trait on it;
+/// 3. Adding a `#[cfg(feature = "<fmt>")]`-gated arm to [`AnyParser`],
+///    [`AnyMeta`], and [`AnyMeta`]'s [`MetaSinker`] impl.
+pub trait FormatParser: parser_sealed::Sealed {
+  /// The typed metadata structure this parser produces on a successful
+  /// parse, as a **generic associated type** parameterized by the input
+  /// borrow lifetime `'a`. Meta types borrow from the input bytes
+  /// (`Meta<'a> = XxxMeta<'a>`), holding `&'a str` / primitive integers /
+  /// `core::time::Duration` / `jiff::civil::DateTime` for no-alloc
+  /// compatibility.
+  ///
+  /// The GAT threads the input lifetime through [`Self::parse`] so the
+  /// returned Meta borrows directly from the `Context<'a>` it was parsed
+  /// from — no `'static` upgrade, no `Box::leak`. Library callers consuming
+  /// `parse_bytes` get a zero-allocation `AnyMeta<'a>` tied to their input
+  /// buffer (Codex AF2).
+  type Meta<'a>
+  where
+    Self: 'a;
+  /// Per-format input view. Leaf formats (MOI, AAC, DV, Audible) use
+  /// `&'a [u8]`; chained formats (ID3, APE, MP3, …) use a struct
+  /// wrapping `&'a [u8]` + `&'a mut SharedFlags`.
+  type Context<'a>
+  where
+    Self: 'a;
+  /// Rust-level fatal error (distinct from Perl `Warn`/`Error` tags, which
+  /// belong to `Meta` and propagate via [`TagWriter::write_warning`] /
+  /// [`TagWriter::write_error`]).
+  type Error;
+
+  /// Run the parser on a per-format `Context`. The returned `Meta<'a>`
+  /// borrows from the same `'a` as the input `Context`. See trait docs for
+  /// return value semantics.
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Self::Error>;
+}
+
+/// Receivers of tag emissions. Implemented by JSON writers, in-memory
+/// `BTreeMap` collectors, validation harnesses, etc.
+///
+/// Sinks that cannot fail use [`core::convert::Infallible`] as `Error` —
+/// the compiler eliminates the `Result` branching at every call site.
+/// Same pattern as `mediaframe::PixelSink::Error`.
+///
+/// Methods take primitive types directly rather than a `TagValue` enum:
+/// this lets implementors write specialized output paths (e.g., JSON
+/// numeric-vs-string emission for `u64` vs `&str`) without an intermediate
+/// boxed/enum allocation. The [`Self::write_fmt`] entry is the no-alloc
+/// workhorse: `PrintConv` strings format directly into the writer's sink,
+/// never materializing as a `String`.
+pub trait TagWriter {
+  /// Sink-level error type. Implementors that cannot fail set this to
+  /// [`core::convert::Infallible`].
+  type Error;
+
+  /// Emit a `&str` value (e.g., `File:FileType=MOI`).
+  fn write_str(&mut self, group: &str, name: &str, value: &str) -> Result<(), Self::Error>;
+  /// Emit a `u64` value (e.g., `File:FileSize=12345`).
+  fn write_u64(&mut self, group: &str, name: &str, value: u64) -> Result<(), Self::Error>;
+  /// Emit an `i64` value (e.g., a signed integer tag).
+  fn write_i64(&mut self, group: &str, name: &str, value: i64) -> Result<(), Self::Error>;
+  /// Emit an `f64` value (e.g., a rational converted to floating point).
+  fn write_f64(&mut self, group: &str, name: &str, value: f64) -> Result<(), Self::Error>;
+  /// Emit raw bytes (e.g., a cover-art payload).
+  fn write_bytes(&mut self, group: &str, name: &str, value: &[u8]) -> Result<(), Self::Error>;
+  /// Format directly into the writer's `core::fmt::Write` sink — no
+  /// intermediate `String` allocation. Used by `PrintConv` emissions
+  /// (e.g., `ConvertDuration` → `"0:05:00.300"`).
+  fn write_fmt(
+    &mut self,
+    group: &str,
+    name: &str,
+    f: impl FnOnce(&mut dyn fmt::Write) -> fmt::Result,
+  ) -> Result<(), Self::Error>;
+  /// Emit a `Warning` tag (Perl `$et->Warn`).
+  fn write_warning(&mut self, text: &str) -> Result<(), Self::Error>;
+  /// Emit an `Error` tag (Perl `$et->Error`).
+  fn write_error(&mut self, text: &str) -> Result<(), Self::Error>;
+  /// Emit a list of `&str` values for a single (group, name) key — the
+  /// list-coalesce primitive used by Vorbis ARTIST=Alice/Bob style tag
+  /// repeats and APE's `Track-tag/Tag2-trailing-list` walker.
+  ///
+  /// The default implementation calls [`Self::write_str`] for each
+  /// element in order. Writers that DO want list-aware semantics (e.g.
+  /// `MetadataTagWriter` → `Metadata::push_listable`) override this method
+  /// to coalesce into a single first-occurrence-position list value.
+  /// Stateless writers (`MapTagWriter`, future JSON-array sinks) keep the
+  /// default and either see last-write-wins (map storage) or emit each
+  /// element as a separate JSON value (array sinks).
+  ///
+  /// Added in Phase G to let OGG/FLAC bridges use the generic
+  /// [`MetaSinker`] path instead of calling `Metadata::push_listable`
+  /// directly (per F3-FLAC / F4-OGG integration notes).
+  fn write_str_list(
+    &mut self,
+    group: &str,
+    name: &str,
+    values: &[&str],
+  ) -> Result<(), Self::Error> {
+    for v in values {
+      self.write_str(group, name, v)?;
+    }
+    Ok(())
+  }
+}
+
+/// Implemented by `Meta` types: emits the format's tags into a [`TagWriter`].
+/// "One who sinks metadata into a destination."
+///
+/// Errors propagate from the writer (the Meta itself has no error states —
+/// fallibility belongs to the destination).
+pub trait MetaSinker {
+  /// Emit this Meta's tags into `out`. Emission order should mirror the
+  /// bundled-Perl iteration order of the format's tag table.
+  fn sink<W: TagWriter>(&self, out: &mut W) -> Result<(), W::Error>;
+}
+
+/// Cross-format shared state. Threaded through chained parsers
+/// (ID3 → APE, APE → ID3, DSF → ID3, etc.). Holds the flags that
+/// bundled ExifTool keeps in `$$et` for cross-recursion gating.
+///
+/// **Storage choice for `file_type_stack`:** per spec §11 open question 3,
+/// the file-type stack depth observed in bundled ExifTool is ≤ 2
+/// (ID3 → APE chain). This struct uses `[Option<&'static str>; 4]` —
+/// fixed inline storage, zero dependencies, no_std-clean. The size bound
+/// of 4 leaves headroom over the observed depth. If a future chain
+/// exceeds 4 it will panic in [`Self::push_file_type`]; we'll grow the
+/// constant if/when that ever happens.
+///
+/// D8 convention: no public fields; accessors only.
+#[derive(Debug, Default, Clone)]
+pub struct SharedFlags {
+  /// `$$et{DoneID3}` — `None` until `ProcessID3` runs (`unless ($$et{DoneID3})`
+  /// recursion guard, ID3.pm:1435); `Some(n)` once run, with `n` the ID3v1
+  /// trailer size in bytes (128 + 227 if Enhanced TAG, etc.; `0` when ID3v2
+  /// was found but no v1 trailer — ID3.pm:1436 sets `1` as a truthy "ran"
+  /// marker, which the APE shift's `> 1` guard treats identically to `0`).
+  /// Read by `APE.pm:169` (`$footPos -= $$et{DoneID3} if $$et{DoneID3} > 1`)
+  /// for the footer-position shift. Mirrors the legacy
+  /// [`crate::value::Metadata::done_id3`] `Option<usize>` shape so the bridge
+  /// and the typed chained dispatch agree on the not-run vs ran-no-trailer
+  /// distinction (Codex AF1/BF3).
+  done_id3: Option<usize>,
+  /// The post-ID3v2-header file position (bundled `$hdrEnd`) recorded when
+  /// the typed `ProcessID3` pass runs. The bundled audio-format loop seeks
+  /// to this offset (`$raf->Seek($hdrEnd, 0)`, ID3.pm:1590) before the
+  /// recursive `ProcessMP3`, so the DoneID3-skip path of `ProcessMP3` scans
+  /// MPEG from `$hdrEnd`, NOT from offset 0. Carry it here so a chained
+  /// typed caller that pre-ran ID3 over the FULL buffer still scans the
+  /// POST-ID3 region for an MPEG frame (Codex B-R3-1). `None` until a typed
+  /// ID3 pass has run.
+  id3_hdr_end: Option<usize>,
+  /// `$$et{DoneAPE}` — set by APE after running, read by `ID3.pm:1723`
+  /// to gate the wrapper APE-trailer fallback.
+  done_ape: bool,
+  /// `$$et{FILE_TYPE}` — file-type stack for the audio-format loop
+  /// (`ID3.pm:1582-1601`). Read by chained parsers to know who dispatched
+  /// them. Fixed-capacity `[Option<&'static str>; 4]` per the storage
+  /// note on this struct.
+  file_type_stack: [Option<&'static str>; 4],
+  /// Number of occupied slots in `file_type_stack` (the stack "len").
+  file_type_stack_len: usize,
+}
+
+impl SharedFlags {
+  /// Construct empty shared flags (alias of [`Default::default`]).
+  #[must_use]
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// `$$et{DoneID3}` — `None` until `ProcessID3` runs; `Some(n)` once run,
+  /// with `n` the ID3v1-trailer size in bytes (`Some(0)` ⇒ ran but no v1
+  /// trailer). The `unless ($$et{DoneID3})` recursion guard (ID3.pm:1435,
+  /// APE.pm:124) maps to `is_none()`; the APE.pm:169 footer shift maps to
+  /// `done_id3().is_some_and(|n| n > 1)`. Mirrors
+  /// [`crate::value::Metadata::done_id3`] (Codex AF1/BF3).
+  #[must_use]
+  pub fn done_id3(&self) -> Option<usize> {
+    self.done_id3
+  }
+
+  /// Set `$$et{DoneID3} = trailer_size`. Called by the ID3 parser after a
+  /// v1 trailer is consumed (pass `0` for the "ID3v2 found, no v1 trailer"
+  /// case — ID3.pm:1436 sets the truthy `1` marker; the APE `> 1` arithmetic
+  /// guard treats `0` and `1` identically, so we normalize to `0`).
+  pub fn set_done_id3(&mut self, trailer_size: usize) {
+    self.done_id3 = Some(trailer_size);
+  }
+
+  /// The post-ID3v2-header file position (bundled `$hdrEnd`) recorded by the
+  /// typed `ProcessID3` pass. `None` until a typed ID3 pass has run. The
+  /// DoneID3-skip path of the typed `ProcessMP3` reads this to scan MPEG
+  /// from `$hdrEnd` instead of offset 0, faithful to the audio-format loop's
+  /// `$raf->Seek($hdrEnd, 0)` (ID3.pm:1590) before recursive `ProcessMP3`
+  /// (Codex B-R3-1).
+  #[must_use]
+  pub fn id3_hdr_end(&self) -> Option<usize> {
+    self.id3_hdr_end
+  }
+
+  /// Record the post-ID3v2-header file position (bundled `$hdrEnd`). Called
+  /// by the typed ID3 pass after it determines the header end so a later
+  /// chained `ProcessMP3` skip path can scan MPEG from there (Codex B-R3-1).
+  pub fn set_id3_hdr_end(&mut self, hdr_end: usize) {
+    self.id3_hdr_end = Some(hdr_end);
+  }
+
+  /// `$$et{DoneAPE}` — APE-trailer-already-handled flag, gates the
+  /// wrapper fallback in `ID3.pm:1723-1726`.
+  #[must_use]
+  pub fn done_ape(&self) -> bool {
+    self.done_ape
+  }
+
+  /// Set `$$et{DoneAPE}`. Called by the APE parser after running.
+  pub fn set_done_ape(&mut self, value: bool) {
+    self.done_ape = value;
+  }
+
+  /// View the current file-type stack as a slice (in push order).
+  #[must_use]
+  pub fn file_type_stack(&self) -> &[Option<&'static str>] {
+    &self.file_type_stack[..self.file_type_stack_len]
+  }
+
+  /// Push a file-type tag onto the stack. Panics if the stack is full
+  /// (current cap = 4; see the struct doc).
+  pub fn push_file_type(&mut self, file_type: &'static str) {
+    assert!(
+      self.file_type_stack_len < self.file_type_stack.len(),
+      "SharedFlags::push_file_type: stack overflow (cap={}, observed depth in bundled ExifTool is ≤ 2)",
+      self.file_type_stack.len(),
+    );
+    self.file_type_stack[self.file_type_stack_len] = Some(file_type);
+    self.file_type_stack_len += 1;
+  }
+
+  /// Pop the most recent file-type tag, returning it if the stack was
+  /// non-empty.
+  pub fn pop_file_type(&mut self) -> Option<&'static str> {
+    if self.file_type_stack_len == 0 {
+      return None;
+    }
+    self.file_type_stack_len -= 1;
+    self.file_type_stack[self.file_type_stack_len].take()
+  }
+
+  /// Peek the most recent file-type tag without popping it.
+  #[must_use]
+  pub fn current_file_type(&self) -> Option<&'static str> {
+    if self.file_type_stack_len == 0 {
+      None
+    } else {
+      self.file_type_stack[self.file_type_stack_len - 1]
+    }
+  }
+}
+
+/// Closed-set enum dispatch over the runtime-keyed parser registry.
+/// Each format adds an arm in Phase E (MOI) / Phase F (all others).
+///
+/// `#[non_exhaustive]` ensures consumers cannot exhaustively match on
+/// the enum across crate-feature combinations — new format arms are
+/// additive within the crate, but no caller can rely on a fixed set.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum AnyParser {
+  // Phase E adds: Moi(crate::formats::moi::ProcessMoi),
+  // Phase F1 adds: Aac, Dv, Audible, Red.
+  // Phase F2 adds: Id3.
+  // Phase F3 adds: Ape, Dsf, Aiff, Flac.
+  // Phase F4 adds: Ogg, MpegAudio.
+  // Phase F5 adds: Mp3, Mpc, WavPack.
+}
+
+/// Closed-set enum of every format's `Meta` output. Mirrors [`AnyParser`].
+///
+/// The `_Phantom` variant exists so the enum compiles before any format
+/// has migrated to the new trait. It is removed in Phase G (last) once
+/// every format has a real arm.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum AnyMeta<'a> {
+  /// Placeholder so the enum compiles before any format arm exists.
+  /// Removed in Phase G after every format has migrated.
+  #[doc(hidden)]
+  _Phantom(PhantomData<&'a ()>),
+  // Phase E adds: Moi(crate::formats::moi::MoiMeta<'a>),
+}
+
+impl MetaSinker for AnyMeta<'_> {
+  fn sink<W: TagWriter>(&self, out: &mut W) -> Result<(), W::Error> {
+    match self {
+      AnyMeta::_Phantom(_) => {
+        // Phantom variant emits no tags; exists only as a type-system
+        // placeholder until Phase E adds the first real format arm.
+        let _ = out;
+        Ok(())
+      } // Phase E adds: AnyMeta::Moi(m) => m.sink(out),
+    }
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::sink::{MapTagWriter, MapValue};
+  use core::convert::Infallible;
+  use std::string::ToString;
+
+  /// Smoke test: `MapTagWriter` actually implements [`TagWriter`] and the
+  /// trait methods are callable without going through any other type.
+  #[test]
+  fn map_tag_writer_implements_tag_writer() {
+    let mut w = MapTagWriter::new();
+    w.write_str("Group", "Name", "value").unwrap();
+    w.write_u64("Group", "U64", 42).unwrap();
+    w.write_i64("Group", "I64", -7).unwrap();
+    w.write_f64("Group", "F64", 3.5).unwrap();
+    w.write_bytes("Group", "Bytes", &[1, 2, 3]).unwrap();
+    w.write_fmt("Group", "Fmt", |f| write!(f, "0:05:00.300"))
+      .unwrap();
+    w.write_warning("warn-text").unwrap();
+    w.write_error("err-text").unwrap();
+
+    // 6 keyed entries + 1 warning + 1 error = 8 total entries in the map.
+    assert_eq!(w.len(), 8);
+    assert_eq!(
+      w.get("Group", "Name").map(MapValue::as_str),
+      Some("value".to_string())
+    );
+    assert_eq!(
+      w.get("Group", "U64").map(MapValue::as_str),
+      Some("42".to_string())
+    );
+    assert_eq!(
+      w.get("Group", "I64").map(MapValue::as_str),
+      Some("-7".to_string())
+    );
+    assert_eq!(
+      w.get("Group", "F64").map(MapValue::as_str),
+      Some("3.5".to_string())
+    );
+    assert_eq!(
+      w.get("Group", "Fmt").map(MapValue::as_str),
+      Some("0:05:00.300".to_string())
+    );
+    assert!(w.warnings().iter().any(|s| s == "warn-text"));
+    assert!(w.errors().iter().any(|s| s == "err-text"));
+  }
+
+  /// A toy Meta + MetaSinker impl proves the dataflow Meta → TagWriter
+  /// compiles end-to-end (associated `Error` type plumbing, lifetime
+  /// bounds on the writer, etc.).
+  #[derive(Debug, Clone, Copy)]
+  struct DummyMeta<'a> {
+    name: &'a str,
+    size: u64,
+  }
+
+  impl MetaSinker for DummyMeta<'_> {
+    fn sink<W: TagWriter>(&self, out: &mut W) -> Result<(), W::Error> {
+      out.write_str("Dummy", "Name", self.name)?;
+      out.write_u64("Dummy", "Size", self.size)?;
+      Ok(())
+    }
+  }
+
+  #[test]
+  fn meta_sinker_emits_into_map_tag_writer() {
+    let meta = DummyMeta {
+      name: "moi-fake",
+      size: 1234,
+    };
+    let mut w = MapTagWriter::new();
+    meta.sink(&mut w).unwrap();
+    assert_eq!(
+      w.get("Dummy", "Name").map(MapValue::as_str),
+      Some("moi-fake".to_string())
+    );
+    assert_eq!(
+      w.get("Dummy", "Size").map(MapValue::as_str),
+      Some("1234".to_string())
+    );
+  }
+
+  /// Demonstrates that an `Infallible`-erroring sink compiles cleanly —
+  /// the Result path is collapsed at type-check time, so a
+  /// `?`-propagating sink chain never needs runtime branching on the
+  /// no-fail leg.
+  struct InfallibleSink;
+
+  impl TagWriter for InfallibleSink {
+    type Error = Infallible;
+    fn write_str(&mut self, _g: &str, _n: &str, _v: &str) -> Result<(), Infallible> {
+      Ok(())
+    }
+    fn write_u64(&mut self, _g: &str, _n: &str, _v: u64) -> Result<(), Infallible> {
+      Ok(())
+    }
+    fn write_i64(&mut self, _g: &str, _n: &str, _v: i64) -> Result<(), Infallible> {
+      Ok(())
+    }
+    fn write_f64(&mut self, _g: &str, _n: &str, _v: f64) -> Result<(), Infallible> {
+      Ok(())
+    }
+    fn write_bytes(&mut self, _g: &str, _n: &str, _v: &[u8]) -> Result<(), Infallible> {
+      Ok(())
+    }
+    fn write_fmt(
+      &mut self,
+      _g: &str,
+      _n: &str,
+      _f: impl FnOnce(&mut dyn fmt::Write) -> fmt::Result,
+    ) -> Result<(), Infallible> {
+      Ok(())
+    }
+    fn write_warning(&mut self, _t: &str) -> Result<(), Infallible> {
+      Ok(())
+    }
+    fn write_error(&mut self, _t: &str) -> Result<(), Infallible> {
+      Ok(())
+    }
+  }
+
+  #[test]
+  fn infallible_sink_compiles_cleanly() {
+    let meta = DummyMeta { name: "x", size: 0 };
+    let mut sink = InfallibleSink;
+    // The `unwrap()` on an `Infallible` result is what the doc claims is
+    // collapsed at type-check; here we just ensure the dataflow compiles.
+    let result: Result<(), Infallible> = meta.sink(&mut sink);
+    let () = result.unwrap();
+  }
+
+  #[test]
+  fn shared_flags_round_trip() {
+    let mut sf = SharedFlags::new();
+    assert_eq!(sf.done_id3(), None);
+    assert!(!sf.done_ape());
+    assert!(sf.file_type_stack().is_empty());
+    assert_eq!(sf.current_file_type(), None);
+
+    sf.set_done_id3(128);
+    sf.set_done_ape(true);
+    sf.push_file_type("MP3");
+    sf.push_file_type("ID3");
+    assert_eq!(sf.done_id3(), Some(128));
+    assert!(sf.done_ape());
+    assert_eq!(sf.current_file_type(), Some("ID3"));
+    assert_eq!(sf.file_type_stack(), &[Some("MP3"), Some("ID3")]);
+
+    assert_eq!(sf.pop_file_type(), Some("ID3"));
+    assert_eq!(sf.pop_file_type(), Some("MP3"));
+    assert_eq!(sf.pop_file_type(), None);
+    assert!(sf.file_type_stack().is_empty());
+  }
+
+  /// The `_Phantom` arm of [`AnyMeta`] sinks nothing. Verifies the
+  /// MetaSinker impl is reachable for the type-level placeholder.
+  #[test]
+  fn any_meta_phantom_sinks_nothing() {
+    let any: AnyMeta<'_> = AnyMeta::_Phantom(PhantomData);
+    let mut w = MapTagWriter::new();
+    any.sink(&mut w).unwrap();
+    assert_eq!(w.len(), 0);
+  }
+}
+
+/// The [`parser_sealed::Sealed`] super-trait is private, so downstream
+/// crates cannot implement [`FormatParser`] for foreign types. This
+/// `compile_fail` doc-test demonstrates: trying to implement
+/// [`FormatParser`] without sealing the type produces an E0405
+/// (trait not satisfied) compilation error.
+///
+/// ```compile_fail
+/// use exifast::parser_new::FormatParser;
+///
+/// struct ForeignParser;
+///
+/// impl FormatParser for ForeignParser {
+///   type Meta = ();
+///   type Context<'a> = &'a [u8];
+///   type Error = ();
+///   fn parse<'a>(&self, _ctx: &'a [u8]) -> Result<Option<()>, ()> {
+///     Ok(None)
+///   }
+/// }
+/// ```
+#[cfg(doctest)]
+#[allow(dead_code)]
+struct SealedTraitDocTestAnchor;

--- a/src/processbinarydata.rs
+++ b/src/processbinarydata.rs
@@ -352,14 +352,14 @@ pub fn process_binary_data(
         } else {
           let bytes = &data[base..base + avail];
           let stripped = strip_at_first_null(bytes); // :10027
-                                                     // Emit raw bytes (faithful to Perl `$val = substr(...)`, which is
-                                                     // a BYTE STRING — no UTF-8 reinterpretation, no `from_utf8_lossy`).
-                                                     // The convert layer is responsible for any MacRoman/UTF-16
-                                                     // ValueConv; hash PrintConv lookups key the bytes via
-                                                     // [`crate::convert::exiftool_val_string`] (FixUTF8 — valid UTF-8
-                                                     // preserved, invalid high bytes replaced with `?`, matching Perl
-                                                     // EscapeJSON's behavior). Codex R3 verified the divergence on
-                                                     // CompressionType `\x80ABC` (Perl: "?ABC"; pre-fix: "U+0080ABC").
+          // Emit raw bytes (faithful to Perl `$val = substr(...)`, which is
+          // a BYTE STRING — no UTF-8 reinterpretation, no `from_utf8_lossy`).
+          // The convert layer is responsible for any MacRoman/UTF-16
+          // ValueConv; hash PrintConv lookups key the bytes via
+          // [`crate::convert::exiftool_val_string`] (FixUTF8 — valid UTF-8
+          // preserved, invalid high bytes replaced with `?`, matching Perl
+          // EscapeJSON's behavior). Codex R3 verified the divergence on
+          // CompressionType `\x80ABC` (Perl: "?ABC"; pre-fix: "U+0080ABC").
           Some(TagValue::Bytes(stripped.to_vec()))
         }
       }
@@ -384,9 +384,9 @@ pub fn process_binary_data(
           } else {
             let bytes = &data[body_start..body_start + count];
             let stripped = strip_at_first_null(bytes); // :10027
-                                                       // Emit raw bytes — see the StringFixed branch above. ValueConv
-                                                       // (e.g. AIFC `CompressorName`'s MacRoman decode) reads the raw
-                                                       // bytes; Codex R1 fix.
+            // Emit raw bytes — see the StringFixed branch above. ValueConv
+            // (e.g. AIFC `CompressorName`'s MacRoman decode) reads the raw
+            // bytes; Codex R1 fix.
             Some(TagValue::Bytes(stripped.to_vec()))
           }
         }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -8,7 +8,7 @@
 //! `serde_json` round-trip) keeps it byte-exact with ExifTool and infallible —
 //! there is no error path, so `Bytes`/`Rational` can never fail the document.
 
-use crate::value::{format_g, perl_nonfinite_str, Metadata, Rational, TagValue};
+use crate::value::{Metadata, Rational, TagValue, format_g, perl_nonfinite_str};
 use std::collections::HashSet;
 
 /// ExifTool's `%jsonChar` short escapes (`exiftool` line 250):

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Tag-writer implementors. Each downstream consumer (JSON, in-memory
+//! collector, validation harness) brings its own [`crate::parser_new::TagWriter`]
+//! impl.
+//!
+//! Phase D ships exactly one reference implementor — [`MapTagWriter`] — to
+//! exercise the trait shape and prove the dataflow Meta → TagWriter compiles
+//! end-to-end. The JSON [`TagWriter`] implementor lands in Phase G alongside
+//! the public API.
+
+use crate::parser_new::TagWriter;
+use core::convert::Infallible;
+use core::fmt;
+use core::fmt::Write as _;
+
+use std::collections::BTreeMap;
+use std::string::{String, ToString};
+use std::vec::Vec;
+
+/// Owned `(Group, Name)` key — used by [`MapTagWriter`] to index emitted
+/// tags. Kept as `(String, String)` rather than `(&'static str, &'static
+/// str)` so the writer is usable with dynamically-derived group/name pairs
+/// (e.g., from a user-supplied tag table).
+type MapKey = (String, String);
+
+/// Owned tag value as emitted by a [`TagWriter`]. Mirrors the input
+/// methods of the trait — the writer eagerly serializes each call into the
+/// stored variant.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MapValue {
+  /// A `write_str` / `write_fmt` value (both produce textual output).
+  Str(String),
+  /// A `write_u64` value.
+  U64(u64),
+  /// A `write_i64` value.
+  I64(i64),
+  /// A `write_f64` value.
+  F64(f64),
+  /// A `write_bytes` value.
+  Bytes(Vec<u8>),
+}
+
+impl MapValue {
+  /// Returns the textual representation of the value — `Str` and
+  /// `write_fmt` outputs return their string verbatim; numeric variants
+  /// produce a `Display`-style rendering. Used by tests; library callers
+  /// typically match on the variant directly.
+  #[must_use]
+  pub fn as_str(&self) -> String {
+    match self {
+      MapValue::Str(s) => s.clone(),
+      MapValue::U64(n) => n.to_string(),
+      MapValue::I64(n) => n.to_string(),
+      MapValue::F64(n) => {
+        let mut s = String::new();
+        // `{}` on `f64` matches `Display` — `3.5_f64.to_string()` →
+        // `"3.5"`. Adequate for the test path; canonical JSON formatting
+        // lives in the future JSON sink.
+        let _ = write!(&mut s, "{n}");
+        s
+      }
+      MapValue::Bytes(b) => {
+        let mut s = String::with_capacity(b.len() * 2);
+        for byte in b {
+          let _ = write!(&mut s, "{byte:02x}");
+        }
+        s
+      }
+    }
+  }
+}
+
+/// In-memory tag collector — primarily for tests and library callers that
+/// want a generic key/value view without the JSON pipeline.
+///
+/// D8 convention: no public fields; accessors only. The internal storage
+/// is a `BTreeMap` so the test assertions can do exact `get(group, name)`
+/// lookups without depending on insertion order. (Library callers who
+/// need insertion order should use a different sink — see [`tracked`
+/// FU-7](../docs/tracking.md).)
+#[derive(Debug, Default, Clone)]
+pub struct MapTagWriter {
+  /// `(Group, Name) -> Value` map. `BTreeMap` for deterministic iteration
+  /// in tests.
+  tags: BTreeMap<MapKey, MapValue>,
+  /// `write_warning` accumulator. Preserves call order.
+  warnings: Vec<String>,
+  /// `write_error` accumulator. Preserves call order.
+  errors: Vec<String>,
+}
+
+impl MapTagWriter {
+  /// Construct an empty writer.
+  #[must_use]
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Number of distinct `(group, name)` tags plus warnings plus errors
+  /// emitted so far.
+  #[must_use]
+  pub fn len(&self) -> usize {
+    self.tags.len() + self.warnings.len() + self.errors.len()
+  }
+
+  /// True if no tags / warnings / errors have been emitted.
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.tags.is_empty() && self.warnings.is_empty() && self.errors.is_empty()
+  }
+
+  /// Look up an emitted tag by `(group, name)`. Returns `None` if the
+  /// pair was never written.
+  #[must_use]
+  pub fn get(&self, group: &str, name: &str) -> Option<&MapValue> {
+    self.tags.get(&(group.to_string(), name.to_string()))
+  }
+
+  /// Iterate all emitted `(group, name) -> value` triples in
+  /// `BTreeMap` order (lexicographic on `(group, name)`).
+  pub fn iter(&self) -> impl Iterator<Item = (&str, &str, &MapValue)> {
+    self
+      .tags
+      .iter()
+      .map(|((g, n), v)| (g.as_str(), n.as_str(), v))
+  }
+
+  /// All warnings emitted via [`TagWriter::write_warning`], in call order.
+  #[must_use]
+  pub fn warnings(&self) -> &[String] {
+    &self.warnings
+  }
+
+  /// All errors emitted via [`TagWriter::write_error`], in call order.
+  #[must_use]
+  pub fn errors(&self) -> &[String] {
+    &self.errors
+  }
+}
+
+impl TagWriter for MapTagWriter {
+  /// `MapTagWriter` cannot fail — every insertion is an in-memory
+  /// `BTreeMap` write or a `Vec::push`. Using [`Infallible`] lets the
+  /// caller's `?` operator compile-eliminate the error branch entirely.
+  type Error = Infallible;
+
+  fn write_str(&mut self, group: &str, name: &str, value: &str) -> Result<(), Infallible> {
+    self.tags.insert(
+      (group.to_string(), name.to_string()),
+      MapValue::Str(value.to_string()),
+    );
+    Ok(())
+  }
+
+  fn write_u64(&mut self, group: &str, name: &str, value: u64) -> Result<(), Infallible> {
+    self
+      .tags
+      .insert((group.to_string(), name.to_string()), MapValue::U64(value));
+    Ok(())
+  }
+
+  fn write_i64(&mut self, group: &str, name: &str, value: i64) -> Result<(), Infallible> {
+    self
+      .tags
+      .insert((group.to_string(), name.to_string()), MapValue::I64(value));
+    Ok(())
+  }
+
+  fn write_f64(&mut self, group: &str, name: &str, value: f64) -> Result<(), Infallible> {
+    self
+      .tags
+      .insert((group.to_string(), name.to_string()), MapValue::F64(value));
+    Ok(())
+  }
+
+  fn write_bytes(&mut self, group: &str, name: &str, value: &[u8]) -> Result<(), Infallible> {
+    self.tags.insert(
+      (group.to_string(), name.to_string()),
+      MapValue::Bytes(value.to_vec()),
+    );
+    Ok(())
+  }
+
+  fn write_fmt(
+    &mut self,
+    group: &str,
+    name: &str,
+    f: impl FnOnce(&mut dyn fmt::Write) -> fmt::Result,
+  ) -> Result<(), Infallible> {
+    // `write_fmt` is documented as the no-alloc workhorse — the
+    // `MapTagWriter` accumulator does allocate (it has to, to store the
+    // result), but consumers receiving the produced `&mut dyn fmt::Write`
+    // see only the streaming-format interface. The single allocation
+    // happens here, in the implementor — not at the Meta call site.
+    let mut s = String::new();
+    f(&mut s).expect("MapTagWriter::write_fmt: in-memory String write cannot fail");
+    self
+      .tags
+      .insert((group.to_string(), name.to_string()), MapValue::Str(s));
+    Ok(())
+  }
+
+  fn write_warning(&mut self, text: &str) -> Result<(), Infallible> {
+    self.warnings.push(text.to_string());
+    Ok(())
+  }
+
+  fn write_error(&mut self, text: &str) -> Result<(), Infallible> {
+    self.errors.push(text.to_string());
+    Ok(())
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn new_is_empty() {
+    let w = MapTagWriter::new();
+    assert!(w.is_empty());
+    assert_eq!(w.len(), 0);
+    assert!(w.warnings().is_empty());
+    assert!(w.errors().is_empty());
+  }
+
+  #[test]
+  fn last_write_wins_per_key() {
+    // BTreeMap insert replaces — verifies the documented behavior of
+    // duplicate (group, name) keys (last-write-wins; useful for tests
+    // building up Meta in stages).
+    let mut w = MapTagWriter::new();
+    w.write_str("G", "N", "first").unwrap();
+    w.write_str("G", "N", "second").unwrap();
+    assert_eq!(
+      w.get("G", "N").map(MapValue::as_str),
+      Some("second".to_string())
+    );
+    assert_eq!(w.len(), 1);
+  }
+
+  #[test]
+  fn numeric_variants_round_trip() {
+    let mut w = MapTagWriter::new();
+    w.write_u64("G", "U", 100).unwrap();
+    w.write_i64("G", "I", -100).unwrap();
+    w.write_f64("G", "F", 1.5).unwrap();
+    assert_eq!(w.get("G", "U"), Some(&MapValue::U64(100)));
+    assert_eq!(w.get("G", "I"), Some(&MapValue::I64(-100)));
+    assert_eq!(w.get("G", "F"), Some(&MapValue::F64(1.5)));
+  }
+
+  #[test]
+  fn bytes_variant_round_trips_and_renders_hex() {
+    let mut w = MapTagWriter::new();
+    w.write_bytes("G", "B", &[0xde, 0xad, 0xbe, 0xef]).unwrap();
+    assert_eq!(
+      w.get("G", "B"),
+      Some(&MapValue::Bytes(vec![0xde, 0xad, 0xbe, 0xef]))
+    );
+    assert_eq!(
+      w.get("G", "B").map(MapValue::as_str),
+      Some("deadbeef".to_string())
+    );
+  }
+
+  #[test]
+  fn write_fmt_streams_into_string() {
+    let mut w = MapTagWriter::new();
+    w.write_fmt("G", "Fmt", |f| write!(f, "{:04}:{:02}:{:02}", 2026, 5, 21))
+      .unwrap();
+    assert_eq!(
+      w.get("G", "Fmt").map(MapValue::as_str),
+      Some("2026:05:21".to_string())
+    );
+  }
+
+  #[test]
+  fn warnings_and_errors_preserve_order() {
+    let mut w = MapTagWriter::new();
+    w.write_warning("w1").unwrap();
+    w.write_warning("w2").unwrap();
+    w.write_error("e1").unwrap();
+    assert_eq!(w.warnings(), &["w1".to_string(), "w2".to_string()]);
+    assert_eq!(w.errors(), &["e1".to_string()]);
+  }
+
+  #[test]
+  fn iter_visits_all_tags() {
+    let mut w = MapTagWriter::new();
+    w.write_str("A", "Name1", "v1").unwrap();
+    w.write_str("B", "Name2", "v2").unwrap();
+    let collected: Vec<_> = w.iter().collect();
+    assert_eq!(collected.len(), 2);
+    // BTreeMap orders by key: ("A","Name1") < ("B","Name2").
+    assert_eq!(collected[0].0, "A");
+    assert_eq!(collected[1].0, "B");
+  }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -727,7 +727,7 @@ mod tests {
     assert_eq!(m.tags().len(), before); // no new tag appended
     let ft = m.tags().iter().find(|t| t.name() == "FileType").unwrap();
     assert_eq!(ft.value(), &TagValue::Str("AAC".into())); // value changed
-                                                          // exactly one FileType tag — the value was overwritten, not duplicated.
+    // exactly one FileType tag — the value was overwritten, not duplicated.
     assert_eq!(
       m.tags().iter().filter(|t| t.name() == "FileType").count(),
       1

--- a/tests/engine_smoke.rs
+++ b/tests/engine_smoke.rs
@@ -2,11 +2,11 @@
 //! through the conversion runtime, serialize, and confirm our own jsondiff
 //! treats the output as equivalent to itself. No format parser involved.
 use exifast::{
+  Group, Metadata, TagValue,
   convert::apply,
   jsondiff::json_equivalent,
   serialize::to_exiftool_json,
   tagtable::{PrintConv, TagDef, ValueConv},
-  Group, Metadata, TagValue,
 };
 
 static FILETYPE: TagDef = TagDef::new("FileType", "System", ValueConv::None, PrintConv::None);

--- a/tests/flac_streaminfo.rs
+++ b/tests/flac_streaminfo.rs
@@ -21,7 +21,7 @@
 //!   FLAC.pm:239-280 (ProcessFLAC — magic + metadata-block-header structure)
 
 use exifast::{
-  bitstream::{process_bit_stream, BitOrder},
+  bitstream::{BitOrder, process_bit_stream},
   tagtable::{PrintConv, TagDef, TagId, TagTable, ValueConv},
   value::{Metadata, TagValue},
 };


### PR DESCRIPTION
**Group A of 3** in the consolidated lib-first redesign. Builds on `main`.

Consolidates Phase C + Phase D (both semantic no-ops — existing tests pass byte-identical).

### Phase C — Cargo features + lib.rs no_std scaffold
- Feature graph mirroring mediaframe: `default=[std,json,all-formats]`, `std` implies `alloc`, per-format gates with cross-format chain deps (`mp3=[id3,mpeg-audio]`, `wavpack=[id3,ape]`, …)
- `lib.rs` no_std preamble + `extern crate alloc as std`
- edition 2024, rust-version 1.95.0, `jiff`/`thiserror` deps (default-features=false)
- CI matrix (std / alloc / wasm32-unknown-unknown / wasm32-wasip1; non-default tiers `continue-on-error` pending migration)

### Phase D — trait scaffold
- `parser_new::FormatParser` (type Meta / Context<'a> / Error)
- `parser_new::MetaSinker` (emitter) + `TagWriter` (fallible sink; `Infallible` compiles out Result)
- `parser_new::SharedFlags` (cross-format DoneID3/DoneAPE)
- `AnyParser`/`AnyMeta` skeletons; `MapTagWriter` reference impl
- Existing `FormatParser` aliased `OldFormatParser`; sealed-trait pattern

**663 tests pass. 4 gates green.** Design spec: `docs/superpowers/specs/2026-05-21-lib-first-formatparser-design.md` (local-only).

Supersedes the granular stack #18 + #19.