### PR TITLE
feat(quicktime): freeGPS GPS-format cluster — dashcam variants, Parrot mett, LigoGPS (faithful 1:1)

### DIFF
--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -366,6 +366,12 @@ pub enum AnyParser {
 /// [`AnyMeta::_Phantom`] variant — present ONLY in a no-format build —
 /// anchors `'a`. Under the `all-formats` default the phantom is `cfg`'d
 /// OUT (Codex CF3).
+// `AnyMeta::QuickTime` carries the QuickTime [`crate::formats::quicktime::Meta`]
+// which accumulates sub-Metas across the SP3 timed-metadata chain (camm,
+// sony_rtmd, canon_ctmd, insta360, gopro, parrot, …) and has grown past
+// 1024 bytes. The architectural fix — boxing the variants — is tracked
+// at issue #106; allow locally so the size-diff doesn't bite each new port.
+#[allow(clippy::large_enum_variant)]
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum AnyMeta<'a> {

--- a/src/formats/insta360.rs
+++ b/src/formats/insta360.rs
@@ -270,12 +270,20 @@ impl TrailerKind {
     }
   }
 
-  /// `true` iff this is the Insta360 trailer (the only kind exifast extracts —
-  /// the [`identify_trailers`] consumer dispatches on this; LigoGPS/MIE are only
-  /// stepped past, so they get no dedicated predicate, matched via `==` instead).
+  /// `true` iff this is the Insta360 trailer. The [`identify_trailers`] consumer
+  /// dispatches on this to drive `ProcessInsta360`.
   #[inline(always)]
   pub(crate) const fn is_insta360(&self) -> bool {
     matches!(self, Self::Insta360)
+  }
+
+  /// `true` iff this is the LigoGPS trailer. The [`identify_trailers`] consumer
+  /// dispatches on this to drive
+  /// [`crate::formats::ligogps::process_trailer`] (QuickTime.pm:10658-10668).
+  /// MIE is still only stepped past (no dedicated predicate, matched via `==`).
+  #[inline(always)]
+  pub(crate) const fn is_ligogps(&self) -> bool {
+    matches!(self, Self::LigoGPS)
   }
 }
 
@@ -1171,19 +1179,38 @@ impl Insta360FullDecode {
 /// (last record first); a void/skipped GPS row does NOT bump it, and the
 /// `0x101` identity INHERITS the current (sticky) value
 /// (QuickTimeStream.pl:3427-3436 has no `FoundSomething`).
+///
+/// `doc_base` is the SHARED `$$et{DOC_COUNT}` value at the moment
+/// `ProcessInsta360` runs in `ProcessMOV`'s trailer loop (after every moov-timed
+/// + `udta`-LigoGPS + earlier-chain trailer source), so each surfaced row gets
+/// `Doc<doc_base + N>` — continuing the ONE global sequence (`$$et{DOC_NUM} =
+/// ++$$et{DOC_COUNT}`). For an Insta360-only file `doc_base == 0` and the first
+/// surfaced row is `Doc1` (byte-identical to the pre-unification local counter).
+/// The STICKY current doc (`$$et{DOC_NUM}`, which the `0x101` identity + the
+/// warnings inherit) starts UNDEF (rendered Main / `0`) at trailer start — it is
+/// NOT seeded from `doc_base`: a warning/identity BEFORE any timed row stays Main
+/// even when `doc_base > 0` (ExifTool `delete`s `$$et{DOC_NUM}` between subs, so
+/// it is undef until the first row's `FoundSomething`).
 #[must_use]
-pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
+pub fn decode_all_records(raw: &[u8], trail_end: usize, doc_base: u32) -> Insta360FullDecode {
   let mut out = Insta360FullDecode::default();
-  // The GLOBAL `DOC_NUM`: `++` once per surfaced timed row; starts at 0, so
-  // the first surfaced row becomes `Doc1`.
-  let mut doc_count: u32 = 0;
+  // The SHARED global running count (`$$et{DOC_COUNT}`): `++` once per surfaced
+  // timed row; starts at `doc_base`, so the first surfaced row becomes
+  // `Doc<doc_base + 1>`.
+  let mut doc_count: u32 = doc_base;
+  // The STICKY current doc (`$$et{DOC_NUM}`) the identity + warnings inherit;
+  // UNDEF (Main → `0`) until the first surfaced row, then the last row's global
+  // doc. Tracked SEPARATELY from `doc_count` so a warning/identity before any row
+  // stays Main even when `doc_base > 0` (ExifTool starts each sub with `$$et
+  // {DOC_NUM}` deleted).
+  let mut sticky_doc: u32 = 0;
 
   let mut visit = |rec: RecordView<'_>| -> core::ops::ControlFlow<()> {
     if rec.accel_capped {
       // QuickTimeStream.pl:3347-3352 — the once-only `%insvLimit` warning,
       // raised before this record's row loop, so it rides the sticky DOC_NUM.
       out.warnings.push((
-        doc_count,
+        sticky_doc,
         SmolStr::new(
           "Insta360 accelerometer data is huge. Processing only the first 20000 records",
         ),
@@ -1196,7 +1223,7 @@ pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
     // `Insta360` `Warning`, priority-0 first-wins) under the sticky DOC_NUM.
     if rec.non_multiple {
       out.warnings.push((
-        doc_count,
+        sticky_doc,
         SmolStr::from(alloc::format!(
           "Unexpected Insta360 record 0x{:x} length",
           rec.id
@@ -1211,7 +1238,7 @@ pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
           // Sticky DOC_NUM: the identity rides whatever the last surfaced
           // timed row left the counter at (0 ⇒ flat/Main). Bundled emits at
           // most one 0x101 per trailer — keep the FIRST.
-          id_dec.set_doc(Some(doc_count));
+          id_dec.set_doc(Some(sticky_doc));
           if out.identity.is_none() {
             out.identity = Some(id_dec);
           }
@@ -1233,6 +1260,7 @@ pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
           while let Some(slot) = rec.body.get(p..p + dlen) {
             if let Some(mut s) = decode_accel_row(slot, dlen) {
               doc_count += 1;
+              sticky_doc = doc_count;
               s.set_doc(Some(doc_count));
               out.accel.push(s);
             }
@@ -1248,6 +1276,7 @@ pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
         while let Some(slot) = rec.body.get(p..p + dlen) {
           if let Some(mut s) = decode_exposure_row(slot) {
             doc_count += 1;
+            sticky_doc = doc_count;
             s.set_doc(Some(doc_count));
             out.exposure.push(s);
           }
@@ -1261,6 +1290,7 @@ pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
         while let Some(slot) = rec.body.get(p..p + dlen) {
           if let Some(mut s) = decode_videotime_row(slot) {
             doc_count += 1;
+            sticky_doc = doc_count;
             s.set_doc(Some(doc_count));
             out.videotime.push(s);
           }
@@ -1280,6 +1310,7 @@ pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
               // `FoundSomething` (the `++$$et{DOC_NUM}`) runs only then; a void
               // ('V') row is `next`-skipped and does NOT advance the counter.
               doc_count += 1;
+              sticky_doc = doc_count;
               s.set_doc(Some(doc_count));
               out.gps.push(s);
             }
@@ -1287,7 +1318,7 @@ pub fn decode_all_records(raw: &[u8], trail_end: usize) -> Insta360FullDecode {
             Err(w) => {
               // QuickTimeStream.pl:3408 — raised BEFORE this row's DOC_NUM bump,
               // so it rides the sticky doc (the last surfaced row's, or 0).
-              out.warnings.push((doc_count, SmolStr::new(w)));
+              out.warnings.push((sticky_doc, SmolStr::new(w)));
               // QuickTimeStream.pl:3409 `last;` — stop walking this record's
               // remaining rows on a format-warning. The outer record-loop
               // continues with the next record.
@@ -1441,6 +1472,32 @@ where
   };
 
   let _ = walk_records(raw, trail_end, &mut visit);
+}
+
+/// Count the SURFACED timed rows of an Insta360 trailer — exactly the number of
+/// `$$et{DOC_NUM} = ++$$et{DOC_COUNT}` bumps `ProcessInsta360` performs
+/// (QuickTimeStream.pl:3374/3388/3394/3412): one per emitted `0x300`/`0x400`/
+/// `0x600`/`0x700`-'A' row. The `0x101` identity + every decode-warning are NOT
+/// counted (they ride the sticky doc, no `FoundSomething`).
+///
+/// Run at PARSE time, in `ProcessMOV`'s trailer phase, to advance the SHARED
+/// global counter past the Insta360 doc range so any LATER chain trailer
+/// (LigoGPS/MIE) takes the next ordinals. Reuses [`stream_records`] — the same
+/// surfacing walk as [`decode_all_records`] — so the count is byte-identical to
+/// the rows the `-ee` decode later emits, but allocation-free (it stores no
+/// row): a crafted huge `0x600`/`0x300` trailer cannot force O(rows) memory here.
+/// Saturating, so a hostile row count cannot wrap.
+#[must_use]
+pub fn count_surfaced_rows(raw: &[u8], trail_end: usize) -> u32 {
+  let mut count: u32 = 0;
+  stream_records(raw, trail_end, &mut |item| match item {
+    Insta360StreamItem::Gps(_)
+    | Insta360StreamItem::Exposure(_)
+    | Insta360StreamItem::VideoTime(_)
+    | Insta360StreamItem::Accel(_) => count = count.saturating_add(1),
+    Insta360StreamItem::Identity(_) | Insta360StreamItem::Warning(_) => {}
+  });
+  count
 }
 
 // ===========================================================================
@@ -1914,7 +1971,7 @@ mod tests {
     let file = build_file(b"PREFIX-BYTES", &[(ID_ACCELEROMETER, body)]);
     // The 0x300 cap lives in the shared walk and is exercised by the FULL
     // (`-ee`) decode — the light scan_trailer skips 0x300 entirely.
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert_eq!(
       full.accel().len(),
       20000,
@@ -1947,7 +2004,7 @@ mod tests {
       body.extend_from_slice(&accel56_row(i, [0.1, 0.2, 9.8], [0.01, -0.02, 0.03]));
     }
     let file = build_file(b"PFX", &[(ID_ACCELEROMETER, body)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert_eq!(
       full.accel().len(),
       20000,
@@ -1971,7 +2028,7 @@ mod tests {
     assert!(out.first_gps().is_none());
     assert!(out.first_exposure().is_none());
     // The full (`-ee`) decode over the same borrowed table is also clean.
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert!(full.identity().is_none());
     assert!(full.gps().is_empty());
     assert!(full.accel().is_empty());
@@ -2012,7 +2069,7 @@ mod tests {
         (ID_DIRECTORY_TABLE, dir_entry),
       ],
     );
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert_eq!(
       full.videotime().len(),
       1,
@@ -2183,7 +2240,7 @@ mod tests {
     assert_eq!(first.timestamp_ms(), Some(1000));
     assert!((first.exposure_time_s().unwrap() - 0.008).abs() < 1e-12);
     // The FULL (`-ee`) decode materializes every row.
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     let samples = full.exposure();
     assert_eq!(samples.len(), 2);
     assert_eq!(samples[0].timestamp_ms(), Some(1000));
@@ -2214,7 +2271,7 @@ mod tests {
     assert!(out.first_gps().is_none());
     assert!(out.first_exposure().is_none());
     // The deferred `-ee` decode over the same bytes yields NOTHING.
-    let full = decode_all_records(&buf, buf.len());
+    let full = decode_all_records(&buf, buf.len(), 0);
     assert!(full.gps().is_empty());
     assert!(full.exposure().is_empty());
     assert!(full.videotime().is_empty());
@@ -2271,7 +2328,7 @@ mod tests {
         (ID_GPS, gps),
       ],
     );
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
 
     // GPS walked first: row1 -> Doc1, row2 -> Doc2 (void -> no doc).
     assert_eq!(full.gps().len(), 2);
@@ -2296,6 +2353,58 @@ mod tests {
   }
 
   #[test]
+  fn decode_all_records_continues_shared_counter_from_doc_base() {
+    // The Insta360 trailer draws its `Doc<N>` from the SHARED global counter, NOT
+    // a local 0-based one. With `doc_base = 5` (5 docs already consumed by
+    // moov-timed + earlier sources) the FIRST surfaced row is `Doc6`
+    // (`++$$et{DOC_COUNT}`), continuing the ONE global sequence.
+    let gps = {
+      let mut g = Vec::new();
+      g.extend_from_slice(&gps_row(
+        1717250400, 0, b'A', 45.0, b'N', 8.0, b'E', 10.0, 90.0, 200.0,
+      ));
+      g.extend_from_slice(&gps_row(
+        1717250401, 0, b'A', 46.0, b'N', 9.0, b'E', 11.0, 91.0, 201.0,
+      ));
+      g
+    };
+    let exposure = {
+      let mut e = exposure_row(1000, 0.008);
+      e.extend_from_slice(&exposure_row(1001, 0.009));
+      e
+    };
+    // Identity is LAST in the file ⇒ walked FIRST (last-record-first) ⇒ before any
+    // timed row ⇒ inherits the sticky doc, which is STILL Main (0), NOT `doc_base`.
+    let identity = identity_body(&[(TAG_MODEL, b"Insta360 X3")]);
+    let file = build_file(
+      b"prefix-bytes",
+      &[
+        (ID_GPS, gps),
+        (ID_EXPOSURE, exposure),
+        (ID_IDENTITY, identity),
+      ],
+    );
+
+    let full = decode_all_records(&file, file.len(), 5);
+    // The walk is LAST-record-first, so the file order [GPS, EXPOSURE, IDENTITY]
+    // is visited IDENTITY → EXPOSURE → GPS. The identity (before any timed row)
+    // rides sticky Main (0); then EXPOSURE rows take Doc6/Doc7, GPS rows Doc8/Doc9.
+    assert_eq!(full.exposure().len(), 2);
+    assert_eq!(full.exposure()[0].doc(), Some(6));
+    assert_eq!(full.exposure()[1].doc(), Some(7));
+    assert_eq!(full.gps().len(), 2);
+    assert_eq!(full.gps()[0].doc(), Some(8));
+    assert_eq!(full.gps()[1].doc(), Some(9));
+    // The identity walked BEFORE any timed row ⇒ sticky doc Main (0), NOT 5: a
+    // record before the first `FoundSomething` rides undef `$$et{DOC_NUM}`.
+    assert_eq!(full.identity().unwrap().doc(), Some(0));
+
+    // `count_surfaced_rows` (the parse-time advance) == the 4 surfaced rows,
+    // INDEPENDENT of `doc_base` (it counts bumps, not absolute ordinals).
+    assert_eq!(count_surfaced_rows(&file, file.len()), 4);
+  }
+
+  #[test]
   fn non_multiple_0x400_decodes_no_rows_and_warns() {
     // QuickTimeStream.pl:3355-3357: a 0x400 (stride 16) record whose length is
     // NOT a multiple of 16 emits ZERO rows (the `elsif` decode is skipped) +
@@ -2304,7 +2413,7 @@ mod tests {
     let mut body = exposure_row(1000, 0.008);
     body.push(0xff); // 17 bytes total — not a multiple of 16
     let file = build_file(b"PFX", &[(ID_EXPOSURE, body)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert!(
       full.exposure().is_empty(),
       "a non-multiple 0x400 must emit no exposure rows"
@@ -2322,7 +2431,7 @@ mod tests {
     let mut body = videotime_row(1000);
     body.push(0xff); // 9 bytes total — not a multiple of 8
     let file = build_file(b"PFX", &[(ID_VIDEO_TIMESTAMP, body)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert!(
       full.videotime().is_empty(),
       "a non-multiple 0x600 must emit no videotime rows"
@@ -2340,7 +2449,7 @@ mod tests {
     let mut body = accel20_row(2000, [32768, 33768, 31768, 32868, 32668, 41768]);
     body.push(0xff); // 21 bytes — not a multiple of 20 (probed stride)
     let file = build_file(b"PFX", &[(ID_ACCELEROMETER, body)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert!(
       full.accel().is_empty(),
       "a non-multiple 0x300 must emit no accel rows"
@@ -2368,7 +2477,7 @@ mod tests {
     // 0x300 record is reached with the terminal block still after it → ≥ 20
     // file bytes from its body start to EOF → probe succeeds).
     let file = build_file(b"PFX", &[(ID_ACCELEROMETER, body), (ID_GPS, gps)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert!(
       full.accel().is_empty(),
       "a non-multiple 0x300 emits no rows"
@@ -2410,7 +2519,7 @@ mod tests {
     // pinned at the `accel_stride` unit level instead.
     let body = vec![0u8; 10];
     let file = build_file(b"PFX", &[(ID_ACCELEROMETER, body)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert!(full.accel().is_empty());
     assert_eq!(
       full.warnings(),
@@ -2429,7 +2538,7 @@ mod tests {
     );
     body.extend_from_slice(&[0u8; 5]); // 58 bytes — not a multiple of 53
     let file = build_file(b"PFX", &[(ID_GPS, body)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert_eq!(
       full.gps().len(),
       1,
@@ -2460,7 +2569,7 @@ mod tests {
     // (the flat/Main document case).
     let id_body = identity_body(&[(TAG_MODEL, b"Insta360 X3")]);
     let file = build_file(b"prefix", &[(ID_IDENTITY, id_body)]);
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert_eq!(full.identity().unwrap().doc(), Some(0));
   }
 
@@ -2499,7 +2608,7 @@ mod tests {
     assert!(out.trailer().is_some());
 
     // (b) The full decode over the same bytes yields all 100000 videotime rows.
-    let full = decode_all_records(&file, file.len());
+    let full = decode_all_records(&file, file.len(), 0);
     assert_eq!(full.videotime().len(), ROWS as usize);
     assert_eq!(full.gps().len(), 1);
   }

--- a/src/formats/ligogps.rs
+++ b/src/formats/ligogps.rs
@@ -1,0 +1,1852 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "quicktime")]
+//! Faithful port of `Image::ExifTool::LigoGPS` (LigoGPS.pm, 431 lines) —
+//! the dashcam vendor GPS module used by various MP4/M2TS dashcam
+//! firmwares (iiway s1, XGODY 12" 4K, ABASK A8 4K, Rexing V1GW-4K,
+//! Kingslim D4, BlueSkySea DV688, Redtiger F9 4K, Yada RoadCam Pro 4K
+//! BT58189, …).
+//!
+//! ## Two reach paths
+//!
+//! 1. **`&&&& `-prefixed trailer at file end** (QuickTime.pm:9906-9907 +
+//!    :10658-10668) — `IdentifyTrailers` reads 40 bytes from `EOF-40` and
+//!    matches `/\&\&\&\&(.{4})$/` to extract the trailer length (BE u32 at
+//!    `EOF-4`, the 4 bytes immediately after the `&&&&` magic). The full
+//!    trailer begins `[size:u32-BE][skip:4-bytes]`
+//!    (`skip` ASCII atom name); after those 8 bytes the payload starts
+//!    with `LIGOGPSINFO\0` and is passed to [`process_ligogps`].
+//! 2. **`LIGOGPSINFO\0`-prefixed embedded sample** (QuickTimeStream.pl
+//!    :1843-1888) — bundled detects the fingerprint at offset 16/48/80
+//!    inside a `freeGPS` block, sets `LigoGPSScale = 3` when the offset-
+//!    16 ABASK A8 4K variant fingerprint hits, and dispatches to
+//!    [`process_ligogps`] with `DirStart = $pos`.
+//!
+//! Both binary paths route through the SAME `ProcessLigoGPS`
+//! (LigoGPS.pm:289-320) and are matched on the binary magic `LIGOGPSINFO\0`
+//! ONLY (QuickTime.pm:639 / :10661 / QuickTimeStream.pl:1843). The JSON form
+//! (`LIGOGPSINFO {`, a space then `{`) is a DIFFERENT ExifTool path — it is
+//! reached solely through the `udta` `LigoJSON` / `GKUData` Conditions
+//! (QuickTime.pm:835/:842), never through the freeGPS / trailer binary sites
+//! (see "JSON variant" below).
+//!
+//! ## Record format
+//!
+//! `ProcessLigoGPS` walks the dir starting at `DirStart + 0x14` (the 20
+//! bytes past the `LIGOGPSINFO\0\0\0\0\xNN` 0x14-byte preamble) in
+//! fixed-stride 0x84 (132)-byte records. Each record is either:
+//!  - **`####`-prefixed encrypted record** — decrypted by
+//!    [`decrypt_record`] (LigoGPS.pm:50-99). The decrypted output is a
+//!    16-byte counter + 4 unknown bytes + ASCII text of the form
+//!    `"YYYY/MM/DD HH:MM:SS N:lat W:lon spd km/h A:track H:alt M:magvar
+//!    x:ax y:ay z:az"`. Parsed by [`parse_decoded_record`]
+//!    (LigoGPS.pm:229-267).
+//!  - **Non-encrypted ASCII record (Redtiger F9 4K)** — LigoGPS.pm:304-307.
+//!    Same text shape, no `####` prefix; flags = `0x03` (not fuzzed, kph
+//!    speed unit).
+//!
+//! ## Fuzzing
+//!
+//! Encrypted records have their lat/lon values "fuzzed" by a per-firmware
+//! scaling formula. [`unfuzz`] applies the bundled inverse
+//! (LigoGPS.pm:38-44):
+//!   - `lat2 = int(lat / 10) * 10`
+//!   - `lon2 = int(lon / 10) * 10`
+//!   - `unfuzzed_lat = lat2 + (lon - lon2) * scale`
+//!   - `unfuzzed_lon = lon2 + (lat - lat2) * scale`
+//!
+//! The scale factor is selected from the per-firmware scale ID (bundled
+//! `%gpsScl` lookup: 1 → 1.524855137, 2 → 1.456027985, 3 → 1.15368). The
+//! ABASK A8 4K fingerprint at offset 16 forces scale 3
+//! (QuickTimeStream.pl:1886).
+//!
+//! ## JSON variant
+//!
+//! `ProcessLigoJSON` (LigoGPS.pm:334-398) handles the Yada RoadCam Pro 4K
+//! BT58189 dashcam, which writes chained records starting
+//! `LIGOGPSINFO {"Hour": "23", ...}`. This is a lighter parser (no
+//! decryption, no fuzzing) — [`process_ligogps_json`]. It is reached in
+//! production ONLY through the `udta` Conditions (QuickTime.pm:834-846), wired
+//! in `quicktime::dispatch_udta_ligogps`:
+//!  - `LigoJSON` (QuickTime.pm:835 `^LIGOGPSINFO \{`) → [`process_ligogps_json`].
+//!  - `GKUData` (QuickTime.pm:842 `^.{8}__V35AX_QVDATA__`) → [`process_gku`], a
+//!    thin wrapper that reads the LE u32 offset at the udta-payload start and
+//!    feeds the inner `LIGOGPSINFO {` JSON to [`process_ligogps_json`]
+//!    (LigoGPS.pm:273-281).
+//!
+//! The JSON variant additionally emits `GPSLatitude2`/`GPSLongitude2` from the
+//! JSON `OLatitude`/`OLongitude` fields (LigoGPS.pm:387-388). It is NOT reached
+//! through the binary freeGPS / trailer detection sites — ExifTool keeps the
+//! two LigoGPS encodings on entirely separate dispatch paths.
+//!
+//! ## DecipherLigoGPS deferral
+//!
+//! The bundled `DecipherLigoGPS` fallback (LigoGPS.pm:143-221) fires when
+//! `DecryptLigoGPS` fails — it accumulates the per-second seconds-digit
+//! transitions across multiple records until it can determine a cipher
+//! table by sequence inversion. This adds significant multi-record
+//! cipher-discovery state with limited real-world utility (modern dashcam
+//! files always decode via `DecryptLigoGPS` on the first try). Tracked as
+//! FOLLOW-UP under issue #70.
+//!
+//! ## GPS priority chain
+//!
+//! LigoGPS records feed the **LOWEST tier** of the cross-port GPS
+//! priority chain that [`crate::metadata::MediaMetadata`] projects from
+//! a QuickTime file: GoPro GPMF → Android CAMM → Parrot mett → Sony rtmd
+//! → Canon CTMD → Insta360 trailer → SP3 stream → freeGPS-variants →
+//! **LigoGPS**. LigoGPS is best-effort dashcam vendor GPS (same tier as
+//! the freeGPS-variants and SP3 stream sources); ordered last by
+//! implementation arrival.
+
+// Parser-panic-safety by construction: every raw index/slice in the decode
+// path is a checked `.get()` (matches the sibling QuickTime parser modules).
+#![deny(clippy::indexing_slicing)]
+
+extern crate alloc;
+use alloc::{string::String, vec::Vec};
+
+use smol_str::SmolStr;
+
+use crate::metadata::{LigoGpsMeta, LigoGpsSample};
+
+// ===========================================================================
+// Constants
+// ===========================================================================
+
+/// Conversion factor knots → km/h (LigoGPS.pm:20).
+const KNOTS_TO_KPH: f64 = 1.852;
+
+/// Default speed scale factor for fuzzed encrypted records (LigoGPS.pm:242).
+const DEFAULT_FUZZED_SPD_SCL: f64 = 1.85407333;
+
+/// LIGOGPSINFO header magic bytes (the 12-byte ASCII prefix +
+/// `LIGOGPSINFO\0`). Length is hard-coded throughout the bundled module.
+pub(crate) const HDR_LIGOGPSINFO: &[u8; 12] = b"LIGOGPSINFO\0";
+
+/// JSON-variant LIGOGPSINFO magic (`LIGOGPSINFO {` — a SPACE then `{`).
+/// ExifTool distinguishes the JSON `ProcessLigoJSON` form from the binary
+/// `ProcessLigoGPS` form by this byte-after-`LIGOGPSINFO` (QuickTime.pm:835
+/// `^LIGOGPSINFO \{` / GKU LigoGPS.pm:278 `LIGOGPSINFO {`).
+pub(crate) const HDR_LIGOGPSINFO_JSON: &[u8; 13] = b"LIGOGPSINFO {";
+
+/// GKUData `udta` Condition marker (`^.{8}__V35AX_QVDATA__`, QuickTime.pm:842).
+/// The 8 bytes preceding the marker carry a LE u32 offset (at byte 0) to the
+/// inner `LIGOGPSINFO {` JSON (LigoGPS.pm:277-280 `ProcessGKU`).
+pub(crate) const GKU_MARKER: &[u8; 16] = b"__V35AX_QVDATA__";
+
+/// Fixed record stride within `ProcessLigoGPS` (LigoGPS.pm:301 `$pos+=0x84`).
+const RECORD_STRIDE: usize = 0x84;
+
+/// The header preamble between the `LIGOGPSINFO\0` magic and the start of
+/// records (LigoGPS.pm:293 `$pos = $$dirInfo{DirStart} + 0x14`). The 20-
+/// byte preamble is `[LIGOGPSINFO\0][4-byte ver-or-counter][\x01\x14 or
+/// random byte][3 bytes]`.
+const RECORDS_OFFSET: usize = 0x14;
+
+// ===========================================================================
+// Trailer signature constants — QuickTime.pm:9906-9907
+// ===========================================================================
+
+/// The 4-byte ASCII signature `"&&&&"` that anchors the LigoGPS trailer
+/// (`/\&\&\&\&(.{4})$/`, QuickTime.pm:9906). The trailer DISCOVERY (the magic +
+/// the BE u32 length at the captured 4 bytes) lives in the shared
+/// `IdentifyTrailers` port [`crate::formats::insta360::identify_trailers`]; this
+/// constant is retained only to build the trailer-shape unit fixtures.
+#[cfg(test)]
+const TRAILER_MAGIC: &[u8; 4] = b"&&&&";
+
+/// Per-`skip`-atom prefix size: the 8-byte `[size:u32-BE][skip]` atom
+/// header that QuickTime.pm:10658 reads at the trailer start
+/// (`$raf->Read($buff, 8) == 8 and $buff =~ /skip$/i`).
+const SKIP_ATOM_HEADER: usize = 8;
+
+// ===========================================================================
+// Endian helpers
+// ===========================================================================
+
+/// LE u32 — the `####`-encrypted record's output-byte count (LigoGPS.pm:53
+/// `Get32u` after `SetByteOrder('II')`).
+#[inline]
+fn le_u32(b: &[u8], off: usize) -> Option<u32> {
+  b.get(off..off + 4)
+    .and_then(|s| <[u8; 4]>::try_from(s).ok())
+    .map(u32::from_le_bytes)
+}
+
+/// BE u32 — the `skip`-atom declared size (QuickTime.pm:10660 `Get32u(buff,0)`
+/// in the default `MM` order at the trailer).
+#[inline]
+fn be_u32(b: &[u8], off: usize) -> Option<u32> {
+  b.get(off..off + 4)
+    .and_then(|s| <[u8; 4]>::try_from(s).ok())
+    .map(u32::from_be_bytes)
+}
+
+// ===========================================================================
+// process_trailer — decode a discovered file-end LigoGPS trailer (QuickTime.pm
+// :10658-10668)
+// ===========================================================================
+
+/// Decode a LigoGPS trailer that [`crate::formats::insta360::identify_trailers`]
+/// (the shared port of `IdentifyTrailers`, QuickTime.pm:9897-9926) already
+/// LOCATED at `[trailer_start, trailer_start + trailer_len)`. The caller (the
+/// `ProcessMOV` trailer loop, [`crate::formats::quicktime`]) owns the discovery
+/// (the `&&&&` magic + LE u32 length) and the box-walk-consumed gate, exactly
+/// like the Insta360 trailer; this fn does only the LigoGPS-specific PROCESSING
+/// (QuickTime.pm:10658-10668).
+///
+/// `trailer_start` is `$$trailer[1]` (the trailer's absolute file offset) and
+/// `trailer_len` is `$$trailer[2]`. The trailer body begins with an 8-byte
+/// `[size:u32-BE][skip]` atom header (QuickTime.pm:10658 `$buff =~ /skip$/i`);
+/// the inner `Get32u(buff,0) - 16` bytes start with `LIGOGPSINFO\0` and are
+/// dispatched to [`process_ligogps`].
+///
+/// ## Error / pathological cases (faithful to QuickTime.pm:10657-10668)
+///
+/// - `trailer_start`/`trailer_len` out of range (a bad-size trailer whose
+///   declared length exceeds the file) → no-op, no warning (bundled's
+///   `Seek($$trailer[1], 0)` fails on the wrapped-negative start ⇒ `last`).
+/// - `skip` atom check fails (or the 8-byte read is short) → no-op, no warning
+///   (the bundled `if` condition is false ⇒ falls through the `elsif` arms,
+///   none of which match a 'LigoGPS'-typed trailer).
+/// - `skip` matched but the inner `Get32u-16` length is `<= 0`, the inner read
+///   is short, OR the buffer doesn't begin `LIGOGPSINFO\0` → `Unrecognized
+///   data in LigoGPS trailer` warning (the bundled `else`, QuickTime.pm:10667).
+// TODO(cluster follow-up): ExifTool emits a "Use the ExtractEmbedded option to
+// extract embedded GPS" notice when the trailer is present but `-ee` is OFF.
+// exifast decodes the trailer unconditionally (decode-always design), so this
+// is warning-parity only — no real-input data difference.
+pub fn process_trailer(
+  data: &[u8],
+  trailer_start: usize,
+  trailer_len: usize,
+  out: &mut LigoGpsMeta,
+) {
+  let Some(trailer_end) = trailer_start.checked_add(trailer_len) else {
+    return;
+  };
+  // QuickTime.pm:10657 `$raf->Seek($$trailer[1], 0)`. The trailer span must be
+  // wholly within the file (a bad-size trailer overruns it → `Get*`/`Read`
+  // fails in the reference; here the `.get` is `None` and we bail).
+  let Some(trailer) = data.get(trailer_start..trailer_end) else {
+    return;
+  };
+  // QuickTime.pm:10658 `if ($$trailer[0] eq 'LigoGPS' and $raf->Read($buff, 8)
+  // == 8 and $buff =~ /skip$/i)`. The 8-byte read is `[size:u32-BE][skip]`; the
+  // atom name lives at bytes 4..8, matched case-insensitively per the bundled
+  // `/i`. When the 8-byte read OR the `/skip$/i` check FAILS, the whole `if`
+  // condition is false: bundled falls through to the `elsif` arms (none match a
+  // 'LigoGPS'-typed trailer) and emits NO warning. Mirror that — bail silently.
+  let Some(head) = trailer.get(..SKIP_ATOM_HEADER) else {
+    return;
+  };
+  if !head
+    .get(4..8)
+    .is_some_and(|n| n.eq_ignore_ascii_case(b"skip"))
+  {
+    return;
+  }
+  // The `skip` atom matched. From here, bundled is inside the `if` body: any
+  // failure of the INNER condition (QuickTime.pm:10661) hits the `else` arm
+  // (:10667) ⇒ `Warn('Unrecognized data in LigoGPS trailer')`. The closure
+  // returns the decoded `payload` on the full success path, or `None` to warn.
+  // The trailer condition is binary-only — `$buff =~ /^LIGOGPSINFO\0/`
+  // (QuickTime.pm:10661); the JSON `LIGOGPSINFO {` form is reached solely via
+  // the `udta` `LigoJSON` Condition (QuickTime.pm:835), NEVER through the
+  // trailer, so this path matches `LIGOGPSINFO\0` only.
+  let payload = (|| {
+    // QuickTime.pm:10660 `my $len = Get32u(\$buff, 0) - 16`. The skip atom's
+    // declared BE size minus 16 (the 8-byte read + an 8-byte inner header). In
+    // Perl this is signed: an `atom_size < 16` yields `$len <= 0`, failing the
+    // `$len > 0` guard. Mirror with `checked_sub` (→ `None` ⇒ warn).
+    let atom_size = be_u32(head, 0)? as usize;
+    let inner_len = atom_size.checked_sub(16)?;
+    // QuickTime.pm:10661 `$len > 0`.
+    if inner_len == 0 {
+      return None;
+    }
+    // QuickTime.pm:10661 `$raf->Read($buff, $len) == $len` — the inner buffer is
+    // `inner_len` bytes read from `trailer_start + 8`. A short read (the bytes
+    // are not all present before the trailer end) fails the `== $len` guard.
+    let payload_end = SKIP_ATOM_HEADER.checked_add(inner_len)?;
+    let payload = trailer.get(SKIP_ATOM_HEADER..payload_end)?;
+    // QuickTime.pm:10661 `$buff =~ /^LIGOGPSINFO\0/` — binary form only.
+    if payload.get(..HDR_LIGOGPSINFO.len()) == Some(HDR_LIGOGPSINFO.as_slice()) {
+      Some(payload)
+    } else {
+      None
+    }
+  })();
+  let Some(payload) = payload else {
+    // QuickTime.pm:10667 `$et->Warn('Unrecognized data in LigoGPS trailer')`.
+    out.set_warning(SmolStr::new("Unrecognized data in LigoGPS trailer"));
+    return;
+  };
+  // QuickTime.pm:10663-10665 `Image::ExifTool::LigoGPS::ProcessLigoGPS($et,
+  // \%dirInfo, $tbl)`. The bundled `%dirInfo` carries no `DirStart`, so it
+  // defaults to 0: the buffer starts with the `LIGOGPSINFO\0` magic and record
+  // dispatch begins at offset 0x14 inside it (LigoGPS.pm:293).
+  process_ligogps(payload, 0, out, /*no_fuzz=*/ false);
+}
+
+// ===========================================================================
+// process_ligogps — main walker, LigoGPS.pm:289-320
+// ===========================================================================
+
+/// Faithful port of `Image::ExifTool::LigoGPS::ProcessLigoGPS`
+/// (LigoGPS.pm:289-320). Walks `data` starting at `dir_start + 0x14` in
+/// fixed `0x84`-byte strides; each record is either a `####`-prefixed
+/// encrypted record (decrypted by [`decrypt_record`] + parsed by
+/// [`parse_decoded_record`]) or a plain ASCII LIGOGPSINFO record
+/// (Redtiger F9 4K variant — LigoGPS.pm:304-307).
+///
+/// `no_fuzz = true` skips the unfuzz step (LigoGPS.pm:248) — set by the
+/// trailer code path AND by the BlueSkySeaDV688 / unknown-0x14 firmware
+/// detection (LigoGPS.pm:299).
+///
+/// `ligogps_scale` is the per-file fuzz scale ID (1/2/3, mapping to the
+/// `%gpsScl` table at LigoGPS.pm:241). The freeGPS embedded path uses
+/// `Some(3)` for the offset-16 ABASK A8 4K fingerprint
+/// (QuickTimeStream.pl:1886); the trailer path uses `None` (defaults to
+/// scale = 1.0, i.e. no rescale beyond the integer-overflow defuzz).
+pub fn process_ligogps(data: &[u8], dir_start: usize, out: &mut LigoGpsMeta, no_fuzz: bool) {
+  process_ligogps_with_scale(data, dir_start, out, no_fuzz, None);
+}
+
+/// `process_ligogps` variant accepting an explicit per-file fuzz scale
+/// ID (Some(1)/Some(2)/Some(3)) — used by the freeGPS embedded path to
+/// pass `LigoGPSScale = 3` for the ABASK A8 4K firmware
+/// (QuickTimeStream.pl:1886).
+pub fn process_ligogps_with_scale(
+  data: &[u8],
+  dir_start: usize,
+  out: &mut LigoGpsMeta,
+  mut no_fuzz: bool,
+  ligogps_scale: Option<u32>,
+) {
+  // LigoGPS.pm:293 `$pos = ($$dirInfo{DirStart} || 0) + 0x14`.
+  let mut pos = dir_start.saturating_add(RECORDS_OFFSET);
+  // LigoGPS.pm:294 `return undef if $pos > length $$dataPt`.
+  if pos > data.len() {
+    return;
+  }
+  // LigoGPS.pm:299 `$noFuzz = 1 if substr($$dataPt, $pos-8, 4) =~
+  // /^\0\0\0[\x01\x14]/`. The 4 bytes at `pos-8` start `\0\0\0` and end
+  // with `\x01` (BlueSkySeaDV688) or `\x14` (unknown) → don't unfuzz.
+  if pos >= 8 && matches!(data.get(pos - 8..pos - 4), Some([0, 0, 0, 0x01 | 0x14])) {
+    no_fuzz = true;
+  }
+  // LigoGPS.pm:301 `for (; $pos + 0x84 <= length($$dataPt); $pos += 0x84)`.
+  while pos + RECORD_STRIDE <= data.len() {
+    // The `while` guard proves `pos + RECORD_STRIDE <= data.len()`, so this
+    // `.get` is always `Some`; `break` on the impossible miss is byte-identical.
+    let Some(rec) = data.get(pos..pos + RECORD_STRIDE) else {
+      break;
+    };
+    pos += RECORD_STRIDE;
+
+    // LigoGPS.pm:303-309 — non-encrypted ASCII record (Redtiger F9 4K).
+    // The bundled `next unless $dat =~ m(^.{4}\d{4}/\d{2}/\d{2} )s` allows
+    // 4-byte counter + ASCII date prefix.
+    if !rec.starts_with(b"####") {
+      if is_plain_ascii_date_record(rec) {
+        // LigoGPS.pm:306 `$dat =~ s/\0+$//`. Strip trailing nulls.
+        let trimmed = strip_trailing_nulls(rec);
+        // LigoGPS.pm:307 `ParseLigoGPS($et, $dat, $tagTbl, 0x03)` — flag
+        // 0x03 = not fuzzed (0x01) AND km/h speed (0x02).
+        parse_decoded_record(trimmed, 0x03, ligogps_scale, no_fuzz, out);
+      }
+      // (otherwise: bundled `next` — silently skip blank/null records).
+      continue;
+    }
+    // LigoGPS.pm:311 — bundled would attempt `DecipherLigoGPS` first if a
+    // cipher table is already known. We DEFER cipher discovery (issue
+    // #70 FOLLOW-UP), so the only path is `DecryptLigoGPS`.
+    let Some(decoded) = decrypt_record(rec) else {
+      // LigoGPS.pm:313 — `defined $str or DecipherLigoGPS(...), next`.
+      // Cipher discovery is deferred; record a one-time warning so the
+      // file's diagnostic is visible.
+      out.set_warning(SmolStr::new(
+        "LigoGPS record decryption failed (cipher discovery deferred)",
+      ));
+      continue;
+    };
+    // LigoGPS.pm:315 `ParseLigoGPS($et, $str, $tagTbl, $noFuzz)`.
+    // `$noFuzz` is just the 0x01 bit; speed-units bit (0x02) is unset
+    // for encrypted records (so speed uses the LigoGPS-internal scale
+    // factor 1.85407333).
+    let flags = if no_fuzz { 0x01 } else { 0x00 };
+    parse_decoded_record(&decoded, flags, ligogps_scale, no_fuzz, out);
+  }
+}
+
+/// Return `true` when the bundled `m(^.{4}\d{4}/\d{2}/\d{2} )s` pattern
+/// matches (LigoGPS.pm:304). The first 4 bytes are arbitrary (counter),
+/// then 10 bytes of `YYYY/MM/DD ` ASCII.
+fn is_plain_ascii_date_record(rec: &[u8]) -> bool {
+  // Bytes 4..15 = `YYYY/MM/DD ` (the 4-byte counter precedes it). A slice
+  // pattern binds the 11 bytes and bounds-checks in one step.
+  let Some(&[y0, y1, y2, y3, sl0, m0, m1, sl1, d0, d1, sp]) = rec.get(4..15) else {
+    return false;
+  };
+  y0.is_ascii_digit()
+    && y1.is_ascii_digit()
+    && y2.is_ascii_digit()
+    && y3.is_ascii_digit()
+    && sl0 == b'/'
+    && m0.is_ascii_digit()
+    && m1.is_ascii_digit()
+    && sl1 == b'/'
+    && d0.is_ascii_digit()
+    && d1.is_ascii_digit()
+    && sp == b' '
+}
+
+/// Strip trailing `\0` bytes (LigoGPS.pm:306 `$dat =~ s/\0+$//`).
+fn strip_trailing_nulls(rec: &[u8]) -> &[u8] {
+  let mut end = rec.len();
+  while end > 0 && rec.get(end - 1) == Some(&0) {
+    end -= 1;
+  }
+  rec.get(..end).unwrap_or(rec)
+}
+
+// ===========================================================================
+// decrypt_record — LigoGPS.pm:50-99 `DecryptLigoGPS`
+// ===========================================================================
+
+/// Faithful port of `Image::ExifTool::LigoGPS::DecryptLigoGPS`
+/// (LigoGPS.pm:50-99). Decrypts one `####`-prefixed encrypted record. The
+/// 8-byte header is `####` (4 bytes) + `[u32-LE counter]` (4 bytes). The
+/// 4-byte LE u32 immediately after `####` is the number of OUTPUT bytes
+/// (capped at 0x84 — record-stride safety).
+///
+/// The decryption operates byte-by-byte, where each input byte's upper
+/// 3 bits steer one of four decryption modes (4 output bytes from 5
+/// input, 4 from 4, 4 from 4 in a different layout, 1 from 2). Returns
+/// the decoded ASCII text (the 4-byte counter is RE-PRESERVED at the
+/// start), or `None` on a malformed cipher stream.
+pub(crate) fn decrypt_record(rec: &[u8]) -> Option<Vec<u8>> {
+  // LigoGPS.pm:53 `my $num = unpack('x4V', $str)`. The 4-byte LE u32 at
+  // offset 4 is the OUTPUT-byte count (bundled output buffer size).
+  if rec.len() < 8 {
+    return None;
+  }
+  let mut num = le_u32(rec, 4)? as usize;
+  // LigoGPS.pm:54 `return undef if $num < 4`.
+  if num < 4 {
+    return None;
+  }
+  // LigoGPS.pm:55 `$num = 0x84 if $num > 0x84`.
+  if num > 0x84 {
+    num = 0x84;
+  }
+  // LigoGPS.pm:56 `my @in = unpack("x8C$num", $str)` — take `num` input
+  // bytes starting at offset 8.
+  let in_end = 8usize.checked_add(num)?;
+  let mut input = rec.get(8..in_end)?.iter().copied();
+  // Output preserved header — bundled keeps the 4-byte counter at the
+  // start (caller re-prepends it). We allocate enough headroom for the
+  // 4 output bytes per steering round; +4 for the header. The output
+  // CANNOT exceed 0x80 + 4 = 0x84.
+  let mut out: Vec<u8> = Vec::with_capacity(0x84);
+  // Caller (ParseLigoGPS) re-adds the 4-byte header from the rec; we
+  // emit only the decrypted body (LigoGPS.pm:217 `"$pre$str"` where
+  // `$pre = substr($str, 4, 4)`). But ProcessLigoGPS calls ParseLigoGPS
+  // directly with the OUTPUT of DecryptLigoGPS. Looking at LigoGPS.pm:315
+  // — `ParseLigoGPS($et, $str, $tagTbl, $noFuzz)` — passes the decrypted
+  // string `$str` directly. ParseLigoGPS expects ".{4}DATE TIME..." so
+  // the first 4 bytes of the OUTPUT are the counter (LigoGPS.pm:225-227).
+  // Bundled DecryptLigoGPS includes the counter in `@out`? Let me re-read:
+  // LigoGPS.pm:98 `return pack 'C*', @out`. `@out` is filled exclusively
+  // by the steering-decryption pushes. So the counter is NOT in `@out`.
+  // Then where does ParseLigoGPS's `.{4}` come from? Reading more
+  // carefully: LigoGPS.pm:53 `$num = unpack('x4V', $str)`. `'x4'` skips
+  // 4 bytes then reads V (u32-LE). So the LE u32 is at offset 4. But the
+  // OUTPUT `@out` is just the decrypted body. ParseLigoGPS at :231 does
+  // `$str =~ /^.{4}(\S+ \S+)\s+/` — the `.{4}` matches FOUR ARBITRARY
+  // BYTES at the start. So ParseLigoGPS is being given OUTPUT that has
+  // some 4-byte header. Where is that header? In ProcessLigoGPS at :315
+  // we see ParseLigoGPS called with `$str` (the OUTPUT of DecryptLigoGPS).
+  // Wait — re-reading LigoGPS.pm:314: `$et->VPrint(... unpack('V',$str)
+  // ...)` — the verbose print extracts the FIRST u32 of `$str` as the
+  // counter. So the counter IS the first 4 bytes of `$str`. Looking at
+  // LigoGPS.pm:51-98, `@out` is the DECRYPTED body. The verbose at :314
+  // reads `unpack('V', $str)` — but `$str` here is the SAME `$str` that
+  // was passed to ProcessLigoGPS (the OUTPUT). So `@out` DOES contain
+  // the counter; the cipher emits 4 bytes per round and one of those
+  // rounds emits the counter. Reading the encryption code more carefully:
+  // the loop runs `num` rounds; each round emits 1 or 4 output bytes.
+  // The TOTAL output size = sum of per-round outputs. For ParseLigoGPS
+  // to see `.{4}` followed by the date, the FIRST 4 output bytes are
+  // the counter — that is, the FIRST decryption round emits 4 bytes
+  // (the counter). All subsequent rounds emit the ASCII payload.
+  //
+  // So the output is just `@out` — no separate prepend needed. Good.
+  while let Some(b) = input.next() {
+    let steering = b & 0xe0;
+    if steering >= 0xc0 {
+      // LigoGPS.pm:62-67 — next 4 bytes are encrypted data.
+      let i1 = input.next()?;
+      let i2 = input.next()?;
+      let i3 = input.next()?;
+      let i4 = input.next()?;
+      out.push((i1 | (b & 0x01)) ^ 0x20);
+      out.push((i2 | (b & 0x02)) ^ 0x20);
+      out.push((i3 | (b & 0x0c)) ^ 0x20);
+      // LigoGPS.pm:67 `shift(@in) ^ 0x20 | $b & 0x30` — note the Perl
+      // precedence: `^` binds tighter than `|`, so this is
+      // `(shift(@in) ^ 0x20) | ($b & 0x30)`.
+      out.push((i4 ^ 0x20) | (b & 0x30));
+    } else if steering >= 0x40 {
+      // LigoGPS.pm:68-90 — next 3 bytes are encrypted data with one of
+      // four sub-modes by the exact steering value.
+      let i1 = input.next()?;
+      let i2 = input.next()?;
+      let i3 = input.next()?;
+      match steering {
+        0x40 => {
+          // LigoGPS.pm:70-74
+          out.push(0x20);
+          out.push((i1 | (b & 0x01)) ^ 0x20);
+          out.push((i2 | (b & 0x06)) ^ 0x20);
+          out.push((i3 | (b & 0x18)) ^ 0x20);
+        }
+        0x60 => {
+          // LigoGPS.pm:75-79
+          out.push((i1 | (b & 0x03)) ^ 0x20);
+          out.push(0x20);
+          out.push((i2 | (b & 0x04)) ^ 0x20);
+          out.push((i3 | (b & 0x18)) ^ 0x20);
+        }
+        0x80 => {
+          // LigoGPS.pm:80-84
+          out.push((i1 | (b & 0x03)) ^ 0x20);
+          out.push((i2 | (b & 0x0c)) ^ 0x20);
+          out.push(0x20);
+          out.push((i3 | (b & 0x10)) ^ 0x20);
+        }
+        _ => {
+          // LigoGPS.pm:85-89 — the bundled `else` covers `0xa0`.
+          out.push((i1 | (b & 0x01)) ^ 0x20);
+          out.push((i2 | (b & 0x06)) ^ 0x20);
+          out.push((i3 | (b & 0x18)) ^ 0x20);
+          out.push(0x20);
+        }
+      }
+    } else if steering == 0x00 {
+      // LigoGPS.pm:91-93 — next byte is encrypted data (single-output).
+      let i1 = input.next()?;
+      out.push(i1 | (b & 0x13));
+    } else {
+      // LigoGPS.pm:94-96 — bundled `else { return undef }`. Shouldn't
+      // happen on valid input; we propagate the failure.
+      return None;
+    }
+  }
+  Some(out)
+}
+
+// ===========================================================================
+// parse_decoded_record — LigoGPS.pm:229-267 `ParseLigoGPS`
+// ===========================================================================
+
+/// Parse a decrypted-or-plain LIGOGPSINFO text record. The buffer is
+/// `[4 bytes counter][YYYY/MM/DD HH:MM:SS] [LATREF]:[neg?]LAT [LONREF]:
+/// [neg?]LON SPEED [optional " km/h"] [optional " A:TRK"] [optional " H:ALT"]
+/// [optional " M:MAGVAR"] [optional " x:AX y:AY z:AZ"]`.
+///
+/// `flags` is the bundled `$flags`:
+///  - `0x01` = NOT fuzzed (skip the `UnfuzzLigoGPS` step).
+///  - `0x02` = speed is already in km/h (skip the knots→km/h conversion).
+///
+/// `scale_id` is the per-file `LigoGPSScale` (LigoGPS.pm:249) — drives
+/// the `%gpsScl` lookup at LigoGPS.pm:241 (1 → 1.524855137 / 2 →
+/// 1.456027985 / 3 → 1.15368).
+pub(crate) fn parse_decoded_record(
+  buf: &[u8],
+  flags: u8,
+  scale_id: Option<u32>,
+  no_fuzz_override: bool,
+  out: &mut LigoGpsMeta,
+) {
+  // Re-apply the `0x01` bit if the caller said `no_fuzz_override` (LigoGPS
+  // .pm:248 reads `$flags & 0x01` — so we OR it in).
+  let flags = if no_fuzz_override {
+    flags | 0x01
+  } else {
+    flags
+  };
+
+  // First 4 bytes are the counter (LigoGPS.pm:235 `^.{4}`); the rest is the
+  // text body. Bundled tolerates trailing zero pads (the `parse_ligogps`
+  // regex anchors are tolerant). Use lossy UTF-8 — the text is ASCII per the
+  // format spec but a malformed record may carry garbage. A buffer shorter
+  // than the 4-byte counter has no body (`.get(4..)` is `None`) ⇒ early
+  // return; an empty body parses to no sample (the date regex needs content).
+  let Some(body_bytes) = buf.get(4..) else {
+    return;
+  };
+  let body = match core::str::from_utf8(body_bytes) {
+    Ok(s) => s,
+    Err(_) => {
+      // Try lossy: strip non-UTF8 bytes by taking the longest valid
+      // prefix (everything up to the first NUL).
+      let cut = body_bytes
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(body_bytes.len());
+      body_bytes
+        .get(..cut)
+        .and_then(|s| core::str::from_utf8(s).ok())
+        .unwrap_or("")
+    }
+  };
+  // Bundled regex (LigoGPS.pm:235):
+  //   /^.{4}(\S+ \S+)\s+([NS?]):(-?)([.\d]+)\s+([EW?]):(-?)([\.\d]+)\s+([.\d]+)/s
+  // (note `.{4}` is already consumed by our slice). The captures:
+  //   1: "YYYY/MM/DD HH:MM:SS"
+  //   2: "N"|"S"|"?"
+  //   3: "-" or empty (lat sign)
+  //   4: lat magnitude (e.g. "31.285065")
+  //   5: "E"|"W"|"?"
+  //   6: "-" or empty (lon sign)
+  //   7: lon magnitude
+  //   8: speed magnitude
+  let Some(fields) = parse_lead_fields(body) else {
+    out.set_warning(SmolStr::new("LIGOGPSINFO format error"));
+    return;
+  };
+  let (date_time_str, lat_ref, lat_neg, mut lat, lon_ref, lon_neg, mut lon, spd_raw) = fields;
+
+  // LigoGPS.pm:244 — `$time =~ tr(/)(:)` — normalise the date separators.
+  let date_time = date_time_str.replace('/', ":");
+
+  // LigoGPS.pm:241-242 — speed scale lookup.
+  let mut spd_scl = if flags & 0x01 != 0 {
+    if flags & 0x02 != 0 {
+      // km/h record, no scaling.
+      1.0
+    } else {
+      // knots record, convert.
+      KNOTS_TO_KPH
+    }
+  } else {
+    DEFAULT_FUZZED_SPD_SCL
+  };
+
+  // LigoGPS.pm:247 — DDMM.MMMMMM detection: if the lat magnitude has 3
+  // leading digits before the first decimal (bundled `$lat =~ /^\d{3}/`),
+  // the format is degrees+minutes (NMEA-style) and we re-scale to
+  // decimal degrees. The bundled regex matches when the magnitude is
+  // ≥ 100 (3-digit integer part).
+  if has_three_leading_digits_f64(lat) {
+    convert_lat_lon_dm_to_decimal(&mut lat, &mut lon);
+    spd_scl = 1.0; // bundled comment: "speed wasn't scaled in my 1 sample"
+  }
+
+  // LigoGPS.pm:248-252 — unfuzz the coordinates if `flags & 0x01 == 0`.
+  //   my $scl = $$et{OPTIONS}{LigoGPSScale} || $$et{LigoGPSScale} || 1;
+  //   $scl = $gpsScl{$scl} if $gpsScl{$scl};
+  // The UNSET scale defaults to `1`, which then remaps through
+  // `%gpsScl{1} = 1.524855137` (LigoGPS.pm:241,249-250) — NOT a literal 1.0.
+  // A scale ID outside `%gpsScl{1,2,3}` passes through as its raw numeric
+  // value (the `$gpsScl{$scl}` guard leaves `$scl` unchanged on a miss).
+  if flags & 0x01 == 0 {
+    let scl = match scale_id {
+      None | Some(1) => 1.524855137_f64,
+      Some(2) => 1.456027985_f64,
+      Some(3) => 1.15368_f64,
+      Some(n) => f64::from(n),
+    };
+    let (ul, ulon) = unfuzz(lat, lon, scl);
+    lat = ul;
+    lon = ulon;
+  }
+
+  // LigoGPS.pm:254 — the final sanity check, which runs AFTER LigoGPS.pm:243
+  // `$$et{DOC_NUM} = ++$$et{DOC_COUNT}`. So a rejected (out-of-range) record has
+  // ALREADY burned a global `Doc<N>`: push a doc-consuming-but-suppressed
+  // placeholder so the deferred `stamp_doc_from` advances the shared counter for
+  // it (the NEXT good record's `Doc<N>` is this burned slot's successor),
+  // matching bundled. It emits no GPS tags, only the warning. (Contrast the
+  // LigoGPS.pm:236-237 format-error / the :312-313 decrypt-failure returns, which
+  // are BEFORE the :243 bump and so do NOT burn a doc — left untouched.)
+  if lat > 90.0 || lon > 180.0 {
+    out.set_warning(SmolStr::new("LIGOGPSINFO coordinates out of range"));
+    out.push_sample(LigoGpsSample::new_suppressed());
+    return;
+  }
+
+  // LigoGPS.pm:256-263 — emit the GPS tags.
+  let mut sample = LigoGpsSample::new();
+  sample.set_date_time(Some(SmolStr::new(date_time)));
+  // LigoGPS.pm:258 — `$lat * (($latNeg or $latRef eq 'S') ? -1 : 1)`.
+  let lat_signed = if lat_neg || lat_ref == 'S' { -lat } else { lat };
+  // LigoGPS.pm:259 — `$lon * (($lonNeg or $lonRef eq 'W') ? -1 : 1)`.
+  let lon_signed = if lon_neg || lon_ref == 'W' { -lon } else { lon };
+  sample.set_latitude(Some(lat_signed));
+  sample.set_longitude(Some(lon_signed));
+  // LigoGPS.pm:260 — `$spd * $spdScl`.
+  sample.set_speed_kph(Some(spd_raw * spd_scl));
+
+  // LigoGPS.pm:261-265 — optional fields (Track, Altitude, MagVar, Accel).
+  if let Some(v) = extract_value(body, " A:") {
+    sample.set_track_deg(Some(v));
+  }
+  if let Some(v) = extract_value(body, " H:") {
+    sample.set_altitude_m(Some(v));
+  }
+  if let Some(v) = extract_value(body, " M:") {
+    sample.set_magnetic_variation(Some(v));
+  }
+  if let Some((ax, ay, az)) = extract_acceleration(body) {
+    // LigoGPS.pm:265 — `"$1 $2 $3"`. The bundled tab-separator is
+    // accepted by `\s` in the regex; we space-join in the output.
+    let mut s = String::with_capacity(24);
+    s.push_str(ax);
+    s.push(' ');
+    s.push_str(ay);
+    s.push(' ');
+    s.push_str(az);
+    sample.set_accelerometer(Some(SmolStr::new(s)));
+  }
+  out.push_sample(sample);
+}
+
+/// Decoded `ParseLigoGPS` lead-line fields (LigoGPS.pm:235 regex captures).
+/// Tuple components: `(date_time_str, lat_ref, lat_neg, lat_magnitude,
+/// lon_ref, lon_neg, lon_magnitude, speed_raw)`.
+type LeadFields = (String, char, bool, f64, char, bool, f64, f64);
+
+/// Parse the lead-line fields. Faithful to the bundled regex
+/// `^(\S+ \S+)\s+([NS?]):(-?)([.\d]+)\s+([EW?]):(-?)([\.\d]+)\s+([.\d]+)`
+/// (LigoGPS.pm:235).
+fn parse_lead_fields(body: &str) -> Option<LeadFields> {
+  // Field 1: \S+ \S+ — date + " " + time. Walk to first whitespace
+  // (date), then through following whitespace, then to the next
+  // whitespace (time). The bundled regex (LigoGPS.pm:235) captures ANY
+  // non-space `\S+` date token — it does NOT require slashes; the date is
+  // then normalised by `tr(/)(:)` (LigoGPS.pm:244, applied downstream in
+  // `parse_decoded_record`), a NO-OP for an already-colon / dash date. So a
+  // record ExifTool accepts with e.g. `2024-01-15` must NOT be dropped here:
+  // do not impose a slash-only guard (the dropped record would lose its GPS
+  // fix AND shift every following `Doc<N>` below the oracle, since the
+  // out-of-range doc-burn at LigoGPS.pm:243 has already consumed an ordinal).
+  let date_end = body.find(char::is_whitespace)?;
+  let date = &body[..date_end];
+  let after_date = body[date_end..].trim_start();
+  let time_end = after_date.find(char::is_whitespace)?;
+  let time = &after_date[..time_end];
+
+  let mut date_time = String::with_capacity(date.len() + 1 + time.len());
+  date_time.push_str(date);
+  date_time.push(' ');
+  date_time.push_str(time);
+
+  let tail = after_date[time_end..].trim_start();
+
+  // Lat ref + sign + magnitude.
+  let (lat_ref, after_lat_ref) = take_ref(tail, &['N', 'S', '?'])?;
+  if !after_lat_ref.starts_with(':') {
+    return None;
+  }
+  let after_colon = &after_lat_ref[1..];
+  let (lat_neg, after_lat_sign) = if let Some(stripped) = after_colon.strip_prefix('-') {
+    (true, stripped)
+  } else {
+    (false, after_colon)
+  };
+  let (lat_mag_str, after_lat) = take_numeric(after_lat_sign)?;
+  let lat: f64 = lat_mag_str.parse().ok()?;
+  let after_lat = after_lat.trim_start();
+
+  // Lon ref + sign + magnitude.
+  let (lon_ref, after_lon_ref) = take_ref(after_lat, &['E', 'W', '?'])?;
+  if !after_lon_ref.starts_with(':') {
+    return None;
+  }
+  let after_colon = &after_lon_ref[1..];
+  let (lon_neg, after_lon_sign) = if let Some(stripped) = after_colon.strip_prefix('-') {
+    (true, stripped)
+  } else {
+    (false, after_colon)
+  };
+  let (lon_mag_str, after_lon) = take_numeric(after_lon_sign)?;
+  let lon: f64 = lon_mag_str.parse().ok()?;
+  let after_lon = after_lon.trim_start();
+
+  // Speed magnitude.
+  let (spd_str, _) = take_numeric(after_lon)?;
+  let spd: f64 = spd_str.parse().ok()?;
+
+  Some((date_time, lat_ref, lat_neg, lat, lon_ref, lon_neg, lon, spd))
+}
+
+/// Take a single character if it's one of the allowed reference chars
+/// (`['N', 'S', '?']` for latitude, `['E', 'W', '?']` for longitude).
+fn take_ref<'a>(s: &'a str, allowed: &[char]) -> Option<(char, &'a str)> {
+  let mut chars = s.chars();
+  let first = chars.next()?;
+  if allowed.contains(&first) {
+    Some((first, &s[first.len_utf8()..]))
+  } else {
+    None
+  }
+}
+
+/// Take the longest numeric prefix (`[.\d]+` per LigoGPS.pm:235).
+fn take_numeric(s: &str) -> Option<(&str, &str)> {
+  let end = s
+    .char_indices()
+    .take_while(|(_, c)| c.is_ascii_digit() || *c == '.')
+    .last()
+    .map(|(i, c)| i + c.len_utf8())
+    .unwrap_or(0);
+  if end == 0 {
+    return None;
+  }
+  Some((&s[..end], &s[end..]))
+}
+
+/// `true` when `s` starts with at least 3 digits (LigoGPS.pm:247
+/// `$lat =~ /^\d{3}/` — the bundled regex matches when the FIRST 3
+/// characters are digits, no anchor on what follows). Used by the
+/// tests; the production path uses [`has_three_leading_digits_f64`]
+/// which avoids the string→f64 reparse.
+#[cfg(test)]
+fn has_three_leading_digits(s: &str) -> bool {
+  s.chars().take(3).filter(|c| c.is_ascii_digit()).count() == 3
+}
+
+/// `true` when the lat magnitude has a 3-digit integer part — equivalent
+/// to the bundled `$lat =~ /^\d{3}/` regex once the magnitude is parsed
+/// as f64. Matches when the integer part is in `100..=9999` (4-digit
+/// max for the bundled DDMM format).
+fn has_three_leading_digits_f64(lat: f64) -> bool {
+  let trunc = lat.trunc();
+  (100.0..10000.0).contains(&trunc)
+}
+
+/// Faithful port of `Image::ExifTool::QuickTime::ConvertLatLon`
+/// (referenced from LigoGPS.pm:247). Bundled converts DDMM.MMMMMM →
+/// DD.DDDDDD in-place: `$_ = int($_/100) + ($_ - int($_/100)*100) / 60
+/// foreach ($lat, $lon)`.
+fn convert_lat_lon_dm_to_decimal(lat: &mut f64, lon: &mut f64) {
+  for v in [lat, lon] {
+    let degrees = (*v / 100.0).trunc();
+    let minutes = *v - degrees * 100.0;
+    *v = degrees + minutes / 60.0;
+  }
+}
+
+/// Faithful port of `UnfuzzLigoGPS` (LigoGPS.pm:38-44):
+///   `$lat2 = int($lat/10) * 10`
+///   `$lon2 = int($lon/10) * 10`
+///   `return ($lat2 + ($lon - $lon2) * $scl, $lon2 + ($lat - $lat2) * $scl)`.
+fn unfuzz(lat: f64, lon: f64, scl: f64) -> (f64, f64) {
+  let lat2 = (lat / 10.0).trunc() * 10.0;
+  let lon2 = (lon / 10.0).trunc() * 10.0;
+  (lat2 + (lon - lon2) * scl, lon2 + (lat - lat2) * scl)
+}
+
+/// Extract a numeric value following the `key` literal (e.g. `" A:"`,
+/// `" H:"`, `" M:"`). Bundled regex pattern `\bA:(\S+)` —
+/// LigoGPS.pm:261-263.
+// TODO(cluster follow-up): the bundled `\b` word boundary before `A:`/`H:`/`M:`
+// matches at more positions than a literal leading space (e.g. start-of-string
+// or after punctuation). Real records use the space separator shown in the
+// sample, so this is a CRAFTED/hostile-input faithfulness edge only.
+fn extract_value(body: &str, key: &str) -> Option<f64> {
+  let idx = body.find(key)?;
+  let after = &body[idx + key.len()..];
+  // Take \S+ (any non-whitespace).
+  let end = after
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after.len());
+  after[..end].parse().ok()
+}
+
+/// Extract the 3-axis accelerometer triplet (LigoGPS.pm:265 regex
+/// `x:(\S+)\sy:(\S+)\sz:(\S+)`). Returns `(ax, ay, az)` as substring
+/// references into `body`.
+fn extract_acceleration(body: &str) -> Option<(&str, &str, &str)> {
+  let xi = body.find("x:")?;
+  let after_x = &body[xi + 2..];
+  let xe = after_x
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after_x.len());
+  let ax = &after_x[..xe];
+  let rest_after_x = &after_x[xe..].trim_start();
+  let after_y = rest_after_x.strip_prefix("y:")?;
+  let ye = after_y
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after_y.len());
+  let ay = &after_y[..ye];
+  let rest_after_y = &after_y[ye..].trim_start();
+  let after_z = rest_after_y.strip_prefix("z:")?;
+  let ze = after_z
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after_z.len());
+  let az = &after_z[..ze];
+  Some((ax, ay, az))
+}
+
+// ===========================================================================
+// process_ligogps_json — LigoGPS.pm:334-398 `ProcessLigoJSON`
+// ===========================================================================
+
+/// Faithful port of `Image::ExifTool::LigoGPS::ProcessLigoJSON`
+/// (LigoGPS.pm:334-398) — the JSON-format variant used by the Yada
+/// RoadCam Pro 4K BT58189 dashcam (chained 512-byte records starting
+/// with `LIGOGPSINFO {`).
+///
+/// Walks `data` for every `LIGOGPSINFO {…}` segment and decodes the
+/// inner JSON into a [`LigoGpsSample`]. Only `status == "A"` records
+/// produce a sample (LigoGPS.pm:353).
+///
+/// The bundled `while ($$dataPt =~ /LIGOGPSINFO (\{.*?\})/g)` (LigoGPS.pm:342)
+/// matches on the RAW byte string — the `GKUData` / `LigoJSON` `udta`
+/// containers are BINARY (a JSON object followed by binary padding, FINDING 2),
+/// so requiring the whole payload to be UTF-8 would reject a valid record. We
+/// mirror Perl: locate `LIGOGPSINFO {` on BYTES, take the braced object up to
+/// its matching `}` (the non-greedy `\{.*?\}` — `.` matches any byte EXCEPT
+/// newline since there is no `/s` flag), and UTF-8-convert ONLY that object for
+/// parsing. A non-UTF-8 braced object is skipped (the digit/quote JSON the
+/// decoder reads is ASCII).
+pub fn process_ligogps_json(data: &[u8], out: &mut LigoGpsMeta) {
+  let mut search_start = 0;
+  while let Some(rel) = find_subslice(
+    data.get(search_start..).unwrap_or_default(),
+    b"LIGOGPSINFO {",
+  ) {
+    // Position of the `{` (the captured group starts at the brace — the literal
+    // space in `LIGOGPSINFO ` is consumed before the capture).
+    let brace = search_start + rel + b"LIGOGPSINFO ".len();
+    // The non-greedy `\{.*?\}` captures up to the FIRST `}` reachable without
+    // crossing a newline (`.` does not match `\n` without `/s`). A `\n` before
+    // any `}` fails the match at this start → advance past the magic and retry.
+    let Some(close) = find_brace_close(data, brace) else {
+      search_start = brace;
+      continue;
+    };
+    let json_end = close + 1;
+    // UTF-8-convert ONLY the braced object (NOT the trailing binary padding).
+    if let Some(json_text) = data
+      .get(brace..json_end)
+      .and_then(|b| core::str::from_utf8(b).ok())
+      && let Some(mut sample) = decode_ligo_json_object(json_text)
+    {
+      // FINDING 1 — tag the JSON family so the emitter applies ProcessLigoJSON's
+      // no-`ee` FIRST-record semantics (LigoGPS.pm:390-393).
+      sample.set_source(crate::metadata::LigoSource::UdtaJson);
+      out.push_sample(sample);
+    }
+    search_start = json_end;
+  }
+}
+
+/// Byte-substring search (no UTF-8 requirement). Returns the index of the first
+/// occurrence of `needle` in `haystack`.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+  if needle.is_empty() {
+    return Some(0);
+  }
+  haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Find the matching `}` for the `{` at `brace`, scanning forward on BYTES.
+/// Mirrors the non-greedy `\{.*?\}` without `/s`: stop (no match) at a newline
+/// (`\n`, 0x0A) before any `}` — `.` does not match `\n`. Returns the absolute
+/// index of the closing brace.
+fn find_brace_close(data: &[u8], brace: usize) -> Option<usize> {
+  let rest = data.get(brace + 1..)?;
+  for (i, &b) in rest.iter().enumerate() {
+    match b {
+      b'}' => return Some(brace + 1 + i),
+      b'\n' => return None,
+      _ => {}
+    }
+  }
+  None
+}
+
+/// Faithful port of `Image::ExifTool::LigoGPS::ProcessGKU`
+/// (LigoGPS.pm:273-281) — the GKU dashcam `udta` variant. The `udta`
+/// payload begins `[offset:u32-LE][..]__V35AX_QVDATA__` (the marker is
+/// the `udta` `GKUData` Condition trigger, QuickTime.pm:842); the LE u32
+/// at offset 0 points to the inner `LIGOGPSINFO {` JSON, which is then
+/// decoded by [`process_ligogps_json`].
+///
+/// LigoGPS.pm:278 `return 0 if $pos + 13 > length $$dataPt or
+/// substr($$dataPt, $pos, 13) ne 'LIGOGPSINFO {'` — a missing/short
+/// header or a non-`LIGOGPSINFO {` payload at `$pos` decodes nothing.
+pub fn process_gku(data: &[u8], out: &mut LigoGpsMeta) {
+  // LigoGPS.pm:277 `my $pos = unpack('V', $$dataPt)`.
+  let Some(pos) = le_u32(data, 0).map(|v| v as usize) else {
+    return;
+  };
+  // LigoGPS.pm:278 — bounds + the `LIGOGPSINFO {` check at `$pos`.
+  let Some(inner) = data.get(pos..) else {
+    return;
+  };
+  if inner.get(..HDR_LIGOGPSINFO_JSON.len()) != Some(HDR_LIGOGPSINFO_JSON.as_slice()) {
+    return;
+  }
+  // LigoGPS.pm:279-280 `pos($$dataPt) = $pos; return ProcessLigoJSON(...)` —
+  // scan the JSON starting at `$pos` (`process_ligogps_json` finds the magic at
+  // the slice start, equivalent to seeding the regex `pos()`).
+  process_ligogps_json(inner, out);
+}
+
+/// Decode a single LIGOGPSINFO JSON-object into a [`LigoGpsSample`].
+/// Faithful per LigoGPS.pm:342-393.
+fn decode_ligo_json_object(json: &str) -> Option<LigoGpsSample> {
+  // Tiny one-pass JSON-object scanner: extract `"key": "value"` or
+  // `"key": <number>` pairs. The bundled `Image::ExifTool::Import::Read
+  // JSON` is a full parser, but LIGOGPSINFO records are flat
+  // `{"key": "val", ...}` so a flat scanner suffices.
+  let mut hour: Option<u32> = None;
+  let mut minute: Option<u32> = None;
+  let mut second: Option<u32> = None;
+  let mut year: Option<u32> = None;
+  let mut month: Option<u32> = None;
+  let mut day: Option<u32> = None;
+  let mut m_hour: Option<u32> = None;
+  let mut m_minute: Option<u32> = None;
+  let mut m_second: Option<u32> = None;
+  let mut m_year: Option<u32> = None;
+  let mut m_month: Option<u32> = None;
+  let mut m_day: Option<u32> = None;
+  let mut status: Option<String> = None;
+  let mut ns: Option<String> = None;
+  let mut ew: Option<String> = None;
+  let mut latitude: Option<f64> = None;
+  let mut longitude: Option<f64> = None;
+  // The RAW JSON string of `Latitude`/`Longitude` — kept so the primary-pair
+  // emission can apply Perl string truthiness (`$$info{Latitude} and
+  // $$info{Longitude}`, LigoGPS.pm:362), which treats `""` and `"0"` as FALSE
+  // (so an exactly-`"0"` equator/prime-meridian coordinate suppresses the
+  // primary tags) while a parsed `0.0` from `"0.0"`/`"0.00000"` stays truthy.
+  let mut latitude_raw: Option<SmolStr> = None;
+  let mut longitude_raw: Option<SmolStr> = None;
+  let mut o_latitude: Option<f64> = None;
+  let mut o_longitude: Option<f64> = None;
+  let mut speed: Option<f64> = None;
+  let mut gsensor_x: Option<String> = None;
+  let mut gsensor_y: Option<String> = None;
+  let mut gsensor_z: Option<String> = None;
+
+  for (key, val) in iter_json_pairs(json) {
+    match key {
+      "Hour" => hour = val.parse().ok(),
+      "Minute" => minute = val.parse().ok(),
+      "Second" => second = val.parse().ok(),
+      "Year" => year = val.parse().ok(),
+      "Month" => month = val.parse().ok(),
+      "Day" => day = val.parse().ok(),
+      "MHour" => m_hour = val.parse().ok(),
+      "MMinute" => m_minute = val.parse().ok(),
+      "MSecond" => m_second = val.parse().ok(),
+      "MYear" => m_year = val.parse().ok(),
+      "MMonth" => m_month = val.parse().ok(),
+      "MDay" => m_day = val.parse().ok(),
+      "status" => status = Some(val.to_string()),
+      "NS" => ns = Some(val.to_string()),
+      "EW" => ew = Some(val.to_string()),
+      "Latitude" => {
+        latitude = val.parse().ok();
+        latitude_raw = Some(SmolStr::new(val));
+      }
+      "Longitude" => {
+        longitude = val.parse().ok();
+        longitude_raw = Some(SmolStr::new(val));
+      }
+      "OLatitude" => o_latitude = val.parse().ok(),
+      "OLongitude" => o_longitude = val.parse().ok(),
+      "Speed" => speed = val.parse().ok(),
+      "GsensorX" => gsensor_x = Some(val.to_string()),
+      "GsensorY" => gsensor_y = Some(val.to_string()),
+      "GsensorZ" => gsensor_z = Some(val.to_string()),
+      _ => {}
+    }
+  }
+
+  // LigoGPS.pm:353 — `next unless defined $$info{status} and $$info{status}
+  // eq 'A'` — only emit when GPS is active.
+  if status.as_deref() != Some("A") {
+    return None;
+  }
+
+  let mut sample = LigoGpsSample::new();
+  // LigoGPS.pm:357-361 — GPSDateTime (UTC, with Z suffix).
+  if let (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) =
+    (year, month, day, hour, minute, second)
+  {
+    let dt = String::from(&format!("{y:04}:{mo:02}:{d:02} {h:02}:{mi:02}:{s:02}Z"));
+    sample.set_date_time(Some(SmolStr::new(dt)));
+  }
+  // LigoGPS.pm:362-369 — Latitude/Longitude. The bundled `if ($$info{Latitude}
+  // and $$info{Longitude})` is PERL TRUTHINESS, NOT a `defined` check (contrast
+  // OLatitude/OLongitude below). A JSON string of exactly `"0"` (or `""`) is
+  // Perl-FALSE, so a coordinate sitting on the equator / prime-meridian written
+  // as `"0"` does NOT emit the primary GPSLatitude/GPSLongitude (the record
+  // still consumed its `Doc<N>`). `"0.0"`/`"0.00000"` are Perl-TRUE and emit.
+  let perl_truthy = |s: &Option<SmolStr>| s.as_deref().is_some_and(|v| !v.is_empty() && v != "0");
+  if perl_truthy(&latitude_raw)
+    && perl_truthy(&longitude_raw)
+    && let (Some(lat0), Some(lon0)) = (latitude, longitude)
+  {
+    let lat = if ns.as_deref() == Some("S") {
+      -lat0
+    } else {
+      lat0
+    };
+    let lon = if ew.as_deref() == Some("W") {
+      -lon0
+    } else {
+      lon0
+    };
+    sample.set_latitude(Some(lat));
+    sample.set_longitude(Some(lon));
+  }
+  // LigoGPS.pm:370 — Speed (knots → km/h).
+  if let Some(sp) = speed {
+    sample.set_speed_kph(Some(sp * KNOTS_TO_KPH));
+  }
+  // LigoGPS.pm:371-373 — Gsensor (raw, space-joined; bundled comment says
+  // "don't know conversion factor").
+  if let (Some(x), Some(y), Some(z)) = (gsensor_x, gsensor_y, gsensor_z) {
+    let mut s = String::with_capacity(x.len() + y.len() + z.len() + 2);
+    s.push_str(&x);
+    s.push(' ');
+    s.push_str(&y);
+    s.push(' ');
+    s.push_str(&z);
+    sample.set_accelerometer(Some(SmolStr::new(s)));
+  }
+  // LigoGPS.pm:376-380 — DateTimeOriginal (dashcam local clock).
+  if let (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) =
+    (m_year, m_month, m_day, m_hour, m_minute, m_second)
+  {
+    let dt = format!("{y:04}:{mo:02}:{d:02} {h:02}:{mi:02}:{s:02}");
+    sample.set_date_time_local(Some(SmolStr::new(dt)));
+  }
+  // LigoGPS.pm:382-388 — GPSLatitude2/GPSLongitude2 from OLatitude/OLongitude.
+  // Gated on `defined` (NOT truthy as the primary lat/lon is — the bundled uses
+  // `if (defined $$info{OLatitude} and defined $$info{OLongitude})`), then signed
+  // by the SAME `NS`/`EW` refs.
+  if let (Some(olat0), Some(olon0)) = (o_latitude, o_longitude) {
+    let olat = if ns.as_deref() == Some("S") {
+      -olat0
+    } else {
+      olat0
+    };
+    let olon = if ew.as_deref() == Some("W") {
+      -olon0
+    } else {
+      olon0
+    };
+    sample.set_latitude2(Some(olat));
+    sample.set_longitude2(Some(olon));
+  }
+  Some(sample)
+}
+
+/// Iterate over `"key": "value"` or `"key": <number>` pairs in a JSON
+/// flat object. Designed for the LIGOGPSINFO JSON variant only — no
+/// nested objects, no escape sequences in values.
+fn iter_json_pairs(json: &str) -> impl Iterator<Item = (&str, &str)> {
+  // Find quoted-string keys followed by `:` and either a quoted string
+  // value or a numeric value.
+  let s = json.trim().trim_start_matches('{').trim_end_matches('}');
+  s.split(',').filter_map(|pair| {
+    let colon = pair.find(':')?;
+    let key_raw = pair[..colon].trim();
+    let key = key_raw.trim_matches('"').trim();
+    let val_raw = pair[colon + 1..].trim();
+    // Strip surrounding quotes if present.
+    let val = if val_raw.starts_with('"') && val_raw.ends_with('"') && val_raw.len() >= 2 {
+      &val_raw[1..val_raw.len() - 1]
+    } else {
+      val_raw
+    };
+    Some((key, val))
+  })
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  // ── decrypt_record ────────────────────────────────────────────────────────
+
+  #[test]
+  fn decrypt_record_rejects_short_header() {
+    assert!(decrypt_record(&[0u8; 4]).is_none());
+    assert!(decrypt_record(&[]).is_none());
+  }
+
+  #[test]
+  fn decrypt_record_rejects_num_too_small() {
+    // num < 4 → return undef
+    let mut buf = vec![b'#', b'#', b'#', b'#'];
+    buf.extend_from_slice(&3u32.to_le_bytes()); // num = 3
+    assert!(decrypt_record(&buf).is_none());
+  }
+
+  #[test]
+  fn decrypt_record_caps_num_at_0x84() {
+    // num = 1000 (capped at 0x84 = 132); provide 132 bytes of single-output
+    // mode 0x00 (steering 0x00 → 1 input byte, 1 output byte).
+    let mut buf = vec![b'#', b'#', b'#', b'#'];
+    buf.extend_from_slice(&1000u32.to_le_bytes());
+    // 132 rounds of (steering=0x00, input_byte=0x10). Each round consumes
+    // 2 bytes (the steering and the input), emitting 1 byte.
+    for _ in 0..132 {
+      buf.push(0x00); // steering
+      buf.push(0x40); // input byte (0x40 | 0x13 = 0x53 = 'S')
+    }
+    let out = decrypt_record(&buf).expect("decrypts");
+    // num was capped at 0x84 = 132, but since each steering=0x00 round
+    // consumes 2 input bytes (steering+1 input), num input bytes only
+    // produces num/2 rounds = 66 output bytes. Bundled consumes `num`
+    // input bytes total.
+    assert!(!out.is_empty());
+  }
+
+  #[test]
+  fn decrypt_record_steering_zero_single_byte() {
+    // Mode 0x00: next byte combined with `b & 0x13` (so b=0x00 means
+    // output = next_byte | 0 = next_byte).
+    let mut buf = vec![b'#', b'#', b'#', b'#'];
+    buf.extend_from_slice(&8u32.to_le_bytes()); // num = 8 (4 rounds × 2 bytes)
+    // 4 rounds of (steering=0x00, input=0x41='A')
+    for _ in 0..4 {
+      buf.push(0x00);
+      buf.push(0x41);
+    }
+    let out = decrypt_record(&buf).expect("decrypts");
+    assert_eq!(out, b"AAAA");
+  }
+
+  // ── unfuzz ────────────────────────────────────────────────────────────────
+
+  #[test]
+  fn unfuzz_identity_when_scale_one() {
+    // With scale = 1 the formula does NOT recover the original; this
+    // verifies the math matches the bundled algorithm.
+    // Pre-fuzz: lat=31.5, lon=124.7
+    // lat2 = floor(3.15)*10 = 30, lon2 = floor(12.47)*10 = 120
+    // result = (30 + (124.7-120)*1, 120 + (31.5-30)*1) = (34.7, 121.5)
+    let (ul, ulon) = unfuzz(31.5, 124.7, 1.0);
+    assert!((ul - 34.7).abs() < 1e-9);
+    assert!((ulon - 121.5).abs() < 1e-9);
+  }
+
+  #[test]
+  fn unfuzz_scale_three_for_abask() {
+    // scale = 1.15368 (ABASK A8 4K, QuickTimeStream.pl:1886).
+    let (ul, _ulon) = unfuzz(31.5, 124.7, 1.15368);
+    // lat2 = 30, lon2 = 120, ul = 30 + (124.7-120)*1.15368 = 30 + 5.422... ≈ 35.422
+    assert!((ul - 35.4229_f64).abs() < 1e-3);
+  }
+
+  #[test]
+  fn parse_record_fuzzed_default_scale_uses_gps_scl_1_not_unity() {
+    // LigoGPS.pm:248-251 — when the record IS fuzzed (`flags & 0x01 == 0`)
+    // and NO LigoGPSScale is set (`scale_id = None`), the default scale is
+    // `1`, which remaps to `%gpsScl{1} = 1.524855137` (LigoGPS.pm:241,250) —
+    // NOT a literal 1.0. This is the iiway s1 / XGODY / Rexing / Kingslim
+    // default-scale path (offsets 16/48/80 set no LigoGPSScale).
+    //
+    // Raw fuzzed lat=31.5, lon=124.7 (both < 100 ⇒ no DDMM conversion). The
+    // ASCII record carries N: / E: refs (positive), and `flags = 0` selects
+    // the fuzzed branch. Speed scale is irrelevant to lat/lon.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]); // 4-byte counter (consumed by `.{4}`)
+    buf.extend_from_slice(b"2024/01/15 10:00:00 N:31.5 E:124.7 30.0");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x00, None, false, &mut out);
+
+    // Oracle (UnfuzzLigoGPS, LigoGPS.pm:38-44) with scl = %gpsScl{1}:
+    //   scl  = 1.524855137
+    //   lat2 = int(31.5 / 10) * 10  = 30
+    //   lon2 = int(124.7 / 10) * 10 = 120
+    //   lat' = lat2 + (lon - lon2) * scl = 30  + (124.7-120)*scl
+    //   lon' = lon2 + (lat - lat2) * scl = 120 + (31.5-30)*scl
+    let scl = 1.524_855_137_f64;
+    let exp_lat = 30.0 + (124.7 - 120.0) * scl;
+    let exp_lon = 120.0 + (31.5 - 30.0) * scl;
+    let s = out
+      .samples()
+      .first()
+      .expect("decoded fuzzed default-scale record");
+    assert!(
+      (s.latitude().unwrap() - exp_lat).abs() < 1e-9,
+      "lat {:?} != oracle {exp_lat} (scl=%gpsScl{{1}})",
+      s.latitude()
+    );
+    assert!(
+      (s.longitude().unwrap() - exp_lon).abs() < 1e-9,
+      "lon {:?} != oracle {exp_lon} (scl=%gpsScl{{1}})",
+      s.longitude()
+    );
+    // Guard against a regression to the old `.unwrap_or(1.0)`: scl=1.0 would
+    // give lat'=34.7, lon'=121.5 — assert we are NOT producing that.
+    assert!(
+      (s.latitude().unwrap() - 34.7).abs() > 1e-3,
+      "must not use scl=1.0"
+    );
+    assert!(
+      (s.longitude().unwrap() - 121.5).abs() > 1e-3,
+      "must not use scl=1.0"
+    );
+  }
+
+  // ── parse_decoded_record ──────────────────────────────────────────────────
+
+  #[test]
+  fn parse_record_known_good_kph_no_fuzz() {
+    // From LigoGPS.pm:234 sample: "....2022/09/19 12:45:24 N:31.285065
+    // W:124.759483 46.93 km/h x:-0.000 y:-0.000 z:-0.000".
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]); // counter
+    buf.extend_from_slice(
+      b"2022/09/19 12:45:24 N:31.285065 W:124.759483 46.93 km/h x:-0.000 y:-0.000 z:-0.000",
+    );
+    let mut out = LigoGpsMeta::new();
+    // flags = 0x03 = not-fuzzed + kph (matches Redtiger F9 4K plain-ASCII path).
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.date_time(), Some("2022:09:19 12:45:24"));
+    // W means longitude is negative.
+    assert_eq!(s.latitude(), Some(31.285065));
+    assert_eq!(s.longitude(), Some(-124.759483));
+    assert_eq!(s.speed_kph(), Some(46.93));
+    assert_eq!(s.accelerometer(), Some("-0.000 -0.000 -0.000"));
+  }
+
+  #[test]
+  fn parse_record_with_track_alt_magvar() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(
+      b"2024/01/15 10:00:00 N:45.500 E:170.500 30.0 A:180.5 H:123.4 M:12.5 x:0 y:0 z:0",
+    );
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.track_deg(), Some(180.5));
+    assert_eq!(s.altitude_m(), Some(123.4));
+    assert_eq!(s.magnetic_variation(), Some(12.5));
+  }
+
+  #[test]
+  fn parse_record_south_latitude_signs_correctly() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"2024/01/15 10:00:00 S:45.500 E:170.500 30.0 km/h");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.latitude(), Some(-45.500));
+    assert_eq!(s.longitude(), Some(170.500));
+  }
+
+  #[test]
+  fn parse_record_explicit_negative_sign() {
+    // The bundled regex captures an explicit `-` in `($latNeg)` (group 3).
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"2024/01/15 10:00:00 N:-45.500 E:-170.500 30.0 km/h");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.latitude(), Some(-45.500));
+    assert_eq!(s.longitude(), Some(-170.500));
+  }
+
+  #[test]
+  fn parse_record_accepts_non_slash_date() {
+    // FINDING 1 — ExifTool's `ParseLigoGPS` regex (LigoGPS.pm:235
+    // `^.{4}(\S+ \S+)\s+([NS?]):...`) captures ANY non-space date token, then
+    // normalises it with `tr(/)(:)` (LigoGPS.pm:244 — a NO-OP for a non-slash
+    // date). A decrypted/binary record with a dash date `2024-01-15` is ACCEPTED
+    // (it decodes, bumps DOC_COUNT, emits GPS); the old slash-only guard DROPPED
+    // it. Assert the sample emits with the `/`→`:`-normalised (here unchanged)
+    // GPSDateTime.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]); // 4-byte counter (the `.{4}` prefix)
+    buf.extend_from_slice(b"2024-01-15 10:00:00 N:45.5 E:170.5 30.0 km/h");
+    let mut out = LigoGpsMeta::new();
+    // flags = 0x03 (not fuzzed + km/h) — the plain raw lat/lon survive.
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    assert!(
+      out.warning().is_none(),
+      "a non-slash date is accepted, not a format error: {:?}",
+      out.warning()
+    );
+    let s = out.samples().first().expect("non-slash record decodes");
+    // `tr(/)(:)` leaves a dash date unchanged (no `/` to translate).
+    assert_eq!(s.date_time(), Some("2024-01-15 10:00:00"));
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+  }
+
+  #[test]
+  fn non_slash_record_takes_its_doc_so_next_record_ordinal_is_successor() {
+    // FINDING 1 — the regression the slash-guard caused on `Doc<N>`. In ExifTool
+    // a non-slash record PASSES the `ParseLigoGPS` regex (LigoGPS.pm:235) and so
+    // reaches `$$et{DOC_NUM} = ++$$et{DOC_COUNT}` (LigoGPS.pm:243): it consumes a
+    // global doc ordinal and the FOLLOWING record is its successor. The old port
+    // dropped the non-slash record BEFORE that bump, so every following record's
+    // `Doc<N>` sat one BELOW the oracle. Two records (non-slash then slash), both
+    // accepted ⇒ doc 1 then doc 2.
+    let mut out = LigoGpsMeta::new();
+    let mut rec1 = Vec::new();
+    rec1.extend_from_slice(&[0; 4]);
+    rec1.extend_from_slice(b"2024-01-15 10:00:00 N:45.5 E:170.5 30.0 km/h");
+    parse_decoded_record(&rec1, 0x03, None, false, &mut out);
+    let mut rec2 = Vec::new();
+    rec2.extend_from_slice(&[0; 4]);
+    rec2.extend_from_slice(b"2024/01/15 10:00:01 N:46.5 E:171.5 31.0 km/h");
+    parse_decoded_record(&rec2, 0x03, None, false, &mut out);
+    // Stamp from the shared counter (start at 0 — both records take docs 1, 2).
+    let next = out.stamp_doc_from(0, 0);
+    assert_eq!(out.samples().len(), 2, "both records produce a sample");
+    assert_eq!(
+      out.samples()[0].doc(),
+      Some(1),
+      "non-slash record takes Doc1"
+    );
+    assert_eq!(
+      out.samples()[1].doc(),
+      Some(2),
+      "the slash record's ordinal is the non-slash record's successor"
+    );
+    assert_eq!(next, 2, "the shared counter advanced for BOTH records");
+  }
+
+  #[test]
+  fn parse_record_emits_format_error_on_garbage() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"NOT A VALID RECORD");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    assert!(out.samples().is_empty());
+    assert_eq!(out.warning(), Some("LIGOGPSINFO format error"));
+  }
+
+  #[test]
+  fn parse_record_emits_oor_when_out_of_range() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"2024/01/15 10:00:00 N:91.0 E:181.0 0.0 km/h");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    // LigoGPS.pm:243 bumps `++DOC_COUNT` BEFORE the :254 out-of-range `return`,
+    // so the rejected record BURNS a `Doc<N>`: a single doc-consuming-but-
+    // suppressed placeholder is pushed (no GPS fields, the warning set).
+    assert_eq!(out.samples().len(), 1);
+    let s = &out.samples()[0];
+    assert!(s.is_suppressed());
+    assert_eq!(s.latitude(), None);
+    assert_eq!(s.longitude(), None);
+    assert_eq!(out.warning(), Some("LIGOGPSINFO coordinates out of range"));
+  }
+
+  // ── process_ligogps trailer-shape walker ─────────────────────────────────
+
+  #[test]
+  fn process_ligogps_too_short_is_silent() {
+    let mut out = LigoGpsMeta::new();
+    process_ligogps(b"too short", 0, &mut out, false);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn process_ligogps_walks_single_plain_record() {
+    // Trailer-style: `LIGOGPSINFO\0\0\0\0\x14` (20-byte preamble),
+    // then ONE 0x84-byte plain ASCII record.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(HDR_LIGOGPSINFO);
+    // 8 more bytes of preamble (the 0x14 byte at offset 0x13 — bytes
+    // [pos-8..pos-4] = [\0,\0,\0,\x14] triggers no_fuzz auto-detect).
+    buf.extend_from_slice(&[0, 0, 0, 0, 0x14, 0, 0, 0]);
+    // record body: 0x84 bytes total. Counter (4) + ASCII payload +
+    // padding.
+    let mut record = Vec::with_capacity(0x84);
+    record.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+    record.extend_from_slice(b"2024/01/15 10:00:00 N:45.5 E:170.5 30.0 km/h");
+    while record.len() < 0x84 {
+      record.push(0);
+    }
+    buf.extend_from_slice(&record);
+    let mut out = LigoGpsMeta::new();
+    process_ligogps(&buf, 0, &mut out, false);
+    assert_eq!(out.samples().len(), 1);
+    let s = &out.samples()[0];
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+  }
+
+  // ── process_trailer (via identify_trailers discovery) ───────────────────────
+
+  /// Drive the FULL trailer path the way `quicktime::parse_inner` does: the
+  /// shared `IdentifyTrailers` port (`insta360::identify_trailers`) discovers
+  /// the `&&&&`-anchored LigoGPS trailer, then [`process_trailer`] decodes its
+  /// `skip`-atom body. Returns the populated [`LigoGpsMeta`].
+  fn scan_trailer(data: &[u8]) -> LigoGpsMeta {
+    let mut out = LigoGpsMeta::new();
+    let trailers = crate::formats::insta360::identify_trailers(data);
+    if let Some(entry) = trailers.iter().find(|e| e.kind().is_ligogps()) {
+      // The box walk never runs in these unit fixtures, so the trailer is never
+      // "consumed by an atom" — process it directly (mirrors the `last_pos <=
+      // start` gate in `quicktime.rs`, trivially true here).
+      process_trailer(data, entry.start() as usize, entry.len() as usize, &mut out);
+    }
+    out
+  }
+
+  #[test]
+  fn scan_trailer_no_signature_leaves_out_empty() {
+    let out = scan_trailer(&[0u8; 100]);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn scan_trailer_short_file_silent() {
+    let out = scan_trailer(&[0u8; 10]);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn scan_trailer_bad_size_is_silent() {
+    // The `&&&&` signature with a trailer length larger than the file. Bundled's
+    // `Seek($$trailer[1], 0)` fails on the wrapped-negative start ⇒ `last`, no
+    // warning. (The #135 "Bad LigoGPS trailer size" warning was non-faithful —
+    // it has no source in QuickTime.pm/LigoGPS.pm.)
+    let mut data = vec![0u8; 80];
+    data[80 - 8..80 - 4].copy_from_slice(TRAILER_MAGIC);
+    data[80 - 4..].copy_from_slice(&999u32.to_le_bytes());
+    let out = scan_trailer(&data);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn scan_trailer_missing_skip_atom_is_silent() {
+    // Valid `&&&&` signature + in-range length, but the trailer body does NOT
+    // begin with a `skip` atom. Bundled's `if (... and $buff =~ /skip$/i)` is
+    // false ⇒ falls through the `elsif` arms (none match 'LigoGPS') ⇒ NO warning.
+    let mut data = vec![0u8; 100];
+    let trailer_len: u32 = 40;
+    let trailer_start = data.len() - trailer_len as usize;
+    // First 8 bytes: a non-`skip` atom name at bytes 4..8.
+    data[trailer_start..trailer_start + 8]
+      .copy_from_slice(&[0, 0, 0, 0x40, b'j', b'u', b'n', b'k']);
+    let sig_off = data.len() - 8;
+    data[sig_off..sig_off + 4].copy_from_slice(TRAILER_MAGIC);
+    data[sig_off + 4..].copy_from_slice(&trailer_len.to_le_bytes());
+    let out = scan_trailer(&data);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn scan_trailer_warns_on_missing_ligogpsinfo_magic() {
+    // Valid skip atom but no LIGOGPSINFO\0 at payload start.
+    let mut buf = Vec::new();
+    // Body: 8-byte skip header + random payload.
+    let body_len = SKIP_ATOM_HEADER + 32usize;
+    let mut body = vec![0u8; body_len];
+    // skip atom header: [size:u32-BE][skip]
+    body[..4].copy_from_slice(&(body_len as u32).to_be_bytes());
+    body[4..8].copy_from_slice(b"skip");
+    // Payload: 24 random bytes (no LIGOGPSINFO\0).
+    for i in 0..24 {
+      body[8 + i] = (i + 0x40) as u8;
+    }
+    // Build the full file: padding + trailer body + signature + len.
+    buf.extend_from_slice(&[0u8; 16]);
+    buf.extend_from_slice(&body);
+    let trailer_len = (body.len() + 8) as u32; // body + signature(4) + len(4)
+    buf.extend_from_slice(TRAILER_MAGIC);
+    // `IdentifyTrailers` reads the LigoGPS trailer length as BE `Get32u(buff,36)`
+    // (QuickTime.pm:9907, default `MM` order — see `insta360::identify_trailers`).
+    buf.extend_from_slice(&trailer_len.to_be_bytes());
+    let out = scan_trailer(&buf);
+    assert_eq!(out.warning(), Some("Unrecognized data in LigoGPS trailer"));
+  }
+
+  #[test]
+  fn scan_trailer_decodes_minimal_plain_ascii() {
+    // Build a valid trailer with the plain-ASCII Redtiger-F9-4K
+    // record format.
+    //
+    // File layout:
+    //   [padding 16 bytes]
+    //   [trailer body:
+    //     [skip atom header: size:u32-BE = body_len, "skip"]
+    //     [LIGOGPSINFO\0]
+    //     [8 more bytes of preamble incl. \0\0\0\x14 at offset 12]
+    //     [0x84 bytes of plain ASCII record]
+    //   ]
+    //   [&&&& : 4 bytes]
+    //   [trailer_len : u32-LE]
+    //
+    // The body the bundled code passes to ProcessLigoGPS is
+    // `LIGOGPSINFO\0...records...` (atom payload). Our scan_trailer
+    // dispatches `process_ligogps` on the *atom payload* (post 8-byte
+    // skip header), with DirStart=0; ProcessLigoGPS starts records at
+    // offset 0x14.
+    let mut payload = Vec::new();
+    payload.extend_from_slice(HDR_LIGOGPSINFO);
+    payload.extend_from_slice(&[0, 0, 0, 0x14, 0, 0, 0, 0]); // preamble: 8 more bytes
+    let mut record = Vec::with_capacity(0x84);
+    record.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+    record.extend_from_slice(b"2024/01/15 10:00:00 N:45.5 E:170.5 30.0 km/h");
+    while record.len() < 0x84 {
+      record.push(0);
+    }
+    payload.extend_from_slice(&record);
+
+    // Body = [skip atom header][payload]. QuickTime.pm:10660 reads the inner
+    // buffer as `$len = Get32u(buff,0) - 16` bytes, so the skip atom's declared
+    // SIZE field must be `16 + payload.len()` for the read to capture the FULL
+    // `LIGOGPSINFO\0...` payload (the #135 fixture wrote `8 + payload.len()`,
+    // i.e. `trailer_len - 8`, which truncated the record under the faithful
+    // `- 16` rule — corrected here).
+    let skip_atom_size = (16 + payload.len()) as u32;
+    let mut body = Vec::with_capacity(SKIP_ATOM_HEADER + payload.len());
+    body.extend_from_slice(&skip_atom_size.to_be_bytes());
+    body.extend_from_slice(b"skip");
+    body.extend_from_slice(&payload);
+
+    let trailer_len = (body.len() + 8) as u32;
+    let mut file = Vec::new();
+    file.extend_from_slice(&[0u8; 64]); // padding
+    file.extend_from_slice(&body);
+    file.extend_from_slice(TRAILER_MAGIC);
+    // BE trailer length (QuickTime.pm:9907 `Get32u(buff,36)`, default `MM`).
+    file.extend_from_slice(&trailer_len.to_be_bytes());
+
+    let out = scan_trailer(&file);
+    assert_eq!(
+      out.samples().len(),
+      1,
+      "expected 1 sample, got {} (warning: {:?})",
+      out.samples().len(),
+      out.warning()
+    );
+    let s = &out.samples()[0];
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+  }
+
+  // ── process_ligogps_json ─────────────────────────────────────────────────
+
+  #[test]
+  fn ligogps_json_decodes_active_record() {
+    let data = br#"LIGOGPSINFO {"Hour": "10", "Minute": "00", "Second": "00", "Year": "2024", "Month": "01", "Day": "15", "status": "A", "NS": "N", "EW": "E", "Latitude": "45.5", "Longitude": "170.5", "Speed": "20"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.date_time(), Some("2024:01:15 10:00:00Z"));
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+    // Speed = 20 knots * 1.852 = 37.04 km/h
+    assert_eq!(s.speed_kph(), Some(37.04));
+  }
+
+  #[test]
+  fn ligogps_json_skips_inactive_record() {
+    let data = br#"LIGOGPSINFO {"status": "V", "Latitude": "45.5"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    assert!(out.samples().is_empty());
+  }
+
+  #[test]
+  fn ligogps_json_decodes_local_time() {
+    let data = br#"LIGOGPSINFO {"status": "A", "MHour": "11", "MMinute": "30", "MSecond": "45", "MYear": "2024", "MMonth": "01", "MDay": "15"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.date_time_local(), Some("2024:01:15 11:30:45"));
+  }
+
+  #[test]
+  fn ligogps_json_south_negates_latitude() {
+    let data = br#"LIGOGPSINFO {"status": "A", "NS": "S", "EW": "W", "Latitude": "45.5", "Longitude": "170.5"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.latitude(), Some(-45.5));
+    assert_eq!(s.longitude(), Some(-170.5));
+  }
+
+  #[test]
+  fn ligogps_json_decodes_olatitude_olongitude_as_lat2_lon2() {
+    // LigoGPS.pm:382-388 — OLatitude/OLongitude → GPSLatitude2/GPSLongitude2,
+    // signed by the SAME NS/EW refs as the primary lat/lon.
+    let data = br#"LIGOGPSINFO {"status": "A", "NS": "S", "EW": "W", "Latitude": "12.5", "Longitude": "34.5", "OLatitude": "12.25", "OLongitude": "34.75"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.latitude(), Some(-12.5));
+    assert_eq!(s.longitude(), Some(-34.5));
+    assert_eq!(s.latitude2(), Some(-12.25));
+    assert_eq!(s.longitude2(), Some(-34.75));
+  }
+
+  #[test]
+  fn process_ligogps_json_tags_source_as_udta_json() {
+    // FINDING 1 — every record decoded by ProcessLigoJSON carries the UdtaJson
+    // source so the emitter can apply the no-`ee` FIRST-record semantics.
+    let data = br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "1.5", "Longitude": "2.5"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert!(
+      s.source().is_udta_json(),
+      "ProcessLigoJSON records are the udta-JSON family (Finding 1)"
+    );
+  }
+
+  #[test]
+  fn process_ligogps_json_decodes_across_non_utf8_padding() {
+    // FINDING 2 — a valid `LIGOGPSINFO {...}` object followed by BINARY (non-UTF8)
+    // padding must still decode: ExifTool matches the braced object on RAW BYTES
+    // (`/LIGOGPSINFO (\{.*?\})/`), it does NOT require the whole payload to be
+    // UTF-8. The previous `from_utf8(WHOLE slice)` rejected such a record.
+    let mut data = Vec::new();
+    data.extend_from_slice(
+      br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "5.5", "Longitude": "6.5"}"#,
+    );
+    // Binary padding (invalid UTF-8: a lone 0xFF / 0xFE / 0x80 run + NULs).
+    data.extend_from_slice(&[0xff, 0xfe, 0x80, 0x00, 0x00, 0x81, 0xc0]);
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(&data, &mut out);
+    let s = out
+      .samples()
+      .first()
+      .expect("the JSON object decodes despite trailing binary padding");
+    assert_eq!(s.latitude(), Some(5.5));
+    assert_eq!(s.longitude(), Some(6.5));
+  }
+
+  #[test]
+  fn gku_decodes_json_followed_by_non_utf8_padding() {
+    // FINDING 2 — the `GKUData` container is BINARY: the LE u32 at offset 0 points
+    // at an inner `LIGOGPSINFO {...}` object that is itself followed by binary
+    // padding. ExifTool decodes the object regardless (ProcessGKU → ProcessLigoJSON
+    // on the raw bytes, LigoGPS.pm:277-280). Build `[offset:u32-LE][pad..][JSON]
+    // [binary padding]`.
+    let json = br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "W", "Latitude": "7.5", "Longitude": "8.5"}"#;
+    let json_off: u32 = 16;
+    let mut data = Vec::new();
+    data.extend_from_slice(&json_off.to_le_bytes()); // bytes 0..4 = offset
+    data.extend_from_slice(&[0u8; 12]); // pad to `offset`
+    assert_eq!(data.len(), json_off as usize);
+    data.extend_from_slice(json); // inner `LIGOGPSINFO {...}` at `offset`
+    data.extend_from_slice(&[0xff, 0x00, 0xfe, 0x90, 0x00]); // trailing binary padding
+    let mut out = LigoGpsMeta::new();
+    process_gku(&data, &mut out);
+    let s = out
+      .samples()
+      .first()
+      .expect("GKU decodes the JSON object before the binary padding");
+    assert_eq!(s.latitude(), Some(7.5));
+    // EW=W ⇒ negative longitude.
+    assert_eq!(s.longitude(), Some(-8.5));
+    assert!(
+      s.source().is_udta_json(),
+      "GKU routes through ProcessLigoJSON"
+    );
+  }
+
+  #[test]
+  fn scan_trailer_rejects_json_variant() {
+    // The file-end trailer Condition is binary-only — `$buff =~ /^LIGOGPSINFO\0/`
+    // (QuickTime.pm:10661). A `LIGOGPSINFO {` JSON payload (12th byte = space) is
+    // NOT a binary trailer, so it falls into the `else` arm (QuickTime.pm:10667)
+    // ⇒ `Unrecognized data in LigoGPS trailer` and decodes NOTHING. The JSON form
+    // is reached only via the `udta` `LigoJSON` Condition (QuickTime.pm:835).
+    let mut payload = Vec::new();
+    payload.extend_from_slice(
+      br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "1.5", "Longitude": "2.5"}"#,
+    );
+    let skip_atom_size = (16 + payload.len()) as u32;
+    let mut body = Vec::with_capacity(SKIP_ATOM_HEADER + payload.len());
+    body.extend_from_slice(&skip_atom_size.to_be_bytes());
+    body.extend_from_slice(b"skip");
+    body.extend_from_slice(&payload);
+
+    let trailer_len = (body.len() + 8) as u32;
+    let mut file = Vec::new();
+    file.extend_from_slice(&[0u8; 64]); // padding
+    file.extend_from_slice(&body);
+    file.extend_from_slice(TRAILER_MAGIC);
+    file.extend_from_slice(&trailer_len.to_be_bytes());
+
+    let out = scan_trailer(&file);
+    assert!(
+      out.samples().is_empty(),
+      "JSON trailer must NOT decode via the binary trailer walker"
+    );
+    assert_eq!(out.warning(), Some("Unrecognized data in LigoGPS trailer"));
+  }
+
+  // ── DM→Decimal conversion ─────────────────────────────────────────────────
+
+  #[test]
+  fn convert_dm_to_decimal_round_trip() {
+    // 4500.5 = 45° + 0.5/60 = 45.00833...
+    let mut lat = 4500.5_f64;
+    let mut lon = 12030.0_f64;
+    convert_lat_lon_dm_to_decimal(&mut lat, &mut lon);
+    assert!((lat - 45.00833333333).abs() < 1e-6);
+    assert!((lon - 120.5).abs() < 1e-6);
+  }
+
+  #[test]
+  fn has_three_leading_digits_detects_dm() {
+    assert!(has_three_leading_digits("4500.5"));
+    assert!(has_three_leading_digits("12030.000"));
+    assert!(!has_three_leading_digits("45.5"));
+    assert!(!has_three_leading_digits("1.5"));
+  }
+
+  // ── Plain ASCII record detection ─────────────────────────────────────────
+
+  #[test]
+  fn is_plain_ascii_date_record_accepts_expected_shape() {
+    // The detector matches `m(^.{4}\d{4}/\d{2}/\d{2} )` (LigoGPS.pm:304)
+    // — 4 leading bytes (counter), then `YYYY/MM/DD `.
+    let mut rec = Vec::new();
+    rec.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // 4-byte counter
+    rec.extend_from_slice(b"2024/01/15 ...");
+    assert!(is_plain_ascii_date_record(&rec));
+  }
+
+  #[test]
+  fn is_plain_ascii_date_record_rejects_short() {
+    assert!(!is_plain_ascii_date_record(b"short"));
+  }
+
+  #[test]
+  fn is_plain_ascii_date_record_rejects_non_date() {
+    let mut rec = Vec::new();
+    rec.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+    rec.extend_from_slice(b"NOT DATE FORMAT");
+    assert!(!is_plain_ascii_date_record(&rec));
+  }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -112,6 +112,32 @@ pub mod canon_ctmd;
 // Gated on the `quicktime` feature.
 #[cfg(feature = "quicktime")]
 pub mod insta360;
+// LigoGPS — dashcam vendor GPS module. Faithful port of
+// `Image::ExifTool::LigoGPS` (LigoGPS.pm:1-431). Reached via TWO paths:
+//   (a) the `&&&& `-prefixed trailer at file EOF (QuickTime.pm:9906-9907
+//       + 10658-10668) — `IdentifyTrailers` matches `/\&\&\&\&(.{4})$/`
+//       at EOF-40, the trailer body begins `[size:u32-BE][skip]
+//       [LIGOGPSINFO\0...]`.
+//   (b) the freeGPS-embedded sample dispatch (QuickTimeStream.pl
+//       :1843-1888) — `LIGOGPSINFO\0` at offset 16/48/80 inside a
+//       freeGPS block. Wired through `quicktime_freegps::process_free_gps`.
+// Records are fixed-stride 0x84 bytes, either `####`-prefixed encrypted
+// (LigoGPS.pm:50-99 DecryptLigoGPS) or plain-ASCII (Redtiger F9 4K).
+// JSON variant (LigoGPS.pm:334-398 ProcessLigoJSON) handles Yada
+// RoadCam Pro 4K BT58189. Gated on the `quicktime` feature.
+#[cfg(feature = "quicktime")]
+pub mod ligogps;
+// Parrot mett — drone timed-metadata walker. Faithful port of
+// `Image::ExifTool::Parrot::Process_mett` (Parrot.pm:791-854) +
+// the per-version binary tables `Image::ExifTool::Parrot::V1`/`V2`/
+// `V3`/`TimeStamp`/`FollowMe`/`Automation` (Parrot.pm:86-660).
+// Reached through the `mett` MetaFormat dispatch in [`quicktime_stream`]
+// (QuickTimeStream.pl:312-315 routes `mett` SubDirectory → Parrot::mett).
+// Surfaces drone GPS + flight telemetry for Anafi / Anafi USA / Anafi
+// Ai / Anafi Thermal / Bebop / Bebop 2 / Disco bodies. Gated on the
+// `quicktime` feature.
+#[cfg(feature = "quicktime")]
+pub mod parrot;
 #[cfg(feature = "real")]
 pub mod real;
 #[cfg(feature = "red")]

--- a/src/formats/parrot.rs
+++ b/src/formats/parrot.rs
@@ -1,0 +1,1306 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "quicktime")]
+//! Faithful port of `Image::ExifTool::Parrot::Process_mett`
+//! (Parrot.pm:791-854) — the Parrot drone `mett` timed-metadata walker
+//! shared by Anafi / Anafi USA / Anafi Ai / Anafi Thermal / Bebop /
+//! Bebop 2 / Disco bodies. Backed by the per-record-version binary
+//! tables `Image::ExifTool::Parrot::V1` / `V2` / `V3` (Parrot.pm:86-539)
+//! and the extension records `TimeStamp` / `FollowMe` / `Automation`
+//! (Parrot.pm:541-660).
+//!
+//! ## Record layout (Parrot.pm:823-852)
+//!
+//! Each `mett` sample is a sequence of records. The walker tries two
+//! shapes in order:
+//!
+//!  1. **MetaType-keyed (ARCore)** — Parrot.pm:802-822. When the
+//!     incoming `MetaType` (e.g. `"application/arcore-accel"`) is a
+//!     key in the `%mett` table, each record is `[0x0a][len:u8][payload
+//!     :len bytes]` (a TLV walk). The `MetaType` value selects the
+//!     ARCore-specific subtable. ARCore data is phone-camera AR
+//!     telemetry, NOT drone-side GPS, so this port WALKS the records
+//!     faithfully but discards their values (camera-indexing scope).
+//!  2. **ID-keyed (Parrot drones)** — Parrot.pm:823-852. Each record
+//!     is `[id:2 bytes][nwords:u16-BE][payload]` where:
+//!      - `id` is `"P1"` / `"P2"` / `"P3"` for a basic record, or
+//!        `"E1"` / `"E2"` / `"E3"` for an extension record;
+//!      - `nwords` is the record byte size minus the 4-byte prefix,
+//!        in `u32`-sized units; total record size is `nwords*4 + 4`;
+//!      - **size override** — `P2` records are forced to 56 bytes and
+//!        `P3` to 72 bytes (Parrot.pm:836-841), since their nwords
+//!        field reports only the basic-record size but the walker
+//!        consumes the E* extension records concatenated after.
+//!      - **V1 fallback** — Parrot.pm:827-833: if the first 2 bytes
+//!        aren't a `[EP]\d` ID AND `dirEnd == 60`, treat the buffer as
+//!        a fake `P1` V1 recording-record, skipping the first 4 bytes
+//!        (the recording-frame timestamp goes undecoded as a bundled
+//!        choice, "augh!").
+//!
+//! ## Endianness
+//!
+//! The walker (Parrot.pm:824 `unpack("x${pos}a2n", $$dataPt)`) reads
+//! `nwords` as `n` = big-endian u16. The PER-RECORD binary tables don't
+//! call `SetByteOrder`, so they inherit the QuickTime movie default of
+//! big-endian (`MM`) — every `int16s` / `int32s` / `int16u` / `int32u`
+//! field decoded from V1 / V2 / V3 / TimeStamp / FollowMe / Automation
+//! payloads is BIG-ENDIAN.
+//!
+//! ## What this port surfaces (FULL mett parity)
+//!
+//! EVERY field of the per-version drone tables and extension records is
+//! decoded:
+//!  - **`P1` / `P2` / `P3` GPS** — lat/lon/alt/SV count, plus the V2/V3
+//!    GNSS velocity vector (`GPSVelocity{North,East,Down}`) →
+//!    [`ParrotGpsSample`];
+//!  - **`P1` / `P2` / `P3` flight + pose** — Battery%, WifiRSSI, ISO,
+//!    ExposureTime, FlyingState, PilotingMode, Binning, Animation,
+//!    AltitudeFromTakeOff (V1), DistanceFromHome (V1), Elevation (V2/V3),
+//!    AirSpeed (V2/V3), DroneYaw/Pitch/Roll (V1), CameraPan/CameraTilt
+//!    (V1/V2), SpeedX/Y/Z (V1), FrameView (all), DroneQuaternion (V2/V3),
+//!    FrameBaseView (V3), RedBalance/BlueBalance (V3), FOV (V3),
+//!    LinkGoodput/LinkQuality (V3) → [`ParrotFlightSample`];
+//!  - **`E1 TimeStamp`** (us counter) concatenated onto the host
+//!    [`ParrotFlightSample`];
+//!  - **`E2 FollowMe`** — follow-me target waypoint + mode/animation →
+//!    [`ParrotFollowMeSample`];
+//!  - **`E3 Automation`** — framing + destination waypoints +
+//!    animation/flags → [`ParrotAutomationSample`].
+//!
+//! ## What this port walks but discards
+//!
+//! Faithful but unsurfaced (the walker visits, the typed layer discards):
+//!  - **ARCore subtables** — phone-side AR telemetry, not drone-side
+//!    GPS. The TLV walker still steps over the records; their values are
+//!    discarded (flagged separately for the user).
+//!
+//! ## GPS priority chain
+//!
+//! Parrot mett GPS is the **THIRD tier** of the cross-port GPS priority
+//! chain that [`crate::metadata::MediaMetadata`] projects from a QuickTime
+//! file: GoPro GPMF → Android CAMM → **Parrot mett** → Sony rtmd →
+//! Canon CTMD → Insta360 trailer → SP3 stream. Parrot mett is on-device
+//! GNSS hardware (the drone's own GNSS) — same fidelity tier as GoPro /
+//! CAMM; ordered after CAMM by implementation arrival (a single file is
+//! produced by exactly one body so the tie-break is hypothetical).
+
+use smol_str::SmolStr;
+
+use crate::metadata::{
+  ParrotAutomationAnimation, ParrotAutomationSample, ParrotFlightSample, ParrotFlyingState,
+  ParrotFollowMeAnimation, ParrotFollowMeSample, ParrotGpsSample, ParrotMeta, ParrotPilotingMode,
+  ParrotRecordVersion,
+};
+
+// ===========================================================================
+// Big-endian readers (Parrot inherits the QuickTime movie default 'MM')
+// ===========================================================================
+
+fn be_u16(b: &[u8], off: usize) -> Option<u16> {
+  Some(u16::from_be_bytes(b.get(off..off + 2)?.try_into().ok()?))
+}
+
+fn be_i16(b: &[u8], off: usize) -> Option<i16> {
+  be_u16(b, off).map(|v| v as i16)
+}
+
+fn be_u32(b: &[u8], off: usize) -> Option<u32> {
+  Some(u32::from_be_bytes(b.get(off..off + 4)?.try_into().ok()?))
+}
+
+fn be_i32(b: &[u8], off: usize) -> Option<i32> {
+  be_u32(b, off).map(|v| v as i32)
+}
+
+fn be_u64(b: &[u8], off: usize) -> Option<u64> {
+  Some(u64::from_be_bytes(b.get(off..off + 8)?.try_into().ok()?))
+}
+
+// ===========================================================================
+// Shared ValueConv helpers
+// ===========================================================================
+
+/// The radian→degree ValueConv used by `DroneYaw` / `DronePitch` / `DroneRoll`
+/// (V1) and `CameraPan` / `CameraTilt` (V1 / V2): `$val / 0x1000 * 180 / 3.14159`
+/// (Parrot.pm:94 etc.). ExifTool uses the literal `3.14159`, NOT a higher-
+/// precision π — match it byte-for-byte.
+#[inline]
+// The literal `3.14159` is REQUIRED for byte-exact parity with ExifTool's
+// ValueConv; `std::f64::consts::PI` (3.141592653589793) would change the result.
+#[allow(clippy::approx_constant)]
+fn rad_int16_to_deg(raw: i16) -> f64 {
+  f64::from(raw) / f64::from(0x1000) * 180.0 / 3.14159
+}
+
+/// A 4-element `int16s[N]` quaternion / view vector, each component divided by
+/// `divisor` (`0x1000` for V1 FrameView, `0x4000` for the V2/V3 quaternions).
+/// Mirrors the bundled `my @a = split " ",$val; $_ /= D foreach @a; "@a"`
+/// (Parrot.pm:119 / :290 / :295 / :431 / :436 / :441) — but the typed layer
+/// stores the four scaled f64 components and the emitter does the `"@a"`
+/// space-join. Returns `None` if fewer than 8 bytes are available.
+#[inline]
+fn be_i16x4(b: &[u8], off: usize, divisor: f64) -> Option<[f64; 4]> {
+  let w0 = be_i16(b, off)?;
+  let w1 = be_i16(b, off + 2)?;
+  let w2 = be_i16(b, off + 4)?;
+  let w3 = be_i16(b, off + 6)?;
+  Some([
+    f64::from(w0) / divisor,
+    f64::from(w1) / divisor,
+    f64::from(w2) / divisor,
+    f64::from(w3) / divisor,
+  ])
+}
+
+/// A 2-element `int16u[2]` vector, each component divided by `divisor`. The
+/// `FOV` ValueConv `my @a = split " ",$val; $_ /= 0x100 foreach @a; "@a"`
+/// (Parrot.pm:473) over `Format => 'int16u[2]'`. Returns `None` if fewer than
+/// 4 bytes are available.
+#[inline]
+fn be_u16x2(b: &[u8], off: usize, divisor: f64) -> Option<[f64; 2]> {
+  let w0 = be_u16(b, off)?;
+  let w1 = be_u16(b, off + 2)?;
+  Some([f64::from(w0) / divisor, f64::from(w1) / divisor])
+}
+
+// ===========================================================================
+// V1 / V2 / V3 record sizes (Parrot.pm:836-841)
+// ===========================================================================
+
+/// V1 60-byte fallback record (Parrot.pm:828 `last unless $dirEnd == 60`).
+const V1_FALLBACK_SIZE: usize = 60;
+
+/// V2 fixed record size (Parrot.pm:836-837): the `nwords` field reports
+/// only the BASIC record size but the walker consumes the E*
+/// extensions concatenated after, so the record is forced to 56 bytes.
+const V2_RECORD_SIZE: usize = 56;
+
+/// V3 fixed record size (Parrot.pm:838-839).
+const V3_RECORD_SIZE: usize = 72;
+
+// ===========================================================================
+// Per-version GPS decoders
+// ===========================================================================
+
+/// V1 GPS decode (Parrot.pm:144-167). The V1 walker `HandleTag`s the
+/// 60-byte slot directly; lat/lon live at offsets 28 / 32 scaled by
+/// `0x100000` (`1 << 20`); altitude is the upper 24 bits of the int32s
+/// at offset 36 scaled by `0x100` (`1 << 8`); SV count is the low byte.
+fn decode_v1_gps(payload: &[u8]) -> ParrotGpsSample {
+  let mut g = ParrotGpsSample::new(ParrotRecordVersion::V1);
+  // Parrot.pm:144-149 — lat int32s @28 / 0x100000.
+  if let Some(raw) = be_i32(payload, 28) {
+    g.set_latitude(Some(f64::from(raw) / f64::from(0x10_0000)));
+  }
+  // Parrot.pm:150-155 — lon int32s @32 / 0x100000.
+  if let Some(raw) = be_i32(payload, 32) {
+    g.set_longitude(Some(f64::from(raw) / f64::from(0x10_0000)));
+  }
+  // Parrot.pm:156-162 — alt int32s @36, `Mask => 0xffffff00`,
+  // `ValueConv => '$val / 0x100'`. ExifTool applies the mask FIRST
+  // (ExifTool.pm:10078-10079 `$val = ($val & $mask) >> $bitShift`, with the
+  // BitShift derived from the mask = 8), THEN the ValueConv divides by 0x100.
+  // Perl's bitwise `&` yields an UNSIGNED integer, so `(int32s & 0xffffff00)`
+  // is never negative (the sign bits are part of the masked-out byte's high
+  // bits but the result is a non-negative UV); read the word UNSIGNED so the
+  // mask + shift + /256 match Perl exactly (the old signed `>> 8` both
+  // sign-extended AND dropped the /256).
+  if let Some(w) = be_u32(payload, 36) {
+    let alt = f64::from((w & 0xffff_ff00) >> 8) / 256.0;
+    g.set_altitude_m(Some(alt));
+  }
+  // Parrot.pm:163-167 — SV count is the low byte of the same word.
+  if let Some(&b) = payload.get(39) {
+    g.set_satellites(Some(b));
+  }
+  g
+}
+
+/// V2/V3 GPS decode (Parrot.pm:242-265 / :383-406). Identical offsets
+/// and scaling between V2 and V3 — lat/lon `int32s / 0x400000` at 8/12,
+/// altitude `(int32s & 0xffffff00) / 0x100` at 16 (low byte = SV count).
+fn decode_v2_v3_gps(payload: &[u8], version: ParrotRecordVersion) -> ParrotGpsSample {
+  let mut g = ParrotGpsSample::new(version);
+  // Parrot.pm:242-247 / :383-388 — lat int32s @8 / 0x400000.
+  if let Some(raw) = be_i32(payload, 8) {
+    g.set_latitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:248-253 / :389-394 — lon int32s @12 / 0x400000.
+  if let Some(raw) = be_i32(payload, 12) {
+    g.set_longitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:254-260 / :395-401 — alt int32s @16, `Mask => 0xffffff00`,
+  // `ValueConv => '$val / 0x100'`. Same two-stage compute as V1 @36: mask +
+  // BitShift(8) (ExifTool.pm:10078-10079) THEN /0x100. Perl's `&` yields an
+  // unsigned result, so read the word UNSIGNED and divide by 256 (the old
+  // signed `>> 8` sign-extended AND dropped the /256).
+  if let Some(w) = be_u32(payload, 16) {
+    g.set_altitude_m(Some(f64::from((w & 0xffff_ff00) >> 8) / 256.0));
+  }
+  // Parrot.pm:261-265 / :402-406 — SV count = low byte of the alt word.
+  if let Some(&b) = payload.get(19) {
+    g.set_satellites(Some(b));
+  }
+  // Parrot.pm:266-280 / :407-421 — GPSVelocity{North,East,Down} int16s @20/22/24
+  // each `/0x100` (m/s). No PrintConv → raw number both modes.
+  if let Some(raw) = be_i16(payload, 20) {
+    g.set_velocity_north_mps(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  if let Some(raw) = be_i16(payload, 22) {
+    g.set_velocity_east_mps(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  if let Some(raw) = be_i16(payload, 24) {
+    g.set_velocity_down_mps(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  g
+}
+
+// ===========================================================================
+// Per-version flight-telemetry decoders
+// ===========================================================================
+
+/// V1 flight-telemetry decode (Parrot.pm:91-228). Field offsets:
+///  - `DroneYaw` / `DronePitch` / `DroneRoll` int16s @4/6/8, rad→deg.
+///  - `CameraPan` / `CameraTilt` int16s @10/12, rad→deg.
+///  - `FrameView` int16s[4] @14, each `/0x1000`.
+///  - `ExposureTime` int16s @22, ValueConv `$val / 0x100 / 1000` (sec).
+///  - `ISO` int16s @24.
+///  - `WifiRSSI` int8s @26 (dBm).
+///  - `Battery` int8u @27 (%).
+///  - `AltitudeFromTakeOff` int32s @40, ValueConv `$val / 0x10000` (m).
+///  - `DistanceFromHome` int32u @44, ValueConv `$val / 0x10000`.
+///  - `SpeedX` / `SpeedY` / `SpeedZ` int16s @48/50/52, each `/0x100`.
+///  - `Binning` byte @54, `Mask => 0x80` (high bit of the FlyingState byte).
+///  - `FlyingState` int8u @54, low 7 bits.
+///  - `Animation` byte @55, `Mask => 0x80` (high bit of the PilotingMode byte).
+///  - `PilotingMode` int8u @55, low 7 bits.
+fn decode_v1_flight(payload: &[u8]) -> ParrotFlightSample {
+  let mut f = ParrotFlightSample::new(ParrotRecordVersion::V1);
+  // Parrot.pm:91-105 — DroneYaw/Pitch/Roll int16s @4/6/8, rad→deg.
+  if let Some(raw) = be_i16(payload, 4) {
+    f.set_drone_yaw_deg(Some(rad_int16_to_deg(raw)));
+  }
+  if let Some(raw) = be_i16(payload, 6) {
+    f.set_drone_pitch_deg(Some(rad_int16_to_deg(raw)));
+  }
+  if let Some(raw) = be_i16(payload, 8) {
+    f.set_drone_roll_deg(Some(rad_int16_to_deg(raw)));
+  }
+  // Parrot.pm:106-115 — CameraPan/CameraTilt int16s @10/12, rad→deg.
+  if let Some(raw) = be_i16(payload, 10) {
+    f.set_camera_pan_deg(Some(rad_int16_to_deg(raw)));
+  }
+  if let Some(raw) = be_i16(payload, 12) {
+    f.set_camera_tilt_deg(Some(rad_int16_to_deg(raw)));
+  }
+  // Parrot.pm:116-120 — FrameView int16s[4] @14, each /0x1000.
+  if let Some(v) = be_i16x4(payload, 14, f64::from(0x1000)) {
+    f.set_frame_view(Some(v));
+  }
+  // Parrot.pm:121-127 — ExposureTime int16s @22 / 0x100 / 1000.
+  if let Some(raw) = be_i16(payload, 22) {
+    f.set_exposure_time_s(Some(f64::from(raw) / f64::from(0x100) / 1000.0));
+  }
+  // Parrot.pm:128-132 — ISO int16s @24.
+  if let Some(raw) = be_i16(payload, 24) {
+    f.set_iso(Some(i32::from(raw)));
+  }
+  // Parrot.pm:133-138 — WifiRSSI int8s @26.
+  if let Some(&b) = payload.get(26) {
+    f.set_wifi_rssi_dbm(Some(b as i8));
+  }
+  // Parrot.pm:139-143 — Battery int8u @27 (no Format key ⇒ default int8u).
+  if let Some(&b) = payload.get(27) {
+    f.set_battery_percent(Some(b));
+  }
+  // Parrot.pm:168-173 — AltitudeFromTakeOff int32s @40 / 0x10000.
+  if let Some(raw) = be_i32(payload, 40) {
+    f.set_altitude_from_takeoff_m(Some(f64::from(raw) / f64::from(0x1_0000)));
+  }
+  // Parrot.pm:174-178 — DistanceFromHome int32u @44 / 0x10000.
+  if let Some(raw) = be_u32(payload, 44) {
+    f.set_distance_from_home_m(Some(f64::from(raw) / f64::from(0x1_0000)));
+  }
+  // Parrot.pm:179-193 — SpeedX/Y/Z int16s @48/50/52, each /0x100.
+  if let Some(raw) = be_i16(payload, 48) {
+    f.set_speed_x(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  if let Some(raw) = be_i16(payload, 50) {
+    f.set_speed_y(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  if let Some(raw) = be_i16(payload, 52) {
+    f.set_speed_z(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  // Parrot.pm:194-211 — Binning (Mask 0x80) + FlyingState (Mask 0x7f), byte @54.
+  if let Some(&b) = payload.get(54) {
+    f.set_binning(Some((b & 0x80) >> 7));
+    f.set_flying_state(Some(ParrotFlyingState::from_raw(b & 0x7f)));
+  }
+  // Parrot.pm:212-227 — Animation (Mask 0x80) + PilotingMode (Mask 0x7f), @55.
+  if let Some(&b) = payload.get(55) {
+    f.set_animation(Some((b & 0x80) >> 7));
+    f.set_piloting_mode(Some(ParrotPilotingMode::from_raw(b & 0x7f)));
+  }
+  f
+}
+
+/// V2 flight-telemetry decode (Parrot.pm:231-369). Field offsets:
+///  - `Elevation` int32s @4, ValueConv `$val / 0x10000`.
+///  - `AirSpeed` int16s @26 / 0x100, with `RawConv $val < 0 ? undef : $val`.
+///  - `DroneQuaternion` int16s[4] @28, each `/0x4000`.
+///  - `FrameView` int16s[4] @36, each `/0x4000`.
+///  - `CameraPan` / `CameraTilt` int16s @44/46, rad→deg.
+///  - `ExposureTime` int16u @48, ValueConv `$val / 0x100 / 1000`.
+///  - `ISO` int16u @50.
+///  - `Binning` byte @52, `Mask => 0x80`.
+///  - `FlyingState` int8u @52, low 7 bits.
+///  - `Animation` byte @53, `Mask => 0x80`.
+///  - `PilotingMode` int8u @53, low 7 bits.
+///  - `WifiRSSI` int8s @54.
+///  - `Battery` int8u @55.
+fn decode_v2_flight(payload: &[u8]) -> ParrotFlightSample {
+  let mut f = ParrotFlightSample::new(ParrotRecordVersion::V2);
+  // Parrot.pm:236-241 — Elevation int32s @4 / 0x10000.
+  if let Some(raw) = be_i32(payload, 4) {
+    f.set_elevation_m(Some(f64::from(raw) / f64::from(0x1_0000)));
+  }
+  // Parrot.pm:281-286 — AirSpeed int16s @26 / 0x100 with RawConv guard.
+  // Bundled `RawConv => '$val < 0 ? undef : $val'` (raw int16s value, not
+  // the post-ValueConv). So we read the raw int16s, drop negatives, then
+  // apply the /0x100 ValueConv. Negative AirSpeed is undef ⇒ None.
+  if let Some(raw) = be_i16(payload, 26)
+    && raw >= 0
+  {
+    f.set_air_speed_mps(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  // Parrot.pm:287-291 — DroneQuaternion int16s[4] @28, each /0x4000.
+  if let Some(v) = be_i16x4(payload, 28, f64::from(0x4000)) {
+    f.set_drone_quaternion(Some(v));
+  }
+  // Parrot.pm:292-296 — FrameView int16s[4] @36, each /0x4000.
+  if let Some(v) = be_i16x4(payload, 36, f64::from(0x4000)) {
+    f.set_frame_view(Some(v));
+  }
+  // Parrot.pm:297-306 — CameraPan/CameraTilt int16s @44/46, rad→deg.
+  if let Some(raw) = be_i16(payload, 44) {
+    f.set_camera_pan_deg(Some(rad_int16_to_deg(raw)));
+  }
+  if let Some(raw) = be_i16(payload, 46) {
+    f.set_camera_tilt_deg(Some(rad_int16_to_deg(raw)));
+  }
+  // Parrot.pm:307-313 — ExposureTime int16u @48 / 0x100 / 1000.
+  if let Some(raw) = be_u16(payload, 48) {
+    f.set_exposure_time_s(Some(f64::from(raw) / f64::from(0x100) / 1000.0));
+  }
+  // Parrot.pm:314-318 — ISO int16u @50.
+  if let Some(raw) = be_u16(payload, 50) {
+    f.set_iso(Some(i32::from(raw)));
+  }
+  // Parrot.pm:319-339 — Binning (Mask 0x80) + FlyingState (Mask 0x7f), byte @52.
+  if let Some(&b) = payload.get(52) {
+    f.set_binning(Some((b & 0x80) >> 7));
+    f.set_flying_state(Some(ParrotFlyingState::from_raw(b & 0x7f)));
+  }
+  // Parrot.pm:340-356 — Animation (Mask 0x80) + PilotingMode (Mask 0x7f), @53.
+  if let Some(&b) = payload.get(53) {
+    f.set_animation(Some((b & 0x80) >> 7));
+    f.set_piloting_mode(Some(ParrotPilotingMode::from_raw(b & 0x7f)));
+  }
+  // Parrot.pm:358-363 — WifiRSSI int8s @54.
+  if let Some(&b) = payload.get(54) {
+    f.set_wifi_rssi_dbm(Some(b as i8));
+  }
+  // Parrot.pm:364-368 — Battery int8u @55.
+  if let Some(&b) = payload.get(55) {
+    f.set_battery_percent(Some(b));
+  }
+  f
+}
+
+/// V3 flight-telemetry decode (Parrot.pm:372-538). Field offsets:
+///  - `Elevation` int32s @4, ValueConv `$val / 0x10000`.
+///  - `AirSpeed` int16s @26 / 0x100, with `RawConv $val < 0 ? undef : $val`.
+///  - `DroneQuaternion` int16s[4] @28, each `/0x4000`.
+///  - `FrameBaseView` int16s[4] @36, each `/0x4000`.
+///  - `FrameView` int16s[4] @44, each `/0x4000`.
+///  - `ExposureTime` int16u @52, ValueConv `$val / 0x100 / 1000`.
+///  - `ISO` int16u @54.
+///  - `RedBalance` int16u @56, ValueConv `$val / 0x4000`.
+///  - `BlueBalance` int16u @58, ValueConv `$val / 0x4000`.
+///  - `FOV` int16u[2] @60, each `/0x100` (degrees).
+///  - `LinkGoodput` int32u @64, `Mask => 0xffffff00` (upper 24 bits), kbit/s.
+///  - `LinkQuality` int32u @64, `Mask => 0xff` (low byte), 0-5.
+///  - `WifiRSSI` int8s @68.
+///  - `Battery` int8u @69.
+///  - `Binning` byte @70, `Mask => 0x80`.
+///  - `FlyingState` int8u @70, low 7 bits.
+///  - `Animation` byte @71, `Mask => 0x80`.
+///  - `PilotingMode` int8u @71, low 7 bits.
+fn decode_v3_flight(payload: &[u8]) -> ParrotFlightSample {
+  let mut f = ParrotFlightSample::new(ParrotRecordVersion::V3);
+  // Parrot.pm:377-382 — Elevation int32s @4 / 0x10000.
+  if let Some(raw) = be_i32(payload, 4) {
+    f.set_elevation_m(Some(f64::from(raw) / f64::from(0x1_0000)));
+  }
+  // Parrot.pm:422-427 — AirSpeed int16s @26 / 0x100, RawConv guard.
+  if let Some(raw) = be_i16(payload, 26)
+    && raw >= 0
+  {
+    f.set_air_speed_mps(Some(f64::from(raw) / f64::from(0x100)));
+  }
+  // Parrot.pm:428-432 — DroneQuaternion int16s[4] @28, each /0x4000.
+  if let Some(v) = be_i16x4(payload, 28, f64::from(0x4000)) {
+    f.set_drone_quaternion(Some(v));
+  }
+  // Parrot.pm:433-437 — FrameBaseView int16s[4] @36, each /0x4000.
+  if let Some(v) = be_i16x4(payload, 36, f64::from(0x4000)) {
+    f.set_frame_base_view(Some(v));
+  }
+  // Parrot.pm:438-442 — FrameView int16s[4] @44, each /0x4000.
+  if let Some(v) = be_i16x4(payload, 44, f64::from(0x4000)) {
+    f.set_frame_view(Some(v));
+  }
+  // Parrot.pm:443-449 — ExposureTime int16u @52 / 0x100 / 1000.
+  if let Some(raw) = be_u16(payload, 52) {
+    f.set_exposure_time_s(Some(f64::from(raw) / f64::from(0x100) / 1000.0));
+  }
+  // Parrot.pm:450-454 — ISO int16u @54.
+  if let Some(raw) = be_u16(payload, 54) {
+    f.set_iso(Some(i32::from(raw)));
+  }
+  // Parrot.pm:455-460 — RedBalance int16u @56 / 0x4000.
+  if let Some(raw) = be_u16(payload, 56) {
+    f.set_red_balance(Some(f64::from(raw) / f64::from(0x4000)));
+  }
+  // Parrot.pm:461-466 — BlueBalance int16u @58 / 0x4000.
+  if let Some(raw) = be_u16(payload, 58) {
+    f.set_blue_balance(Some(f64::from(raw) / f64::from(0x4000)));
+  }
+  // Parrot.pm:467-474 — FOV int16u[2] @60, each /0x100 (degrees).
+  if let Some(v) = be_u16x2(payload, 60, f64::from(0x100)) {
+    f.set_fov_deg(Some(v));
+  }
+  // Parrot.pm:475-488 — LinkGoodput (Mask 0xffffff00) + LinkQuality (Mask 0xff),
+  // int32u @64. The mask + BitShift(8) on the upper 24 bits gives kbit/s; the
+  // low byte is the 0-5 quality. Perl `&` is unsigned, so read the word UNSIGNED.
+  if let Some(w) = be_u32(payload, 64) {
+    f.set_link_goodput_kbitps(Some((w & 0xffff_ff00) >> 8));
+    // `Mask => 0xff` ⇒ low byte (BitShift 0).
+    f.set_link_quality(Some((w & 0xff) as u8));
+  }
+  // Parrot.pm:489-494 — WifiRSSI int8s @68.
+  if let Some(&b) = payload.get(68) {
+    f.set_wifi_rssi_dbm(Some(b as i8));
+  }
+  // Parrot.pm:495-499 — Battery int8u @69.
+  if let Some(&b) = payload.get(69) {
+    f.set_battery_percent(Some(b));
+  }
+  // Parrot.pm:500-520 — Binning (Mask 0x80) + FlyingState (Mask 0x7f), byte @70.
+  if let Some(&b) = payload.get(70) {
+    f.set_binning(Some((b & 0x80) >> 7));
+    f.set_flying_state(Some(ParrotFlyingState::from_raw(b & 0x7f)));
+  }
+  // Parrot.pm:521-538 — Animation (Mask 0x80) + PilotingMode (Mask 0x7f), @71.
+  if let Some(&b) = payload.get(71) {
+    f.set_animation(Some((b & 0x80) >> 7));
+    f.set_piloting_mode(Some(ParrotPilotingMode::from_raw(b & 0x7f)));
+  }
+  f
+}
+
+// ===========================================================================
+// E1 TimeStamp extension decoder
+// ===========================================================================
+
+/// `Image::ExifTool::Parrot::TimeStamp` (Parrot.pm:541-551) — a 12-byte
+/// extension record `[id:"E1"][nwords:u16-BE]` followed by an int64u
+/// microsecond counter at offset 4 of the payload. ValueConv `$val / 1e6`
+/// converts microseconds → seconds, but the typed layer surfaces the
+/// raw microsecond integer (lossless) — the projection layer can divide
+/// when needed.
+fn decode_e1_timestamp(payload: &[u8]) -> Option<u64> {
+  // The payload here is the WHOLE record bytes (incl. the 4-byte
+  // id/nwords prefix); the timestamp lives at record offset 4.
+  // Parrot.pm:546-550 `Format => 'int64u'` at table offset 4.
+  be_u64(payload, 4)
+}
+
+// ===========================================================================
+// E2 FollowMe / E3 Automation extension decoders
+// ===========================================================================
+
+/// `Image::ExifTool::Parrot::FollowMe` (Parrot.pm:553-593). The payload is the
+/// WHOLE record bytes (incl. the 4-byte `[E2][nwords]` prefix), so the table
+/// offsets are positions within it. Fields:
+///  - `GPSTargetLatitude` int32s @4 / 0x400000.
+///  - `GPSTargetLongitude` int32s @8 / 0x400000.
+///  - `GPSTargetAltitude` int32s @12 / 0x10000.
+///  - `Follow-meMode` int8u @16 (BITMASK — stored raw, rendered at emit time).
+///  - `Follow-meAnimation` int8u @17.
+fn decode_e2_followme(payload: &[u8]) -> ParrotFollowMeSample {
+  let mut s = ParrotFollowMeSample::new();
+  // Parrot.pm:558-562 — GPSTargetLatitude int32s @4 / 0x400000.
+  if let Some(raw) = be_i32(payload, 4) {
+    s.set_target_latitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:563-567 — GPSTargetLongitude int32s @8 / 0x400000.
+  if let Some(raw) = be_i32(payload, 8) {
+    s.set_target_longitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:568-572 — GPSTargetAltitude int32s @12 / 0x10000.
+  if let Some(raw) = be_i32(payload, 12) {
+    s.set_target_altitude_m(Some(f64::from(raw) / f64::from(0x1_0000)));
+  }
+  // Parrot.pm:573-581 — Follow-meMode int8u @16 (BITMASK).
+  if let Some(&b) = payload.get(16) {
+    s.set_mode_flags(Some(b));
+  }
+  // Parrot.pm:582-592 — Follow-meAnimation int8u @17.
+  if let Some(&b) = payload.get(17) {
+    s.set_animation(Some(ParrotFollowMeAnimation::from_raw(b)));
+  }
+  s
+}
+
+/// `Image::ExifTool::Parrot::Automation` (Parrot.pm:595-660). The payload is the
+/// WHOLE record bytes (incl. the 4-byte `[E3][nwords]` prefix). Fields:
+///  - `GPSFramingLatitude` int32s @4 / 0x400000.
+///  - `GPSFramingLongitude` int32s @8 / 0x400000.
+///  - `GPSFramingAltitude` int32s @12 / 0x10000.
+///  - `GPSDestLatitude` int32s @16 / 0x400000.
+///  - `GPSDestLongitude` int32s @20 / 0x400000.
+///  - `GPSDestAltitude` int32s @24 / 0x10000.
+///  - `AutomationAnimation` int8u @28.
+///  - `AutomationFlags` int8u @29 (BITMASK — stored raw, rendered at emit time).
+fn decode_e3_automation(payload: &[u8]) -> ParrotAutomationSample {
+  let mut s = ParrotAutomationSample::new();
+  // Parrot.pm:600-604 — GPSFramingLatitude int32s @4 / 0x400000.
+  if let Some(raw) = be_i32(payload, 4) {
+    s.set_framing_latitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:605-609 — GPSFramingLongitude int32s @8 / 0x400000.
+  if let Some(raw) = be_i32(payload, 8) {
+    s.set_framing_longitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:610-614 — GPSFramingAltitude int32s @12 / 0x10000.
+  if let Some(raw) = be_i32(payload, 12) {
+    s.set_framing_altitude_m(Some(f64::from(raw) / f64::from(0x1_0000)));
+  }
+  // Parrot.pm:615-619 — GPSDestLatitude int32s @16 / 0x400000.
+  if let Some(raw) = be_i32(payload, 16) {
+    s.set_dest_latitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:620-624 — GPSDestLongitude int32s @20 / 0x400000.
+  if let Some(raw) = be_i32(payload, 20) {
+    s.set_dest_longitude(Some(f64::from(raw) / f64::from(0x40_0000)));
+  }
+  // Parrot.pm:625-629 — GPSDestAltitude int32s @24 / 0x10000.
+  if let Some(raw) = be_i32(payload, 24) {
+    s.set_dest_altitude_m(Some(f64::from(raw) / f64::from(0x1_0000)));
+  }
+  // Parrot.pm:630-650 — AutomationAnimation int8u @28.
+  if let Some(&b) = payload.get(28) {
+    s.set_animation(Some(ParrotAutomationAnimation::from_raw(b)));
+  }
+  // Parrot.pm:651-659 — AutomationFlags int8u @29 (BITMASK).
+  if let Some(&b) = payload.get(29) {
+    s.set_flags(Some(b));
+  }
+  s
+}
+
+// ===========================================================================
+// process_mett — the bundled Process_mett port
+// ===========================================================================
+
+/// Parrot.pm:791-854 — walk one `mett` timed-metadata sample.
+///
+/// Single sample per call (the QuickTime sample loop already iterates).
+/// Each `[EP]\d` ID-keyed record yields one [`ParrotGpsSample`] AND/OR
+/// [`ParrotFlightSample`] depending on which version produced it. The
+/// V2 / V3 size override (Parrot.pm:836-841) folds the E* extensions
+/// into the same record buffer; the E1 timestamp (when present at the
+/// end of a V2 / V3 record) is attached to the host flight sample.
+///
+/// `meta_type` is the bundled `$$et{MetaType}` — the sample-description
+/// MetaType string (`"application/arcore-accel"` and friends). When
+/// non-empty AND the string is one of the ARCore subtable keys, the
+/// walker switches to the TLV ARCore loop (Parrot.pm:802-822). For
+/// plain Parrot-drone `mett` (MetaType empty), it walks the [EP]\d ID
+/// loop (Parrot.pm:823-852).
+///
+/// Returns nothing — accumulates into `out` (one sample per `mett`
+/// record decoded).
+pub fn process_mett(data: &[u8], meta_type: Option<&str>, out: &mut ParrotMeta) {
+  let dir_end = data.len();
+  let mut pos = 0usize;
+  // Pre-call flight watermark. ExifTool's `Process_mett` runs under the ONE
+  // `DOC_NUM` that `ProcessSamples` opened for THIS `mett` sample
+  // (QuickTimeStream.pl:1517-1523), and `HandleTag`s every record — the
+  // P2/P3 GPS/flight fields and any E1 TimeStamp concatenated after them —
+  // under it (Parrot.pm:844-850). The port's dispatch
+  // ([`crate::formats::quicktime_stream::process_samples`]) mirrors that by
+  // watermarking the sample vectors before the call and stamping the CURRENT
+  // sample's `Doc<N>`/`Track<N>` onto exactly the records this call appended.
+  // So an E1 may only fold into a flight sample CREATED IN THIS CALL; folding
+  // into a flight sample left by a PRIOR `mett` sample would write the E1's
+  // timestamp onto the wrong document (and lose the standalone E1's own
+  // `Doc<N>`). Capture the count so the E1 arm can tell the two apart.
+  let flight_watermark = out.flight_sample_count();
+
+  // Parrot.pm:802 — `if ($$tagTbl{$metaType})`. The bundled `%mett`
+  // table includes the ARCore string keys (`application/arcore-accel`
+  // etc.). exifast does not decode the ARCore subtables (phone-side AR
+  // telemetry, not camera-indexing). Faithful walker for the ARCore
+  // case still needs to STEP over the records (so a future port can
+  // hook in) — bundled `Process_mett` returns 1 after the loop in either
+  // branch (Parrot.pm:821 / :853).
+  let is_arcore = meta_type.is_some_and(is_arcore_meta_type);
+  if is_arcore {
+    // Parrot.pm:804-820 — TLV loop: `[0x0a][len:u8][payload:len bytes]`.
+    // Oracle bound `while ($pos < $dirEnd - 2)` — a record needs the 0x0a tag
+    // byte + the length byte + at least one payload byte, so `pos + 2 < dir_end`
+    // (NOT `<=`; the trailing record must have a non-empty payload). Written
+    // additively to avoid the `dir_end - 2` underflow when `dir_end < 2`.
+    while pos + 2 < dir_end {
+      // Parrot.pm:805 `last unless substr(.., $pos, 1) eq "\x0a"`.
+      if data.get(pos) != Some(&0x0a) {
+        break;
+      }
+      let Some(&len_raw) = data.get(pos + 1) else {
+        break;
+      };
+      let len_byte = len_raw as usize;
+      let total = pos.saturating_add(len_byte).saturating_add(2);
+      // Parrot.pm:807-810 — overflow ⇒ first-only warning + stop.
+      if total > dir_end {
+        out.set_warning(SmolStr::new("Unexpected length for ARCore mett record"));
+        break;
+      }
+      // Parrot.pm:811 `$len or $len = $dirEnd - $pos - 2` — len 0 means
+      // "use the rest of the record".
+      let effective_len = if len_byte == 0 {
+        dir_end - pos - 2
+      } else {
+        len_byte
+      };
+      // FOLLOW-UP: decode the ARCore subtables (Parrot::ARCoreAccel /
+      // ARCoreAccel0 / ARCoreGyro / ARCoreGyro0 / ARCoreVideo /
+      // ARCoreCustom). Phone-side AR telemetry, not camera identity.
+      let _ = effective_len;
+      pos += len_byte + 2;
+      if len_byte == 0 {
+        // Defensive: a len-0 record means "consume the rest", so stop.
+        break;
+      }
+    }
+    return;
+  }
+
+  // Parrot.pm:823 `while ($pos + 4 < $dirLen)` — strict-less. A record
+  // needs the 4-byte id+nwords prefix readable past `$pos`.
+  while pos + 4 < dir_end {
+    let Some(id_bytes) = data
+      .get(pos..pos + 2)
+      .and_then(|s| <[u8; 2]>::try_from(s).ok())
+    else {
+      break;
+    };
+    let nwords = match be_u16(data, pos + 2) {
+      Some(v) => v,
+      None => break,
+    };
+
+    // Parrot.pm:826 `if ($id !~ /^[EP]\d/)`.
+    let id_is_ep = is_ep_id(&id_bytes);
+
+    let size: usize;
+    let mut effective_pos = pos;
+    let effective_id: [u8; 2];
+    if !id_is_ep {
+      // Parrot.pm:827-833 — V1 60-byte fallback. Only fires when the
+      // total dirEnd is exactly 60 bytes; otherwise stop.
+      if dir_end != V1_FALLBACK_SIZE {
+        break;
+      }
+      effective_id = *b"P1";
+      // Parrot.pm:832 `$pos += 4` — skip the first 4 bytes so the V1
+      // fields align with the rest of the V1 record (bundled "ignore
+      // the first 4 of the record"). Then `$size = $dirEnd - $pos`.
+      effective_pos = pos + 4;
+      size = dir_end - effective_pos;
+    } else if &id_bytes == b"P2" {
+      // Parrot.pm:836-837 — force V2 size to 56.
+      effective_id = id_bytes;
+      size = V2_RECORD_SIZE;
+    } else if &id_bytes == b"P3" {
+      // Parrot.pm:838-839 — force V3 size to 72.
+      effective_id = id_bytes;
+      size = V3_RECORD_SIZE;
+    } else {
+      // Parrot.pm:840-842 — `$size = $nwords * 4 + 4` for any other
+      // [EP]\d ID (P1 in a normal sample, E1/E2/E3 when freestanding).
+      effective_id = id_bytes;
+      size = usize::from(nwords) * 4 + 4;
+    }
+
+    // Parrot.pm:843 `last if $pos + $size > $dirEnd`.
+    if effective_pos.checked_add(size).is_none_or(|e| e > dir_end) {
+      break;
+    }
+
+    let Some(payload) = data.get(effective_pos..effective_pos + size) else {
+      break;
+    };
+
+    // Parrot.pm:844-850 — HandleTag dispatch. Per-id decoders here.
+    match &effective_id {
+      b"P1" => {
+        // V1: emit GPS + flight from the same 60-byte payload.
+        let g = decode_v1_gps(payload);
+        if !g.is_empty() {
+          out.push_gps_sample(g);
+        }
+        let f = decode_v1_flight(payload);
+        if !f.is_empty() {
+          out.push_flight_sample(f);
+        }
+      }
+      b"P2" => {
+        // Per Parrot.pm:836-837 — the size override advances $pos by
+        // exactly 56 bytes (the basic V2 record). Any E1/E2/E3
+        // extensions concatenated after live PAST $pos+56 in the
+        // sample buffer and are picked up as separate iterations of
+        // the outer while-loop below (where they hit the `b"E1"` /
+        // `b"E2"` / `b"E3"` arms).
+        let g = decode_v2_v3_gps(payload, ParrotRecordVersion::V2);
+        if !g.is_empty() {
+          out.push_gps_sample(g);
+        }
+        let f = decode_v2_flight(payload);
+        if !f.is_empty() {
+          out.push_flight_sample(f);
+        }
+      }
+      b"P3" => {
+        // Same outer-loop continuation as P2 (Parrot.pm:838-839).
+        let g = decode_v2_v3_gps(payload, ParrotRecordVersion::V3);
+        if !g.is_empty() {
+          out.push_gps_sample(g);
+        }
+        let f = decode_v3_flight(payload);
+        if !f.is_empty() {
+          out.push_flight_sample(f);
+        }
+      }
+      b"E1" => {
+        // E1 TimeStamp extension (Parrot.pm:541-551). ExifTool `HandleTag`s
+        // the timestamp under the CURRENT `mett` sample's `DOC_NUM`
+        // (Parrot.pm:844-850), so it must ride on a flight sample belonging
+        // to THIS `process_mett` call. When the E1 is concatenated after a
+        // P2/P3 in the SAME `mett` sample buffer (the common case — bundled
+        // comments say the extensions are concat'd after the basic record),
+        // fold it into that just-emitted flight sample. When it is the only
+        // record in the sample (a SEPARATE `mett` sample carrying just an
+        // E1 — its own `DOC_NUM`), PUSH a fresh TimeStamp-only sample so the
+        // dispatch's `stamp_doc_from` assigns it the current `Doc<N>`/`Track`
+        // (folding into a PRIOR call's flight sample would mis-attach the
+        // timestamp to the wrong document and drop this sample's `Doc<N>`).
+        if let Some(ts) = decode_e1_timestamp(payload) {
+          // payload layout: [E1][nwords:u16-BE][int64u ts...].
+          // decode_e1_timestamp reads the int64u at record offset 4.
+          let folds_into_this_call = out.flight_sample_count() > flight_watermark;
+          if let Some(last) = out
+            .flight_samples_mut_last()
+            .filter(|_| folds_into_this_call)
+          {
+            last.set_time_stamp_us(Some(ts));
+          } else {
+            let mut f = ParrotFlightSample::new(ParrotRecordVersion::V2);
+            f.set_time_stamp_us(Some(ts));
+            out.push_flight_sample(f);
+          }
+        }
+      }
+      b"E2" => {
+        // E2 FollowMe extension (Parrot.pm:553-593). Concatenated after a
+        // P2/P3 in the same `mett` sample buffer (or freestanding). Decode the
+        // follow-me target waypoint + mode/animation.
+        let s = decode_e2_followme(payload);
+        if !s.is_empty() {
+          out.push_follow_me_sample(s);
+        }
+      }
+      b"E3" => {
+        // E3 Automation extension (Parrot.pm:595-660). Framing + destination
+        // waypoints + animation/flags.
+        let s = decode_e3_automation(payload);
+        if !s.is_empty() {
+          out.push_automation_sample(s);
+        }
+      }
+      _ => {
+        // Unknown ID under [EP]\d (defensive — bundled has no
+        // explicit fall-through, but we keep the walk going to mirror
+        // ProcessBinaryData's `next` semantics).
+      }
+    }
+
+    // Parrot.pm:851 `$pos += $size`.
+    pos = effective_pos + size;
+  }
+}
+
+/// Match the 2-char ID byte pattern `[EP]\d`. Parrot.pm:826
+/// `$id !~ /^[EP]\d/`.
+fn is_ep_id(id: &[u8; 2]) -> bool {
+  matches!(id[0], b'E' | b'P') && id[1].is_ascii_digit()
+}
+
+/// Match the ARCore MetaType strings that bundled's `%mett` table
+/// declares (Parrot.pm:60-83). Anything not on this list does NOT
+/// switch the walker into the TLV branch, regardless of MetaType.
+fn is_arcore_meta_type(s: &str) -> bool {
+  matches!(
+    s,
+    "application/arcore-accel"
+      | "application/arcore-accel-0"
+      | "application/arcore-gyro"
+      | "application/arcore-gyro-0"
+      | "application/arcore-video-0"
+      | "application/arcore-custom-event"
+  )
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  extern crate alloc;
+  use super::*;
+  use alloc::vec::Vec;
+
+  fn p1_record(payload60: &[u8; 60]) -> Vec<u8> {
+    // Parrot.pm:840-842 `$size = $nwords * 4 + 4` — P1 doesn't get a
+    // size override (only P2 / P3 do). For nwords=14 the total size is
+    // 4 + 14*4 = 60 bytes. The walker passes the WHOLE 60-byte slot to
+    // the V1 decoder, with the bundled `[P1][nwords]` prefix occupying
+    // record offsets 0..3. So bundled V1 field offsets (Parrot.pm:91+)
+    // are positions WITHIN that 60-byte slot.
+    //
+    // Mirrors the `p2_record`/`p3_record` convention: the caller supplies
+    // a 60-byte array whose indices match bundled record offsets directly
+    // (e.g. GPSLatitude at record offset 28 ⇒ `payload60[28..32]`). The
+    // helper overwrites slots 0..4 with `[P1][nwords=14]`.
+    let mut v = Vec::with_capacity(60);
+    v.extend_from_slice(b"P1");
+    v.extend_from_slice(&14u16.to_be_bytes()); // nwords ⇒ size = 60
+    v.extend_from_slice(&payload60[4..]); // skip the 4 prefix bytes
+    assert_eq!(v.len(), 60);
+    v
+  }
+
+  fn p2_record(payload56: &[u8; 56]) -> Vec<u8> {
+    // For P2 the walker forces size = 56 regardless of nwords; the
+    // 56-byte payload starts at the record's offset 0 (the [P2]
+    // [nwords] prefix is INCLUDED in the 56 since bundled passes
+    // `Start => pos` + `Size => 56` — i.e. the prefix is part of the
+    // V2 table's offset 0..3).
+    let mut v = Vec::with_capacity(56);
+    v.extend_from_slice(b"P2");
+    v.extend_from_slice(&13u16.to_be_bytes()); // nwords (ignored when override fires)
+    v.extend_from_slice(&payload56[4..]); // skip the 4 prefix bytes
+    assert_eq!(v.len(), 56);
+    v
+  }
+
+  fn p3_record(payload72: &[u8; 72]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(72);
+    v.extend_from_slice(b"P3");
+    v.extend_from_slice(&17u16.to_be_bytes()); // nwords (ignored when override fires)
+    v.extend_from_slice(&payload72[4..]);
+    assert_eq!(v.len(), 72);
+    v
+  }
+
+  #[test]
+  fn walks_empty_buffer_no_panic() {
+    let mut m = ParrotMeta::new();
+    process_mett(&[], None, &mut m);
+    assert!(m.is_empty());
+  }
+
+  #[test]
+  fn v1_gps_decodes_lat_lon_alt_sv() {
+    // V1 record: 60-byte payload where:
+    //   offsets 28..32 = lat int32s @ 47.6062 * 0x100000 ≈ 0x02f9b71e
+    //   offsets 32..36 = lon int32s @ -122.3321 * 0x100000 ≈ 0xf85d57e7
+    //   offsets 36..40 = GPSAltitude word (Mask 0xffffff00 / 0x100) | SV count.
+    // ExifTool decodes altitude as `((w & 0xffffff00) >> 8) / 0x100`
+    // (Parrot.pm:156-162 + ExifTool.pm:10078-10079). To encode ALT metres
+    // with the low byte carrying the SV count, set
+    //   w = (alt_m * 0x10000) | sv   ⇒   ((w & 0xffffff00) >> 8)/256 = alt_m.
+    // Worked example (audit): w=0x00320009 → (0x320000>>8)/256 = 12800/256 = 50.0.
+    let lat_raw = (47.6062_f64 * f64::from(0x10_0000)).round() as i32;
+    let lon_raw = (-122.3321_f64 * f64::from(0x10_0000)).round() as i32;
+    let alt_m = 120_u32; // metres
+    let sv_count = 9_u8;
+    let alt_word = (alt_m * 0x1_0000) | u32::from(sv_count);
+    let mut payload = [0u8; 60];
+    // The walker reads at the WHOLE record offsets (not payload+4);
+    // bundled `HandleTag ... Start => $pos` so V1's offset 28 is at
+    // record offset 28 — which for our test fixture is payload[28].
+    payload[28..32].copy_from_slice(&lat_raw.to_be_bytes());
+    payload[32..36].copy_from_slice(&lon_raw.to_be_bytes());
+    payload[36..40].copy_from_slice(&alt_word.to_be_bytes());
+    let mut m = ParrotMeta::new();
+    process_mett(&p1_record(&payload), None, &mut m);
+    assert_eq!(m.gps_samples().len(), 1);
+    let g = &m.gps_samples()[0];
+    assert_eq!(g.version(), ParrotRecordVersion::V1);
+    assert!((g.latitude().unwrap() - 47.6062).abs() < 1e-5);
+    assert!((g.longitude().unwrap() - (-122.3321)).abs() < 1e-5);
+    // Oracle: ((alt_word & 0xffffff00) >> 8) / 256.0 = 120.0.
+    assert!((g.altitude_m().unwrap() - 120.0).abs() < 1e-6);
+    assert_eq!(g.satellites(), Some(9));
+  }
+
+  #[test]
+  fn v1_flight_decodes_battery_iso_exposure_state() {
+    let mut payload = [0u8; 60];
+    // ExposureTime: int16s @22, raw = 1/0x100/1000 ⇒ for 1/60 s → raw = 0x100 * 1000 / 60 ≈ 4267
+    payload[22..24].copy_from_slice(&(4267_i16).to_be_bytes());
+    // ISO @24
+    payload[24..26].copy_from_slice(&(800_i16).to_be_bytes());
+    // WifiRSSI @26 (int8s)
+    payload[26] = (-65i8) as u8;
+    // Battery @27
+    payload[27] = 75;
+    // FlyingState @54: 3 (Flying), with the high "Binning" bit cleared.
+    payload[54] = 3;
+    // PilotingMode @55: 1 (Return Home), with the high "Animation" bit cleared.
+    payload[55] = 1;
+    let mut m = ParrotMeta::new();
+    process_mett(&p1_record(&payload), None, &mut m);
+    let f = &m.flight_samples()[0];
+    assert_eq!(f.version(), ParrotRecordVersion::V1);
+    assert!((f.exposure_time_s().unwrap() - 4267.0 / 256.0 / 1000.0).abs() < 1e-9);
+    assert_eq!(f.iso(), Some(800));
+    assert_eq!(f.wifi_rssi_dbm(), Some(-65));
+    assert_eq!(f.battery_percent(), Some(75));
+    assert_eq!(f.flying_state(), Some(ParrotFlyingState::Flying));
+    assert_eq!(f.piloting_mode(), Some(ParrotPilotingMode::ReturnHome));
+  }
+
+  #[test]
+  fn v1_altitude_from_takeoff_and_distance_from_home() {
+    let mut payload = [0u8; 60];
+    // AltitudeFromTakeOff @40 int32s / 0x10000 — 15.5 m * 0x10000 = 1015808
+    payload[40..44].copy_from_slice(&(1_015_808_i32).to_be_bytes());
+    // DistanceFromHome @44 int32u / 0x10000 — 50.0 * 0x10000 = 3_276_800
+    payload[44..48].copy_from_slice(&(3_276_800_u32).to_be_bytes());
+    let mut m = ParrotMeta::new();
+    process_mett(&p1_record(&payload), None, &mut m);
+    let f = &m.flight_samples()[0];
+    assert!((f.altitude_from_takeoff_m().unwrap() - 15.5).abs() < 1e-9);
+    assert!((f.distance_from_home_m().unwrap() - 50.0).abs() < 1e-9);
+  }
+
+  #[test]
+  fn v2_gps_and_flight_with_size_override() {
+    // V2 record forced to 56 bytes via override.
+    let lat_raw = (47.6062_f64 * f64::from(0x40_0000)).round() as i32;
+    let lon_raw = (-122.3321_f64 * f64::from(0x40_0000)).round() as i32;
+    // GPSAltitude (Mask 0xffffff00 / 0x100): w = alt_m*0x10000 | sv ⇒
+    // ((w & 0xffffff00)>>8)/256 = alt_m. Here 50 m with SV count 11.
+    let alt_word = (50_u32 * 0x1_0000) | 11;
+    let mut payload = [0u8; 56];
+    payload[8..12].copy_from_slice(&lat_raw.to_be_bytes());
+    payload[12..16].copy_from_slice(&lon_raw.to_be_bytes());
+    payload[16..20].copy_from_slice(&alt_word.to_be_bytes());
+    // AirSpeed @26 raw int16s — 5.5 * 0x100 = 1408
+    payload[26..28].copy_from_slice(&(1408_i16).to_be_bytes());
+    // ExposureTime @48 int16u — 1/120 s ⇒ raw = 256000/120 ≈ 2133
+    payload[48..50].copy_from_slice(&(2133_u16).to_be_bytes());
+    // ISO @50
+    payload[50..52].copy_from_slice(&(400_u16).to_be_bytes());
+    // FlyingState @52: 2 Hovering
+    payload[52] = 2;
+    // PilotingMode @53: 0 Manual
+    payload[53] = 0;
+    // WifiRSSI @54 int8s
+    payload[54] = (-55i8) as u8;
+    // Battery @55
+    payload[55] = 92;
+    // Elevation @4 int32s / 0x10000 — 3.5 * 0x10000 = 229376
+    payload[4..8].copy_from_slice(&(229_376_i32).to_be_bytes());
+    let mut m = ParrotMeta::new();
+    process_mett(&p2_record(&payload), None, &mut m);
+    let g = &m.gps_samples()[0];
+    assert_eq!(g.version(), ParrotRecordVersion::V2);
+    assert!((g.latitude().unwrap() - 47.6062).abs() < 1e-5);
+    assert!((g.longitude().unwrap() - (-122.3321)).abs() < 1e-5);
+    assert!((g.altitude_m().unwrap() - 50.0).abs() < 1e-6);
+    assert_eq!(g.satellites(), Some(11));
+    let f = &m.flight_samples()[0];
+    assert_eq!(f.version(), ParrotRecordVersion::V2);
+    assert!((f.air_speed_mps().unwrap() - 5.5).abs() < 1e-6);
+    assert!((f.exposure_time_s().unwrap() - 2133.0 / 256.0 / 1000.0).abs() < 1e-9);
+    assert_eq!(f.iso(), Some(400));
+    assert_eq!(f.flying_state(), Some(ParrotFlyingState::Hovering));
+    assert_eq!(f.piloting_mode(), Some(ParrotPilotingMode::Manual));
+    assert_eq!(f.wifi_rssi_dbm(), Some(-55));
+    assert_eq!(f.battery_percent(), Some(92));
+    assert!((f.elevation_m().unwrap() - 3.5).abs() < 1e-9);
+  }
+
+  #[test]
+  fn v2_negative_air_speed_is_undef() {
+    let mut payload = [0u8; 56];
+    payload[26..28].copy_from_slice(&(-1_i16).to_be_bytes());
+    let mut m = ParrotMeta::new();
+    process_mett(&p2_record(&payload), None, &mut m);
+    assert!(
+      m.flight_samples()
+        .iter()
+        .all(|f| f.air_speed_mps().is_none())
+    );
+  }
+
+  #[test]
+  fn v3_gps_and_flight_with_size_override() {
+    // V3 forced to 72 bytes.
+    let lat_raw = (45.0_f64 * f64::from(0x40_0000)).round() as i32;
+    let lon_raw = (8.0_f64 * f64::from(0x40_0000)).round() as i32;
+    // GPSAltitude (Mask 0xffffff00 / 0x100): w = alt_m*0x10000 | sv ⇒
+    // ((w & 0xffffff00)>>8)/256 = alt_m. Here 100 m with SV count 12.
+    let alt_word = (100_u32 * 0x1_0000) | 12;
+    let mut payload = [0u8; 72];
+    payload[8..12].copy_from_slice(&lat_raw.to_be_bytes());
+    payload[12..16].copy_from_slice(&lon_raw.to_be_bytes());
+    payload[16..20].copy_from_slice(&alt_word.to_be_bytes());
+    // AirSpeed @26
+    payload[26..28].copy_from_slice(&(512_i16).to_be_bytes()); // 2.0 m/s
+    // ExposureTime @52 int16u
+    payload[52..54].copy_from_slice(&(2133_u16).to_be_bytes());
+    // ISO @54 int16u
+    payload[54..56].copy_from_slice(&(200_u16).to_be_bytes());
+    // WifiRSSI @68
+    payload[68] = (-70i8) as u8;
+    // Battery @69
+    payload[69] = 50;
+    // FlyingState @70: 3 Flying
+    payload[70] = 3;
+    // PilotingMode @71: 4 Magic Carpet
+    payload[71] = 4;
+    // Elevation @4
+    payload[4..8].copy_from_slice(&(459_776_i32).to_be_bytes()); // ~7.014 m
+    let mut m = ParrotMeta::new();
+    process_mett(&p3_record(&payload), None, &mut m);
+    let g = &m.gps_samples()[0];
+    assert_eq!(g.version(), ParrotRecordVersion::V3);
+    assert!((g.latitude().unwrap() - 45.0).abs() < 1e-6);
+    assert!((g.longitude().unwrap() - 8.0).abs() < 1e-6);
+    assert!((g.altitude_m().unwrap() - 100.0).abs() < 1e-6);
+    let f = &m.flight_samples()[0];
+    assert_eq!(f.version(), ParrotRecordVersion::V3);
+    assert!((f.air_speed_mps().unwrap() - 2.0).abs() < 1e-9);
+    assert_eq!(f.iso(), Some(200));
+    assert_eq!(f.wifi_rssi_dbm(), Some(-70));
+    assert_eq!(f.battery_percent(), Some(50));
+    assert_eq!(f.flying_state(), Some(ParrotFlyingState::Flying));
+    assert_eq!(f.piloting_mode(), Some(ParrotPilotingMode::MagicCarpet));
+  }
+
+  #[test]
+  fn v1_60_byte_fallback_no_id() {
+    // Parrot.pm:827-833 — when the buffer is exactly 60 bytes AND
+    // doesn't start with [EP]\d, the walker generates a fake P1 ID
+    // and advances pos by 4 (the recording-frame timestamp goes
+    // undecoded). Build a 60-byte fixture starting with NOT-EP bytes.
+    let mut payload = [0u8; 60];
+    payload[0] = 0xAB; // not [EP]
+    payload[1] = 0xCD;
+    // After `pos += 4`, the walker treats payload[4..] as the start of
+    // the V1 record. So V1 offsets (e.g. lat @28 in the record) become
+    // payload[4+28] = payload[32]. To put lat=45.0 in the right place:
+    // payload[32..36] = lat int32s big-endian.
+    let lat_raw = (45.0_f64 * f64::from(0x10_0000)).round() as i32;
+    payload[32..36].copy_from_slice(&lat_raw.to_be_bytes());
+    let mut m = ParrotMeta::new();
+    process_mett(&payload, None, &mut m);
+    // Per bundled (Parrot.pm:828 `last unless $dirEnd == 60`), this
+    // fallback only fires when the WHOLE input buffer is exactly 60
+    // bytes (the walker condition is on $dirEnd).
+    assert_eq!(m.gps_samples().len(), 1);
+    let g = &m.gps_samples()[0];
+    assert_eq!(g.version(), ParrotRecordVersion::V1);
+    assert!((g.latitude().unwrap() - 45.0).abs() < 1e-6);
+  }
+
+  #[test]
+  fn v1_fallback_does_not_fire_for_non_60_byte_no_id() {
+    // A non-EP buffer with size != 60 should produce nothing.
+    let payload = [0xABu8; 100];
+    let mut m = ParrotMeta::new();
+    process_mett(&payload, None, &mut m);
+    assert!(m.is_empty());
+  }
+
+  #[test]
+  fn e1_timestamp_freestanding() {
+    // [E1][nwords=2][int64u ts] — 12 bytes total. Nwords reports the
+    // payload-in-u32-words, here 2 (= 8 bytes for the int64u).
+    let mut buf = Vec::with_capacity(12);
+    buf.extend_from_slice(b"E1");
+    buf.extend_from_slice(&2u16.to_be_bytes());
+    buf.extend_from_slice(&1_234_567_890u64.to_be_bytes());
+    // pad to make the buffer's dir_end > 12 (so the strict-less while
+    // guard accepts the read; Parrot.pm:823 `while ($pos + 4 < $dirLen)`).
+    buf.extend_from_slice(&[0u8; 4]);
+    let mut m = ParrotMeta::new();
+    process_mett(&buf, None, &mut m);
+    assert_eq!(m.flight_samples().len(), 1);
+    assert_eq!(m.flight_samples()[0].time_stamp_us(), Some(1_234_567_890));
+  }
+
+  #[test]
+  fn e1_concatenated_after_p2_in_same_sample_folds_into_that_sample() {
+    // The common case (Parrot.pm:836-837 + 844-850): a P2 basic record with an
+    // E1 TimeStamp concatenated AFTER it, both in ONE `mett` sample buffer. The
+    // E1 must fold into the P2's flight sample (one document), NOT push a second.
+    let mut payload = [0u8; 56];
+    payload[26..28].copy_from_slice(&(512_i16).to_be_bytes()); // AirSpeed 2.0 m/s
+    let mut buf = p2_record(&payload);
+    buf.extend_from_slice(b"E1");
+    buf.extend_from_slice(&2u16.to_be_bytes()); // nwords = 2 ⇒ 8-byte int64u
+    buf.extend_from_slice(&777_000u64.to_be_bytes());
+    buf.extend_from_slice(&[0u8; 4]); // pad so the strict-less while guard reads the E1
+    let mut m = ParrotMeta::new();
+    process_mett(&buf, None, &mut m);
+    // ONE flight sample (the P2's), now carrying the concatenated E1 timestamp.
+    assert_eq!(m.flight_samples().len(), 1);
+    assert!((m.flight_samples()[0].air_speed_mps().unwrap() - 2.0).abs() < 1e-9);
+    assert_eq!(m.flight_samples()[0].time_stamp_us(), Some(777_000));
+  }
+
+  #[test]
+  fn standalone_e1_in_separate_sample_gets_its_own_doc_not_previous() {
+    // FINDING 1 regression. ExifTool's `Process_mett` `HandleTag`s every E1
+    // under the CURRENT `mett` sample's `DOC_NUM` (Parrot.pm:844-850), set once
+    // per sample by `ProcessSamples` (QuickTimeStream.pl:1517-1523). So a
+    // standalone E1 in its OWN `mett` sample must land on a NEW flight sample
+    // with that sample's `Doc<N>`/`Track<N>` — NOT mutate the prior sample's.
+    // We drive the two `mett` samples exactly as the dispatch
+    // (`process_samples`) does: watermark the flight vector, `process_mett`,
+    // then `stamp_doc_from` the new records with the sample's doc/track.
+    let mut m = ParrotMeta::new();
+
+    // Sample 1: a P2 with a CONCATENATED E1 (its own timestamp) → Doc1/Track1.
+    let mut p2 = [0u8; 56];
+    p2[26..28].copy_from_slice(&(512_i16).to_be_bytes()); // AirSpeed 2.0 m/s
+    let mut s1 = p2_record(&p2);
+    s1.extend_from_slice(b"E1");
+    s1.extend_from_slice(&2u16.to_be_bytes());
+    s1.extend_from_slice(&111_000u64.to_be_bytes());
+    s1.extend_from_slice(&[0u8; 4]);
+    let (g0, f0, fm0, a0) = (
+      m.gps_sample_count(),
+      m.flight_sample_count(),
+      m.follow_me_sample_count(),
+      m.automation_sample_count(),
+    );
+    process_mett(&s1, None, &mut m);
+    m.stamp_doc_from(
+      g0,
+      f0,
+      fm0,
+      a0,
+      /*doc=*/ 1,
+      /*track=*/ 1,
+      Some(0.0),
+      Some(1.0),
+    );
+
+    // Sample 2: ONLY a standalone E1 (a different timestamp) → Doc2/Track1.
+    let mut s2 = Vec::new();
+    s2.extend_from_slice(b"E1");
+    s2.extend_from_slice(&2u16.to_be_bytes());
+    s2.extend_from_slice(&222_000u64.to_be_bytes());
+    s2.extend_from_slice(&[0u8; 4]);
+    let (g1, f1, fm1, a1) = (
+      m.gps_sample_count(),
+      m.flight_sample_count(),
+      m.follow_me_sample_count(),
+      m.automation_sample_count(),
+    );
+    process_mett(&s2, None, &mut m);
+    m.stamp_doc_from(
+      g1,
+      f1,
+      fm1,
+      a1,
+      /*doc=*/ 2,
+      /*track=*/ 1,
+      Some(1.0),
+      Some(1.0),
+    );
+
+    // Two distinct flight samples: the standalone E1 created its OWN.
+    assert_eq!(m.flight_samples().len(), 2);
+    // Sample 1 keeps its P2 + its concatenated E1's timestamp, at Doc1.
+    let s1_flight = &m.flight_samples()[0];
+    assert!((s1_flight.air_speed_mps().unwrap() - 2.0).abs() < 1e-9);
+    assert_eq!(s1_flight.time_stamp_us(), Some(111_000));
+    assert_eq!(s1_flight.doc(), 1);
+    assert_eq!(s1_flight.track_index(), 1);
+    // The standalone E1 landed on its OWN sample at Doc2 (NOT overwriting Doc1).
+    let s2_flight = &m.flight_samples()[1];
+    assert_eq!(s2_flight.time_stamp_us(), Some(222_000));
+    assert!(s2_flight.air_speed_mps().is_none());
+    assert_eq!(s2_flight.doc(), 2);
+    assert_eq!(s2_flight.track_index(), 1);
+  }
+
+  #[test]
+  fn arcore_meta_type_walks_without_panic() {
+    // Build a TLV record `[0x0a][len=4][4 bytes payload]` — the walker
+    // should step over it, not push any samples.
+    let mut buf = Vec::new();
+    buf.push(0x0a);
+    buf.push(4);
+    buf.extend_from_slice(&[0u8; 4]);
+    let mut m = ParrotMeta::new();
+    process_mett(&buf, Some("application/arcore-accel"), &mut m);
+    assert!(m.is_empty());
+  }
+
+  #[test]
+  fn is_ep_id_matches_pattern() {
+    assert!(is_ep_id(b"P1"));
+    assert!(is_ep_id(b"P9"));
+    assert!(is_ep_id(b"E0"));
+    assert!(is_ep_id(b"E3"));
+    assert!(!is_ep_id(b"PX"));
+    assert!(!is_ep_id(b"AB"));
+    assert!(!is_ep_id(b"p1")); // lowercase doesn't match Perl's [EP]
+    assert!(!is_ep_id(b"  "));
+  }
+
+  #[test]
+  fn arcore_meta_type_classifier() {
+    assert!(is_arcore_meta_type("application/arcore-accel"));
+    assert!(is_arcore_meta_type("application/arcore-accel-0"));
+    assert!(is_arcore_meta_type("application/arcore-gyro"));
+    assert!(is_arcore_meta_type("application/arcore-gyro-0"));
+    assert!(is_arcore_meta_type("application/arcore-video-0"));
+    assert!(is_arcore_meta_type("application/arcore-custom-event"));
+    assert!(!is_arcore_meta_type(""));
+    assert!(!is_arcore_meta_type("application/meta"));
+    assert!(!is_arcore_meta_type("application/microvideo-image-meta"));
+  }
+}

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -55,10 +55,13 @@
 use crate::{
   datetime::{convert_datetime, convert_duration, convert_unix_time},
   format_parser::{FormatParser, parser_sealed},
-  formats::{insta360 as insta360_fmt, quicktime_freegps, quicktime_stream},
+  formats::{
+    insta360 as insta360_fmt, ligogps as ligogps_fmt, quicktime_freegps, quicktime_stream,
+  },
   metadata::{
     CammMeta, CanonCtmdMeta, GoProConv, GoProMeta, GoProTag, GoProTagValue, Insta360Meta,
-    MediaTrack, QuickTimeGps, QuickTimeMeta, QuickTimeStreamMeta, SonyRtmdMeta,
+    LigoGpsMeta, MediaTrack, ParrotMeta, QuickTimeGps, QuickTimeMeta, QuickTimeStreamMeta,
+    SonyRtmdMeta,
   },
   value::{binary_placeholder, format_g},
 };
@@ -2025,6 +2028,45 @@ fn decode_moov_udta_meta(
   );
 }
 
+/// Mirror ExifTool's LigoGPS `udta` SubDirectory Conditions in the
+/// `%QuickTime::Main` (TOP-LEVEL) `udta` table (QuickTime.pm:826-846): match the
+/// WHOLE udta payload (`$$valPt`) against the `LigoJSON` and `GKUData` Conditions
+/// and dispatch the matching decoder into the shared `ligo` accumulator. Returns
+/// `true` when a Condition matched (the udta is consumed — these arms are
+/// mutually exclusive with each other, like ExifTool's first-match Condition
+/// list). Called ONLY from the top-level `udta` arm: the `moov/udta`
+/// (`%QuickTime::Movie`) UserData walk does NOT host these Conditions.
+///
+///   - `LigoJSON` (QuickTime.pm:835 `$$valPt =~ /^LIGOGPSINFO \{/`) →
+///     `Image::ExifTool::LigoGPS::ProcessLigoJSON`.
+///   - `GKUData` (QuickTime.pm:842 `$$valPt =~ /^.{8}__V35AX_QVDATA__/`) →
+///     `Image::ExifTool::LigoGPS::ProcessGKU`.
+///
+/// `KenwoodData` (QuickTime.pm:827) and the `FLIRData` default arm
+/// (QuickTime.pm:847) are out of scope here (Kenwood timed GPS is decoded via
+/// the freeGPS stream path; FLIR UserData is unported).
+fn dispatch_udta_ligogps(payload: &[u8], ligo: &mut crate::metadata::LigoGpsMeta) -> bool {
+  use crate::formats::ligogps as ligogps_fmt;
+  // QuickTime.pm:835 `^LIGOGPSINFO \{`.
+  if payload.get(..ligogps_fmt::HDR_LIGOGPSINFO_JSON.len())
+    == Some(ligogps_fmt::HDR_LIGOGPSINFO_JSON.as_slice())
+  {
+    ligogps_fmt::process_ligogps_json(payload, ligo);
+    return true;
+  }
+  // QuickTime.pm:842 `^.{8}__V35AX_QVDATA__` — the marker sits at offset 8 (the
+  // leading 8 bytes carry the LE u32 offset that `ProcessGKU` reads). The
+  // Condition has no `/s`, so `.` excludes newline: each of the first 8 bytes
+  // must be non-`\n` for the regex to match (faithful to the un-`/s` `.{8}`).
+  if payload.get(8..8 + ligogps_fmt::GKU_MARKER.len()) == Some(ligogps_fmt::GKU_MARKER.as_slice())
+    && payload.get(..8).is_some_and(|h| !h.contains(&b'\n'))
+  {
+    ligogps_fmt::process_gku(payload, ligo);
+    return true;
+  }
+  false
+}
+
 /// Walk one `udta` atom payload, decoding the camera/GPS/capture-identity
 /// atoms into `ud` (QuickTime.pm:1585-1900). Two atom families are handled:
 ///
@@ -2042,6 +2084,11 @@ fn decode_moov_udta_meta(
 /// layer resolves duplicates (see
 /// [`crate::metadata::QuickTimeUserData`]). A contained malformed atom surfaces
 /// a warning through `w`.
+///
+/// This is the `%QuickTime::Movie` `moov/udta` UserData walk (QuickTime.pm:1214),
+/// which does NOT host the LigoGPS Conditions — those live in the `%QuickTime::Main`
+/// (top-level) `udta` (QuickTime.pm:834-846) and are dispatched there via
+/// [`dispatch_udta_ligogps`], not here.
 fn walk_udta(
   depth: u32,
   payload: &[u8],
@@ -3339,6 +3386,25 @@ pub struct Meta<'a> {
   /// a borrow of the input bytes (`'a`); the heavy timed-row decode is
   /// deferred to `-ee` emit time (lazy-decode DoS guard).
   insta360: Insta360Meta<'a>,
+  /// **SP4** — Parrot drone `mett` timed-metadata (GPS + flight
+  /// telemetry). Decoded through the `mett` MetaFormat dispatch in
+  /// [`quicktime_stream`]. Empty ([`ParrotMeta::is_empty`]) for a
+  /// non-Parrot video. Faithful port of
+  /// `Image::ExifTool::Parrot::Process_mett` (Parrot.pm:791-854) plus
+  /// the per-version binary tables `Image::ExifTool::Parrot::V1`/`V2`/
+  /// `V3`/`TimeStamp` (Parrot.pm:86-551).
+  parrot: ParrotMeta,
+  /// **SP4** — LigoGPS dashcam vendor GPS records. Decoded via TWO
+  /// faithful entry points: (a) the `&&&& `-prefixed trailer at file
+  /// EOF (QuickTime.pm:9906-9907 + 10658-10668) — populated by
+  /// [`ligogps_fmt::scan_trailer`]; (b) the freeGPS-embedded sample
+  /// dispatch (QuickTimeStream.pl:1843-1888) — populated by
+  /// [`quicktime_freegps::process_free_gps`] which calls
+  /// [`ligogps_fmt::process_ligogps_with_scale`] on a `LIGOGPSINFO\0`
+  /// fingerprint hit. Empty ([`LigoGpsMeta::is_empty`]) for a non-
+  /// LigoGPS file. Faithful port of `Image::ExifTool::LigoGPS`
+  /// (LigoGPS.pm:1-431).
+  ligogps: LigoGpsMeta,
   /// **SP3** — `true` when an embedded Exif/TIFF block (a `QVMI` / `MVTG` /
   /// `uuid`-Exif atom) was DETECTED but its parse is DEFERRED until the
   /// Exif+GPS port (`exif::parse_exif_block`, PR #36 / `lib/exif-gps`) lands.
@@ -3464,6 +3530,36 @@ impl Meta<'_> {
     &self.insta360
   }
 
+  /// **SP4** — Parrot drone `mett` timed metadata. [`ParrotMeta::is_empty`]
+  /// for a non-Parrot video (or one whose `mett` track is absent).
+  ///
+  /// Faithful port of `Image::ExifTool::Parrot::Process_mett`
+  /// (Parrot.pm:791-854) plus the per-version binary tables
+  /// `Image::ExifTool::Parrot::V1`/`V2`/`V3` (Parrot.pm:86-539).
+  /// Populated by the `mett` MetaFormat dispatch in [`quicktime_stream`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn parrot(&self) -> &ParrotMeta {
+    &self.parrot
+  }
+
+  /// **SP4** — LigoGPS dashcam vendor GPS records.
+  /// [`LigoGpsMeta::is_empty`] for a non-LigoGPS file (or one whose
+  /// trailer / embedded fingerprint is absent).
+  ///
+  /// Faithful port of `Image::ExifTool::LigoGPS` (LigoGPS.pm:1-431).
+  /// Reached through TWO paths:
+  ///  - the `&&&& `-prefixed trailer at file EOF (QuickTime.pm:9906-9907 +
+  ///    :10658-10668) — populated by [`ligogps_fmt::scan_trailer`];
+  ///  - the freeGPS-embedded sample dispatch (QuickTimeStream.pl:1843-
+  ///    1888) — populated by [`quicktime_freegps::process_free_gps`]
+  ///    when it detects `LIGOGPSINFO\0` at offset 16/48/80.
+  #[must_use]
+  #[inline(always)]
+  pub const fn ligogps(&self) -> &LigoGpsMeta {
+    &self.ligogps
+  }
+
   /// **SP3** — `true` when an embedded Exif/TIFF block was detected but its
   /// parse is deferred until the Exif+GPS port lands (see [`Meta`]).
   #[must_use]
@@ -3502,6 +3598,12 @@ impl Meta<'_> {
     // source already populated GPS); fills only the GPS domain (CAMM carries
     // no camera-identity record).
     self.android_camm.project_into(&mut md);
+    // **SP4 — Parrot mett** on-device GNSS (drone hardware GPS) — same
+    // fidelity tier as GoPro / CAMM; ordered after CAMM by implementation
+    // arrival (a single file is produced by exactly one body so the
+    // tie-break is hypothetical). Sits ABOVE the phone-paired Sony rtmd /
+    // generic SP3 timed-metadata scan.
+    self.parrot.project_into(&mut md);
     // **SP4 — Sony rtmd** phone-paired GPS (Imaging Edge Mobile) + camera
     // identity/capture. THIRD-HIGHEST tier — below GoPro / CAMM on-device
     // hardware, above the generic SP3 timed-metadata scan. Set-once per domain
@@ -3534,6 +3636,13 @@ impl Meta<'_> {
         .update_timestamp(fix.date_time().map(str::to_string));
       md.set_gps(gps);
     }
+    // LigoGPS sits at the SAME tier as the SP3 stream — dashcam vendor
+    // GPS (best-effort brute-force-scan) projects AFTER everything
+    // else. The freeGPS embedded path already routes its decoded
+    // LigoGPS samples through this same field (see
+    // [`quicktime_freegps::process_free_gps`]), so this projection
+    // covers both the trailer + embedded sources.
+    self.ligogps.project_into(&mut md);
     md
   }
 
@@ -3773,6 +3882,24 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // scan. `trailers` is HEAD-FIRST (earliest trailer first).
   let trailers = insta360_fmt::identify_trailers(data);
   let mut insta360_meta = Insta360Meta::new();
+  // **SP4** — the LigoGPS accumulator. Populated (in `ProcessMOV` walk order) by
+  // the moov-timed `gps `-box GPSType-5 path (inside `extract_stream`), THEN the
+  // deferred top-level `udta`-LigoGPS (appended after `extract_stream`), THEN the
+  // file-end `&&&&` trailer (the trailer phase, off the SAME `identify_trailers`
+  // discovery), THEN the `mdat` freeGPS-embedded `LIGOGPSINFO\0` fingerprint
+  // (`scan_media_data`, LAST). Declared here so each phase can fill it in order;
+  // most files leave it empty (`LigoGpsMeta::is_empty()`).
+  let mut ligogps_meta = LigoGpsMeta::new();
+  // The embedded timed-metadata accumulator (`mebx`/`gps0`/`gsen`/camm/freeGPS/
+  // …). Created HERE — BEFORE the LigoGPS `udta`/trailer/freeGPS sources — so it
+  // owns the single GLOBAL `Doc<N>` counter (`$$et{DOC_COUNT}`) that EVERY
+  // embedded source shares: the LigoGPS sources decode into the SEPARATE
+  // `ligogps_meta` yet allocate their per-record `Doc<N>` off THIS counter (via
+  // [`LigoGpsMeta::stamp_doc_from`] + [`QuickTimeStreamMeta::doc_counter`]),
+  // continuing the same global sequence as the in-`stream` sources — so a mixed
+  // file (LigoGPS + camm/mebx) gets non-colliding, monotonically-increasing doc
+  // ordinals across all of them (LigoGPS.pm:243/:354; #214 cross-source rule).
+  let mut stream = QuickTimeStreamMeta::new();
   // The HEAD (earliest) trailer drives BOTH the box-walk stop and the positional
   // warning (QuickTime.pm:10599-10600 use `$$trailer[1]`/`[0]`/`[2]` of the
   // linked-list head). Record its `(name, start, len)` for the always-on
@@ -3803,31 +3930,29 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // trailer-less file `box_region_end == data.len()`.
   let scan_end = box_region_end;
   let scan_data: &[u8] = data.get(..scan_end).unwrap_or(data);
-  // EXTRACT the Insta360 trailer only when the box walk did NOT consume it
-  // (`$lastPos <= $$trailer[1]`, the negation of QuickTime.pm:10656's
-  // `next if $lastPos > $$trailer[1]`). When an atom SPANNED the trailer the
-  // reference still emits the positional warning (via `head_trailer` above, then
-  // suppressed by the box-walk's own earlier `ExifTool:Warning` under
-  // priority-0 first-wins) but does NOT re-process the trailer as a trailer.
-  if let Some(entry) = trailers.iter().find(|e| e.kind().is_insta360()) {
-    let entry_signed_start = entry.start() as i64;
-    if (last_pos as i64) <= entry_signed_start {
-      // Scan the FIRST Insta360 trailer in the chain (its body ends at `start +
-      // len`, which == EOF for a standalone trailer at the file end). A bad-size
-      // trailer (`trailerLen > file size`) has a NEGATIVE signed start, so the
-      // gate is false and we skip extraction — the positional warning still
-      // fires off `head_trailer`, and bundled likewise decodes no records.
-      let entry_end = entry
-        .start()
-        .saturating_add(entry.len())
-        .min(data.len() as u64) as usize;
-      insta360_fmt::scan_trailer(data, entry_end, &mut insta360_meta);
-      insta360_meta.set_trail_end(entry_end);
-    }
-  }
+
+  // **SP4 — the TRAILER PHASE is DEFERRED** to AFTER `extract_stream` (the
+  // moov-timed sources) + the deferred `udta`-LigoGPS stamp, then the `mdat`
+  // `ScanMediaData` runs LAST. This mirrors ExifTool's single `ProcessMOV` order
+  // (QuickTime.pm:10654-10681): the atom walk's moov-timed metadata + top-level
+  // `udta` FIRST, THEN the trailer linked-list loop (`for (; $trailer; $trailer =
+  // $$trailer[3])`, Insta360 + LigoGPS + MIE in CHAIN order), THEN
+  // `ScanMediaData`. So NEITHER the Insta360 NOR the LigoGPS trailer is processed
+  // here — both happen in the `process_trailers` block below `extract_stream`,
+  // each drawing its `Doc<N>` from the ONE shared counter. The box-walk-consumed
+  // gate (`$lastPos <= $$trailer[1]`) is applied there too.
 
   // Pass 1: ftyp + every moov's mvhd (last-wins TimeScale) + mdat.
   let mut qt = QuickTimeMeta::new();
+  // **SP4 / Finding 3** — the top-level `udta`-LigoGPS (LigoJSON/GKU) records are
+  // DECODED here in Pass 1 (their atom-walk position) but their `Doc<N>` stamp is
+  // DEFERRED: ExifTool's single `ProcessMOV` walk emits the moov-timed metadata
+  // BEFORE a top-level `udta` that follows `moov` in file order, so the udta
+  // records must take the HIGHER `Doc<N>` ordinals. Decode into this TEMP holder
+  // now; stamp it off the shared counter AFTER `extract_stream` and APPEND to
+  // `ligogps_meta` then (so its samples land after the moov-timed LigoGPS in both
+  // doc order AND append order). See the post-`extract_stream` stamp block.
+  let mut udta_ligo = LigoGpsMeta::new();
   // R6/F2: the FIRST `ProcessMOV` warning (`ExifTool:Warning` under `-j`).
   let mut warning: Option<String> = None;
   let mut pos = 0usize;
@@ -3853,6 +3978,23 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
             // UserData/Keys are populated before emission; the box walk runs at
             // the moov child depth (1, one level below the top-level walk).
             decode_moov_udta_meta(1, body, &mut qt, &mut warning);
+          }
+          // A TOP-LEVEL `udta` atom (`%QuickTime::Main` ⇒ QuickTime.pm:826-850).
+          // The Main table's `udta` is a Condition list whose first matching arm
+          // wins; the only in-scope arms are the LigoGPS GPS decoders
+          // (`LigoJSON` / `GKUData`). This is the genuinely-faithful home of the
+          // LigoGPS JSON `udta` path (the Main table — NOT the `moov/udta`
+          // UserData walk, which is `%QuickTime::Movie`). A non-LigoGPS root-udta
+          // is left to the (unported) FLIRData default arm.
+          b"udta" => {
+            // **SP4 / Finding 3** — the `udta` LigoGPS JSON/GKU records open a
+            // new GLOBAL `Doc<N>` each (`$$et{DOC_NUM} = ++$$et{DOC_COUNT}`,
+            // LigoGPS.pm:354). DECODE here (atom-walk position) into the TEMP
+            // `udta_ligo`, but DEFER the doc stamp + the merge into `ligogps_meta`
+            // until AFTER `extract_stream`: the moov-timed sources take the LOWER
+            // ordinals (ExifTool emits them before a top-level `udta` that follows
+            // `moov` in file order). See the post-`extract_stream` stamp block.
+            dispatch_udta_ligogps(body, &mut udta_ligo);
           }
           // The top-level `frea` atom (Kodak PixPro / Rexing — QuickTime.pm:610
           // `%QuickTime::Main` ⇒ `Image::ExifTool::Kodak::frea`). Decoded in
@@ -4057,6 +4199,13 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // sample). Additive to the existing per-format sample dispatch, exactly like
   // `sony_rtmd_meta`.
   let mut canon_ctmd_meta = CanonCtmdMeta::new();
+  // **SP4 — Parrot mett**: the `mett` MetaFormat dispatch in
+  // [`quicktime_stream`] populates `parrot_meta` for each timed-
+  // metadata sample whose track carries Parrot drone telemetry. Faithful
+  // port of `Image::ExifTool::Parrot::Process_mett` (Parrot.pm:791-854) +
+  // the per-version binary tables `Image::ExifTool::Parrot::V1`/`V2`/
+  // `V3` (Parrot.pm:86-539).
+  let mut parrot_meta = ParrotMeta::new();
   // `found_embedded` is ExifTool's `$$et{FoundEmbedded}` (QuickTimeStream.pl:1650):
   // set when a `moov`-level `gps ` box dispatched a `freeGPS ` block into
   // `ProcessFreeGPS`, OR when a GoPro source entered `ProcessGoPro`
@@ -4092,15 +4241,95 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // freeGPS/GP6 scan) all live inside the QuickTime box hierarchy, which ends
   // at the Insta360 trailer's start — the trailer's bytes must not be scanned
   // for a freeGPS signature.
-  let (mut stream, found_embedded) = quicktime_stream::extract_stream(
+  // `stream` is created up-front (above) so it owns the shared global `Doc<N>`
+  // counter across the LigoGPS `udta`/trailer sources too — pass it in by `&mut`
+  // (the in-`stream` `mebx`/camm/gps0/freeGPS sources continue the counter the
+  // `udta` LigoGPS records already advanced).
+  let found_embedded = quicktime_stream::extract_stream(
     scan_data,
     create_date_raw,
     kodak_version,
+    &mut stream,
     &mut gopro_meta,
     &mut camm_meta,
     &mut sony_rtmd_meta,
     &mut canon_ctmd_meta,
+    &mut parrot_meta,
+    &mut ligogps_meta,
   );
+
+  // **SP4 / Finding 3** — stamp the DEFERRED top-level `udta`-LigoGPS records
+  // (decoded into `udta_ligo` during Pass 1) NOW, AFTER every moov-timed source
+  // bumped the shared counter — so the udta records take the HIGHER `Doc<N>`
+  // ordinals (`$$et{DOC_NUM} = ++$$et{DOC_COUNT}`, LigoGPS.pm:354), mirroring
+  // ExifTool's single `ProcessMOV` walk emitting moov-timed metadata BEFORE a
+  // top-level `udta` that follows `moov` in file order. Then APPEND `udta_ligo`
+  // to `ligogps_meta`, so the udta samples land AFTER the moov-timed LigoGPS in
+  // append order too. (Documented LIMITATION: a `udta` PRECEDING `moov` in file
+  // order would, in ExifTool, take the LOWER ordinals — this multi-phase port
+  // always stamps udta after moov-timed, a phase-boundary divergence only for
+  // that uncommon layout; within each phase the order is faithful.)
+  let next = udta_ligo.stamp_doc_from(0, stream.doc_counter());
+  stream.set_doc_counter(next);
+  ligogps_meta.append(udta_ligo);
+
+  // **SP4 — the TRAILER PHASE** (QuickTime.pm:10654-10677 `for (; $trailer;
+  // $trailer = $$trailer[3])`). ExifTool walks the trailer linked list in CHAIN
+  // order — `identify_trailers` returns it HEAD-first (earliest/closest-to-BOF
+  // trailer first), exactly ExifTool's `$trailer`→`[3]` direction (its backward
+  // EOF walk builds the list so the returned head is the earliest and `[3]` steps
+  // toward EOF). Each trailer draws its `Doc<N>` from the ONE shared counter
+  // (which already reflects every moov-timed + `udta`-LigoGPS bump), so the
+  // trailers take the HIGHEST, non-colliding ordinals — and they precede only the
+  // `mdat` `ScanMediaData` scan (run LAST, below). The box-walk-consumed gate
+  // (`next if $lastPos > $$trailer[1]`, QuickTime.pm:10656) is applied per
+  // trailer: a trailer an atom already spanned is skipped (a bad-size trailer's
+  // NEGATIVE signed start likewise fails the gate, matching bundled, which would
+  // fail its `Seek`/`Read`). MIE trailers are recognized by `identify_trailers`
+  // (to walk past them) but not processed (unported, like the pre-reorder code).
+  for entry in &trailers {
+    let entry_signed_start = entry.start() as i64;
+    if (last_pos as i64) > entry_signed_start {
+      continue; // QuickTime.pm:10656 — an atom already consumed this trailer.
+    }
+    if entry.kind().is_insta360() {
+      // **Insta360** (QuickTime.pm:10669-10673 → `ProcessInsta360`). Scan the
+      // trailer (its body ends at `start + len`, == EOF for a standalone trailer)
+      // and FOLD it onto the shared counter: record `doc_base` (the counter value
+      // NOW, so the deferred `-ee` row decode stamps `Doc<doc_base + N>`), then
+      // advance the counter by the trailer's surfaced-row count
+      // (`count_surfaced_rows`) so any LATER chain trailer continues after the
+      // Insta360 doc range. Only the FIRST Insta360 trailer is extracted
+      // (`set_*`/`set_raw` are set-once); a second one's rows would not surface.
+      let entry_end = entry
+        .start()
+        .saturating_add(entry.len())
+        .min(data.len() as u64) as usize;
+      if insta360_meta.raw().is_none() {
+        insta360_meta.set_doc_base(stream.doc_counter());
+        insta360_fmt::scan_trailer(data, entry_end, &mut insta360_meta);
+        insta360_meta.set_trail_end(entry_end);
+        let rows = insta360_fmt::count_surfaced_rows(data, entry_end);
+        stream.set_doc_counter(stream.doc_counter().saturating_add(rows));
+      }
+    } else if entry.kind().is_ligogps() {
+      // **LigoGPS** file-end trailer (QuickTime.pm:10658-10668 → `ProcessLigoGPS`).
+      // `identify_trailers` recognized the `&&&& ` magic at `buff[32..36]` (BE u32
+      // length at `buff[36..40]`); the `skip`-atom + `LIGOGPSINFO\0` decode is in
+      // [`ligogps_fmt::process_trailer`]. Watermark-then-stamp off the shared
+      // counter: each record opens a new GLOBAL `Doc<N>` (LigoGPS.pm:243), in
+      // append (walk) order.
+      let ligo_start = ligogps_meta.sample_count();
+      ligogps_fmt::process_trailer(
+        data,
+        entry.start() as usize,
+        entry.len() as usize,
+        &mut ligogps_meta,
+      );
+      let next = ligogps_meta.stamp_doc_from(ligo_start, stream.doc_counter());
+      stream.set_doc_counter(next);
+    }
+  }
 
   // **SP3.5** — `ProcessFreeGPS` + brute-force scan of `mdat`
   // (QuickTimeStream.pl `ScanMediaData`:3679-3789). Faithful: ExifTool only
@@ -4117,6 +4346,8 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // `Image::ExifTool::GoPro::ProcessGP6` which parses the contained GPMF
   // KLV. exifast routes both through this single call: `scan_media_data`
   // now appends to the freeGPS-style stream samples AND fills `gopro`.
+  // It ALSO fills `ligogps_meta` (declared up-front with the trailer scan)
+  // on a freeGPS-embedded `LIGOGPSINFO\0` fingerprint hit.
   if let (Some(off), Some(size)) = (qt.media_data_offset(), qt.media_data_size()) {
     let already = found_embedded;
     // `-ee`-only source (the brute-force `mdat` scan runs inside
@@ -4124,6 +4355,9 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
     // onto exactly the fixes the scan appends so the emitter keeps them gated
     // (no no-`ee` fix, no file-level warning).
     let scan_start = stream.gps_sample_count();
+    // (A freeGPS Type-5 `LIGOGPSINFO\0` block decoded by the scan opens its own
+    // GLOBAL `Doc<N>` per record off the shared counter — stamped INSIDE
+    // `process_free_gps` at the record's walk position, Finding 3.)
     // Bounded to `scan_data` (the box hierarchy / mdat end at the Insta360
     // trailer's start): the brute-force freeGPS scan + its first-GP6 window
     // expansion must NOT reach into the trailer, which is `ProcessInsta360`'s
@@ -4131,6 +4365,11 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
     // trailer-less file `scan_data == data`, so this is a no-op. Passing
     // `scan_data` clamps both the `size` window and the GP6 EOF-expansion to
     // `scan_end` regardless of the declared `size`.
+    //
+    // **SP4** — the `Some(&mut ligogps_meta)` accumulator routes a GPSType-5
+    // (`LIGOGPSINFO\0`) fingerprint hit inside a `freeGPS ` block to
+    // `LigoGPS::ProcessLigoGPS` (QuickTimeStream.pl:1843-1888); most files
+    // leave it empty.
     quicktime_freegps::scan_media_data(
       scan_data,
       off,
@@ -4140,6 +4379,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
       already,
       &mut stream,
       &mut gopro_meta,
+      Some(&mut ligogps_meta),
     );
     stream.stamp_gps_origin_from(scan_start, crate::metadata::GpsOrigin::FreeGpsScan);
     // The brute-force `mdat` freeGPS scan runs LAST in ExifTool's walk
@@ -4148,6 +4388,11 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
     // counter after every earlier source (P1 + cross-source #214).
     stream.stamp_gps_doc_from(scan_start);
   }
+
+  // (The Insta360 + LigoGPS file-end trailers were processed in the TRAILER PHASE
+  // above — BEFORE this `mdat` `ScanMediaData` scan, mirroring ExifTool's
+  // `ProcessMOV` order: the trailer loop THEN `ScanMediaData`,
+  // QuickTime.pm:10654-10681.)
 
   // **SP3** — embedded Exif/TIFF hop. ExifTool dispatches certain atoms
   // (`QVMI` Casio, `MVTG` FujiFilm, `uuid`-Exif) to
@@ -4159,10 +4404,11 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // inside the box hierarchy — never in the file-end trailer).
   let embedded_exif_deferred = detect_embedded_exif(scan_data);
 
-  // **SP4** — the Insta360 INSV/INSP trailer (`insta360_meta`) was already
-  // decoded up-front (before the box walk), because `IdentifyTrailers`
-  // (QuickTime.pm:9897-9926) bounds the atom walk to the trailer's start. See
-  // the `scan_trailer` call near Pass 1.
+  // **SP4** — the Insta360 INSV/INSP trailer (`insta360_meta`) was decoded in the
+  // TRAILER PHASE (above, after `extract_stream` + the deferred `udta`-LigoGPS
+  // stamp, before the `mdat` scan), folding its `Doc<N>` onto the shared counter
+  // in `identify_trailers` chain order — ExifTool's `ProcessMOV` trailer loop
+  // (QuickTime.pm:10654-10677).
 
   Some(Meta {
     qt,
@@ -4172,6 +4418,8 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
     sony_rtmd: sony_rtmd_meta,
     canon_ctmd: canon_ctmd_meta,
     insta360: insta360_meta,
+    parrot: parrot_meta,
+    ligogps: ligogps_meta,
     embedded_exif_deferred,
     file_type,
     mime,
@@ -4352,13 +4600,36 @@ impl crate::diagnostics::Diagnose for Meta<'_> {
   /// QuickTime's diagnostics in the retired drain order: (a) the FIRST
   /// `ProcessMOV` warning (`Truncated '...' data` / `Invalid atom size`,
   /// QuickTime.pm:10242/10590) — the per-track truncation warnings ride the
-  /// TAG stream under `Track<N>:Warning`, not here (R6/F2); (b) the SP3
-  /// embedded-Exif-hop deferral notice when an Exif/TIFF block was detected
-  /// (`embedded_exif_deferred`, awaiting the Exif+GPS port). Byte-identical
-  /// net `TagMap`.
+  /// TAG stream under `Track<N>:Warning`, not here (R6/F2); (b) the LigoGPS
+  /// decoder warning (`Unrecognized data in LigoGPS trailer` /
+  /// `LIGOGPSINFO coordinates out of range` / `LIGOGPSINFO format error` / the
+  /// decrypt-failure deferral); (c) the SP3 embedded-Exif-hop deferral notice
+  /// when an Exif/TIFF block was detected (`embedded_exif_deferred`, awaiting
+  /// the Exif+GPS port).
+  ///
+  /// The LigoGPS warning is **document-level** (`ExifTool:Warning`), NOT a
+  /// group-scoped `LIGO:Warning`. ExifTool only sets `$$et{SET_GROUP1} = 'LIGO'`
+  /// AFTER the out-of-range / format-error returns: `ParseLigoGPS` raises both
+  /// `LIGOGPSINFO coordinates out of range` (LigoGPS.pm:254) and `LIGOGPSINFO
+  /// format error` (LigoGPS.pm:236) BEFORE the `SET_GROUP1='LIGO'` at
+  /// LigoGPS.pm:255, while `Unrecognized data in LigoGPS trailer`
+  /// (QuickTime.pm:10667) is raised in the `ProcessMOV` trailer loop with no
+  /// `SET_GROUP1` in effect. With `$$self{SET_GROUP1}` unset, `FoundTag`
+  /// (ExifTool.pm:9475 `$grps[1] or $grps[1] = $$self{SET_GROUP1}`) leaves the
+  /// `Warning` tag at the document level — contrast the LigoGPS *GPS tags*, which
+  /// ARE `LIGO`-grouped because they are `HandleTag`'d AFTER LigoGPS.pm:255 (the
+  /// camm/CTMD `Track<N>:Warning` ride does NOT apply — those decoders run inside
+  /// a `trak` whose `SET_GROUP1='Track<N>'` is active at the `Warn`). Pushed
+  /// AFTER the `ProcessMOV` warning so the priority-0 first-wins `Warning` slot
+  /// (LigoGPS warnings fire DURING extraction — the trailer loop / `ScanMediaData`
+  /// freeGPS pass — i.e. after the atom-walk `ProcessMOV` warning) keeps the
+  /// earlier-extracted document warning, matching ExifTool's file order.
   fn diagnostics(&self) -> std::vec::Vec<crate::diagnostics::Diagnostic> {
     let mut out = std::vec::Vec::new();
     if let Some(w) = self.warning() {
+      out.push(crate::diagnostics::Diagnostic::warn(w));
+    }
+    if let Some(w) = self.ligogps().warning() {
       out.push(crate::diagnostics::Diagnostic::warn(w));
     }
     if self.embedded_exif_deferred() {
@@ -5049,6 +5320,15 @@ impl crate::emit::Taggable for Meta<'_> {
         false,
       ));
     }
+
+    // ── SP4: LigoGPS dashcam GPS (Image::ExifTool::LigoGPS) ─────────────────
+    // The dashcam vendor GPS records (`ProcessLigoGPS` / `ProcessLigoJSON`,
+    // reached via the `&&&& ` file-end trailer OR a `freeGPS`-embedded
+    // `LIGOGPSINFO` sample) emit through the `%QuickTime::Stream` table under the
+    // family-1 `LIGO` group, one `Doc<N>` per record. `-ee`-gated. See
+    // [`emit_ligogps`] for the per-record order + per-tag PrintConv.
+    emit_ligogps(&self.ligogps, opts, print_conv, &mut tags);
+
     // The Apple `mebx` key/value pairs — ExifTool emits these per timed sample
     // under the enclosing `Track<N>` (family-1) at its `Doc<N>` (oracle:
     // `Track1:GPSCoordinates` / `Doc1:Track1:GPSCoordinates`), preceded by the
@@ -5764,6 +6044,13 @@ impl crate::emit::Taggable for Meta<'_> {
     // WAS_WARNED `[xN]` dedup), exactly like [`emit_camm_warnings`]. The
     // MINOR residue warning (`Warn(..., 1)`) carries the `[minor] ` prefix.
     emit_ctmd_warnings(self.canon_ctmd.warnings(), opts, &mut first_seen, &mut tags);
+
+    // ── SP4: Parrot drone `mett` (Image::ExifTool::Parrot) ─────────────────
+    // The per-sample GPS + flight telemetry decoded from a Parrot `mett` track
+    // (`Process_mett`, Parrot.pm:791-854) on the shared `-ee` `Doc<N>` /
+    // `Track<N>` axis — same machinery as the rtmd / CTMD arms above. See
+    // [`emit_parrot`] for the per-version offset order + per-tag PrintConv.
+    emit_parrot(&self.parrot, opts, print_conv, &mut tags);
 
     // ── SP4: Insta360 INSV/INSP trailer (ProcessInsta360) ──────────────────
     // The file-END trailer's tags (QuickTimeStream.pl:3252-3478) under the
@@ -7430,7 +7717,11 @@ fn emit_insta360<F: FnMut(&str, &str) -> bool>(
 
   // ── (2+3) the `-ee -G3` path — full decode + doc-sorted per-Doc emission ──
   // Inherently O(rows) = O(output) (one `Doc<N>` per row, matching ExifTool).
-  let full = insta360_fmt::decode_all_records(raw, trail_end);
+  // `doc_base` is the SHARED global counter value at the trailer-phase point
+  // `ProcessInsta360` ran (after moov-timed + `udta`-LigoGPS + earlier-chain
+  // trailers), so each row gets `Doc<doc_base + N>` — the ONE global sequence. `0`
+  // for an Insta360-only file (byte-identical to the pre-unification 0-based).
+  let full = insta360_fmt::decode_all_records(raw, trail_end, meta.doc_base());
 
   // Build the doc-ORDERED UNION of every timed record's tags as
   // `(doc, EmittedTag)` pairs (the per-sample formatting is the SHARED
@@ -7546,6 +7837,1003 @@ fn emit_camm_timing_only(
           TagValue::F64(secs)
         };
         tags.push(EmittedTag::new(group.clone(), name.into(), value, false));
+      }
+    }
+  }
+}
+
+/// `sprintf("%.3f m", $val)` PrintConv shared by the Parrot `GPSAltitude` /
+/// `AltitudeFromTakeOff` / `Elevation` tags (Parrot.pm:161 / :172 / :240 /
+/// :259 / :381 / :400) — fixed 3 decimals with a literal `" m"` suffix. `-n`
+/// emits the raw metres [`TagValue::F64`]. (Distinct from the `%QuickTime::Stream`
+/// altitude's `+ 0` numeric strip — Parrot keeps the trailing zeros.)
+#[cfg(feature = "alloc")]
+fn parrot_metres_value(val: f64, print_conv: bool) -> crate::value::TagValue {
+  use crate::value::TagValue;
+  if print_conv {
+    TagValue::Str(std::format!("{val:.3} m").into())
+  } else {
+    TagValue::F64(val)
+  }
+}
+
+/// The `"@a"` interpolation of a scaled `int16s[N]` / `int16u[N]` Parrot vector
+/// (`FrameView` / `FrameBaseView` / `DroneQuaternion` / `FOV`, Parrot.pm:119
+/// etc.) — the per-component f64 stringified via Perl's default number format
+/// (`%.15g`, [`crate::value::format_g`]) and space-joined. These columns carry
+/// NO PrintConv, so the value is the same in `-n` and `-j` (a string in both).
+#[cfg(feature = "alloc")]
+fn parrot_vec_value(components: &[f64]) -> crate::value::TagValue {
+  use crate::value::format_g;
+  let mut s = std::string::String::new();
+  for (i, &c) in components.iter().enumerate() {
+    if i != 0 {
+      s.push(' ');
+    }
+    s.push_str(&format_g(c, 15));
+  }
+  crate::value::TagValue::Str(s.into())
+}
+
+/// Parrot `FlyingState` PrintConv display (Parrot.pm:203-211 V1 / :328-338 V2 /
+/// :509-519 V3). V1 only defines keys 0..=5; V2 / V3 add 6..=8. A value with no
+/// table entry renders as the raw integer (ExifTool's PrintConv-hash miss).
+fn parrot_flying_state_display(
+  s: crate::metadata::ParrotFlyingState,
+  version: crate::metadata::ParrotRecordVersion,
+) -> std::string::String {
+  use crate::metadata::{ParrotFlyingState as F, ParrotRecordVersion as V};
+  let name = match s {
+    F::Landed => Some("Landed"),
+    F::TakingOff => Some("Taking Off"),
+    F::Hovering => Some("Hovering"),
+    F::Flying => Some("Flying"),
+    F::Landing => Some("Landing"),
+    F::Emergency => Some("Emergency"),
+    // 6..=8 exist only in the V2 / V3 PrintConv hash; a V1 record carrying one
+    // would miss the hash and render raw (faithful to the per-version table).
+    F::UserTakeoff if !matches!(version, V::V1) => Some("User Takeoff"),
+    F::MotorRamping if !matches!(version, V::V1) => Some("Motor Ramping"),
+    F::EmergencyLanding if !matches!(version, V::V1) => Some("Emergency Landing"),
+    _ => None,
+  };
+  match name {
+    Some(n) => n.into(),
+    None => std::format!("{}", s.as_u8()),
+  }
+}
+
+/// Parrot `PilotingMode` PrintConv display (Parrot.pm:221-227 V1 / :349-356 V2 /
+/// :530-537 V3). Key 3 is `"Follow Me"` for V1 but `"Follow Me / Tracking"` for
+/// V2 / V3 (same numeric value, wider description); keys 4..=5 exist only in
+/// V2 / V3. A miss renders the raw integer.
+fn parrot_piloting_mode_display(
+  s: crate::metadata::ParrotPilotingMode,
+  version: crate::metadata::ParrotRecordVersion,
+) -> std::string::String {
+  use crate::metadata::{ParrotPilotingMode as P, ParrotRecordVersion as V};
+  let v1 = matches!(version, V::V1);
+  let name = match s {
+    P::Manual => Some("Manual"),
+    P::ReturnHome => Some("Return Home"),
+    P::FlightPlan => Some("Flight Plan"),
+    P::FollowMe if v1 => Some("Follow Me"),
+    P::FollowMe => Some("Follow Me / Tracking"),
+    P::MagicCarpet if !v1 => Some("Magic Carpet"),
+    P::MoveTo if !v1 => Some("Move To"),
+    _ => None,
+  };
+  match name {
+    Some(n) => n.into(),
+    None => std::format!("{}", s.as_u8()),
+  }
+}
+
+/// Emit the Parrot drone `mett` timed-metadata samples (`Process_mett`,
+/// Parrot.pm:791-854; per-version binary tables `Parrot::V1`/`V2`/`V3` +
+/// `TimeStamp`) through the `tags()` engine. `ProcessSamples` opens ONE `Doc<N>`
+/// per `mett` SAMPLE and `Process_mett` `HandleTag`s every record (the P-record
+/// GPS + flight fields, then any concat'd E1 `TimeStamp`) under that one
+/// document, scoped to the enclosing `Track<N>` (family-1) — IDENTICAL group
+/// machinery to the `rtmd` / `CTMD` arms (the Parrot tables declare only
+/// `GROUPS => { 2 => ... }`, so `ProcessSamples`' `SET_GROUP1 = "Track$num"`
+/// supplies family-1 and family-0 is `QuickTime`). Gated on `-ee`; `-G3` emits
+/// each sample as its own `Doc<N>`, `-G1` collapses the doc axis to one
+/// `(Track<N>, name)` row FIRST-wins.
+///
+/// FULL mett parity: the typed [`ParrotMeta`] stores a [`ParrotGpsSample`] + a
+/// [`ParrotFlightSample`] per P-record and a [`ParrotFollowMeSample`] /
+/// [`ParrotAutomationSample`] per E2 / E3 extension (all stamped with the
+/// record's `Doc<N>` + `Track<N>`). This emits EVERY decoded field in the
+/// bundled per-version OFFSET order (ProcessBinaryData emits by ascending
+/// offset, so the rendered key order matches the oracle). The vectors are
+/// re-paired by their shared `Doc<N>` (one `mett` SAMPLE = one document — the
+/// P-record + any E1/E2/E3 concatenated after share it), so the fields of a
+/// sample interleave in offset / buffer order.
+///
+/// Emitted tags + PrintConv (VERBATIM from the V1/V2/V3 + E1/E2/E3 tables):
+///  - `ExposureTime` — `Exif::PrintExposureTime` (typed seconds, post-ValueConv).
+///  - `ISO` — plain integer.
+///  - `WifiRSSI` — `"$val dBm"`.
+///  - `Battery` — `"$val %"`.
+///  - `GPSLatitude` / `GPSLongitude` — `GPS::ToDMS` signed (N/S · E/W).
+///  - `GPSAltitude` / `AltitudeFromTakeOff` (V1) / `Elevation` (V2/V3) —
+///    `sprintf("%.3f m", $val)` ([`parrot_metres_value`]).
+///  - `GPSSatellites` — plain integer.
+///  - `GPSVelocityNorth`/`East`/`Down` (V2/V3) — raw number (ValueConv only).
+///  - `DistanceFromHome` (V1) / `AirSpeed` (V2/V3) — raw number (no PrintConv).
+///  - `DroneYaw`/`DronePitch`/`DroneRoll` (V1), `CameraPan`/`CameraTilt`
+///    (V1/V2) — rad→deg ValueConv, raw number (no PrintConv).
+///  - `SpeedX`/`SpeedY`/`SpeedZ` (V1) — raw number (`/0x100` ValueConv).
+///  - `FrameView` (all) / `DroneQuaternion` (V2/V3) / `FrameBaseView` (V3) /
+///    `FOV` (V3) — space-joined `"@a"` vector ([`parrot_vec_value`]).
+///  - `RedBalance`/`BlueBalance` (V3) — raw number (`/0x4000` ValueConv).
+///  - `LinkGoodput` (V3) — `"$val kbit/s"`; `LinkQuality` (V3) — plain integer.
+///  - `Binning`/`Animation` — `Mask => 0x80` flag, raw 0/1 (no PrintConv).
+///  - `FlyingState` / `PilotingMode` — the per-version PrintConv hash
+///    ([`parrot_flying_state_display`] / [`parrot_piloting_mode_display`]).
+///  - `TimeStamp` (E1 extension) — `$val / 1e6` seconds, raw number, emitted
+///    AFTER the P-record fields (the later `HandleTag` in buffer order).
+///  - `E2 FollowMe` — `GPSTargetLatitude`/`Longitude`/`Altitude` (raw, no
+///    PrintConv), `Follow-meMode` (BITMASK DecodeBits), `Follow-meAnimation`
+///    (PrintConv hash) ([`parrot_emit_follow_me`]).
+///  - `E3 Automation` — `GPSFramingLatitude` … / `GPSDestLatitude` … (raw),
+///    `AutomationAnimation` (PrintConv hash), `AutomationFlags` (BITMASK
+///    DecodeBits) ([`parrot_emit_automation`]).
+///
+/// The ARCore `application/arcore-*` subtables remain walk-and-discard (phone-
+/// side AR telemetry, not drone GPS — see the `parrot` module docs).
+#[cfg(feature = "alloc")]
+#[allow(clippy::too_many_lines)]
+fn emit_parrot(
+  meta: &crate::metadata::ParrotMeta,
+  opts: crate::emit::EmitOptions,
+  print_conv: bool,
+  tags: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::serialize_key::GroupMode;
+  use crate::value::{Group, TagValue};
+  if !opts.extract_embedded {
+    return;
+  }
+  let gps = meta.gps_samples();
+  let flight = meta.flight_samples();
+  let follow_me = meta.follow_me_samples();
+  let automation = meta.automation_samples();
+  if gps.is_empty() && flight.is_empty() && follow_me.is_empty() && automation.is_empty() {
+    return;
+  }
+  let g3 = matches!(opts.group_mode, GroupMode::G3);
+  // Distinct `Doc<N>` values across ALL FOUR record vectors, in ascending
+  // (= walk) order. Every production record carries a non-zero stamped doc;
+  // unit-built samples (doc == 0) all share document 0, which still emits as one
+  // group. `ProcessSamples` opens ONE `Doc<N>` per `mett` SAMPLE, so a P-record
+  // and any E1/E2/E3 extensions concatenated after it in the SAME sample share
+  // the doc — they re-pair here by `doc()`.
+  let mut docs: std::vec::Vec<u32> = std::vec::Vec::new();
+  for d in gps
+    .iter()
+    .map(|s| s.doc())
+    .chain(flight.iter().map(|s| s.doc()))
+    .chain(follow_me.iter().map(|s| s.doc()))
+    .chain(automation.iter().map(|s| s.doc()))
+  {
+    if !docs.contains(&d) {
+      docs.push(d);
+    }
+  }
+  docs.sort_unstable();
+  // `-G1` across-doc FIRST-wins collapse, keyed by `(family1, name)`.
+  let mut committed: std::vec::Vec<(smol_str::SmolStr, smol_str::SmolStr)> = std::vec::Vec::new();
+  let mut scratch: std::vec::Vec<EmittedTag> = std::vec::Vec::new();
+  for doc in docs {
+    // One P-record (+ its E1/E2/E3 extensions) per document in real Parrot
+    // files: the FIRST gps / flight / follow-me / automation sample stamped with
+    // this doc. (A degenerate multi-record sample re-pairs positionally by doc;
+    // the universal real-world shape is one of each.)
+    let g = gps.iter().find(|s| s.doc() == doc);
+    let f = flight.iter().find(|s| s.doc() == doc);
+    let e2 = follow_me.iter().find(|s| s.doc() == doc);
+    let e3 = automation.iter().find(|s| s.doc() == doc);
+    // The family-1 `Track<N>` + the sample-table timing come from whichever
+    // sample carries them (flight / E2 / E3 hold SampleTime/SampleDuration). A
+    // `0` (unstamped, unit-built) track index renders `Track1` like the other
+    // timed-sample emitters.
+    let track_index = f
+      .map(crate::metadata::ParrotFlightSample::track_index)
+      .or_else(|| g.map(crate::metadata::ParrotGpsSample::track_index))
+      .or_else(|| e2.map(crate::metadata::ParrotFollowMeSample::track_index))
+      .or_else(|| e3.map(crate::metadata::ParrotAutomationSample::track_index))
+      .filter(|&t| t != 0)
+      .unwrap_or(1);
+    let track = std::format!("Track{track_index}");
+    let group = if g3 {
+      Group::with_doc("QuickTime", track.as_str(), doc)
+    } else {
+      Group::new("QuickTime", track.as_str())
+    };
+    scratch.clear();
+    // SampleTime / SampleDuration (`ConvertDuration` at `-j`, raw seconds at
+    // `-n`) — emitted ONLY at `-G3` ahead of the payload (the `mett` track's
+    // `ProcessSamples` timing); at `-G1` the cross-kind min-doc precompute owns
+    // the single `Track<N>:SampleTime`, so do not duplicate it here. The timing
+    // comes from whichever record of this doc carries it.
+    let (sample_time, sample_duration) = f
+      .map(|f| (f.sample_time(), f.sample_duration()))
+      .or_else(|| e2.map(|s| (s.sample_time(), s.sample_duration())))
+      .or_else(|| e3.map(|s| (s.sample_time(), s.sample_duration())))
+      .unwrap_or((None, None));
+    if g3 {
+      for (val, name) in [
+        (sample_time, "SampleTime"),
+        (sample_duration, "SampleDuration"),
+      ] {
+        if let Some(secs) = val {
+          let value = if print_conv {
+            TagValue::Str(crate::datetime::convert_duration(secs).into())
+          } else {
+            TagValue::F64(secs)
+          };
+          scratch.push(EmittedTag::new(group.clone(), name.into(), value, false));
+        }
+      }
+    }
+    let version = f
+      .map(crate::metadata::ParrotFlightSample::version)
+      .or_else(|| g.map(crate::metadata::ParrotGpsSample::version))
+      .unwrap_or(crate::metadata::ParrotRecordVersion::V1);
+    parrot_emit_record(version, g, f, &group, print_conv, &mut scratch);
+    // E2 FollowMe / E3 Automation extensions of THIS sample (Parrot.pm:553-660),
+    // emitted AFTER the P-record + E1 fields (later records in buffer order).
+    if let Some(s) = e2 {
+      parrot_emit_follow_me(s, &group, print_conv, &mut scratch);
+    }
+    if let Some(s) = e3 {
+      parrot_emit_automation(s, &group, print_conv, &mut scratch);
+    }
+    if g3 {
+      tags.append(&mut scratch);
+    } else {
+      for tag in scratch.drain(..) {
+        let key = (
+          smol_str::SmolStr::new(tag.tag().group_ref().family1()),
+          smol_str::SmolStr::new(tag.tag().name()),
+        );
+        if committed.contains(&key) {
+          continue;
+        }
+        committed.push(key);
+        tags.push(tag);
+      }
+    }
+  }
+}
+
+/// Emit ONE Parrot P-record's stored fields in the bundled per-version OFFSET
+/// order (the order `ProcessBinaryData` `HandleTag`s ascending offsets), then the
+/// E1 `TimeStamp` extension. Helper for [`emit_parrot`] — keeps the offset-order
+/// table in one place per version.
+#[cfg(feature = "alloc")]
+fn parrot_emit_record(
+  version: crate::metadata::ParrotRecordVersion,
+  g: Option<&crate::metadata::ParrotGpsSample>,
+  f: Option<&crate::metadata::ParrotFlightSample>,
+  group: &crate::value::Group,
+  print_conv: bool,
+  out: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::metadata::ParrotRecordVersion as V;
+  use crate::value::TagValue;
+  let push = |out: &mut std::vec::Vec<EmittedTag>, name: &str, value: TagValue| {
+    out.push(EmittedTag::new(group.clone(), name.into(), value, false));
+  };
+  // Shared field emitters (each guarded on the typed Option).
+  let emit_exposure = |out: &mut std::vec::Vec<EmittedTag>,
+                       f: &crate::metadata::ParrotFlightSample| {
+    if let Some(secs) = f.exposure_time_s() {
+      let v = if print_conv {
+        TagValue::Str(crate::exif::tables::print_exposure_time(secs).into())
+      } else {
+        TagValue::F64(secs)
+      };
+      push(out, "ExposureTime", v);
+    }
+  };
+  let emit_iso = |out: &mut std::vec::Vec<EmittedTag>, f: &crate::metadata::ParrotFlightSample| {
+    if let Some(iso) = f.iso() {
+      push(out, "ISO", TagValue::I64(i64::from(iso)));
+    }
+  };
+  let emit_wifi = |out: &mut std::vec::Vec<EmittedTag>, f: &crate::metadata::ParrotFlightSample| {
+    if let Some(rssi) = f.wifi_rssi_dbm() {
+      // PrintConv `"$val dBm"`; `-n` emits the raw int8s.
+      let v = if print_conv {
+        TagValue::Str(std::format!("{rssi} dBm").into())
+      } else {
+        TagValue::I64(i64::from(rssi))
+      };
+      push(out, "WifiRSSI", v);
+    }
+  };
+  let emit_battery = |out: &mut std::vec::Vec<EmittedTag>,
+                      f: &crate::metadata::ParrotFlightSample| {
+    if let Some(b) = f.battery_percent() {
+      // PrintConv `"$val %"`; `-n` emits the raw int.
+      let v = if print_conv {
+        TagValue::Str(std::format!("{b} %").into())
+      } else {
+        TagValue::U64(u64::from(b))
+      };
+      push(out, "Battery", v);
+    }
+  };
+  let emit_gps_core = |out: &mut std::vec::Vec<EmittedTag>,
+                       g: &crate::metadata::ParrotGpsSample| {
+    if let Some(lat) = g.latitude() {
+      let v = if print_conv {
+        TagValue::Str(dms_signed(lat, 'N', 'S').into())
+      } else {
+        TagValue::F64(lat)
+      };
+      push(out, "GPSLatitude", v);
+    }
+    if let Some(lon) = g.longitude() {
+      let v = if print_conv {
+        TagValue::Str(dms_signed(lon, 'E', 'W').into())
+      } else {
+        TagValue::F64(lon)
+      };
+      push(out, "GPSLongitude", v);
+    }
+    if let Some(alt) = g.altitude_m() {
+      push(out, "GPSAltitude", parrot_metres_value(alt, print_conv));
+    }
+    if let Some(sv) = g.satellites() {
+      push(out, "GPSSatellites", TagValue::U64(u64::from(sv)));
+    }
+    // GPSVelocity{North,East,Down} (V2/V3 — Parrot.pm:266-280 / :407-421):
+    // ValueConv `/0x100` only, no PrintConv ⇒ raw f64 in both modes. V1 fixes
+    // never set these (naturally skipped), so the offset order holds: the
+    // velocity triple sits at offsets 20/22/24, right after GPSSatellites(16.1)
+    // and before AirSpeed(26).
+    if let Some(v) = g.velocity_north_mps() {
+      push(out, "GPSVelocityNorth", TagValue::F64(v));
+    }
+    if let Some(v) = g.velocity_east_mps() {
+      push(out, "GPSVelocityEast", TagValue::F64(v));
+    }
+    if let Some(v) = g.velocity_down_mps() {
+      push(out, "GPSVelocityDown", TagValue::F64(v));
+    }
+  };
+  // FlyingState / PilotingMode are emitted individually (per-version their
+  // sibling Binning / Animation flag interleaves at the SAME byte offset BEFORE
+  // them in offset order — `54` Binning then `54.1` FlyingState, etc.).
+  let emit_flying = |out: &mut std::vec::Vec<EmittedTag>,
+                     f: &crate::metadata::ParrotFlightSample| {
+    if let Some(fs) = f.flying_state() {
+      let v = if print_conv {
+        TagValue::Str(parrot_flying_state_display(fs, version).into())
+      } else {
+        TagValue::U64(u64::from(fs.as_u8()))
+      };
+      push(out, "FlyingState", v);
+    }
+  };
+  let emit_piloting = |out: &mut std::vec::Vec<EmittedTag>,
+                       f: &crate::metadata::ParrotFlightSample| {
+    if let Some(pm) = f.piloting_mode() {
+      let v = if print_conv {
+        TagValue::Str(parrot_piloting_mode_display(pm, version).into())
+      } else {
+        TagValue::U64(u64::from(pm.as_u8()))
+      };
+      push(out, "PilotingMode", v);
+    }
+  };
+  // `Binning` / `Animation` (Parrot.pm:194/212 etc.) — `Mask => 0x80` integer
+  // flag, no PrintConv ⇒ raw 0/1 in both modes.
+  let emit_binning = |out: &mut std::vec::Vec<EmittedTag>,
+                      f: &crate::metadata::ParrotFlightSample| {
+    if let Some(b) = f.binning() {
+      push(out, "Binning", TagValue::U64(u64::from(b)));
+    }
+  };
+  let emit_animation = |out: &mut std::vec::Vec<EmittedTag>,
+                        f: &crate::metadata::ParrotFlightSample| {
+    if let Some(a) = f.animation() {
+      push(out, "Animation", TagValue::U64(u64::from(a)));
+    }
+  };
+  // The rad→deg pose / gimbal scalars (`DroneYaw` … `CameraTilt`) — ValueConv
+  // only, no PrintConv ⇒ raw f64 in both modes.
+  let emit_deg = |out: &mut std::vec::Vec<EmittedTag>, name: &str, v: Option<f64>| {
+    if let Some(d) = v {
+      push(out, name, TagValue::F64(d));
+    }
+  };
+  // The `/0x100` speed scalars (`SpeedX/Y/Z`) — ValueConv only ⇒ raw f64.
+  let emit_speed = |out: &mut std::vec::Vec<EmittedTag>, name: &str, v: Option<f64>| {
+    if let Some(s) = v {
+      push(out, name, TagValue::F64(s));
+    }
+  };
+  match version {
+    V::V1 => {
+      // Offset order (Parrot.pm:91-227): DroneYaw(4) DronePitch(6) DroneRoll(8)
+      // CameraPan(10) CameraTilt(12) FrameView(14) ExposureTime(22) ISO(24)
+      // WifiRSSI(26) Battery(27) GPS{Lat(28)/Lon(32)/Alt(36)/Sat(36.1)}
+      // AltitudeFromTakeOff(40) DistanceFromHome(44) SpeedX(48) SpeedY(50)
+      // SpeedZ(52) Binning(54) FlyingState(54.1) Animation(55) PilotingMode(55.1).
+      if let Some(f) = f {
+        emit_deg(out, "DroneYaw", f.drone_yaw_deg());
+        emit_deg(out, "DronePitch", f.drone_pitch_deg());
+        emit_deg(out, "DroneRoll", f.drone_roll_deg());
+        emit_deg(out, "CameraPan", f.camera_pan_deg());
+        emit_deg(out, "CameraTilt", f.camera_tilt_deg());
+        if let Some(v) = f.frame_view() {
+          push(out, "FrameView", parrot_vec_value(&v));
+        }
+        emit_exposure(out, f);
+        emit_iso(out, f);
+        emit_wifi(out, f);
+        emit_battery(out, f);
+      }
+      if let Some(g) = g {
+        emit_gps_core(out, g);
+      }
+      if let Some(f) = f {
+        if let Some(a) = f.altitude_from_takeoff_m() {
+          push(
+            out,
+            "AltitudeFromTakeOff",
+            parrot_metres_value(a, print_conv),
+          );
+        }
+        if let Some(d) = f.distance_from_home_m() {
+          // No PrintConv (Parrot.pm:174-178) — raw number in both modes.
+          push(out, "DistanceFromHome", TagValue::F64(d));
+        }
+        emit_speed(out, "SpeedX", f.speed_x());
+        emit_speed(out, "SpeedY", f.speed_y());
+        emit_speed(out, "SpeedZ", f.speed_z());
+        emit_binning(out, f);
+        emit_flying(out, f);
+        emit_animation(out, f);
+        emit_piloting(out, f);
+      }
+    }
+    V::V2 => {
+      // Offset order (Parrot.pm:235-368): Elevation(4)
+      // GPS{Lat(8)/Lon(12)/Alt(16)/Sat(16.1)/VelN(20)/VelE(22)/VelD(24)}
+      // AirSpeed(26) DroneQuaternion(28) FrameView(36) CameraPan(44)
+      // CameraTilt(46) ExposureTime(48) ISO(50) Binning(52) FlyingState(52.1)
+      // Animation(53) PilotingMode(53.1) WifiRSSI(54) Battery(55).
+      if let Some(f) = f
+        && let Some(e) = f.elevation_m()
+      {
+        push(out, "Elevation", parrot_metres_value(e, print_conv));
+      }
+      if let Some(g) = g {
+        emit_gps_core(out, g);
+      }
+      if let Some(f) = f {
+        if let Some(a) = f.air_speed_mps() {
+          // No PrintConv (Parrot.pm:281-286) — raw number.
+          push(out, "AirSpeed", TagValue::F64(a));
+        }
+        if let Some(v) = f.drone_quaternion() {
+          push(out, "DroneQuaternion", parrot_vec_value(&v));
+        }
+        if let Some(v) = f.frame_view() {
+          push(out, "FrameView", parrot_vec_value(&v));
+        }
+        emit_deg(out, "CameraPan", f.camera_pan_deg());
+        emit_deg(out, "CameraTilt", f.camera_tilt_deg());
+        emit_exposure(out, f);
+        emit_iso(out, f);
+        emit_binning(out, f);
+        emit_flying(out, f);
+        emit_animation(out, f);
+        emit_piloting(out, f);
+        emit_wifi(out, f);
+        emit_battery(out, f);
+      }
+    }
+    V::V3 => {
+      // Offset order (Parrot.pm:376-538): Elevation(4)
+      // GPS{Lat(8)/Lon(12)/Alt(16)/Sat(16.1)/VelN(20)/VelE(22)/VelD(24)}
+      // AirSpeed(26) DroneQuaternion(28) FrameBaseView(36) FrameView(44)
+      // ExposureTime(52) ISO(54) RedBalance(56) BlueBalance(58) FOV(60)
+      // LinkGoodput(64) LinkQuality(64.1) WifiRSSI(68) Battery(69) Binning(70)
+      // FlyingState(70.1) Animation(71) PilotingMode(71.1).
+      if let Some(f) = f
+        && let Some(e) = f.elevation_m()
+      {
+        push(out, "Elevation", parrot_metres_value(e, print_conv));
+      }
+      if let Some(g) = g {
+        emit_gps_core(out, g);
+      }
+      if let Some(f) = f {
+        if let Some(a) = f.air_speed_mps() {
+          push(out, "AirSpeed", TagValue::F64(a));
+        }
+        if let Some(v) = f.drone_quaternion() {
+          push(out, "DroneQuaternion", parrot_vec_value(&v));
+        }
+        if let Some(v) = f.frame_base_view() {
+          push(out, "FrameBaseView", parrot_vec_value(&v));
+        }
+        if let Some(v) = f.frame_view() {
+          push(out, "FrameView", parrot_vec_value(&v));
+        }
+        emit_exposure(out, f);
+        emit_iso(out, f);
+        // RedBalance / BlueBalance (Parrot.pm:455-466) — ValueConv only ⇒ raw f64.
+        if let Some(r) = f.red_balance() {
+          push(out, "RedBalance", TagValue::F64(r));
+        }
+        if let Some(b) = f.blue_balance() {
+          push(out, "BlueBalance", TagValue::F64(b));
+        }
+        if let Some(v) = f.fov_deg() {
+          // FOV (Parrot.pm:467-474) — int16u[2] `"@a"` join, no PrintConv.
+          push(out, "FOV", parrot_vec_value(&v));
+        }
+        // LinkGoodput (Parrot.pm:475-481): PrintConv `"$val kbit/s"`; `-n` raw int.
+        if let Some(lg) = f.link_goodput_kbitps() {
+          let v = if print_conv {
+            TagValue::Str(std::format!("{lg} kbit/s").into())
+          } else {
+            TagValue::U64(u64::from(lg))
+          };
+          push(out, "LinkGoodput", v);
+        }
+        // LinkQuality (Parrot.pm:482-488): low byte, no PrintConv ⇒ raw int.
+        if let Some(lq) = f.link_quality() {
+          push(out, "LinkQuality", TagValue::U64(u64::from(lq)));
+        }
+        emit_wifi(out, f);
+        emit_battery(out, f);
+        emit_binning(out, f);
+        emit_flying(out, f);
+        emit_animation(out, f);
+        emit_piloting(out, f);
+      }
+    }
+  }
+  // E1 `TimeStamp` extension (Parrot.pm:541-551) — ValueConv `$val / 1e6`
+  // (seconds), no PrintConv, emitted AFTER the P-record fields (a later record
+  // in buffer order). The typed layer holds the raw microsecond counter.
+  if let Some(f) = f
+    && let Some(us) = f.time_stamp_us()
+  {
+    let secs = us as f64 / 1e6;
+    push(out, "TimeStamp", TagValue::F64(secs));
+  }
+}
+
+/// `Follow-meAnimation` PrintConv hash display (Parrot.pm:585-591). A miss
+/// renders the raw integer (ExifTool's PrintConv-hash miss).
+fn parrot_follow_me_animation_display(
+  a: crate::metadata::ParrotFollowMeAnimation,
+) -> std::string::String {
+  use crate::metadata::ParrotFollowMeAnimation as A;
+  match a {
+    A::None => "None".into(),
+    A::Orbit => "Orbit".into(),
+    A::Boomerang => "Boomerang".into(),
+    A::Parabola => "Parabola".into(),
+    A::Zenith => "Zenith".into(),
+    A::Unknown(n) => std::format!("{n}"),
+  }
+}
+
+/// `AutomationAnimation` PrintConv hash display (Parrot.pm:633-649). A miss
+/// renders the raw integer.
+fn parrot_automation_animation_display(
+  a: crate::metadata::ParrotAutomationAnimation,
+) -> std::string::String {
+  use crate::metadata::ParrotAutomationAnimation as A;
+  let name = match a {
+    A::None => "None",
+    A::Orbit => "Orbit",
+    A::Boomerang => "Boomerang",
+    A::Parabola => "Parabola",
+    A::DollySlide => "Dolly Slide",
+    A::DollyZoom => "Dolly Zoom",
+    A::RevealVertical => "Reveal Vertical",
+    A::RevealHorizontal => "Reveal Horizontal",
+    A::Candle => "Candle",
+    A::FlipFront => "Flip Front",
+    A::FlipBack => "Flip Back",
+    A::FlipLeft => "Flip Left",
+    A::FlipRight => "Flip Right",
+    A::TwistUp => "Twist Up",
+    A::PositionTwistUp => "Position Twist Up",
+    A::Unknown(n) => return std::format!("{n}"),
+  };
+  name.into()
+}
+
+/// Emit ONE Parrot `E2` FollowMe extension record (`Parrot::FollowMe`,
+/// Parrot.pm:553-593) in offset order: GPSTargetLatitude(4) /
+/// GPSTargetLongitude(8) / GPSTargetAltitude(12) — ValueConv only (raw decimal
+/// degrees / metres in both modes, NO ToDMS) — then Follow-meMode(16) (BITMASK
+/// DecodeBits) and Follow-meAnimation(17) (PrintConv hash; `-n` raw int).
+#[cfg(feature = "alloc")]
+fn parrot_emit_follow_me(
+  s: &crate::metadata::ParrotFollowMeSample,
+  group: &crate::value::Group,
+  print_conv: bool,
+  out: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::value::TagValue;
+  let push = |out: &mut std::vec::Vec<EmittedTag>, name: &str, value: TagValue| {
+    out.push(EmittedTag::new(group.clone(), name.into(), value, false));
+  };
+  // GPSTarget{Latitude,Longitude,Altitude} — ValueConv only, no PrintConv.
+  if let Some(v) = s.target_latitude() {
+    push(out, "GPSTargetLatitude", TagValue::F64(v));
+  }
+  if let Some(v) = s.target_longitude() {
+    push(out, "GPSTargetLongitude", TagValue::F64(v));
+  }
+  if let Some(v) = s.target_altitude_m() {
+    push(out, "GPSTargetAltitude", TagValue::F64(v));
+  }
+  // Follow-meMode (Parrot.pm:573-581): `PrintConv => { BITMASK => {...} }` ⇒
+  // DecodeBits; the table has no `BitsPerWord` so the bundled default of 32 bits
+  // applies (`0` ⇒ 32 in the helper, mirroring Perl's `$bits or $bits = 32`).
+  // The field is int8u so only bits 0-7 can ever be set — 32 vs 8 is identical
+  // here, but `0` is the faithful "BitsPerWord omitted". `-n` emits the raw int.
+  if let Some(flags) = s.mode_flags() {
+    let v = if print_conv {
+      let lookup = [
+        (0u8, "Follow-me enabled"),
+        (1, "Follow-me"),
+        (2, "Angle locked"),
+      ];
+      TagValue::Str(crate::convert::decode_bits(&std::format!("{flags}"), Some(&lookup), 0).into())
+    } else {
+      TagValue::U64(u64::from(flags))
+    };
+    push(out, "Follow-meMode", v);
+  }
+  // Follow-meAnimation (Parrot.pm:582-592): PrintConv hash; `-n` raw int.
+  if let Some(a) = s.animation() {
+    let v = if print_conv {
+      TagValue::Str(parrot_follow_me_animation_display(a).into())
+    } else {
+      TagValue::U64(u64::from(a.as_u8()))
+    };
+    push(out, "Follow-meAnimation", v);
+  }
+}
+
+/// Emit ONE Parrot `E3` Automation extension record (`Parrot::Automation`,
+/// Parrot.pm:595-660) in offset order: GPSFramingLatitude(4) /
+/// GPSFramingLongitude(8) / GPSFramingAltitude(12) / GPSDestLatitude(16) /
+/// GPSDestLongitude(20) / GPSDestAltitude(24) — ValueConv only (raw, NO ToDMS)
+/// — then AutomationAnimation(28) (PrintConv hash; `-n` raw int) and
+/// AutomationFlags(29) (BITMASK DecodeBits; `-n` raw int).
+#[cfg(feature = "alloc")]
+fn parrot_emit_automation(
+  s: &crate::metadata::ParrotAutomationSample,
+  group: &crate::value::Group,
+  print_conv: bool,
+  out: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::value::TagValue;
+  let push = |out: &mut std::vec::Vec<EmittedTag>, name: &str, value: TagValue| {
+    out.push(EmittedTag::new(group.clone(), name.into(), value, false));
+  };
+  // GPSFraming{Latitude,Longitude,Altitude} / GPSDest{...} — ValueConv only.
+  if let Some(v) = s.framing_latitude() {
+    push(out, "GPSFramingLatitude", TagValue::F64(v));
+  }
+  if let Some(v) = s.framing_longitude() {
+    push(out, "GPSFramingLongitude", TagValue::F64(v));
+  }
+  if let Some(v) = s.framing_altitude_m() {
+    push(out, "GPSFramingAltitude", TagValue::F64(v));
+  }
+  if let Some(v) = s.dest_latitude() {
+    push(out, "GPSDestLatitude", TagValue::F64(v));
+  }
+  if let Some(v) = s.dest_longitude() {
+    push(out, "GPSDestLongitude", TagValue::F64(v));
+  }
+  if let Some(v) = s.dest_altitude_m() {
+    push(out, "GPSDestAltitude", TagValue::F64(v));
+  }
+  // AutomationAnimation (Parrot.pm:630-650): PrintConv hash; `-n` raw int.
+  if let Some(a) = s.animation() {
+    let v = if print_conv {
+      TagValue::Str(parrot_automation_animation_display(a).into())
+    } else {
+      TagValue::U64(u64::from(a.as_u8()))
+    };
+    push(out, "AutomationAnimation", v);
+  }
+  // AutomationFlags (Parrot.pm:651-659): `PrintConv => { BITMASK => {...} }`; no
+  // `BitsPerWord` ⇒ DecodeBits default 32 bits (`0` ⇒ 32 in the helper). The
+  // field is int8u, so 32 vs 8 is identical. `-n` raw int.
+  if let Some(flags) = s.flags() {
+    let v = if print_conv {
+      let lookup = [
+        (0u8, "Follow-me enabled"),
+        (1, "Look-at-me enabled"),
+        (2, "Angle locked"),
+      ];
+      TagValue::Str(crate::convert::decode_bits(&std::format!("{flags}"), Some(&lookup), 0).into())
+    } else {
+      TagValue::U64(u64::from(flags))
+    };
+    push(out, "AutomationFlags", v);
+  }
+}
+
+/// Emit the LigoGPS dashcam GPS samples (`ProcessLigoGPS` / `ProcessLigoJSON`,
+/// LigoGPS.pm) through the `tags()` engine. ExifTool routes these through the
+/// shared `%QuickTime::Stream` tag table (LigoGPS.pm passes the caller's
+/// `$tagTbl`, which is `QuickTime::Stream`), opening a NEW `Doc<N>` per record
+/// (`$$et{DOC_NUM} = ++$$et{DOC_COUNT}`, LigoGPS.pm:243 / :354) and scoping every
+/// record to family-1 `LIGO` (`$$et{SET_GROUP1} = 'LIGO'`, LigoGPS.pm:255 / :341).
+/// family-0 is `QuickTime` (the Stream table's module group — IDENTICAL to the
+/// SP3 stream / rtmd / CTMD timed sources, which the port emits under
+/// `QuickTime:…`).
+///
+/// **`-ee` gating (FINDING 1 — split by source, [`crate::metadata::LigoSource`]).**
+/// The two LigoGPS families gate differently:
+///  - **`udta` JSON/GKU** (`ProcessLigoJSON`): ExifTool processes the FIRST
+///    active record EVEN WITHOUT `-ee`, then `Warn`s + `last`s
+///    (LigoGPS.pm:390-393); `-ee` extracts the rest. So at no-`ee` the FIRST
+///    `udta`-JSON-sourced record emits (FLAT, no `Doc<N>`); the remaining
+///    `udta`-JSON records + ALL binary records are suppressed.
+///  - **binary `ProcessLigoGPS`** (trailer / freeGPS-embedded): the entry points
+///    run only inside the `-ee` trailer / scan pass, so the binary family is
+///    FULLY `-ee`-gated (nothing at no-`ee`).
+///
+/// **`Doc<N>` (FINDING 3 — global counter).** Each record's `Doc<N>` is the
+/// GLOBAL ordinal stamped at extraction off the SHARED `QuickTimeStreamMeta` doc
+/// counter (`crate::metadata::LigoGpsSample::doc`), allocated at the record's
+/// walk position from the SAME `++DOC_COUNT` the `mebx`/camm/`gps0`/freeGPS
+/// sources use — so a mixed `-ee -G3` file gets non-colliding, monotone doc
+/// ordinals across every source (no per-source restart). `s.doc()` is used
+/// VERBATIM; the running fallback covers only UNSTAMPED unit-built samples.
+/// `-G3` emits every record as its own `Doc<N>` row; `-G1` (and no-`ee`)
+/// collapses the `Doc<N>` axis to one `(family1, name)` row, FIRST-wins (each
+/// record is its own document, so the collapse is purely across-doc first-wins —
+/// the same `%noDups` rule the other timed sources use).
+///
+/// Per-record emit ORDER + PrintConv are taken VERBATIM from `ParseLigoGPS`
+/// (LigoGPS.pm:256-265) and the `%QuickTime::Stream` table (QuickTimeStream.pl:
+/// 116-150): GPSDateTime (`ConvertDateTime`, identity at the default DateFormat —
+/// emitted verbatim like every other Stream GPSDateTime), GPSLatitude /
+/// GPSLongitude (`GPS::ToDMS` with the N/S · E/W hemisphere at `-j`, raw decimal
+/// degrees at `-n`), GPSSpeed (`sprintf("%.4f",$val)+0` km/h, no suffix),
+/// GPSTrack (`sprintf("%.4f",$val)+0`), GPSAltitude (`(sprintf("%.4f",$val)+0)."
+/// m"`), MagneticVariation (no conv), Accelerometer (no conv), and — for the JSON
+/// variant — DateTimeOriginal (`ConvertDateTime`, verbatim) after Accelerometer
+/// (LigoGPS.pm:380).
+#[cfg(feature = "alloc")]
+fn emit_ligogps(
+  meta: &crate::metadata::LigoGpsMeta,
+  opts: crate::emit::EmitOptions,
+  print_conv: bool,
+  tags: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::serialize_key::GroupMode;
+  use crate::value::{Group, TagValue};
+  // FINDING 1 — per-sample no-`ee` gate. The binary family is fully `-ee`-gated;
+  // the `udta`-JSON family emits its FIRST active record even without `-ee`
+  // (`ProcessLigoJSON` processes record 1 then `last`s, LigoGPS.pm:390-393). So
+  // at no-`ee` ONLY the FIRST `udta`-JSON-sourced sample qualifies — track
+  // whether it has been emitted yet. With `-ee` every sample qualifies. Bail
+  // early when nothing can emit (the common no-`ee` non-`udta`-JSON case), so the
+  // hot path pays no dedup bookkeeping.
+  let has_first_udta_json = meta.samples().iter().any(|s| s.source().is_udta_json());
+  if !opts.extract_embedded && !has_first_udta_json {
+    return;
+  }
+  // Without `-ee` ExifTool opens NO `Doc<N>` sub-document (the single record
+  // surfaces FLAT, `QuickTime:…`) and only the first `udta`-JSON record's columns
+  // survive: force the `Doc<N>` axis OFF + the first-wins collapse ON at no-`ee`
+  // (regardless of the requested `-G3`), mirroring [`emit_timed_samples`]. With
+  // `-ee` the requested group mode drives the doc axis.
+  let g3 = opts.extract_embedded && matches!(opts.group_mode, GroupMode::G3);
+  // Fallback running ordinal for an UNSTAMPED sample (unit-built samples in the
+  // emitter tests). Production samples carry the GLOBAL `s.doc()` stamped at
+  // extraction (Finding 3); each record is its own `Doc<N>` (LigoGPS.pm:243), so
+  // a per-record running ordinal is a faithful fallback.
+  let mut doc: u32 = 0;
+  // `-G1` / no-`ee` collapse state, keyed by `(family1, name)`. Each LigoGPS
+  // record is its own document, so the collapse is across-doc FIRST-wins (no
+  // within-doc last-wins case as for camm). Mirrors the sony/rtmd `flush_doc`.
+  let mut committed: std::vec::Vec<(smol_str::SmolStr, smol_str::SmolStr)> = std::vec::Vec::new();
+  let mut scratch: std::vec::Vec<EmittedTag> = std::vec::Vec::new();
+  // FINDING 1 — has the no-`ee` first `udta`-JSON record been emitted?
+  let mut emitted_no_ee_first = false;
+  for sample in meta.samples() {
+    // FINDING 1 — skip samples that don't qualify under the current `-ee` state.
+    if !opts.extract_embedded {
+      // No-`ee`: emit ONLY the first `udta`-JSON record; skip the rest + all
+      // binary records.
+      if emitted_no_ee_first || !sample.source().is_udta_json() {
+        continue;
+      }
+      emitted_no_ee_first = true;
+    }
+    doc += 1;
+    // FINDING 3 — use the GLOBAL doc stamped at extraction; the running `doc` is
+    // only a fallback for unstamped unit-built samples.
+    let doc_n = sample.doc().unwrap_or(doc);
+    // An out-of-range binary record burned a `Doc<N>` (LigoGPS.pm:243 before the
+    // :254 range-check return) but emits NO GPS tags: it has already advanced the
+    // `doc` ordinal above (so the NEXT record gets the burned slot's successor) —
+    // skip its tag emission. (At no-`ee` it is a binary record, already skipped
+    // by the `continue` above, so this only matters under `-ee`.)
+    if sample.is_suppressed() {
+      continue;
+    }
+    let group = if g3 {
+      Group::with_doc("QuickTime", "LIGO", doc_n)
+    } else {
+      Group::new("QuickTime", "LIGO")
+    };
+    scratch.clear();
+    // GPSDateTime (LigoGPS.pm:256 / :360): `ConvertDateTime` is identity at the
+    // default DateFormat — emit the stored `YYYY:MM:DD HH:MM:SS[Z]` verbatim in
+    // both modes (the same treatment as the SP3 / rtmd GPSDateTime).
+    if let Some(dt) = sample.date_time() {
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "GPSDateTime".into(),
+        TagValue::Str(dt.into()),
+        false,
+      ));
+    }
+    // GPSLatitude / GPSLongitude (LigoGPS.pm:258-259): the typed layer holds the
+    // SIGNED decimal degrees (the hemisphere sign already applied). `GPS::ToDMS`
+    // with the N/S · E/W hemisphere suffix at `-j`, raw `F64` at `-n`.
+    if let Some(lat) = sample.latitude() {
+      let v = if print_conv {
+        TagValue::Str(dms_signed(lat, 'N', 'S').into())
+      } else {
+        TagValue::F64(lat)
+      };
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "GPSLatitude".into(),
+        v,
+        false,
+      ));
+    }
+    if let Some(lon) = sample.longitude() {
+      let v = if print_conv {
+        TagValue::Str(dms_signed(lon, 'E', 'W').into())
+      } else {
+        TagValue::F64(lon)
+      };
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "GPSLongitude".into(),
+        v,
+        false,
+      ));
+    }
+    // GPSSpeed (LigoGPS.pm:260): km/h post-scale; `sprintf("%.4f",$val)+0`
+    // PrintConv (QuickTimeStream.pl:121), raw F64 at `-n`.
+    if let Some(sp) = sample.speed_kph() {
+      let v = if print_conv {
+        TagValue::Str(crate::value::format_g(round_to_decimals(sp, 4), 15).into())
+      } else {
+        TagValue::F64(sp)
+      };
+      scratch.push(EmittedTag::new(group.clone(), "GPSSpeed".into(), v, false));
+    }
+    // GPSTrack (LigoGPS.pm:261): `sprintf("%.4f",$val)+0` (QuickTimeStream.pl:123).
+    if let Some(tr) = sample.track_deg() {
+      let v = if print_conv {
+        TagValue::Str(crate::value::format_g(round_to_decimals(tr, 4), 15).into())
+      } else {
+        TagValue::F64(tr)
+      };
+      scratch.push(EmittedTag::new(group.clone(), "GPSTrack".into(), v, false));
+    }
+    // GPSAltitude (LigoGPS.pm:262): `(sprintf("%.4f",$val)+0)." m"`
+    // (QuickTimeStream.pl:120), raw metres at `-n`.
+    if let Some(alt) = sample.altitude_m() {
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "GPSAltitude".into(),
+        gps_altitude_stream_value(alt, print_conv),
+        false,
+      ));
+    }
+    // MagneticVariation (LigoGPS.pm:263): no PrintConv (QuickTimeStream.pl:363 is
+    // a bare `{}`) — emit the raw `F64` in both modes.
+    if let Some(mv) = sample.magnetic_variation() {
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "MagneticVariation".into(),
+        TagValue::F64(mv),
+        false,
+      ));
+    }
+    // Accelerometer (LigoGPS.pm:265 / :373): the space-joined "ax ay az" string,
+    // no PrintConv (QuickTimeStream.pl:149 is `Notes`-only) — emit verbatim.
+    if let Some(acc) = sample.accelerometer() {
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "Accelerometer".into(),
+        TagValue::Str(acc.into()),
+        false,
+      ));
+    }
+    // DateTimeOriginal (JSON variant only, LigoGPS.pm:380): the dashcam local
+    // clock; `ConvertDateTime` is identity at the default DateFormat — verbatim.
+    if let Some(dt) = sample.date_time_local() {
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "DateTimeOriginal".into(),
+        TagValue::Str(dt.into()),
+        false,
+      ));
+    }
+    // GPSLatitude2 / GPSLongitude2 (JSON variant only, LigoGPS.pm:387-388 from
+    // OLatitude/OLongitude): the typed layer holds the SIGNED decimal degrees.
+    // Same `GPS::ToDMS` PrintConv as the primary lat/lon (QuickTimeStream.pl:
+    // 118-119), raw `F64` at `-n`. Emitted AFTER DateTimeOriginal, matching the
+    // bundled `HandleTag` order.
+    if let Some(lat2) = sample.latitude2() {
+      let v = if print_conv {
+        TagValue::Str(dms_signed(lat2, 'N', 'S').into())
+      } else {
+        TagValue::F64(lat2)
+      };
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "GPSLatitude2".into(),
+        v,
+        false,
+      ));
+    }
+    if let Some(lon2) = sample.longitude2() {
+      let v = if print_conv {
+        TagValue::Str(dms_signed(lon2, 'E', 'W').into())
+      } else {
+        TagValue::F64(lon2)
+      };
+      scratch.push(EmittedTag::new(
+        group.clone(),
+        "GPSLongitude2".into(),
+        v,
+        false,
+      ));
+    }
+    if g3 {
+      tags.append(&mut scratch);
+    } else {
+      // `-G1` / default: collapse the `Doc<N>` axis to one `(family1, name)` row,
+      // FIRST-wins across records (each record is its own doc).
+      for tag in scratch.drain(..) {
+        let key = (
+          smol_str::SmolStr::new(tag.tag().group_ref().family1()),
+          smol_str::SmolStr::new(tag.tag().name()),
+        );
+        if committed.contains(&key) {
+          continue;
+        }
+        committed.push(key);
+        tags.push(tag);
       }
     }
   }
@@ -10196,6 +11484,1465 @@ mod tests {
     );
   }
 
+  /// A `gpmd_Kingslim` timed-metadata sample routes to
+  /// the bundled `ProcessFreeGPS` process-proc (QuickTimeStream.pl:182-187),
+  /// which sets `$$et{FoundEmbedded} = 1` (:1650) and so SUPPRESSES the later
+  /// brute-force `ScanMediaData` `mdat` scan (:3689). The pre-fix port decoded
+  /// the Kingslim block against a THROWAWAY `FreeGpsState`, so the flag never
+  /// reached `extract_stream` and a stray `freeGPS`-looking block buried in
+  /// `mdat` would be double-decoded by the scan. Threading the walk-level
+  /// `FreeGpsState` into `dispatch_gpmd` fixes it: the Kingslim LigoGPS sample is
+  /// extracted AND the redundant `mdat` scan is suppressed (no spurious stream
+  /// GPS). Mirrors `moov_gps_box_decode_suppresses_redundant_mdat_scan`.
+  #[test]
+  fn kingslim_gpmd_sample_suppresses_mdat_scan() {
+    // The Kingslim D4 `gpmd` sample (same shape as the freegps unit test
+    // `dispatch_gpmd_routes_kingslim_to_ligogps`): Condition `^.{21}\0\0\0A[NS][EW]`,
+    // `LIGOGPSINFO\0` at 0x50, an ASCII LigoGPS record at 0x50+0x14.
+    let mut kingslim = vec![0u8; 240];
+    kingslim[24] = b'A';
+    kingslim[25] = b'N';
+    kingslim[26] = b'W';
+    kingslim[80..92].copy_from_slice(b"LIGOGPSINFO\0");
+    let mut rec = vec![0u8, 0, 0, 0]; // 4-byte counter consumed by `.{4}`
+    rec.extend_from_slice(b"2024/01/15 10:00:00 N:45.5 E:170.5 30.0");
+    kingslim[100..100 + rec.len()].copy_from_slice(&rec);
+
+    // A SEPARATE Type-6 (Akaso) freeGPS block (distinct coordinates) that the
+    // brute-force `mdat` scan WOULD decode if it were not suppressed.
+    let mut stray = vec![0u8; 0x100];
+    wr(&mut stray, 0, &0x0100u32.to_be_bytes());
+    wr(&mut stray, 4, b"freeGPS ");
+    wb(&mut stray, 60, b'A');
+    wb(&mut stray, 68, b'N');
+    wb(&mut stray, 76, b'W');
+    wr(&mut stray, 0x30, &12u32.to_le_bytes());
+    wr(&mut stray, 0x34, &13u32.to_le_bytes());
+    wr(&mut stray, 0x38, &14u32.to_le_bytes());
+    wr(&mut stray, 0x58, &2023u32.to_le_bytes());
+    wr(&mut stray, 0x5c, &1u32.to_le_bytes());
+    wr(&mut stray, 0x60, &2u32.to_le_bytes());
+    wr(&mut stray, 0x40, &1000.0f32.to_le_bytes());
+    wr(&mut stray, 0x48, &2000.0f32.to_le_bytes());
+
+    // Layout = ftyp || mdat(kingslim + stray + >=0x8000 pad) || moov(gpmd trak).
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut mdat_payload = kingslim.clone();
+    mdat_payload.extend_from_slice(&stray);
+    mdat_payload.extend_from_slice(&[0u8; 0x8000]);
+    let mdat = atom(b"mdat", &mdat_payload);
+    // The Kingslim sample's ABSOLUTE offset = ftyp.len() + 8 (mdat payload start).
+    let kingslim_offset = (ftyp.len() + 8) as u32;
+
+    // A `meta`-HandlerType trak with a `gpmd` MetaFormat stsd whose single
+    // sample is the Kingslim block.
+    let mut hdlr_body = vec![0u8; 24];
+    wr(&mut hdlr_body, 8, b"meta");
+    let hdlr = atom(b"hdlr", &hdlr_body);
+    let mut mdhd_body = vec![0u8; 24];
+    wr(&mut mdhd_body, 12, &1000u32.to_be_bytes());
+    let mdhd = atom(b"mdhd", &mdhd_body);
+    let mut stsd_body = vec![0u8; 8];
+    wr(&mut stsd_body, 4, &1u32.to_be_bytes());
+    let mut entry = vec![0u8; 16];
+    wr(&mut entry, 0, &16u32.to_be_bytes());
+    wr(&mut entry, 4, b"gpmd");
+    stsd_body.extend_from_slice(&entry);
+    let stsd = atom(b"stsd", &stsd_body);
+    let mut stco_body = vec![0u8; 8];
+    wr(&mut stco_body, 4, &1u32.to_be_bytes());
+    stco_body.extend_from_slice(&kingslim_offset.to_be_bytes());
+    let stco = atom(b"stco", &stco_body);
+    let mut stsc_body = vec![0u8; 8];
+    wr(&mut stsc_body, 4, &1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    let stsc = atom(b"stsc", &stsc_body);
+    let mut stsz_body = vec![0u8; 8];
+    wr(&mut stsz_body, 4, &0u32.to_be_bytes());
+    stsz_body.extend_from_slice(&1u32.to_be_bytes());
+    stsz_body.extend_from_slice(&(kingslim.len() as u32).to_be_bytes());
+    let stsz = atom(b"stsz", &stsz_body);
+    let mut stbl_body = stsd;
+    stbl_body.extend_from_slice(&stco);
+    stbl_body.extend_from_slice(&stsc);
+    stbl_body.extend_from_slice(&stsz);
+    let stbl = atom(b"stbl", &stbl_body);
+    let minf = atom(b"minf", &stbl);
+    let mut mdia_body = mdhd;
+    mdia_body.extend_from_slice(&hdlr);
+    mdia_body.extend_from_slice(&minf);
+    let mdia = atom(b"mdia", &mdia_body);
+    let trak = atom(b"trak", &mdia);
+    let mvhd = atom(b"mvhd", &[0u8; 100]);
+    let mut moov_body = mvhd;
+    moov_body.extend_from_slice(&trak);
+    let moov = atom(b"moov", &moov_body);
+
+    let mut data = ftyp;
+    data.extend_from_slice(&mdat);
+    data.extend_from_slice(&moov);
+
+    let meta = parse_inner(&data, None).expect("accepted");
+    // The Kingslim sample decoded into the LigoGPS accumulator.
+    let ligo = meta
+      .ligogps()
+      .samples()
+      .first()
+      .expect("Kingslim must decode via the GPSType-5 LigoGPS arm");
+    assert_eq!(ligo.latitude(), Some(45.5));
+    assert_eq!(ligo.longitude(), Some(170.5));
+    // And FoundEmbedded (set by the Kingslim ProcessFreeGPS) suppressed the
+    // brute-force `mdat` scan — the stray block is NOT decoded, so there is no
+    // spurious stream GPS sample.
+    assert_eq!(
+      meta.stream().gps_samples().len(),
+      0,
+      "Kingslim FoundEmbedded must suppress the redundant mdat freeGPS scan (no spurious GPS)"
+    );
+  }
+
+  /// Build an MP4 whose single `meta`-handler `gpmd` track sample is a Kingslim
+  /// D4 LigoGPS block (decodes via the GPSType-5 `ProcessLigoGPS` arm into
+  /// `ligogps`). Shared by the LigoGPS emission tests.
+  fn kingslim_ligogps_mp4() -> Vec<u8> {
+    // N:45.5 E:170.5, 30.0 km/h, A:120 track, H:46 alt (ParseLigoGPS fields).
+    let mut rec = vec![0u8, 0, 0, 0];
+    rec.extend_from_slice(b"2024/01/15 10:00:00 N:45.5 E:170.5 30.0 A:120 H:46");
+    kingslim_ligogps_mp4_with_record(&rec)
+  }
+
+  /// Build the Kingslim-D4-shaped `gpmd`-track MP4 of [`kingslim_ligogps_mp4`]
+  /// but with a CUSTOM 132-byte-max LigoGPS record body (the `[4-byte counter]
+  /// …` payload written at offset 100 of the `LIGOGPSINFO\0`-at-80 block). Used
+  /// by the Finding 2 warning tests to drive an out-of-range / decrypt-failure
+  /// record through the FULL freeGPS-embedded `ProcessLigoGPS` path.
+  fn kingslim_ligogps_mp4_with_record(record_body: &[u8]) -> Vec<u8> {
+    let mut kingslim = vec![0u8; 240];
+    kingslim[24] = b'A';
+    kingslim[25] = b'N';
+    kingslim[26] = b'W';
+    kingslim[80..92].copy_from_slice(b"LIGOGPSINFO\0");
+    // Records start at the `LIGOGPSINFO\0` offset (80) + 0x14 = 100; one 0x84
+    // (132)-byte stride fits in the 240-byte block (100..232).
+    assert!(record_body.len() <= 0x84, "record exceeds one 0x84 stride");
+    kingslim[100..100 + record_body.len()].copy_from_slice(record_body);
+
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut mdat_payload = kingslim.clone();
+    mdat_payload.extend_from_slice(&[0u8; 0x100]); // small pad (no stray block)
+    let mdat = atom(b"mdat", &mdat_payload);
+    let kingslim_offset = (ftyp.len() + 8) as u32;
+
+    let mut hdlr_body = vec![0u8; 24];
+    wr(&mut hdlr_body, 8, b"meta");
+    let hdlr = atom(b"hdlr", &hdlr_body);
+    let mut mdhd_body = vec![0u8; 24];
+    wr(&mut mdhd_body, 12, &1000u32.to_be_bytes());
+    let mdhd = atom(b"mdhd", &mdhd_body);
+    let mut stsd_body = vec![0u8; 8];
+    wr(&mut stsd_body, 4, &1u32.to_be_bytes());
+    let mut entry = vec![0u8; 16];
+    wr(&mut entry, 0, &16u32.to_be_bytes());
+    wr(&mut entry, 4, b"gpmd");
+    stsd_body.extend_from_slice(&entry);
+    let stsd = atom(b"stsd", &stsd_body);
+    let mut stco_body = vec![0u8; 8];
+    wr(&mut stco_body, 4, &1u32.to_be_bytes());
+    stco_body.extend_from_slice(&kingslim_offset.to_be_bytes());
+    let stco = atom(b"stco", &stco_body);
+    let mut stsc_body = vec![0u8; 8];
+    wr(&mut stsc_body, 4, &1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    let stsc = atom(b"stsc", &stsc_body);
+    let mut stsz_body = vec![0u8; 8];
+    wr(&mut stsz_body, 4, &0u32.to_be_bytes());
+    stsz_body.extend_from_slice(&1u32.to_be_bytes());
+    stsz_body.extend_from_slice(&(kingslim.len() as u32).to_be_bytes());
+    let stsz = atom(b"stsz", &stsz_body);
+    let mut stbl_body = stsd;
+    stbl_body.extend_from_slice(&stco);
+    stbl_body.extend_from_slice(&stsc);
+    stbl_body.extend_from_slice(&stsz);
+    let stbl = atom(b"stbl", &stbl_body);
+    let minf = atom(b"minf", &stbl);
+    let mut mdia_body = mdhd;
+    mdia_body.extend_from_slice(&hdlr);
+    mdia_body.extend_from_slice(&minf);
+    let mdia = atom(b"mdia", &mdia_body);
+    let trak = atom(b"trak", &mdia);
+    let mvhd = atom(b"mvhd", &[0u8; 100]);
+    let mut moov_body = mvhd;
+    moov_body.extend_from_slice(&trak);
+    let moov = atom(b"moov", &moov_body);
+    let mut data = ftyp;
+    data.extend_from_slice(&mdat);
+    data.extend_from_slice(&moov);
+    data
+  }
+
+  /// Decoded LigoGPS records must EMIT through
+  /// `Meta::tags()` under family-1 `LIGO` (the `%QuickTime::Stream` table,
+  /// `$$et{SET_GROUP1}='LIGO'`, LigoGPS.pm:255). At `-ee -n` the GPS columns are
+  /// the raw post-ValueConv scalars (lat/lon decimal degrees, speed km/h, track
+  /// degrees), GPSDateTime the normalised UTC string.
+  #[test]
+  fn ligogps_tags_emitted_under_ee() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    let data = kingslim_ligogps_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    // Sanity: the LigoGPS record decoded.
+    assert!(!meta.ligogps().samples().is_empty(), "LigoGPS must decode");
+
+    // `-ee -n`: collect the family-1 `LIGO` tags.
+    let ee = EmitOptions::g1(ConvMode::ValueConv, true);
+    let ligo: std::vec::Vec<(String, crate::value::TagValue)> = meta
+      .tags(ee)
+      .filter(|t| t.tag().group_ref().family1() == "LIGO")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect();
+    let get = |name: &str| ligo.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    use crate::value::TagValue;
+    assert_eq!(get("GPSLatitude"), Some(&TagValue::F64(45.5)));
+    assert_eq!(get("GPSLongitude"), Some(&TagValue::F64(170.5)));
+    assert_eq!(get("GPSTrack"), Some(&TagValue::F64(120.0)));
+    assert_eq!(get("GPSAltitude"), Some(&TagValue::F64(46.0)));
+    assert_eq!(
+      get("GPSDateTime"),
+      Some(&TagValue::Str("2024:01:15 10:00:00".into()))
+    );
+    // GPSSpeed: km/h post-scale (flags 0x03 ⇒ spdScl = 1, so the raw 30.0).
+    assert_eq!(get("GPSSpeed"), Some(&TagValue::F64(30.0)));
+
+    // `-j` (PrintConv): GPSLatitude is the DMS string WITH the hemisphere.
+    let pj = EmitOptions::g1(ConvMode::PrintConv, true);
+    let lat_pj = meta
+      .tags(pj)
+      .find(|t| t.tag().group_ref().family1() == "LIGO" && t.tag().name() == "GPSLatitude")
+      .map(|t| t.tag().value_ref().clone());
+    match lat_pj {
+      Some(TagValue::Str(s)) => {
+        assert!(
+          s.ends_with(" N"),
+          "GPSLatitude DMS carries the N hemisphere: {s}"
+        );
+      }
+      other => panic!("GPSLatitude -j should be a DMS string, got {other:?}"),
+    }
+  }
+
+  /// The LigoGPS tags are `-ee`-gated: WITHOUT
+  /// ExtractEmbedded `Meta::tags()` emits NONE of them (LigoGPS emission only
+  /// happens under the `-ee` scan / trailer pass).
+  #[test]
+  fn ligogps_tags_absent_without_ee() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    let data = kingslim_ligogps_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(
+      !meta.ligogps().samples().is_empty(),
+      "LigoGPS still decodes"
+    );
+    let noee = EmitOptions::g1(ConvMode::PrintConv, false);
+    let any_ligo = meta
+      .tags(noee)
+      .any(|t| t.tag().group_ref().family1() == "LIGO");
+    assert!(!any_ligo, "no LIGO tags without -ee");
+  }
+
+  /// Drain a `Meta`'s `Diagnose` stream into a `TagMap` and return the
+  /// document-level warning channel (`ExifTool:Warning`) — the production sink
+  /// path (`AnyMeta::serialize_tags` runs `run_emission` + `run_diagnostics`).
+  #[cfg(feature = "alloc")]
+  fn rendered_warnings(meta: &Meta<'_>) -> std::vec::Vec<String> {
+    let mut w = crate::tagmap::TagMap::new();
+    crate::diagnostics::run_diagnostics(meta, &mut w);
+    w.warnings().to_vec()
+  }
+
+  /// FINDING 2 — an out-of-range binary LigoGPS record (lat > 90) decoded via the
+  /// freeGPS-embedded `ProcessLigoGPS` path surfaces its `LIGOGPSINFO coordinates
+  /// out of range` warning (LigoGPS.pm:254) in the RENDERED output, as a
+  /// DOCUMENT-level `ExifTool:Warning` (the `Warn` fires BEFORE the LigoGPS.pm:255
+  /// `SET_GROUP1='LIGO'`, so it is not `LIGO`-scoped). Before this fix the warning
+  /// was stored on `LigoGpsMeta::warning()` but never surfaced — a file whose GPS
+  /// record was rejected looked clean.
+  #[test]
+  fn ligogps_out_of_range_warning_surfaces_in_rendered_output() {
+    // Plain-ASCII record (no `####`) with lat 91 (> 90). flags 0x03 (not fuzzed)
+    // ⇒ the raw 91.0 survives the unfuzz step and trips the range check.
+    let mut rec = vec![0u8, 0, 0, 0];
+    rec.extend_from_slice(b"2024/01/15 10:00:00 N:91.0 E:0.0 0.0 km/h");
+    let data = kingslim_ligogps_mp4_with_record(&rec);
+    let meta = parse_inner(&data, None).expect("accepted");
+    // The record burned a Doc<N> (suppressed sample) and recorded the warning.
+    assert_eq!(
+      meta.ligogps().warning(),
+      Some("LIGOGPSINFO coordinates out of range")
+    );
+    assert!(
+      rendered_warnings(&meta)
+        .iter()
+        .any(|w| w == "LIGOGPSINFO coordinates out of range"),
+      "the out-of-range warning must surface as a document-level ExifTool:Warning, got {:?}",
+      rendered_warnings(&meta)
+    );
+  }
+
+  /// FINDING 2 — a `####`-prefixed record whose cipher stream is malformed fails
+  /// `DecryptLigoGPS` (LigoGPS.pm:312); the port records the decrypt-failure
+  /// deferral warning (cipher discovery is the deferred LigoGPS.pm:143-221
+  /// `DecipherLigoGPS` fallback). It must surface in the rendered output.
+  #[test]
+  fn ligogps_decrypt_failure_warning_surfaces_in_rendered_output() {
+    // `####` + LE u32 count(4) + a first input byte 0x20 whose steering bits
+    // (0x20 & 0xe0 = 0x20) hit `DecryptLigoGPS`'s final `else { return undef }`
+    // (LigoGPS.pm:94-96) ⇒ decode fails on the first byte.
+    let mut rec = Vec::new();
+    rec.extend_from_slice(b"####");
+    rec.extend_from_slice(&4u32.to_le_bytes()); // num = 4
+    rec.extend_from_slice(&[0x20, 0x00, 0x00, 0x00]); // first input byte → return None
+    let data = kingslim_ligogps_mp4_with_record(&rec);
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert_eq!(
+      meta.ligogps().warning(),
+      Some("LigoGPS record decryption failed (cipher discovery deferred)")
+    );
+    assert!(
+      rendered_warnings(&meta)
+        .iter()
+        .any(|w| w == "LigoGPS record decryption failed (cipher discovery deferred)"),
+      "the decrypt-failure warning must surface in the rendered output, got {:?}",
+      rendered_warnings(&meta)
+    );
+  }
+
+  /// Build a file-end LigoGPS `&&&&` trailer whose `skip`-atom payload is NOT
+  /// `LIGOGPSINFO\0` (random bytes) — the `Unrecognized data in LigoGPS trailer`
+  /// case (QuickTime.pm:10667). Same shape as [`ligogps_ampersand_trailer`] minus
+  /// the `LIGOGPSINFO\0` magic.
+  fn ligogps_ampersand_trailer_unrecognized() -> Vec<u8> {
+    // Payload: 24 non-LIGOGPSINFO bytes (after the 8-byte skip header).
+    let mut payload = Vec::new();
+    for i in 0..24u8 {
+      payload.push(i.wrapping_add(0x40));
+    }
+    let skip_atom_size = (16 + payload.len()) as u32;
+    let mut body = Vec::new();
+    body.extend_from_slice(&skip_atom_size.to_be_bytes());
+    body.extend_from_slice(b"skip");
+    body.extend_from_slice(&payload);
+    let trailer_len = (body.len() + 8) as u32;
+    let mut out = body;
+    out.extend_from_slice(b"&&&&");
+    out.extend_from_slice(&trailer_len.to_be_bytes());
+    out
+  }
+
+  /// FINDING 2 — an unrecognized LigoGPS `&&&&` trailer (a valid `skip` atom but a
+  /// non-`LIGOGPSINFO\0` payload) surfaces `Unrecognized data in LigoGPS trailer`
+  /// (QuickTime.pm:10667) in the rendered output, as a DOCUMENT-level
+  /// `ExifTool:Warning` (the `Warn` is raised in the `ProcessMOV` trailer loop
+  /// with no `SET_GROUP1` in effect).
+  #[test]
+  fn ligogps_unrecognized_trailer_warning_surfaces_in_rendered_output() {
+    // ftyp || moov(mvhd) || &&&&-trailer (the trailer follows complete atoms, so
+    // the box-walk `last_pos` lands at the trailer start and the gate passes).
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut data = ftyp;
+    data.extend_from_slice(&atom(b"moov", &atom(b"mvhd", &[0u8; 100])));
+    data.extend_from_slice(&ligogps_ampersand_trailer_unrecognized());
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert_eq!(
+      meta.ligogps().warning(),
+      Some("Unrecognized data in LigoGPS trailer")
+    );
+    assert!(
+      rendered_warnings(&meta)
+        .iter()
+        .any(|w| w == "Unrecognized data in LigoGPS trailer"),
+      "the unrecognized-trailer warning must surface in the rendered output, got {:?}",
+      rendered_warnings(&meta)
+    );
+  }
+
+  /// Wrap a `udta`-payload `body` inside a minimal `ftyp` + ROOT-level `udta`
+  /// MP4. A top-level `udta` is the `%QuickTime::Main` path (QuickTime.pm:826-846)
+  /// that hosts the LigoGPS Conditions and reaches [`dispatch_udta_ligogps`]
+  /// through the full container parser. (The `moov/udta` `%QuickTime::Movie`
+  /// UserData walk does NOT carry those Conditions, so it is NOT exercised here.)
+  fn top_level_udta_mp4(body: &[u8]) -> Vec<u8> {
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let udta = atom(b"udta", body);
+    let mut data = ftyp;
+    data.extend_from_slice(&udta);
+    data
+  }
+
+  /// Collect the `-ee` `-G1` `LIGO`-group `(name, value)` tags emitted by a Meta.
+  fn ligo_tags(meta: &Meta<'_>) -> std::vec::Vec<(String, crate::value::TagValue)> {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    let ee = EmitOptions::g1(ConvMode::ValueConv, true);
+    meta
+      .tags(ee)
+      .filter(|t| t.tag().group_ref().family1() == "LIGO")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect()
+  }
+
+  /// FAITHFUL udta `LigoJSON` path (QuickTime.pm:835): a TOP-LEVEL (`%QuickTime::Main`)
+  /// `udta` atom whose payload begins `LIGOGPSINFO {` reaches `process_ligogps_json`
+  /// via `dispatch_udta_ligogps` through the FULL container parser
+  /// (`parse_inner` → `tags()`), emitting the GPS tags — including
+  /// GPSLatitude2/GPSLongitude2 from the JSON OLatitude/OLongitude
+  /// (LigoGPS.pm:387-388).
+  #[test]
+  fn udta_ligojson_emitted_end_to_end() {
+    use crate::value::TagValue;
+    let json = br#"LIGOGPSINFO {"Hour": "10", "Minute": "00", "Second": "00", "Year": "2024", "Month": "01", "Day": "15", "status": "A", "NS": "N", "EW": "E", "Latitude": "12.5", "Longitude": "34.5", "OLatitude": "12.25", "OLongitude": "34.75"}"#;
+    let data = top_level_udta_mp4(json);
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(
+      !meta.ligogps().samples().is_empty(),
+      "udta LigoJSON must decode via the container dispatch"
+    );
+
+    let ligo = ligo_tags(&meta);
+    let get = |name: &str| ligo.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    assert_eq!(get("GPSLatitude"), Some(&TagValue::F64(12.5)));
+    assert_eq!(get("GPSLongitude"), Some(&TagValue::F64(34.5)));
+    assert_eq!(
+      get("GPSDateTime"),
+      Some(&TagValue::Str("2024:01:15 10:00:00Z".into()))
+    );
+    // OLatitude/OLongitude surface as GPSLatitude2/GPSLongitude2.
+    assert_eq!(get("GPSLatitude2"), Some(&TagValue::F64(12.25)));
+    assert_eq!(get("GPSLongitude2"), Some(&TagValue::F64(34.75)));
+  }
+
+  /// FAITHFUL top-level (`%QuickTime::Main`) udta `LigoJSON` path: a ROOT-level
+  /// `udta` (not under `moov`) is where ExifTool actually hosts the LigoGPS
+  /// Conditions (QuickTime.pm:826-846). It must also reach the JSON decoder.
+  #[test]
+  fn top_level_udta_ligojson_emitted() {
+    use crate::value::TagValue;
+    let json = br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "W", "Latitude": "1.5", "Longitude": "2.5"}"#;
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let udta = atom(b"udta", json);
+    let mut data = ftyp;
+    data.extend_from_slice(&udta);
+    let meta = parse_inner(&data, None).expect("accepted");
+    let ligo = ligo_tags(&meta);
+    let get = |name: &str| ligo.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    assert_eq!(get("GPSLatitude"), Some(&TagValue::F64(1.5)));
+    // EW=W ⇒ negative longitude.
+    assert_eq!(get("GPSLongitude"), Some(&TagValue::F64(-2.5)));
+  }
+
+  /// FAITHFUL udta `GKUData` path (QuickTime.pm:842 + LigoGPS.pm:273-281): a
+  /// TOP-LEVEL (`%QuickTime::Main`) `udta` whose payload is
+  /// `[offset:u32-LE][..]__V35AX_QVDATA__` with the LE u32 pointing at an inner
+  /// `LIGOGPSINFO {` JSON reaches `ProcessGKU` → `process_ligogps_json`.
+  #[test]
+  fn udta_gkudata_emitted_end_to_end() {
+    use crate::value::TagValue;
+    let json = br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "3.5", "Longitude": "4.5"}"#;
+    // udta payload: [LE u32 offset][marker `__V35AX_QVDATA__` at byte 8][pad up
+    // to `offset`][JSON]. Put the JSON right after the 8-byte header + 16-byte
+    // marker (offset = 24).
+    let json_off = 24u32;
+    let mut body = Vec::new();
+    body.extend_from_slice(&json_off.to_le_bytes()); // bytes 0..4 = offset
+    body.extend_from_slice(&[0u8; 4]); // bytes 4..8 (the `.{8}` head)
+    body.extend_from_slice(b"__V35AX_QVDATA__"); // bytes 8..24 = marker
+    assert_eq!(body.len(), json_off as usize);
+    body.extend_from_slice(json); // JSON at `offset`
+
+    let data = top_level_udta_mp4(&body);
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(
+      !meta.ligogps().samples().is_empty(),
+      "udta GKUData must decode via ProcessGKU"
+    );
+    let ligo = ligo_tags(&meta);
+    let get = |name: &str| ligo.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    assert_eq!(get("GPSLatitude"), Some(&TagValue::F64(3.5)));
+    assert_eq!(get("GPSLongitude"), Some(&TagValue::F64(4.5)));
+  }
+
+  /// A top-level `udta` LigoJSON payload carrying THREE active records. Two
+  /// concatenated `LIGOGPSINFO {...}` objects are the bundled chained-record
+  /// shape (LigoGPS.pm:326 "chained 512-byte records").
+  fn multi_record_udta_ligojson_mp4() -> Vec<u8> {
+    let mut json = Vec::new();
+    json.extend_from_slice(br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "1.0", "Longitude": "10.0"}"#);
+    json.extend_from_slice(br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "2.0", "Longitude": "20.0"}"#);
+    json.extend_from_slice(br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "3.0", "Longitude": "30.0"}"#);
+    top_level_udta_mp4(&json)
+  }
+
+  /// **FINDING 1** — WITHOUT `-ee`, a `udta` LigoJSON file emits EXACTLY the
+  /// FIRST record (`ProcessLigoJSON` processes record 1 then `Warn`s + `last`s,
+  /// LigoGPS.pm:390-393). The output is FLAT (no `Doc<N>`).
+  #[test]
+  fn udta_ligojson_no_ee_emits_only_first_record() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::value::TagValue;
+    let data = multi_record_udta_ligojson_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert_eq!(
+      meta.ligogps().samples().len(),
+      3,
+      "all three records decode into the typed surface"
+    );
+    // No-`ee` `-G1` (PrintConv): collect every LIGO-group GPSLatitude.
+    let noee = EmitOptions::g1(ConvMode::ValueConv, false);
+    let lats: std::vec::Vec<TagValue> = meta
+      .tags(noee)
+      .filter(|t| t.tag().group_ref().family1() == "LIGO" && t.tag().name() == "GPSLatitude")
+      .map(|t| t.tag().value_ref().clone())
+      .collect();
+    assert_eq!(
+      lats,
+      std::vec![TagValue::F64(1.0)],
+      "without -ee, ONLY the first udta-JSON record emits (LigoGPS.pm:390-393)"
+    );
+  }
+
+  /// **FINDING 1** — WITH `-ee`, the SAME `udta` LigoJSON file emits ALL records,
+  /// each as its own `Doc<N>` row at `-G3`.
+  #[test]
+  fn udta_ligojson_ee_emits_all_records() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+    use crate::value::TagValue;
+    let data = multi_record_udta_ligojson_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    // `-ee -G3`: every record surfaces as its own `Doc<N>:QuickTime:LIGO` row.
+    let ee_g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let lats: std::vec::Vec<TagValue> = meta
+      .tags(ee_g3)
+      .filter(|t| t.tag().group_ref().family1() == "LIGO" && t.tag().name() == "GPSLatitude")
+      .map(|t| t.tag().value_ref().clone())
+      .collect();
+    assert_eq!(
+      lats,
+      std::vec![TagValue::F64(1.0), TagValue::F64(2.0), TagValue::F64(3.0)],
+      "with -ee, ALL three udta-JSON records emit"
+    );
+  }
+
+  /// **FINDING 3** — in a MIXED `-ee -G3` file (a freeGPS-embedded LigoGPS block
+  /// PLUS another GPS source), the LigoGPS records open `Doc<N>` ordinals off the
+  /// SAME global counter as the other source — so the two sources' docs do NOT
+  /// collide and the LigoGPS rows continue the global sequence in walk order
+  /// (`$$et{DOC_NUM} = ++$$et{DOC_COUNT}`, LigoGPS.pm:243; #214 cross-source).
+  #[test]
+  fn ligogps_mixed_source_global_doc_ordering() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+    // Build a file with a TOP-LEVEL `gps0` magic box (one fix → Doc1, walked
+    // first) FOLLOWED by a `moov` whose `gps ` offset box points at a freeGPS
+    // Type-5 LigoGPS block (→ Doc2..). The `gps0` box bumps the global counter
+    // first (walk order), so the LigoGPS records must take the HIGHER ordinals.
+    // (The `moov`-`gps `-box vehicle decodes a freeGPS block at any absolute
+    // offset — no 0x8000 `mdat`-chunk requirement, so it is reliable in a unit
+    // fixture.)
+    //
+    // gps0: one 32-byte LE record (DDDMM.MMMM lat/lon, alt, speed, date, track).
+    let mut gps0 = Vec::new();
+    gps0.extend_from_slice(&4530.0f64.to_le_bytes()); // lat 45°30' = 45.5
+    gps0.extend_from_slice(&12030.0f64.to_le_bytes()); // lon 120°30' = 120.5
+    gps0.extend_from_slice(&100i32.to_le_bytes()); // altitude
+    gps0.extend_from_slice(&50u16.to_le_bytes()); // speed
+    gps0.extend_from_slice(&[24, 1, 15, 10, 0, 0]); // y-2000,mo,d,h,mi,s @0x16
+    gps0.extend_from_slice(&[0, 0]); // pad to 0x1c
+    gps0.extend_from_slice(&[60]); // track/2 @0x1c
+    while gps0.len() < 32 {
+      gps0.push(0);
+    }
+    let gps0_atom = atom(b"gps0", &gps0);
+
+    // freeGPS Type-5 LigoGPS block: 4-byte BE size word (0x100, NUL bytes 0+3 so
+    // the scanner regex is happy + a multiple of 256) + `freeGPS ` magic at
+    // offset 4, then `LIGOGPSINFO\0` at offset 16 (the GPSType-5 fingerprint,
+    // QuickTimeStream.pl:1843), an 8-byte preamble, and one plain-ASCII record.
+    // Built push-only (no indexing) so the byte layout is explicit.
+    let mut block = Vec::new();
+    block.extend_from_slice(&0x0100u32.to_be_bytes()); // 0..4: BE size word
+    block.extend_from_slice(b"freeGPS "); // 4..12: magic
+    block.extend_from_slice(&[0u8; 4]); // 12..16
+    block.extend_from_slice(crate::formats::ligogps::HDR_LIGOGPSINFO); // 16..28
+    block.extend_from_slice(&[0, 0, 0, 0x14, 0, 0, 0, 0]); // 28..36: preamble tail
+    block.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // record counter
+    block.extend_from_slice(b"2024/01/15 10:00:01 N:46.5 E:171.5 30.0 km/h");
+    while block.len() < 0x100 {
+      block.push(0); // pad to the declared 0x100 size
+    }
+
+    // Layout = ftyp || gps0 || freeGPS-block || moov(mvhd + gps -offset-box).
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut data = ftyp;
+    data.extend_from_slice(&gps0_atom);
+    let block_offset = data.len() as u32; // absolute offset of the freeGPS block
+    data.extend_from_slice(&block);
+
+    // The moov `gps ` offset box: [reserved:4=0][count:4=1] + one (start, size)
+    // pair, big-endian (the QuickTime `'MM'` order).
+    let mut gps_body = Vec::new();
+    gps_body.extend_from_slice(&[0u8; 4]); // reserved
+    gps_body.extend_from_slice(&1u32.to_be_bytes()); // count = 1
+    gps_body.extend_from_slice(&block_offset.to_be_bytes()); // absolute start
+    gps_body.extend_from_slice(&(block.len() as u32).to_be_bytes()); // size
+    let gps_box = atom(b"gps ", &gps_body);
+    let mvhd = atom(b"mvhd", &[0u8; 100]);
+    let mut moov_body = mvhd;
+    moov_body.extend_from_slice(&gps_box);
+    let moov = atom(b"moov", &moov_body);
+    data.extend_from_slice(&moov);
+
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(
+      !meta.ligogps().samples().is_empty(),
+      "the freeGPS-embedded LigoGPS block must decode"
+    );
+    // The LigoGPS sample's stamped doc must be GREATER than the gps0 fix's doc
+    // (gps0 was processed first in walk order → lower global ordinal).
+    let ligo_doc = meta.ligogps().samples()[0]
+      .doc()
+      .expect("LigoGPS sample carries a GLOBAL doc (Finding 3)");
+    let gps0_doc = meta
+      .stream()
+      .gps_samples()
+      .iter()
+      .find_map(|s| s.doc())
+      .expect("gps0 fix carries a global doc");
+    assert!(
+      ligo_doc > gps0_doc,
+      "LigoGPS doc {ligo_doc} must continue the GLOBAL sequence after the gps0 doc {gps0_doc} (no restart/collision)"
+    );
+
+    // `-ee -G3`: the LigoGPS row carries its stamped global `Doc<N>` (family-3).
+    let ee_g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let ligo_docs: std::vec::Vec<u32> = meta
+      .tags(ee_g3)
+      .filter(|t| t.tag().group_ref().family1() == "LIGO" && t.tag().name() == "GPSLatitude")
+      .map(|t| t.tag().group_ref().doc())
+      .collect();
+    assert_eq!(ligo_docs.len(), 1, "one LigoGPS GPSLatitude row");
+    assert_eq!(
+      ligo_docs[0], ligo_doc,
+      "the LigoGPS row uses its stamped global Doc<N>"
+    );
+  }
+
+  /// Build a file-end LigoGPS `&&&&` trailer carrying ONE plain-ASCII binary
+  /// record at `lat`/`lon`. Layout = `[skip atom: size:u32-BE | "skip"]` +
+  /// `LIGOGPSINFO\0` + 8-byte preamble (`\0\0\0\x14…`) + a 0x84 ASCII record,
+  /// then the `&&&&` magic + the trailer length as BE-u32 (the `IdentifyTrailers`
+  /// `Get32u(buff,36)` order, QuickTime.pm:9907). The `skip` atom's declared SIZE
+  /// is `16 + payload.len()` (the QuickTime.pm:10660 `$len = size - 16` rule).
+  fn ligogps_ampersand_trailer(lat: &str, lon: &str) -> Vec<u8> {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(crate::formats::ligogps::HDR_LIGOGPSINFO);
+    payload.extend_from_slice(&[0, 0, 0, 0x14, 0, 0, 0, 0]);
+    let mut record = Vec::with_capacity(0x84);
+    record.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+    record
+      .extend_from_slice(std::format!("2024/01/15 10:00:02 N:{lat} E:{lon} 30.0 km/h").as_bytes());
+    while record.len() < 0x84 {
+      record.push(0);
+    }
+    payload.extend_from_slice(&record);
+    let skip_atom_size = (16 + payload.len()) as u32;
+    let mut body = Vec::new();
+    body.extend_from_slice(&skip_atom_size.to_be_bytes());
+    body.extend_from_slice(b"skip");
+    body.extend_from_slice(&payload);
+    let trailer_len = (body.len() + 8) as u32;
+    let mut out = body;
+    out.extend_from_slice(b"&&&&");
+    out.extend_from_slice(&trailer_len.to_be_bytes());
+    out
+  }
+
+  /// The canonical `ProcessMOV` `Doc<N>` allocation order across a MIXED-source
+  /// file (QuickTime.pm:10654-10681). One file carries THREE LigoGPS-tier GPS
+  /// sources at DIFFERENT phases: a top-level `gps0` magic box (moov-timed, via
+  /// `extract_stream`), a top-level `udta`-LigoGPS-JSON record, and a file-end
+  /// `&&&&` LigoGPS binary trailer. The faithful single-walk order is:
+  /// moov-timed FIRST (`gps0` → Doc1), THEN the `udta`-LigoGPS (→ Doc2, stamped
+  /// AFTER the moov-timed phase), THEN the trailer (→ Doc3, the trailer phase) —
+  /// one CONTINUOUS global sequence, NO collision. (`ScanMediaData` would run
+  /// last; this file has no `mdat` freeGPS so it contributes nothing.)
+  #[test]
+  fn mixed_source_canonical_doc_order_moov_then_udta_then_trailer() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+
+    // gps0 — one 32-byte LE record (the existing `ligogps_mixed_source` shape).
+    let mut gps0 = Vec::new();
+    gps0.extend_from_slice(&4530.0f64.to_le_bytes()); // lat 45°30' = 45.5
+    gps0.extend_from_slice(&12030.0f64.to_le_bytes()); // lon 120°30' = 120.5
+    gps0.extend_from_slice(&100i32.to_le_bytes());
+    gps0.extend_from_slice(&50u16.to_le_bytes());
+    gps0.extend_from_slice(&[24, 1, 15, 10, 0, 0]);
+    gps0.extend_from_slice(&[0, 0]);
+    gps0.extend_from_slice(&[60]);
+    while gps0.len() < 32 {
+      gps0.push(0);
+    }
+    let gps0_atom = atom(b"gps0", &gps0);
+
+    // Top-level `udta` carrying a LigoGPS JSON record (one active fix).
+    let udta_json = br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "46.5", "Longitude": "121.5"}"#;
+    let udta_atom = atom(b"udta", udta_json);
+
+    // Layout = ftyp || gps0 || udta || moov(mvhd) || &&&&-trailer.
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut data = ftyp;
+    data.extend_from_slice(&gps0_atom);
+    data.extend_from_slice(&udta_atom);
+    data.extend_from_slice(&atom(b"moov", &atom(b"mvhd", &[0u8; 100])));
+    data.extend_from_slice(&ligogps_ampersand_trailer("47.5", "122.5"));
+
+    let meta = parse_inner(&data, None).expect("accepted");
+
+    // ── typed-layer doc assertions ────────────────────────────────────────────
+    // gps0 → Doc1 (the lone moov-timed GPS sample).
+    let gps0_doc = meta
+      .stream()
+      .gps_samples()
+      .iter()
+      .find_map(|s| s.doc())
+      .expect("gps0 fix carries a global doc");
+    assert_eq!(gps0_doc, 1, "gps0 (moov-timed) opens Doc1");
+    // The two LigoGPS samples (udta first in the Vec, then trailer) → Doc2, Doc3.
+    let ligo: std::vec::Vec<u32> = meta
+      .ligogps()
+      .samples()
+      .iter()
+      .map(|s| s.doc().expect("LigoGPS sample carries a global doc"))
+      .collect();
+    assert_eq!(
+      ligo,
+      std::vec![2, 3],
+      "udta-LigoGPS (Doc2) precedes the &&&&-trailer (Doc3) — the canonical phase order"
+    );
+
+    // ── `-ee -G3` emission: continuous, collision-free global sequence ─────────
+    let ee_g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let mut lat_docs: std::vec::Vec<u32> = meta
+      .tags(ee_g3)
+      .filter(|t| t.tag().name() == "GPSLatitude")
+      .map(|t| t.tag().group_ref().doc())
+      .collect();
+    lat_docs.sort_unstable();
+    assert_eq!(
+      lat_docs,
+      std::vec![1, 2, 3],
+      "the three GPSLatitude rows take a CONTINUOUS, non-colliding global Doc1/Doc2/Doc3"
+    );
+    // gps0's GPSLatitude is family1 `QuickTime`; the two LigoGPS ones are `LIGO`.
+    let gps0_lat_doc = meta
+      .tags(ee_g3)
+      .find(|t| t.tag().name() == "GPSLatitude" && t.tag().group_ref().family1() == "QuickTime")
+      .map(|t| t.tag().group_ref().doc())
+      .expect("gps0 GPSLatitude row");
+    assert_eq!(gps0_lat_doc, 1, "the moov-timed gps0 row is Doc1 (lowest)");
+  }
+
+  /// The Insta360 INSV/INSP trailer draws its `Doc<N>` from the ONE SHARED global
+  /// counter (NOT a local 0-based one) AND is processed in the TRAILER PHASE
+  /// (AFTER `extract_stream`), mirroring ExifTool's `ProcessMOV` trailer loop
+  /// (QuickTime.pm:10669-10673 `ProcessInsta360`). A file with a moov-timed `gps0`
+  /// box (→ Doc1) followed by an Insta360 trailer carrying one GPS `'A'` row: the
+  /// Insta360 row must take Doc2 (`doc_base = 1` after gps0), proving divergences
+  /// (c) the shared counter + (d) the trailer-LAST phase order end-to-end.
+  #[test]
+  fn insta360_trailer_doc_continues_shared_counter_after_moov_timed() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+
+    // gps0 — one 32-byte LE record → Doc1 (moov-timed, via `extract_stream`).
+    let mut gps0 = Vec::new();
+    gps0.extend_from_slice(&4530.0f64.to_le_bytes()); // 45.5
+    gps0.extend_from_slice(&12030.0f64.to_le_bytes()); // 120.5
+    gps0.extend_from_slice(&100i32.to_le_bytes());
+    gps0.extend_from_slice(&50u16.to_le_bytes());
+    gps0.extend_from_slice(&[24, 1, 15, 10, 0, 0]);
+    gps0.extend_from_slice(&[0, 0, 60]);
+    while gps0.len() < 32 {
+      gps0.push(0);
+    }
+
+    // A minimal Insta360 trailer: one 0x700 GPS `'A'` row + its 6-byte record
+    // footer, then the 78-byte trailer footer (`[id:u16][len:u32]` + opaque +
+    // `[trailer_len:u32]` + opaque + the 32-byte MAGIC). The record body is
+    // `[unixtime:u32][unknown:u32][ms:u16][status:u8][lat:f64][NS:u8][lon:f64]
+    // [EW:u8][speed:f64][track:f64][alt:f64]` (53 bytes, QuickTimeStream.pl:3397).
+    const INSTA360_GPS: u16 = 0x700;
+    let mut gps_body = Vec::new();
+    gps_body.extend_from_slice(&1_717_250_400u32.to_le_bytes()); // unixtime
+    gps_body.extend_from_slice(&0u32.to_le_bytes()); // unknown
+    gps_body.extend_from_slice(&0u16.to_le_bytes()); // ms
+    gps_body.push(b'A'); // status
+    gps_body.extend_from_slice(&48.0f64.to_le_bytes()); // lat
+    gps_body.push(b'N');
+    gps_body.extend_from_slice(&9.0f64.to_le_bytes()); // lon
+    gps_body.push(b'E');
+    gps_body.extend_from_slice(&10.0f64.to_le_bytes()); // speed m/s
+    gps_body.extend_from_slice(&90.0f64.to_le_bytes()); // track
+    gps_body.extend_from_slice(&200.0f64.to_le_bytes()); // altitude
+    assert_eq!(gps_body.len(), 53);
+
+    // The trailer span = [record body][record footer(6) is FOLDED into the 78-byte
+    // trailer footer's first 6 bytes]. So: body + 72 opaque bytes + MAGIC, with the
+    // footer's leading `[id:u16][len:u32]` = the last record's (id, len).
+    let mut trailer = gps_body.clone();
+    // The Insta360 trailer footer is a FIXED 78 bytes (QuickTimeStream.pl:3270
+    // `Seek(-78,2)`): id/len (6) + 32 opaque + trailer_len (4) + 4 opaque + the
+    // 32-byte MAGIC.
+    let trailer_len = (trailer.len() + 78) as u32;
+    trailer.extend_from_slice(&INSTA360_GPS.to_le_bytes());
+    trailer.extend_from_slice(&(gps_body.len() as u32).to_le_bytes());
+    trailer.resize(trailer.len() + 32, 0);
+    trailer.extend_from_slice(&trailer_len.to_le_bytes());
+    trailer.resize(trailer.len() + 4, 0);
+    trailer.extend_from_slice(crate::formats::insta360::MAGIC);
+
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut data = ftyp;
+    data.extend_from_slice(&atom(b"gps0", &gps0));
+    data.extend_from_slice(&atom(b"moov", &atom(b"mvhd", &[0u8; 100])));
+    data.extend_from_slice(&trailer);
+
+    let meta = parse_inner(&data, None).expect("accepted");
+    // gps0 → Doc1.
+    let gps0_doc = meta
+      .stream()
+      .gps_samples()
+      .iter()
+      .find_map(|s| s.doc())
+      .expect("gps0 doc");
+    assert_eq!(gps0_doc, 1, "gps0 (moov-timed) is Doc1");
+    // The Insta360 trailer's `doc_base` is the shared counter AFTER gps0 = 1, so
+    // its first surfaced row is Doc2 (NOT Doc1 — proving the shared counter).
+    assert_eq!(
+      meta.insta360().doc_base(),
+      1,
+      "Insta360 doc_base continues the shared counter after gps0 (Doc1)"
+    );
+    let ee_g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let insta_lat_doc = meta
+      .tags(ee_g3)
+      .find(|t| t.tag().name() == "GPSLatitude" && t.tag().group_ref().family1() == "Insta360")
+      .map(|t| t.tag().group_ref().doc())
+      .expect("Insta360 GPSLatitude row");
+    assert_eq!(
+      insta_lat_doc, 2,
+      "the Insta360 GPS row takes Doc2 — the shared global successor of gps0's Doc1"
+    );
+  }
+
+  /// An out-of-range binary LigoGPS record BEFORE a good one BURNS a `Doc<N>`
+  /// (LigoGPS.pm:243 `++DOC_COUNT` runs BEFORE the :254 range-check `return`), so
+  /// the good record's `Doc<N>` is the burned slot's SUCCESSOR — an off-by-one vs
+  /// a no-reject file, matching bundled. Driven through the full `&&&&`-trailer
+  /// pipeline so the doc stamping is exercised end-to-end.
+  #[test]
+  fn out_of_range_binary_ligogps_burns_a_doc_before_good_record() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+
+    // A trailer with TWO 0x84 records: record 1 out-of-range (N:91.0 > 90),
+    // record 2 valid (N:45.5). Both share the one `LIGOGPSINFO\0` payload.
+    fn two_record_trailer() -> Vec<u8> {
+      let mut payload = Vec::new();
+      payload.extend_from_slice(crate::formats::ligogps::HDR_LIGOGPSINFO);
+      payload.extend_from_slice(&[0, 0, 0, 0x14, 0, 0, 0, 0]);
+      for (i, rec) in [
+        b"2024/01/15 10:00:00 N:91.0 E:181.0 0.0 km/h".as_slice(),
+        b"2024/01/15 10:00:01 N:45.5 E:170.5 30.0 km/h".as_slice(),
+      ]
+      .into_iter()
+      .enumerate()
+      {
+        let mut record = Vec::with_capacity(0x84);
+        record.extend_from_slice(&[0x01, 0x02, 0x03, i as u8]);
+        record.extend_from_slice(rec);
+        while record.len() < 0x84 {
+          record.push(0);
+        }
+        payload.extend_from_slice(&record);
+      }
+      let skip_atom_size = (16 + payload.len()) as u32;
+      let mut body = Vec::new();
+      body.extend_from_slice(&skip_atom_size.to_be_bytes());
+      body.extend_from_slice(b"skip");
+      body.extend_from_slice(&payload);
+      let trailer_len = (body.len() + 8) as u32;
+      let mut out = body;
+      out.extend_from_slice(b"&&&&");
+      out.extend_from_slice(&trailer_len.to_be_bytes());
+      out
+    }
+
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut data = ftyp;
+    data.extend_from_slice(&atom(b"moov", &atom(b"mvhd", &[0u8; 100])));
+    data.extend_from_slice(&two_record_trailer());
+
+    let meta = parse_inner(&data, None).expect("accepted");
+    // Two samples: [0] = the burned out-of-range placeholder, [1] = the good fix.
+    let samples = meta.ligogps().samples();
+    assert_eq!(samples.len(), 2, "the rejected record burns a slot");
+    assert!(
+      samples[0].is_suppressed(),
+      "record 1 is the burned placeholder"
+    );
+    assert_eq!(samples[0].doc(), Some(1), "the burned record consumed Doc1");
+    assert!(!samples[1].is_suppressed());
+    assert_eq!(
+      samples[1].doc(),
+      Some(2),
+      "the good record's Doc is the burned slot's successor (off-by-one)"
+    );
+    assert_eq!(
+      meta.ligogps().warning(),
+      Some("LIGOGPSINFO coordinates out of range")
+    );
+
+    // `-ee -G3`: ONLY the good record emits a GPSLatitude, under Doc2 (the burned
+    // slot emits nothing yet still consumed Doc1).
+    let ee_g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let lat_docs: std::vec::Vec<u32> = meta
+      .tags(ee_g3)
+      .filter(|t| t.tag().name() == "GPSLatitude")
+      .map(|t| t.tag().group_ref().doc())
+      .collect();
+    assert_eq!(
+      lat_docs,
+      std::vec![2],
+      "only the good record emits GPSLatitude, at Doc2 (the burned Doc1 emits nothing)"
+    );
+  }
+
+  /// A JSON LigoGPS record at latitude 0 (the equator written as `"0"`) emits NO
+  /// primary GPSLatitude/GPSLongitude (ExifTool's `$$info{Latitude} and
+  /// $$info{Longitude}` is Perl-FALSE for `"0"`, LigoGPS.pm:362) but STILL emits
+  /// GPSLatitude2/GPSLongitude2 from OLatitude/OLongitude (`defined`-gated,
+  /// LigoGPS.pm:382) and STILL consumes its `Doc<N>` (the bump is at :354, before
+  /// the coordinate emission).
+  #[test]
+  fn json_zero_primary_coord_suppresses_primary_keeps_secondary_and_doc() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+
+    // Latitude exactly "0" (Perl-false) ⇒ primary suppressed; OLatitude/OLongitude
+    // present ⇒ GPSLatitude2/GPSLongitude2 emit; the record still gets a Doc.
+    let udta_json = br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "E", "Latitude": "0", "Longitude": "121.5", "OLatitude": "12.25", "OLongitude": "121.5"}"#;
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mut data = ftyp;
+    data.extend_from_slice(&atom(b"udta", udta_json));
+    data.extend_from_slice(&atom(b"moov", &atom(b"mvhd", &[0u8; 100])));
+
+    let meta = parse_inner(&data, None).expect("accepted");
+    let samples = meta.ligogps().samples();
+    assert_eq!(samples.len(), 1, "the active record decodes");
+    let s = &samples[0];
+    assert_eq!(
+      s.latitude(),
+      None,
+      "primary GPSLatitude suppressed (lat == 0)"
+    );
+    assert_eq!(
+      s.longitude(),
+      None,
+      "primary GPSLongitude suppressed (lat == 0)"
+    );
+    assert_eq!(
+      s.latitude2(),
+      Some(12.25),
+      "GPSLatitude2 from OLatitude survives"
+    );
+    assert_eq!(
+      s.longitude2(),
+      Some(121.5),
+      "GPSLongitude2 from OLongitude survives"
+    );
+    assert_eq!(s.doc(), Some(1), "the record still consumed its Doc1");
+
+    // `-ee -G3`: no primary GPSLatitude, but a GPSLatitude2 under Doc1.
+    let ee_g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let names: std::vec::Vec<smol_str::SmolStr> = meta
+      .tags(ee_g3)
+      .filter(|t| t.tag().group_ref().family1() == "LIGO")
+      .map(|t| smol_str::SmolStr::new(t.tag().name()))
+      .collect();
+    assert!(
+      !names.iter().any(|n| n == "GPSLatitude"),
+      "no primary GPSLatitude emitted"
+    );
+    assert!(
+      names.iter().any(|n| n == "GPSLatitude2"),
+      "GPSLatitude2 IS emitted"
+    );
+  }
+
+  /// Wrap an arbitrary single `mett`-MetaFormat track SAMPLE (the raw record
+  /// bytes) in a minimal MP4 (no `application/...` MetaType ⇒ the Parrot drone
+  /// `[EP]\d` path). Shared by the Parrot emission tests so each can supply its
+  /// own V1 / V2 / V3 / E* sample.
+  fn parrot_mett_mp4_from(sample: &[u8]) -> Vec<u8> {
+    let ftyp = atom(b"ftyp", b"qt  \0\0\0\0");
+    let mdat = atom(b"mdat", sample);
+    let sample_offset = (ftyp.len() + 8) as u32;
+
+    let mut hdlr_body = vec![0u8; 24];
+    wr(&mut hdlr_body, 8, b"meta");
+    let hdlr = atom(b"hdlr", &hdlr_body);
+    let mut mdhd_body = vec![0u8; 24];
+    wr(&mut mdhd_body, 12, &1000u32.to_be_bytes());
+    let mdhd = atom(b"mdhd", &mdhd_body);
+    // stsd: one `mett` entry (no `application/...` ⇒ MetaType cleared ⇒ drone path).
+    let mut stsd_body = vec![0u8; 8];
+    wr(&mut stsd_body, 4, &1u32.to_be_bytes());
+    let mut entry = vec![0u8; 16];
+    wr(&mut entry, 0, &16u32.to_be_bytes());
+    wr(&mut entry, 4, b"mett");
+    stsd_body.extend_from_slice(&entry);
+    let stsd = atom(b"stsd", &stsd_body);
+    let mut stco_body = vec![0u8; 8];
+    wr(&mut stco_body, 4, &1u32.to_be_bytes());
+    stco_body.extend_from_slice(&sample_offset.to_be_bytes());
+    let stco = atom(b"stco", &stco_body);
+    let mut stsc_body = vec![0u8; 8];
+    wr(&mut stsc_body, 4, &1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    stsc_body.extend_from_slice(&1u32.to_be_bytes());
+    let stsc = atom(b"stsc", &stsc_body);
+    let mut stsz_body = vec![0u8; 8];
+    wr(&mut stsz_body, 4, &0u32.to_be_bytes());
+    stsz_body.extend_from_slice(&1u32.to_be_bytes());
+    stsz_body.extend_from_slice(&(sample.len() as u32).to_be_bytes());
+    let stsz = atom(b"stsz", &stsz_body);
+    let mut stbl_body = stsd;
+    stbl_body.extend_from_slice(&stco);
+    stbl_body.extend_from_slice(&stsc);
+    stbl_body.extend_from_slice(&stsz);
+    let stbl = atom(b"stbl", &stbl_body);
+    let minf = atom(b"minf", &stbl);
+    let mut mdia_body = mdhd;
+    mdia_body.extend_from_slice(&hdlr);
+    mdia_body.extend_from_slice(&minf);
+    let mdia = atom(b"mdia", &mdia_body);
+    let trak = atom(b"trak", &mdia);
+    let mvhd = atom(b"mvhd", &[0u8; 100]);
+    let mut moov_body = mvhd;
+    moov_body.extend_from_slice(&trak);
+    let moov = atom(b"moov", &moov_body);
+    let mut data = ftyp;
+    data.extend_from_slice(&mdat);
+    data.extend_from_slice(&moov);
+    data
+  }
+
+  /// Build an MP4 whose single `mett`-MetaFormat track sample is a Parrot V1
+  /// (`P1`) drone record carrying GPS + flight + pose telemetry. Shared by the
+  /// Parrot emission tests.
+  fn parrot_mett_mp4() -> Vec<u8> {
+    // A 60-byte V1 record: `[P1][nwords=14]` then bundled V1 offsets.
+    let mut p1 = vec![0u8; 60];
+    p1[0..2].copy_from_slice(b"P1");
+    wr(&mut p1, 2, &14u16.to_be_bytes());
+    // DroneYaw int16s @4, rad→deg: raw 0x1000 ⇒ 1*180/3.14159 ≈ 57.2959 deg.
+    p1[4..6].copy_from_slice(&(0x1000i16).to_be_bytes());
+    // CameraTilt int16s @12, rad→deg: raw -0x800 ⇒ -0.5*180/3.14159 ≈ -28.648.
+    p1[12..14].copy_from_slice(&(-0x800i16).to_be_bytes());
+    // FrameView int16s[4] @14, each /0x1000 ⇒ [1, 0.5, -0.25, 0].
+    p1[14..16].copy_from_slice(&(0x1000i16).to_be_bytes());
+    p1[16..18].copy_from_slice(&(0x800i16).to_be_bytes());
+    p1[18..20].copy_from_slice(&(-0x400i16).to_be_bytes());
+    p1[20..22].copy_from_slice(&(0i16).to_be_bytes());
+    // ExposureTime int16s @22, ValueConv /0x100/1000 — 1/60 s ⇒ raw ≈ 4267.
+    p1[22..24].copy_from_slice(&4267i16.to_be_bytes());
+    // ISO int16s @24.
+    p1[24..26].copy_from_slice(&800i16.to_be_bytes());
+    // WifiRSSI int8s @26.
+    p1[26] = (-65i8) as u8;
+    // Battery @27.
+    p1[27] = 75;
+    // GPSLatitude int32s @28 / 0x100000.
+    let lat_raw = (47.6062_f64 * f64::from(0x10_0000)).round() as i32;
+    p1[28..32].copy_from_slice(&lat_raw.to_be_bytes());
+    // GPSLongitude int32s @32 / 0x100000.
+    let lon_raw = (-122.3321_f64 * f64::from(0x10_0000)).round() as i32;
+    p1[32..36].copy_from_slice(&lon_raw.to_be_bytes());
+    // GPSAltitude word @36: (alt_m * 0x10000) | sv ⇒ ((w&0xffffff00)>>8)/256 = alt.
+    let alt_word = (120u32 * 0x1_0000) | 9;
+    p1[36..40].copy_from_slice(&alt_word.to_be_bytes());
+    // SpeedX int16s @48 / 0x100 ⇒ raw 0x100 ⇒ 1.0.
+    p1[48..50].copy_from_slice(&(0x100i16).to_be_bytes());
+    // Binning @54: high bit set (0x80) ⇒ Binning=1; low 7 bits = 3 (Flying).
+    p1[54] = 0x80 | 3;
+    // Animation @55: high bit clear ⇒ Animation=0; PilotingMode = 1 (Return Home).
+    p1[55] = 1;
+    parrot_mett_mp4_from(&p1)
+  }
+
+  /// Decoded Parrot `mett` telemetry must EMIT through
+  /// `Meta::tags()` under the enclosing `Track<N>` (family-1) at `-ee`, with the
+  /// per-version PrintConv from the V1 table (Parrot.pm:87-228).
+  // The DroneYaw/CameraTilt expectations recompute the bundled `180/3.14159`
+  // rad→deg ValueConv with the SAME literal the port uses (byte-exact parity).
+  #[allow(clippy::approx_constant)]
+  #[test]
+  fn parrot_tags_emitted_under_ee() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+    use crate::value::TagValue;
+    let data = parrot_mett_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(!meta.parrot().is_empty(), "Parrot mett must decode");
+
+    // `-ee -n`: the raw post-ValueConv scalars under `Track1`.
+    let ee = EmitOptions::g1(ConvMode::ValueConv, true);
+    let parrot: std::vec::Vec<(String, TagValue)> = meta
+      .tags(ee)
+      .filter(|t| t.tag().group_ref().family1() == "Track1")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect();
+    let get = |name: &str| parrot.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    assert_eq!(get("GPSLatitude"), Some(&TagValue::F64(lat_round(47.6062))));
+    assert_eq!(
+      get("GPSLongitude"),
+      Some(&TagValue::F64(lat_round(-122.3321)))
+    );
+    assert_eq!(get("GPSAltitude"), Some(&TagValue::F64(120.0)));
+    assert_eq!(get("GPSSatellites"), Some(&TagValue::U64(9)));
+    assert_eq!(get("ISO"), Some(&TagValue::I64(800)));
+    // FlyingState / PilotingMode raw codes at `-n`.
+    assert_eq!(get("FlyingState"), Some(&TagValue::U64(3)));
+    assert_eq!(get("PilotingMode"), Some(&TagValue::U64(1)));
+    // NEW V1 fields. DroneYaw raw 0x1000 → 0x1000/0x1000*180/3.14159 (rad→deg).
+    assert_eq!(
+      get("DroneYaw"),
+      Some(&TagValue::F64(
+        f64::from(0x1000) / f64::from(0x1000) * 180.0 / 3.14159
+      ))
+    );
+    // CameraTilt raw -0x800 → -0.5*180/3.14159.
+    assert_eq!(
+      get("CameraTilt"),
+      Some(&TagValue::F64(
+        f64::from(-0x800) / f64::from(0x1000) * 180.0 / 3.14159
+      ))
+    );
+    // FrameView int16s[4] @14, each /0x1000 → "1 0.5 -0.25 0" (space-joined,
+    // no PrintConv ⇒ same string at `-n`).
+    assert_eq!(
+      get("FrameView"),
+      Some(&TagValue::Str("1 0.5 -0.25 0".into()))
+    );
+    // SpeedX int16s @48 / 0x100, raw 0x100 → 1.0.
+    assert_eq!(get("SpeedX"), Some(&TagValue::F64(1.0)));
+    // Binning (high bit of FlyingState byte) → 1; Animation (high bit of
+    // PilotingMode byte) → 0. Raw int both modes.
+    assert_eq!(get("Binning"), Some(&TagValue::U64(1)));
+    assert_eq!(get("Animation"), Some(&TagValue::U64(0)));
+
+    // `-j`: the per-version PrintConv hashes + the WifiRSSI/Battery suffixes.
+    let pj = EmitOptions::g1(ConvMode::PrintConv, true);
+    let parrot_pj: std::vec::Vec<(String, TagValue)> = meta
+      .tags(pj)
+      .filter(|t| t.tag().group_ref().family1() == "Track1")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect();
+    let getp = |name: &str| parrot_pj.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    assert_eq!(getp("FlyingState"), Some(&TagValue::Str("Flying".into())));
+    assert_eq!(
+      getp("PilotingMode"),
+      Some(&TagValue::Str("Return Home".into()))
+    );
+    assert_eq!(getp("WifiRSSI"), Some(&TagValue::Str("-65 dBm".into())));
+    assert_eq!(getp("Battery"), Some(&TagValue::Str("75 %".into())));
+    assert_eq!(
+      getp("GPSAltitude"),
+      Some(&TagValue::Str("120.000 m".into()))
+    );
+    assert_eq!(getp("ExposureTime"), Some(&TagValue::Str("1/60".into())));
+
+    // `-ee -G3`: every record is its own `Doc<N>` (one `mett` sample = Doc1),
+    // scoped to `Track1` (oracle `Doc1:Track1:GPSLatitude`).
+    let g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let lat = meta
+      .tags(g3)
+      .find(|t| t.tag().group_ref().family1() == "Track1" && t.tag().name() == "GPSLatitude")
+      .expect("GPSLatitude under Track1 at -G3");
+    assert_eq!(lat.tag().group_ref().doc(), 1, "first mett sample is Doc1");
+  }
+
+  /// Build an MP4 whose single `mett` sample is a Parrot V3 (`P3`) record
+  /// exercising the NEW V3-only columns (velocity, quaternion, colour balance,
+  /// FOV, link quality) — Parrot.pm:371-539.
+  fn parrot_v3_mett_mp4() -> Vec<u8> {
+    // 72-byte V3 record: `[P3][nwords]` + bundled V3 offsets (walker forces 72).
+    let mut p3 = vec![0u8; 72];
+    p3[0..2].copy_from_slice(b"P3");
+    wr(&mut p3, 2, &17u16.to_be_bytes());
+    // GPSLatitude/Longitude int32s @8/12 / 0x400000.
+    let lat_raw = (45.0_f64 * f64::from(0x40_0000)).round() as i32;
+    let lon_raw = (8.0_f64 * f64::from(0x40_0000)).round() as i32;
+    p3[8..12].copy_from_slice(&lat_raw.to_be_bytes());
+    p3[12..16].copy_from_slice(&lon_raw.to_be_bytes());
+    // GPSAltitude word @16: (100 m * 0x10000) | sv=12.
+    let alt_word = (100u32 * 0x1_0000) | 12;
+    p3[16..20].copy_from_slice(&alt_word.to_be_bytes());
+    // GPSVelocityNorth int16s @20 / 0x100 ⇒ raw 0x100 ⇒ 1.0.
+    p3[20..22].copy_from_slice(&(0x100i16).to_be_bytes());
+    // DroneQuaternion int16s[4] @28, each /0x4000 ⇒ [1, 0, 0, 0].
+    p3[28..30].copy_from_slice(&(0x4000i16).to_be_bytes());
+    // ExposureTime int16u @52 ⇒ 1/120 s ⇒ raw ≈ 2133.
+    p3[52..54].copy_from_slice(&(2133u16).to_be_bytes());
+    // ISO int16u @54.
+    p3[54..56].copy_from_slice(&(200u16).to_be_bytes());
+    // RedBalance int16u @56 / 0x4000 ⇒ raw 0x4000 ⇒ 1.0; BlueBalance @58 ⇒ 0.5.
+    p3[56..58].copy_from_slice(&(0x4000u16).to_be_bytes());
+    p3[58..60].copy_from_slice(&(0x2000u16).to_be_bytes());
+    // FOV int16u[2] @60, each /0x100 ⇒ [96, 64].
+    p3[60..62].copy_from_slice(&(0x6000u16).to_be_bytes());
+    p3[62..64].copy_from_slice(&(0x4000u16).to_be_bytes());
+    // LinkGoodput/LinkQuality word @64: (5000 << 8) | 4.
+    let link_word = (5000u32 << 8) | 4;
+    p3[64..68].copy_from_slice(&link_word.to_be_bytes());
+    // WifiRSSI @68, Battery @69.
+    p3[68] = (-70i8) as u8;
+    p3[69] = 50;
+    // FlyingState @70 = 4 (Landing); PilotingMode @71 = 5 (Move To).
+    p3[70] = 4;
+    p3[71] = 5;
+    parrot_mett_mp4_from(&p3)
+  }
+
+  /// The NEW V3-only Parrot columns must EMIT through `Meta::tags()` at `-ee`
+  /// with their bundled ValueConv (`-n`) and PrintConv (`-j`).
+  #[test]
+  fn parrot_v3_new_fields_emitted_under_ee() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::value::TagValue;
+    let data = parrot_v3_mett_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(!meta.parrot().is_empty(), "Parrot V3 mett must decode");
+
+    // `-ee -n`: raw post-ValueConv scalars.
+    let ee = EmitOptions::g1(ConvMode::ValueConv, true);
+    let parrot: std::vec::Vec<(String, TagValue)> = meta
+      .tags(ee)
+      .filter(|t| t.tag().group_ref().family1() == "Track1")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect();
+    let get = |name: &str| parrot.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    // GPSVelocityNorth raw 0x100 / 0x100 = 1.0 (raw number, no PrintConv).
+    assert_eq!(get("GPSVelocityNorth"), Some(&TagValue::F64(1.0)));
+    // DroneQuaternion [0x4000,0,0,0] / 0x4000 = "1 0 0 0" (space-joined).
+    assert_eq!(
+      get("DroneQuaternion"),
+      Some(&TagValue::Str("1 0 0 0".into()))
+    );
+    // RedBalance raw 0x4000 / 0x4000 = 1.0; BlueBalance 0x2000 = 0.5.
+    assert_eq!(get("RedBalance"), Some(&TagValue::F64(1.0)));
+    assert_eq!(get("BlueBalance"), Some(&TagValue::F64(0.5)));
+    // FOV int16u[2] [0x6000,0x4000] / 0x100 = "96 64" (space-joined).
+    assert_eq!(get("FOV"), Some(&TagValue::Str("96 64".into())));
+    // LinkGoodput (Mask 0xffffff00 >> 8) = 5000 (raw int at -n).
+    assert_eq!(get("LinkGoodput"), Some(&TagValue::U64(5000)));
+    // LinkQuality (Mask 0xff) = 4.
+    assert_eq!(get("LinkQuality"), Some(&TagValue::U64(4)));
+    // FlyingState / PilotingMode raw codes.
+    assert_eq!(get("FlyingState"), Some(&TagValue::U64(4)));
+    assert_eq!(get("PilotingMode"), Some(&TagValue::U64(5)));
+
+    // `-j`: LinkGoodput PrintConv `"$val kbit/s"` + per-version state hashes.
+    let pj = EmitOptions::g1(ConvMode::PrintConv, true);
+    let parrot_pj: std::vec::Vec<(String, TagValue)> = meta
+      .tags(pj)
+      .filter(|t| t.tag().group_ref().family1() == "Track1")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect();
+    let getp = |name: &str| parrot_pj.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    assert_eq!(
+      getp("LinkGoodput"),
+      Some(&TagValue::Str("5000 kbit/s".into()))
+    );
+    assert_eq!(getp("FlyingState"), Some(&TagValue::Str("Landing".into())));
+    assert_eq!(getp("PilotingMode"), Some(&TagValue::Str("Move To".into())));
+    // FOV / DroneQuaternion carry no PrintConv ⇒ identical strings at `-j`.
+    assert_eq!(getp("FOV"), Some(&TagValue::Str("96 64".into())));
+  }
+
+  /// Build an MP4 whose single `mett` sample is a P2 V2 basic record followed by
+  /// concatenated `E2` FollowMe and `E3` Automation extension records (the
+  /// universal real-world shape — Parrot.pm:836-852 folds the extensions into the
+  /// same sample buffer). All three share the one `Doc<N>` `ProcessSamples` opens.
+  fn parrot_e2_e3_mett_mp4() -> Vec<u8> {
+    // P2 record forced to 56 bytes; put a GPS fix so the sample is non-empty.
+    let mut p2 = vec![0u8; 56];
+    p2[0..2].copy_from_slice(b"P2");
+    wr(&mut p2, 2, &13u16.to_be_bytes());
+    let lat_raw = (47.0_f64 * f64::from(0x40_0000)).round() as i32;
+    p2[8..12].copy_from_slice(&lat_raw.to_be_bytes());
+
+    // E2 FollowMe: `[E2][nwords]` + table offsets. nwords*4+4 = size; the body
+    // runs through offset 17 (Follow-meAnimation) ⇒ need ≥ 18 bytes ⇒ nwords=4
+    // gives 20 bytes.
+    let mut e2 = vec![0u8; 20];
+    e2[0..2].copy_from_slice(b"E2");
+    wr(&mut e2, 2, &4u16.to_be_bytes());
+    // GPSTargetLatitude int32s @4 / 0x400000.
+    let tlat_raw = (47.5_f64 * f64::from(0x40_0000)).round() as i32;
+    e2[4..8].copy_from_slice(&tlat_raw.to_be_bytes());
+    // Follow-meMode int8u @16: bits 0 and 1 set ⇒ "Follow-me enabled, Follow-me".
+    e2[16] = 0b011;
+    // Follow-meAnimation int8u @17 = 1 (Orbit).
+    e2[17] = 1;
+
+    // E3 Automation: body through offset 29 (AutomationFlags) ⇒ ≥ 30 bytes ⇒
+    // nwords=7 gives 32 bytes.
+    let mut e3 = vec![0u8; 32];
+    e3[0..2].copy_from_slice(b"E3");
+    wr(&mut e3, 2, &7u16.to_be_bytes());
+    // GPSFramingLatitude int32s @4 / 0x400000.
+    let flat_raw = (47.25_f64 * f64::from(0x40_0000)).round() as i32;
+    e3[4..8].copy_from_slice(&flat_raw.to_be_bytes());
+    // AutomationAnimation int8u @28 = 4 (Dolly Slide).
+    e3[28] = 4;
+    // AutomationFlags int8u @29: bit 1 set ⇒ "Look-at-me enabled".
+    e3[29] = 0b010;
+
+    let mut sample = p2;
+    sample.extend_from_slice(&e2);
+    sample.extend_from_slice(&e3);
+    parrot_mett_mp4_from(&sample)
+  }
+
+  /// The `E2` FollowMe + `E3` Automation extension fields must EMIT through
+  /// `Meta::tags()` at `-ee`, under the SAME `Track1` / `Doc1` as the host P2,
+  /// with their bundled ValueConv (`-n`) and PrintConv / BITMASK (`-j`).
+  #[test]
+  fn parrot_e2_e3_fields_emitted_under_ee() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    use crate::serialize_key::GroupMode;
+    use crate::value::TagValue;
+    let data = parrot_e2_e3_mett_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(!meta.parrot().is_empty(), "Parrot E2/E3 mett must decode");
+
+    // `-ee -n`: raw post-ValueConv scalars (the waypoint coords carry NO ToDMS).
+    let ee = EmitOptions::g1(ConvMode::ValueConv, true);
+    let parrot: std::vec::Vec<(String, TagValue)> = meta
+      .tags(ee)
+      .filter(|t| t.tag().group_ref().family1() == "Track1")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect();
+    let get = |name: &str| parrot.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    // GPSTargetLatitude raw decimal degrees (round-trip through the fixture).
+    let tlat = {
+      let raw = (47.5_f64 * f64::from(0x40_0000)).round() as i32;
+      f64::from(raw) / f64::from(0x40_0000)
+    };
+    assert_eq!(get("GPSTargetLatitude"), Some(&TagValue::F64(tlat)));
+    // GPSFramingLatitude likewise.
+    let flat = {
+      let raw = (47.25_f64 * f64::from(0x40_0000)).round() as i32;
+      f64::from(raw) / f64::from(0x40_0000)
+    };
+    assert_eq!(get("GPSFramingLatitude"), Some(&TagValue::F64(flat)));
+    // Follow-meMode / AutomationFlags raw ints at `-n`.
+    assert_eq!(get("Follow-meMode"), Some(&TagValue::U64(0b011)));
+    assert_eq!(get("AutomationFlags"), Some(&TagValue::U64(0b010)));
+    // Follow-meAnimation / AutomationAnimation raw ints at `-n`.
+    assert_eq!(get("Follow-meAnimation"), Some(&TagValue::U64(1)));
+    assert_eq!(get("AutomationAnimation"), Some(&TagValue::U64(4)));
+
+    // `-j`: the BITMASK DecodeBits + the animation PrintConv hashes.
+    let pj = EmitOptions::g1(ConvMode::PrintConv, true);
+    let parrot_pj: std::vec::Vec<(String, TagValue)> = meta
+      .tags(pj)
+      .filter(|t| t.tag().group_ref().family1() == "Track1")
+      .map(|t| (t.tag().name().to_string(), t.tag().value_ref().clone()))
+      .collect();
+    let getp = |name: &str| parrot_pj.iter().find(|(n, _)| n == name).map(|(_, v)| v);
+    // Follow-meMode bits 0,1 ⇒ "Follow-me enabled, Follow-me" (DecodeBits join).
+    assert_eq!(
+      getp("Follow-meMode"),
+      Some(&TagValue::Str("Follow-me enabled, Follow-me".into()))
+    );
+    assert_eq!(
+      getp("Follow-meAnimation"),
+      Some(&TagValue::Str("Orbit".into()))
+    );
+    // AutomationFlags bit 1 ⇒ "Look-at-me enabled".
+    assert_eq!(
+      getp("AutomationFlags"),
+      Some(&TagValue::Str("Look-at-me enabled".into()))
+    );
+    assert_eq!(
+      getp("AutomationAnimation"),
+      Some(&TagValue::Str("Dolly Slide".into()))
+    );
+
+    // All three records share ONE `Doc<N>` (the `mett` sample's document) at -G3.
+    let g3 = EmitOptions::with_group_mode(ConvMode::ValueConv, true, GroupMode::G3);
+    let docs: std::vec::Vec<u32> = meta
+      .tags(g3)
+      .filter(|t| {
+        t.tag().group_ref().family1() == "Track1"
+          && matches!(
+            t.tag().name(),
+            "GPSLatitude" | "GPSTargetLatitude" | "GPSFramingLatitude"
+          )
+      })
+      .map(|t| t.tag().group_ref().doc())
+      .collect();
+    assert_eq!(docs.len(), 3, "P2 + E2 + E3 latitudes all present");
+    assert!(
+      docs.iter().all(|&d| d == 1),
+      "P2/E2/E3 share the one sample Doc1"
+    );
+  }
+
+  /// The Parrot tags are `-ee`-gated: WITHOUT
+  /// ExtractEmbedded `Meta::tags()` emits NONE of them.
+  #[test]
+  fn parrot_tags_absent_without_ee() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable};
+    let data = parrot_mett_mp4();
+    let meta = parse_inner(&data, None).expect("accepted");
+    assert!(!meta.parrot().is_empty(), "Parrot still decodes");
+    let noee = EmitOptions::g1(ConvMode::PrintConv, false);
+    let any_parrot = meta.tags(noee).any(|t| {
+      t.tag().group_ref().family1() == "Track1"
+        && matches!(
+          t.tag().name(),
+          "GPSLatitude" | "GPSAltitude" | "FlyingState" | "Battery" | "ISO"
+        )
+    });
+    assert!(!any_parrot, "no Parrot mett tags without -ee");
+  }
+
+  /// The `f64::from(int32s)/0x100000` round-trip the V1 GPS decoder applies —
+  /// the test's expected decimal-degree value (not exactly the literal, since the
+  /// fixture encodes `round(deg * 0x100000)`).
+  fn lat_round(deg: f64) -> f64 {
+    let raw = (deg * f64::from(0x10_0000)).round() as i32;
+    f64::from(raw) / f64::from(0x10_0000)
+  }
+
   /// **R8-B class-sweep** — a `moov/udta/GPMF` atom sets ExifTool's
   /// `$$et{FoundEmbedded}` (it routes through `GoPro::ProcessGoPro`, which sets
   /// the flag on ENTRY, GoPro.pm:822), and in ExifTool the `moov` walk runs
@@ -11612,14 +14359,17 @@ mod tests {
     data.extend_from_slice(&moov2);
 
     let mut meta = GoProMeta::new();
-    let (_stream, found_embedded) = quicktime_stream::extract_stream(
+    let found_embedded = quicktime_stream::extract_stream(
       &data,
       None,
       None,
+      &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert_eq!(meta.device_name(), Some("Hero8 Black"));
     assert!(
@@ -11651,10 +14401,13 @@ mod tests {
       &data,
       None,
       None,
+      &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert_eq!(
       meta.device_name(),
@@ -11693,10 +14446,13 @@ mod tests {
       &data_a,
       None,
       None,
+      &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta_a,
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert_eq!(
       meta_a.device_name(),
@@ -11721,10 +14477,13 @@ mod tests {
       &data_b,
       None,
       None,
+      &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta_b,
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert_eq!(
       meta_b.device_name(),
@@ -11743,14 +14502,17 @@ mod tests {
     let mut data = atom(b"ftyp", b"qt  ");
     data.extend_from_slice(&moov);
     let mut meta = GoProMeta::new();
-    let (_stream, found_embedded) = quicktime_stream::extract_stream(
+    let found_embedded = quicktime_stream::extract_stream(
       &data,
       None,
       None,
+      &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert_eq!(meta.device_name(), Some("Hero6 Black"));
     assert!(found_embedded);
@@ -11762,14 +14524,17 @@ mod tests {
   fn moov_udta_gpmf_none_and_truncation_safe() {
     let data = atom(b"ftyp", b"qt  ");
     let mut meta = GoProMeta::new();
-    let (_stream, found_embedded) = quicktime_stream::extract_stream(
+    let found_embedded = quicktime_stream::extract_stream(
       &data,
       None,
       None,
+      &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert!(meta.is_empty());
     assert!(!found_embedded);
@@ -11785,10 +14550,13 @@ mod tests {
       &trunc,
       None,
       None,
+      &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta2,
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert!(meta2.is_empty());
   }

--- a/src/formats/quicktime_freegps.rs
+++ b/src/formats/quicktime_freegps.rs
@@ -91,13 +91,14 @@
 //!
 //! ## GPS priority chain
 //!
-//! The samples ProcessFreeGPS appends feed [`QuickTimeStreamMeta`] (the
-//! same `Vec<GpsSample>` the bounded SP3 decoders fill). That meta is the
-//! **LOWEST tier** of the cross-port GPS priority chain — consulted only
-//! when no higher-tier source (GoPro → CAMM → Sony rtmd → Insta360 →
-//! Parrot) decoded a coordinate pair. The brute-force scan is intentionally
-//! a fallback; it lights up dashcam-only files that have no first-party
-//! timed-metadata track.
+//! The samples ProcessFreeGPS appends — including every variant decoded
+//! here (Kingslim / Rove / FMAS / Wolfbox) — feed [`QuickTimeStreamMeta`]
+//! (the same `Vec<GpsSample>` the bounded SP3 decoders fill). That meta
+//! is the **LOWEST tier** of the cross-port GPS priority chain —
+//! consulted only when no higher-tier source (GoPro → CAMM → Sony rtmd →
+//! Insta360 → Parrot) decoded a coordinate pair. The brute-force scan
+//! is intentionally a fallback; it lights up dashcam-only files that
+//! have no first-party timed-metadata track.
 
 #![deny(clippy::indexing_slicing)]
 
@@ -123,6 +124,8 @@ use crate::{
 const KNOTS_TO_KPH: f64 = 1.852;
 /// `$mpsToKph = 3.6` (QuickTimeStream.pl:74).
 const MPS_TO_KPH: f64 = 3.6;
+/// `$mphToKph = 1.60934` (QuickTimeStream.pl:75).
+const MPH_TO_KPH: f64 = 1.60934;
 
 /// `$gpsBlockSize = 0x8000` (QuickTimeStream.pl:70) — the brute-force scanner
 /// reads media data in 32-KiB chunks.
@@ -144,6 +147,14 @@ fn le_u32(b: &[u8], off: usize) -> Option<u32> {
 
 fn le_i32(b: &[u8], off: usize) -> Option<i32> {
   le_u32(b, off).map(|v| v as i32)
+}
+
+fn le_u64(b: &[u8], off: usize) -> Option<u64> {
+  Some(u64::from_le_bytes(b.get(off..off + 8)?.try_into().ok()?))
+}
+
+fn le_i64(b: &[u8], off: usize) -> Option<i64> {
+  le_u64(b, off).map(|v| v as i64)
 }
 
 fn le_f32(b: &[u8], off: usize) -> Option<f64> {
@@ -188,6 +199,13 @@ fn be_u32(b: &[u8], off: usize) -> Option<u32> {
 /// `already_found_embedded` mirrors ExifTool's `$$et{FoundEmbedded}` short-
 /// circuit (QuickTimeStream.pl:3689): if the timed-metadata path already
 /// produced GPS samples, skip the brute-force scan entirely.
+///
+/// **SP4** — `ligogps_out` is the LigoGPS accumulator threaded into
+/// [`process_free_gps`]: a `freeGPS ` block carrying a GPSType-5
+/// (`LIGOGPSINFO\0`) fingerprint is dispatched into
+/// [`crate::formats::ligogps::process_ligogps_with_scale`]
+/// (QuickTimeStream.pl:1843-1888). Most files leave it empty.
+#[allow(clippy::too_many_arguments)]
 pub fn scan_media_data(
   data: &[u8],
   mdat_offset: u64,
@@ -197,6 +215,7 @@ pub fn scan_media_data(
   already_found_embedded: bool,
   out: &mut QuickTimeStreamMeta,
   gopro_out: &mut GoProMeta,
+  mut ligogps_out: Option<&mut crate::metadata::LigoGpsMeta>,
 ) {
   // QuickTimeStream.pl:3689 `return if $$et{FoundEmbedded} or not $dataPos`.
   if already_found_embedded || mdat_offset == 0 {
@@ -299,7 +318,15 @@ pub fn scan_media_data(
           // the brute-force scan's `$dirInfo` carries NO `SampleTime`, so
           // `sample_time` is `None` here (a Type-19 block found by the scan
           // gets no synthesized GPSDateTime, matching the oracle).
-          process_free_gps(block, create_date_raw, None, kodak_version, &mut state, out);
+          process_free_gps(
+            block,
+            create_date_raw,
+            None,
+            kodak_version,
+            &mut state,
+            out,
+            ligogps_out.as_deref_mut(),
+          );
           found = true;
           if block_abs + len > chunk_end {
             // The block ran past the current chunk. ExifTool's `$pos += $len;
@@ -590,6 +617,15 @@ impl Default for FreeGpsState {
 ///
 /// QuickTimeStream.pl:1645 `return 0 if $dirLen < 82` — a block too short to
 /// carry any fingerprint is silently dropped.
+///
+/// **SP4** — `ligogps_out` is the LigoGPS accumulator: when a GPSType-5
+/// (`LIGOGPSINFO\0`) fingerprint is hit (QuickTimeStream.pl:1843-1888) the
+/// block is dispatched to
+/// [`crate::formats::ligogps::process_ligogps_with_scale`]. The walk path
+/// threads a real accumulator (the `mdat` scan, the `moov` `gps ` box, and
+/// the `gpmd` Kingslim re-route all pass `Some(..)`); callers with no LigoGPS
+/// accumulator (some unit tests) pass `None`, which silently drops a Type-5
+/// fingerprint in that path.
 pub fn process_free_gps(
   data: &[u8],
   create_date_raw: Option<u64>,
@@ -597,6 +633,7 @@ pub fn process_free_gps(
   kodak_version: Option<&str>,
   state: &mut FreeGpsState,
   out: &mut QuickTimeStreamMeta,
+  ligogps_out: Option<&mut crate::metadata::LigoGpsMeta>,
 ) {
   // QuickTimeStream.pl:1645 `return 0 if $dirLen < 82` — too short to carry any
   // fingerprint; bails BEFORE the FoundEmbedded flag is set (:1650), so such a
@@ -637,12 +674,36 @@ pub fn process_free_gps(
     return;
   }
 
-  // GPSType 5: LigoGPS — DEFERRED.
-  // (QuickTimeStream.pl:1843-1904). Detected by `LIGOGPSINFO\0` at offset
-  // 16/48/80. We DETECT the fingerprint here to match the dispatch, but the
-  // actual parse needs `Image::ExifTool::LigoGPS::ProcessLigoGPS`.
-  if detect_type5_ligogps(data).is_some() {
-    // DEFERRED: port the LigoGPS module separately.
+  // GPSType 5: LigoGPS embedded-in-freeGPS path.
+  // (QuickTimeStream.pl:1843-1888). Detected by `LIGOGPSINFO\0` at offset
+  // 16/48/80; dispatch to `Image::ExifTool::LigoGPS::ProcessLigoGPS`.
+  // The offset-16 + `\xf0\x03\0\0...{16}\0{4}` fingerprint sets the
+  // ABASK A8 4K scale = 3 (QuickTimeStream.pl:1886).
+  if let Some(off) = detect_type5_ligogps(data) {
+    if let Some(ligo_meta) = ligogps_out {
+      // QuickTimeStream.pl:1886 — scale = 3 when offset = 16 AND the
+      // `\xf0\x03\0\0`+20-zero-bytes Rexing/ABASK fingerprint matches.
+      let scale_id = if off == 16
+        && data.get(12..16) == Some(&[0xf0, 0x03, 0x00, 0x00])
+        && data.get(32..36) == Some(&[0x00, 0x00, 0x00, 0x00])
+      {
+        Some(3)
+      } else {
+        None
+      };
+      // **Finding 3** — each binary LigoGPS record opens a new GLOBAL `Doc<N>`
+      // (`$$et{DOC_NUM} = ++$$et{DOC_COUNT}`, LigoGPS.pm:243). This freeGPS arm
+      // is reached at the record's walk position from ALL THREE binary paths
+      // (the `moov`-level `gps ` box, the Kingslim `gpmd` sample, and the
+      // brute-force `mdat` scan), each of which has the SHARED `out` counter in
+      // scope — so watermark-then-stamp here off `out.doc_counter()` continues
+      // the same global sequence as the file's other embedded sources.
+      let ligo_start = ligo_meta.sample_count();
+      // QuickTimeStream.pl:1883 — `DirStart = $pos` (i.e. `off`).
+      crate::formats::ligogps::process_ligogps_with_scale(data, off, ligo_meta, false, scale_id);
+      let next = ligo_meta.stamp_doc_from(ligo_start, out.doc_counter());
+      out.set_doc_counter(next);
+    }
     return;
   }
 
@@ -2762,6 +2823,1069 @@ fn decode_type20_nextbase512(data: &[u8], out: &mut QuickTimeStreamMeta) {
 }
 
 // ===========================================================================
+// Dashcam-vendor `gpmd` variant handlers (QuickTimeStream.pl:181-212)
+// ===========================================================================
+//
+// The `gpmd` MetaFormat re-dispatches by `Condition` to one of five variant
+// process-procs. The Kingslim case routes to `ProcessFreeGPS`, whose
+// GPSType-5 arm decodes the `LIGOGPSINFO\0`-at-offset-0x50 LigoGPS block
+// (QuickTimeStream.pl:1843-1888) — exifast passes the raw sample to
+// [`process_free_gps`] (no synthetic header). The remaining variants — Rove
+// (ASCII XOR-text), FMAS (Vantrue N2S binary), Wolfbox (G900 / Redtiger F9 4K
+// binary) — have dedicated process-procs in bundled which we port below.
+//
+// Dispatch site (this module's `dispatch_gpmd`) mirrors the bundled
+// `QuickTimeStream.pl:181-212` Condition cascade exactly:
+//   * `^.{21}\0\0\0A[NS][EW]` → ProcessFreeGPS (Kingslim D4 dashcam → LigoGPS)
+//   * `^\0\0\xf2\xe1\xf0\xeeTT` → Process_text (Rove Stealth 4K encrypted)
+//   * `^FMAS\0\0\0\0` → ProcessFMAS (Vantrue N2S)
+//   * `^.{136}(0{16}[A-Z]{4}|https:\/\/www.redtiger\0)` → ProcessWolfbox
+//   * (else) → GoPro GPMF
+//
+// All four self-contained branches funnel into the same [`GpsSample`]
+// vector via [`FreeGpsTags::emit`]; the GoPro branch routes to the GoPro
+// KLV walker.
+
+/// Dispatch a `gpmd` sample by the bundled QuickTimeStream.pl:181-212
+/// Condition cascade. Returns `true` if any of the dashcam-variant branches
+/// matched (Kingslim / Rove / FMAS / Wolfbox); the caller falls back to the
+/// GoPro GPMF parser on `false`.
+///
+/// `data` is the raw sample bytes (no `freeGPS ` 16-byte header — these
+/// arrive through the `stbl` sample tables, not the brute-force mdat scan).
+///
+/// `ligogps_out` is the walk-level LigoGPS accumulator: the Kingslim branch
+/// routes to the GPSType-5 / `ProcessLigoGPS` arm of [`process_free_gps`]
+/// (QuickTimeStream.pl:1843-1888), which writes there.
+///
+/// `free_gps_state` is the WALK-LEVEL `$$et{FoundEmbedded}` accumulator: the
+/// Kingslim branch is the bundled `gpmd_Kingslim` process-proc `ProcessFreeGPS`,
+/// which sets `$$et{FoundEmbedded} = 1` (QuickTimeStream.pl:1650) and so
+/// SUPPRESSES the later brute-force `ScanMediaData` `mdat` scan
+/// (QuickTimeStream.pl:3689). Threading the same state the moov walk later reads
+/// (via [`FreeGpsState::found_embedded`]) makes that suppression propagate
+/// faithfully — a real Kingslim file plus stray `freeGPS`-looking `mdat` bytes
+/// no longer double-emits. The Rove / FMAS / Wolfbox process-procs
+/// (`Process_text` / `ProcessFMAS` / `ProcessWolfbox`) do NOT set
+/// `FoundEmbedded`, so they leave the state untouched.
+pub fn dispatch_gpmd(
+  data: &[u8],
+  out: &mut QuickTimeStreamMeta,
+  ligogps_out: &mut crate::metadata::LigoGpsMeta,
+  free_gps_state: &mut FreeGpsState,
+) -> bool {
+  // gpmd_Kingslim — `^.{21}\0\0\0A[NS][EW]` (QuickTimeStream.pl:183).
+  // A real Kingslim D4 `gpmd` sample carries `LIGOGPSINFO\0` at offset 0x50
+  // (80) and a `####`/ASCII LigoGPS record at 0x50+0x14 (QuickTimeStream.pl
+  // :1874-1888 — the `.{80}LIGOGPSINFO\0` alternative of the GPSType-5
+  // regex). `ProcessFreeGPS` is the `gpmd_Kingslim` process-proc; its Type-5
+  // arm dispatches `ProcessLigoGPS` at `DirStart=80` with scale 1 (line 1886
+  // sets scale=3 only when `pos == 16`). The condition signature bytes
+  // (`\0\0\0A[NS][EW]` at 21..27) only IDENTIFY the variant; the actual GPS
+  // lives in the LigoGPS block (the `A`-at-offset-24 raw lat/lon is the
+  // COMMENTED-OUT secondary, QuickTimeStream.pl:1890-1904). Pass the RAW
+  // sample straight to `process_free_gps` so `detect_type5_ligogps` fires at
+  // offset 80 and routes to `process_ligogps` via `ligogps_out`.
+  if data.len() >= 28
+    && data.get(21..25) == Some(&[0, 0, 0, b'A'])
+    && matches!(data.get(25), Some(&b'N' | &b'S'))
+    && matches!(data.get(26), Some(&b'E' | &b'W'))
+  {
+    // The gpmd Kingslim path carries no Kodak version and no enclosing sample
+    // time (`create_date_raw`/`sample_time = None`). `process_free_gps` guards
+    // `< 82` internally and sets `state.found_embedded = true`
+    // (QuickTimeStream.pl:1650) once the block reaches the decoder. Threading the
+    // WALK-LEVEL `free_gps_state` (not a throwaway) makes that `FoundEmbedded`
+    // propagate to `extract_stream`, suppressing the brute-force `mdat` scan
+    // (QuickTimeStream.pl:3689) — faithful to bundled's `gpmd_Kingslim`.
+    process_free_gps(
+      data,
+      None,
+      None,
+      None,
+      free_gps_state,
+      out,
+      Some(ligogps_out),
+    );
+    return true;
+  }
+  // gpmd_Rove — `^\0\0\xf2\xe1\xf0\xeeTT` (QuickTimeStream.pl:190).
+  if data.get(0..8) == Some(&[0x00, 0x00, 0xf2, 0xe1, 0xf0, 0xee, 0x54, 0x54][..]) {
+    process_text(data, out);
+    return true;
+  }
+  // gpmd_FMAS — `^FMAS\0\0\0\0` (QuickTimeStream.pl:197).
+  if data.get(0..8) == Some(b"FMAS\0\0\0\0".as_slice()) {
+    process_fmas(data, out);
+    return true;
+  }
+  // gpmd_Wolfbox — `^.{136}(0{16}[A-Z]{4}|https:\/\/www.redtiger\0)`
+  // (QuickTimeStream.pl:204).
+  if detect_wolfbox(data) {
+    process_wolfbox(data, out);
+    return true;
+  }
+  false
+}
+
+/// Detect the Wolfbox / Redtiger Condition (QuickTimeStream.pl:204):
+/// `^.{136}(0{16}[A-Z]{4}|https:\/\/www.redtiger\0)`.
+fn detect_wolfbox(data: &[u8]) -> bool {
+  let Some(tail) = data.get(136..) else {
+    return false;
+  };
+  // Branch A: `0{16}[A-Z]{4}` — 16 ASCII '0' chars then 4 uppercase letters.
+  if tail.get(0..16) == Some(&[b'0'; 16][..])
+    && tail
+      .get(16..20)
+      .is_some_and(|s| s.iter().all(u8::is_ascii_uppercase))
+  {
+    return true;
+  }
+  // Branch B: `https://www.redtiger\0` (literal 21 bytes incl. NUL).
+  if tail.get(0..21) == Some(b"https://www.redtiger\0".as_slice()) {
+    return true;
+  }
+  false
+}
+
+// ─────────────────────────── Process_text (Rove + general) ─────────────────
+
+/// `Process_text` (QuickTimeStream.pl:1053-1295) — faithful port of the
+/// ASCII NMEA / dashcam text-stream parser. Used for:
+///   * `gpmd_Rove` — Rove Stealth 4K encrypted ASCII (XOR-0xAA payload at
+///     offset 8) (QuickTimeStream.pl:190-194 → 1175-1211),
+///   * timed-text samples (`text` / `sbtl` handler, QuickTimeStream.pl:1467-
+///     1516),
+///   * `camm` GPRMC fallback (QuickTimeStream.pl:1540-1546).
+///
+/// `data` is the sample bytes; the function inspects them for known
+/// markers and emits a [`GpsSample`] via the common [`FreeGpsTags::emit`]
+/// path when one or more known sentences match.
+pub fn process_text(data: &[u8], out: &mut QuickTimeStreamMeta) {
+  let mut t = FreeGpsTags::new();
+  let mut emitted_via_text = false;
+  // QuickTimeStream.pl:1066 `while ($$dataPt =~ /\$(\w+)([^\$\0]*)/g)` —
+  // scan ASCII `$TAG...` sequences (terminated by next `$` or NUL).
+  let s = core::str::from_utf8(data).unwrap_or("");
+  for (tag, dat) in DollarRecords::new(s) {
+    // QuickTimeStream.pl:1068 — $XXRMC sentence.
+    if is_two_upper(tag)
+      && tag.ends_with("RMC")
+      && let Some(parsed) = parse_text_rmc(dat)
+    {
+      t.hr = Some(parsed.hr);
+      t.min = Some(parsed.min);
+      t.sec = Some(parsed.sec);
+      t.yr = Some(parsed.yr);
+      t.mon = Some(parsed.mon);
+      t.day = Some(parsed.day);
+      t.lat = Some(parsed.lat);
+      t.lon = Some(parsed.lon);
+      t.ddd = true; // Process_text computes decimal degrees directly.
+      if let Some(spd) = parsed.spd {
+        t.spd = Some(spd);
+      }
+      if let Some(trk) = parsed.trk {
+        t.trk = Some(trk);
+      }
+      emitted_via_text = true;
+      continue;
+    }
+    // QuickTimeStream.pl:1084 — $XXGGA sentence.
+    if is_two_upper(tag)
+      && tag.ends_with("GGA")
+      && let Some(parsed) = parse_text_gga(dat)
+    {
+      t.hr = Some(parsed.hr);
+      t.min = Some(parsed.min);
+      t.sec = Some(parsed.sec);
+      t.lat = Some(parsed.lat);
+      t.lon = Some(parsed.lon);
+      t.ddd = true;
+      if let Some(alt) = parsed.alt {
+        t.alt = Some(alt);
+      }
+      emitted_via_text = true;
+      continue;
+    }
+    // QuickTimeStream.pl:1094 — `$G:YYYY-MM-DD HH:MM:SS-[NS]LAT-[EW]LON-Sspd`.
+    if tag == "G"
+      && let Some((dt, lat, lon, spd)) = parse_text_g_sentence(dat)
+    {
+      t.yr = Some(dt.0);
+      t.mon = Some(dt.1);
+      t.day = Some(dt.2);
+      t.hr = Some(dt.3);
+      t.min = Some(dt.4);
+      t.sec = Some(dt.5);
+      t.lat = Some(lat);
+      t.lon = Some(lon);
+      t.ddd = true;
+      t.spd = Some(spd);
+      emitted_via_text = true;
+    }
+  }
+  if emitted_via_text {
+    t.emit(out);
+    return;
+  }
+  // QuickTimeStream.pl:1175 — BlueSkySea / Ambarella A12 enciphered binary.
+  // `^\0\0(..\xaa\xaa|\xf2\xe1\xf0\xee)` and length ≥ 282.
+  if data.len() >= 282
+    && data.get(0..2) == Some(&[0, 0][..])
+    && (data.get(4..6) == Some(&[0xaa, 0xaa][..])
+      || data.get(2..6) == Some(&[0xf2, 0xe1, 0xf0, 0xee][..]))
+  {
+    if decode_xor_aa_block(data, &mut t) {
+      t.ddd = true;
+      t.emit(out);
+    }
+    return;
+  }
+  // The Mini 0806 / Roadhawk / DJI telemetry / Thinkware-NMEA branches are
+  // text-only fallbacks; their fingerprints are independent of the binary
+  // dashcam variants we wire up here. Faithful-port stubs follow the same
+  // ASCII flow path used by NMEA above and surface via [`FreeGpsTags::emit`].
+  // (See follow-up issue: less common Process_text fallbacks.)
+  let _ = data;
+}
+
+/// Iterate `$TAG..[^$\0]*` records inside an ASCII haystack
+/// (QuickTimeStream.pl:1066 `/\$(\w+)([^\$\0]*)/g`). The match consumes
+/// non-overlapping records left-to-right.
+struct DollarRecords<'a> {
+  bytes: &'a [u8],
+  pos: usize,
+}
+
+impl<'a> DollarRecords<'a> {
+  fn new(s: &'a str) -> Self {
+    Self {
+      bytes: s.as_bytes(),
+      pos: 0,
+    }
+  }
+}
+
+impl<'a> Iterator for DollarRecords<'a> {
+  type Item = (&'a str, &'a str);
+  fn next(&mut self) -> Option<Self::Item> {
+    while self.pos < self.bytes.len() {
+      // Find next `$`.
+      let rel = self
+        .bytes
+        .get(self.pos..)?
+        .iter()
+        .position(|&b| b == b'$')?;
+      let tag_start = self.pos + rel + 1;
+      // Read \w+ (alnum + underscore — bundled `\w` matches [A-Za-z0-9_]).
+      let mut tag_end = tag_start;
+      while self
+        .bytes
+        .get(tag_end)
+        .is_some_and(|&b| b.is_ascii_alphanumeric() || b == b'_')
+      {
+        tag_end += 1;
+      }
+      if tag_end == tag_start {
+        // `$` alone — skip past it.
+        self.pos = tag_start;
+        continue;
+      }
+      // Read `[^\$\0]*` — anything not `$` or NUL.
+      let mut data_end = tag_end;
+      while self
+        .bytes
+        .get(data_end)
+        .is_some_and(|&b| b != b'$' && b != 0)
+      {
+        data_end += 1;
+      }
+      let tag = match self
+        .bytes
+        .get(tag_start..tag_end)
+        .and_then(|s| core::str::from_utf8(s).ok())
+      {
+        Some(t) => t,
+        None => {
+          self.pos = data_end;
+          continue;
+        }
+      };
+      let dat = match self
+        .bytes
+        .get(tag_end..data_end)
+        .and_then(|s| core::str::from_utf8(s).ok())
+      {
+        Some(d) => d,
+        None => {
+          self.pos = data_end;
+          continue;
+        }
+      };
+      self.pos = data_end;
+      return Some((tag, dat));
+    }
+    None
+  }
+}
+
+/// True for a two-upper-case-letter `\w+` prefix (`GP`, `GN`, `BD`, `GL` …).
+fn is_two_upper(tag: &str) -> bool {
+  let b = tag.as_bytes();
+  b.first().is_some_and(u8::is_ascii_uppercase) && b.get(1).is_some_and(u8::is_ascii_uppercase)
+}
+
+/// Parsed XXRMC fields (QuickTimeStream.pl:1069).
+struct TextRmc {
+  hr: u32,
+  min: u32,
+  sec: String,
+  yr: i32,
+  mon: u32,
+  day: u32,
+  lat: f64,
+  lon: f64,
+  spd: Option<f64>,
+  trk: Option<f64>,
+}
+
+/// Parse `,HHMMSS.sss,A?,LLMM.MMMM,N/S,LLLMM.MMMM,E/W,spd,trk,DDMMYY...`
+/// matching QuickTimeStream.pl:1069 `^,(\d{2})(\d{2})(\d+(?:\.\d*)),A?,
+/// (\d*?)(\d{1,2}\.\d+),([NS]),(\d*?)(\d{1,2}\.\d+),([EW]),(\d*\.?\d*),
+/// (\d*\.?\d*),(\d{2})(\d{2})(\d+)`. Returns decimal-degrees lat/lon
+/// (`(deg + min/60) * sign`).
+fn parse_text_rmc(dat: &str) -> Option<TextRmc> {
+  let b = dat.as_bytes();
+  if b.first() != Some(&b',') {
+    return None;
+  }
+  let mut p = 1usize;
+  // 2-digit hr.
+  let hr = parse_uint_fixed(b, &mut p, 2)?;
+  let min = parse_uint_fixed(b, &mut p, 2)?;
+  // Sec: \d+(\.\d*) — at least one int digit + REQUIRED dot + zero+ frac.
+  let sec_start = p;
+  while digit_at(b, p) {
+    p += 1;
+  }
+  if p == sec_start || !byte_at_eq(b, p, b'.') {
+    return None;
+  }
+  p += 1; // skip '.'
+  while digit_at(b, p) {
+    p += 1;
+  }
+  let sec = core::str::from_utf8(b.get(sec_start..p)?).ok()?.to_string();
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // Optional 'A,'.
+  if byte_at_eq(b, p, b'A') {
+    p += 1;
+    if !byte_at_eq(b, p, b',') {
+      return None;
+    }
+    p += 1;
+  }
+  // lat: (\d*?)(\d{1,2}\.\d+) — the lazy prefix captures the degrees,
+  // remainder is decimal-minutes.
+  let (lat_deg, lat_min) = read_dddmm(b, &mut p)?;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // N/S
+  let lat_sign = match b.get(p)? {
+    b'N' => 1.0,
+    b'S' => -1.0,
+    _ => return None,
+  };
+  p += 1;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // lon
+  let (lon_deg, lon_min) = read_dddmm(b, &mut p)?;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  let lon_sign = match b.get(p)? {
+    b'E' => 1.0,
+    b'W' => -1.0,
+    _ => return None,
+  };
+  p += 1;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // speed (knots) — \d*\.?\d*  → optional.
+  let spd = parse_optional_decimal(b, &mut p)?;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  let trk = parse_optional_decimal(b, &mut p)?;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // date: DDMMYY (the YY group is \d+ — greedy, but only first two are
+  // used per QuickTimeStream.pl:1076 `$14 + ($14 >= 70 ? 1900 : 2000)`).
+  let day = parse_uint_fixed(b, &mut p, 2)?;
+  let mon = parse_uint_fixed(b, &mut p, 2)?;
+  // Year: \d+ — read at least 2; the year-window heuristic uses the
+  // 2-digit value.
+  let yr_start = p;
+  while digit_at(b, p) {
+    p += 1;
+  }
+  if p - yr_start < 2 {
+    return None;
+  }
+  let yr_2: i32 = core::str::from_utf8(b.get(yr_start..yr_start + 2)?)
+    .ok()?
+    .parse()
+    .ok()?;
+  let yr = yr_2 + if yr_2 >= 70 { 1900 } else { 2000 };
+  Some(TextRmc {
+    hr,
+    min,
+    sec,
+    yr,
+    mon,
+    day,
+    lat: (lat_deg + lat_min / 60.0) * lat_sign,
+    lon: (lon_deg + lon_min / 60.0) * lon_sign,
+    spd: spd.map(|v| v * KNOTS_TO_KPH),
+    trk,
+  })
+}
+
+/// Parsed XXGGA fields (QuickTimeStream.pl:1084).
+struct TextGga {
+  hr: u32,
+  min: u32,
+  sec: String,
+  lat: f64,
+  lon: f64,
+  alt: Option<f64>,
+}
+
+fn parse_text_gga(dat: &str) -> Option<TextGga> {
+  let b = dat.as_bytes();
+  if b.first() != Some(&b',') {
+    return None;
+  }
+  let mut p = 1usize;
+  let hr = parse_uint_fixed(b, &mut p, 2)?;
+  let min = parse_uint_fixed(b, &mut p, 2)?;
+  // sec: \d+(\.\d*)?  — fractional is OPTIONAL for GGA.
+  let sec_start = p;
+  while digit_at(b, p) {
+    p += 1;
+  }
+  if p == sec_start {
+    return None;
+  }
+  if byte_at_eq(b, p, b'.') {
+    p += 1;
+    while digit_at(b, p) {
+      p += 1;
+    }
+  }
+  let sec = core::str::from_utf8(b.get(sec_start..p)?).ok()?.to_string();
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  let (lat_deg, lat_min) = read_dddmm(b, &mut p)?;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  let lat_sign = match b.get(p)? {
+    b'N' => 1.0,
+    b'S' => -1.0,
+    _ => return None,
+  };
+  p += 1;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  let (lon_deg, lon_min) = read_dddmm(b, &mut p)?;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  let lon_sign = match b.get(p)? {
+    b'E' => 1.0,
+    b'W' => -1.0,
+    _ => return None,
+  };
+  p += 1;
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // [1-6]?, then comma, then satellites/dop/altitude.
+  if matches!(b.get(p), Some(b'1'..=b'6')) {
+    p += 1;
+  }
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // satellites (digits, optional).
+  while digit_at(b, p) {
+    p += 1;
+  }
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // DOP (decimal, optional).
+  while digit_at(b, p) || byte_at_eq(b, p, b'.') {
+    p += 1;
+  }
+  if !byte_at_eq(b, p, b',') {
+    return None;
+  }
+  p += 1;
+  // altitude — `-?\d+(\.\d*)?` optional.
+  let alt_start = p;
+  if byte_at_eq(b, p, b'-') {
+    p += 1;
+  }
+  let int_start = p;
+  while digit_at(b, p) {
+    p += 1;
+  }
+  let alt = if p > int_start {
+    if byte_at_eq(b, p, b'.') {
+      p += 1;
+      while digit_at(b, p) {
+        p += 1;
+      }
+    }
+    core::str::from_utf8(b.get(alt_start..p)?)
+      .ok()?
+      .parse::<f64>()
+      .ok()
+  } else {
+    None
+  };
+  Some(TextGga {
+    hr,
+    min,
+    sec,
+    lat: (lat_deg + lat_min / 60.0) * lat_sign,
+    lon: (lon_deg + lon_min / 60.0) * lon_sign,
+    alt,
+  })
+}
+
+/// Parse a `$G:YYYY-MM-DD HH:MM:SS-[NS]LAT-[EW]LON-Sspd` sentence
+/// (QuickTimeStream.pl:1094). Returns ((yr,mon,day,hr,min,sec), lat, lon, spd).
+#[allow(clippy::type_complexity)]
+fn parse_text_g_sentence(dat: &str) -> Option<((i32, u32, u32, u32, u32, String), f64, f64, f64)> {
+  let b = dat.as_bytes();
+  if b.first() != Some(&b':') {
+    return None;
+  }
+  let mut p = 1usize;
+  let yr = parse_uint_fixed(b, &mut p, 4)? as i32;
+  if !byte_at_eq(b, p, b'-') {
+    return None;
+  }
+  p += 1;
+  let mon = parse_uint_fixed(b, &mut p, 2)?;
+  if !byte_at_eq(b, p, b'-') {
+    return None;
+  }
+  p += 1;
+  let day = parse_uint_fixed(b, &mut p, 2)?;
+  if !byte_at_eq(b, p, b' ') {
+    return None;
+  }
+  p += 1;
+  let hr = parse_uint_fixed(b, &mut p, 2)?;
+  if !byte_at_eq(b, p, b':') {
+    return None;
+  }
+  p += 1;
+  let min = parse_uint_fixed(b, &mut p, 2)?;
+  if !byte_at_eq(b, p, b':') {
+    return None;
+  }
+  p += 1;
+  let sec_start = p;
+  let _ = parse_uint_fixed(b, &mut p, 2)?;
+  let sec = core::str::from_utf8(b.get(sec_start..p)?).ok()?.to_string();
+  if !byte_at_eq(b, p, b'-') {
+    return None;
+  }
+  p += 1;
+  let lat_sign = match b.get(p)? {
+    b'N' => 1.0,
+    b'S' => -1.0,
+    _ => return None,
+  };
+  p += 1;
+  let lat = parse_decimal(b, &mut p)?;
+  if !byte_at_eq(b, p, b'-') {
+    return None;
+  }
+  p += 1;
+  let lon_sign = match b.get(p)? {
+    b'E' => 1.0,
+    b'W' => -1.0,
+    _ => return None,
+  };
+  p += 1;
+  let lon = parse_decimal(b, &mut p)?;
+  if !byte_at_eq(b, p, b'-') {
+    return None;
+  }
+  p += 1;
+  if !byte_at_eq(b, p, b'S') {
+    return None;
+  }
+  p += 1;
+  // Speed = \d+ per bundled regex `S(\d+)` — integer.
+  let spd_start = p;
+  while digit_at(b, p) {
+    p += 1;
+  }
+  if p == spd_start {
+    return None;
+  }
+  let spd: f64 = core::str::from_utf8(b.get(spd_start..p)?)
+    .ok()?
+    .parse()
+    .ok()?;
+  Some((
+    (yr, mon, day, hr, min, sec),
+    lat * lat_sign,
+    lon * lon_sign,
+    spd,
+  ))
+}
+
+/// Parse `(\d*?)(\d{1,2}\.\d+)` — the lazy-prefix + 1-2-digit degrees +
+/// fractional-minutes scheme NMEA uses. Returns `(deg, min)`. The bundled
+/// regex's `\d*?` lazy match means we extract the LAST 1-2 digits before the
+/// `.` as the integer minutes part, and the remainder is degrees.
+fn read_dddmm(b: &[u8], p: &mut usize) -> Option<(f64, f64)> {
+  let start = *p;
+  while digit_at(b, *p) {
+    *p += 1;
+  }
+  if !byte_at_eq(b, *p, b'.') {
+    return None;
+  }
+  let dot = *p;
+  // After the dot, advance over fractional digits.
+  *p += 1;
+  while digit_at(b, *p) {
+    *p += 1;
+  }
+  // Integer part = `b[start..dot]`; \d{1,2} are the minutes integer.
+  let int_part = b.get(start..dot)?;
+  if int_part.is_empty() {
+    return None;
+  }
+  // Minutes integer is the LAST 1-2 chars; degrees prefix is the rest.
+  // `\d{1,2}` — bundled is greedy here: match as many as possible up to 2.
+  let take = int_part.len().min(2);
+  let deg_str = int_part.get(..int_part.len() - take)?;
+  let min_int = int_part.get(int_part.len() - take..)?;
+  let frac = b.get(dot..*p)?; // includes the dot
+  let deg = if deg_str.is_empty() {
+    0.0
+  } else {
+    core::str::from_utf8(deg_str).ok()?.parse::<f64>().ok()?
+  };
+  let mut min_s: String = core::str::from_utf8(min_int).ok()?.into();
+  min_s.push_str(core::str::from_utf8(frac).ok()?);
+  let min: f64 = min_s.parse().ok()?;
+  Some((deg, min))
+}
+
+/// `true` when the byte at `p` exists and is an ASCII digit (the checked form
+/// of `p < b.len() && b[p].is_ascii_digit()`; the file `deny`s indexing).
+fn digit_at(b: &[u8], p: usize) -> bool {
+  b.get(p).is_some_and(u8::is_ascii_digit)
+}
+
+/// `true` when the byte at `p` exists and equals `c` (the checked form of
+/// `p < b.len() && b[p] == c`). Its negation is the `p >= b.len() || b[p] != c`
+/// guard the NMEA parsers use to require a literal separator.
+fn byte_at_eq(b: &[u8], p: usize, c: u8) -> bool {
+  b.get(p) == Some(&c)
+}
+
+/// Read a `\d{N}` fixed-width unsigned integer, advancing the cursor.
+fn parse_uint_fixed(b: &[u8], p: &mut usize, n: usize) -> Option<u32> {
+  let slice = b.get(*p..*p + n)?;
+  if !slice.iter().all(u8::is_ascii_digit) {
+    return None;
+  }
+  let v: u32 = core::str::from_utf8(slice).ok()?.parse().ok()?;
+  *p += n;
+  Some(v)
+}
+
+/// Read `\d*\.?\d*` (decimal, possibly empty). Returns `Ok(None)` if the
+/// field is empty (matches Perl `length` test before assignment, lines
+/// 1082-1083), `Ok(Some(v))` if non-empty. Returns `None` only on parse fail.
+fn parse_optional_decimal(b: &[u8], p: &mut usize) -> Option<Option<f64>> {
+  let start = *p;
+  while digit_at(b, *p) || byte_at_eq(b, *p, b'.') {
+    *p += 1;
+  }
+  if *p == start {
+    return Some(None);
+  }
+  let s = core::str::from_utf8(b.get(start..*p)?).ok()?;
+  if s == "." || s.is_empty() {
+    return Some(None);
+  }
+  let v: f64 = s.parse().ok()?;
+  Some(Some(v))
+}
+
+/// Read a `\d+\.\d+` decimal, advancing the cursor.
+fn parse_decimal(b: &[u8], p: &mut usize) -> Option<f64> {
+  let start = *p;
+  while digit_at(b, *p) {
+    *p += 1;
+  }
+  if *p == start {
+    return None;
+  }
+  if byte_at_eq(b, *p, b'.') {
+    *p += 1;
+    while digit_at(b, *p) {
+      *p += 1;
+    }
+  }
+  core::str::from_utf8(b.get(start..*p)?).ok()?.parse().ok()
+}
+
+/// Decode the BlueSkySea / Ambarella A12 XOR-0xAA enciphered binary block
+/// (QuickTimeStream.pl:1175-1211). Returns `true` if `t` was populated.
+fn decode_xor_aa_block(data: &[u8], t: &mut FreeGpsTags) -> bool {
+  let dec14 = xor_aa_slice(data, 8, 14);
+  if dec14.len() != 14 || !dec14.iter().all(|c| c.is_ascii_digit()) {
+    return false;
+  }
+  let s = core::str::from_utf8(&dec14).unwrap_or("");
+  if s.len() != 14 {
+    return false;
+  }
+  t.yr = s.get(0..4).and_then(|x| x.parse().ok());
+  t.mon = s.get(4..6).and_then(|x| x.parse().ok());
+  t.day = s.get(6..8).and_then(|x| x.parse().ok());
+  t.hr = s.get(8..10).and_then(|x| x.parse().ok());
+  t.min = s.get(10..12).and_then(|x| x.parse().ok());
+  t.sec = s.get(12..14).map(str::to_string);
+  // Latitude — 9 XOR'd bytes at offset 38, pattern `[NS]\d{2}\d+`.
+  let lat_bytes = xor_aa_slice(data, 38, 9);
+  if lat_bytes.len() == 9 {
+    let lat_s = core::str::from_utf8(&lat_bytes).unwrap_or("");
+    if let Some(c) = lat_s.chars().next()
+      && (c == 'N' || c == 'S')
+      && let Some(deg_s) = lat_s.get(1..3)
+      && let Some(frac_s) = lat_s.get(3..)
+      && let (Ok(deg), Ok(frac)) = (deg_s.parse::<f64>(), frac_s.parse::<f64>())
+    {
+      let mut lat = deg + frac / 600000.0;
+      if c == 'S' {
+        lat = -lat;
+      }
+      t.lat = Some(lat);
+      t.lat_ref = None;
+    }
+  }
+  // Longitude — 10 XOR'd bytes at offset 47, pattern `[EW]\d{3}\d+`.
+  let lon_bytes = xor_aa_slice(data, 47, 10);
+  if lon_bytes.len() == 10 {
+    let lon_s = core::str::from_utf8(&lon_bytes).unwrap_or("");
+    if let Some(c) = lon_s.chars().next()
+      && (c == 'E' || c == 'W')
+      && let Some(deg_s) = lon_s.get(1..4)
+      && let Some(frac_s) = lon_s.get(4..)
+      && let (Ok(deg), Ok(frac)) = (deg_s.parse::<f64>(), frac_s.parse::<f64>())
+    {
+      let mut lon = deg + frac / 600000.0;
+      if c == 'W' {
+        lon = -lon;
+      }
+      t.lon = Some(lon);
+      t.lon_ref = None;
+    }
+  }
+  // Altitude — 5 bytes at 0x39, `[-+]\d+`.
+  let alt_b = xor_aa_slice(data, 0x39, 5);
+  if let Ok(alt_s) = core::str::from_utf8(&alt_b)
+    && (alt_s.starts_with('+') || alt_s.starts_with('-'))
+    && alt_s
+      .get(1..)
+      .is_some_and(|d| d.bytes().all(|c| c.is_ascii_digit()))
+    && let Ok(v) = alt_s.parse::<f64>()
+  {
+    t.alt = Some(v);
+  }
+  // Speed — 3 bytes at 0x3e, `\d+`.
+  let spd_b = xor_aa_slice(data, 0x3e, 3);
+  if let Ok(spd_s) = core::str::from_utf8(&spd_b)
+    && spd_s.chars().all(|c| c.is_ascii_digit())
+    && let Ok(v) = spd_s.parse::<f64>()
+  {
+    t.spd = Some(v);
+  }
+  // Accelerometer — BlueSkySea (data[4..6] == 0xaaaa): 12 bytes at 0xad,
+  // ASCII `[-+]\d{3}` × 3.
+  if data.get(4..6) == Some(&[0xaa, 0xaa][..]) && data.len() >= 0xad + 12 {
+    let acc_b = xor_aa_slice(data, 0xad, 12);
+    if let Ok(acc_s) = core::str::from_utf8(&acc_b)
+      && acc_s.len() == 12
+    {
+      let x = acc_s.get(0..4).and_then(|v| v.parse::<f64>().ok());
+      let y = acc_s.get(4..8).and_then(|v| v.parse::<f64>().ok());
+      let z = acc_s.get(8..12).and_then(|v| v.parse::<f64>().ok());
+      if let (Some(x), Some(y), Some(z)) = (x, y, z) {
+        t.accel = Some((x, y, z));
+      }
+    }
+  }
+  true
+}
+
+/// XOR `len` bytes from `data[off..off+len]` with 0xaa, returning the
+/// decrypted Vec. Returns empty Vec if out of range.
+fn xor_aa_slice(data: &[u8], off: usize, len: usize) -> Vec<u8> {
+  match data.get(off..off + len) {
+    Some(slice) => slice.iter().map(|b| b ^ 0xaa).collect(),
+    None => Vec::new(),
+  }
+}
+
+// ─────────────────────────── ProcessFMAS (Vantrue N2S) ─────────────────────
+
+/// `ProcessFMAS` (QuickTimeStream.pl:3580-3609) — Vantrue N2S dashcam binary
+/// GPS record. Fixed 160-byte (+) layout with a 36-byte FMAS prelude and an
+/// 8-byte INFO/SAMM marker pair at offset 64.
+///
+/// Layout (bundled QuickTimeStream.pl:3586-3596):
+///   off 0x00-0x07 = "FMAS\0\0\0\0"
+///   off 0x40-0x47 = "OFNIMMAS" (reversed "INFO"+"SAMM")
+///   off 0x48-0x4b = "SAMM"
+///   off 0x60-0x6b = yr (LE u16) + mon u8 + day u8 + hr u8 + min u8 + sec u8 …
+///   off 0x6c-0x77 = 3× LE f32 acceleration (X/Y/Z — Z first per ExifTool
+///                   comment "looks like Z comes first in my sample")
+///   off 0x78-0x80 = `AWNQ` markers (E/W + lon deg + min hi + 0 + lat ref + lat deg + min hi)
+///   …
+///
+/// `unpack('x96vCCCCCCx16AAACCCvCCvvv', $dataPt)` decodes (offset 0x60):
+///   $a[0] = yr (u16), $a[1..5] = mon/day/hr/min/sec (u8), then x16 skip,
+///   $a[6..8] = 3 chars (FMAS layout's "AWNQ" markers), $a[9..10] = lon-ref +
+///   lat-ref, $a[10..13] = lon (u8, u8, u16), $a[14..16] = lat (u8, u8, u16),
+///   $a[17..19] = spd, dir (u16 each), plus extras.
+///
+/// Bundled formula:
+///   lon = $a[10] + ($a[11] + $a[13]/6000) / 60
+///   lat = $a[14] + ($a[15] + $a[16]/6000) / 60
+pub fn process_fmas(data: &[u8], out: &mut QuickTimeStreamMeta) {
+  if let Some(sample) = decode_fmas(data) {
+    out.push_gps_sample(sample);
+  }
+}
+
+fn decode_fmas(data: &[u8]) -> Option<GpsSample> {
+  // QuickTimeStream.pl:3584 — strict sig + length guard.
+  if data.len() < 160 {
+    return None;
+  }
+  if data.get(0..8) != Some(b"FMAS\0\0\0\0") {
+    return None;
+  }
+  // Strict bundled regex: `/^FMAS\0\0\0\0.{72}SAMM.{36}A/s`. That is:
+  //   FMAS-marker (8) + 72 bytes + "SAMM" (4) + 36 bytes + "A".
+  // Offset of "SAMM" = 80, offset of the trailing "A" = 120.
+  if data.get(80..84) != Some(b"SAMM") {
+    return None;
+  }
+  if data.get(120) != Some(&b'A') {
+    return None;
+  }
+  // unpack offsets — `x96` puts the cursor at 0x60. The fields are:
+  //   $a[0]=yr (v=u16 LE at 0x60), $a[1..5]=mon/day/hr/min/sec (5×u8 at 0x62-0x66),
+  //   `x16` skip to 0x77, $a[6..8] = 3 chars (A/W/N/E/S markers), $a[9]=lon-ref,
+  //   `$a[10]=lon-deg u8`, $a[11]=lon-min u8, $a[12]=0-pad u8, $a[13]=lon-min-frac u16,
+  //   $a[14]=lat-deg u8, $a[15]=lat-min u8, $a[16]=lat-min-frac u16,
+  //   $a[17]=spd u16, $a[18]=dir u16.
+  // Per bundled comments: $a[8] = E/W ref, $a[9] = N/S ref (the `A` flag is at 120).
+  // The `unpack('x96vCCCCCCx16AAACCCvCCvvv')` template breakdown:
+  //   x96 → seek to 96(0x60)
+  //   v   → $a[0] = u16 LE  (yr)
+  //   C×6 → $a[1..6] (mon, day, hr, min, sec, +1 more byte at 0x69)
+  //   x16 → skip 16 bytes (now at 0x77 + 16 = 0x77; cursor was at 0x67 after 5
+  //         × C, so really 0x66 + 5 + 16 = 0x77; ExifTool unpack consumed 6 C's
+  //         (0x62-0x67) then x16 → 0x77).
+  //
+  // Re-checking ExifTool's template `x96vCCCCCCx16AAACCCvCCvvv`:
+  //   x96  → pos = 96 (0x60)
+  //   v    → u16 LE → pos += 2  → 0x62
+  //   C×6  → 6 bytes → pos += 6 → 0x68
+  //   x16  → skip 16 → pos      → 0x78
+  //   A×3  → 3 chars → pos += 3 → 0x7b
+  //   C×3  → 3 bytes → pos += 3 → 0x7e
+  //   v    → u16 LE → pos += 2  → 0x80
+  //   C×2  → 2 bytes → pos += 2 → 0x82
+  //   v×3  → 3 × u16 → pos += 6 → 0x88
+  //
+  // So:
+  //   $a[0]    = u16 at 0x60 (yr)
+  //   $a[1..6] = u8  at 0x62..0x67 (mon, day, hr, min, sec, +1 extra)
+  //   $a[7..9] = 3 chars at 0x78..0x7a — "AWN" / "AWS" / "AEN" / etc. markers
+  //              ($a[7] = 'A' fix-valid flag, $a[8] = E/W ref, $a[9] = N/S ref)
+  //   $a[10]   = u8 at 0x7b (lon deg)
+  //   $a[11]   = u8 at 0x7c (lon min int)
+  //   $a[12]   = u8 at 0x7d (always 0 — the "why zero byte at $a[12]?")
+  //   $a[13]   = u16 at 0x7e (lon min frac × 6000)
+  //   $a[14]   = u8 at 0x80 (lat deg)
+  //   $a[15]   = u8 at 0x81 (lat min int)
+  //   $a[16]   = u16 at 0x82 (lat min frac × 6000)
+  //   $a[17]   = u16 at 0x84 (spd)
+  //   $a[18]   = u16 at 0x86 (dir)
+  let yr = le_u16(data, 0x60)? as i32;
+  let mon = *data.get(0x62)? as u32;
+  let day = *data.get(0x63)? as u32;
+  let hr = *data.get(0x64)? as u32;
+  let min = *data.get(0x65)? as u32;
+  let sec = *data.get(0x66)? as u32;
+  let ew_ref = *data.get(0x79)? as char; // E or W
+  let ns_ref = *data.get(0x7a)? as char; // N or S
+  let lon_deg = *data.get(0x7b)? as f64;
+  let lon_min = *data.get(0x7c)? as f64;
+  let lon_frac = le_u16(data, 0x7e)? as f64;
+  let lat_deg = *data.get(0x80)? as f64;
+  let lat_min = *data.get(0x81)? as f64;
+  let lat_frac = le_u16(data, 0x82)? as f64;
+  let spd_raw = le_u16(data, 0x84)? as f64;
+  let dir = le_u16(data, 0x86)? as f64;
+  // Acceleration — 3 × LE f32 at 0x6c (QuickTimeStream.pl:3598 "Z first").
+  let ax = le_f32(data, 0x6c);
+  let ay = le_f32(data, 0x70);
+  let az = le_f32(data, 0x74);
+
+  let mut lon = lon_deg + (lon_min + lon_frac / 6000.0) / 60.0;
+  let mut lat = lat_deg + (lat_min + lat_frac / 6000.0) / 60.0;
+  if ns_ref == 'S' {
+    lat = -lat;
+  }
+  if ew_ref == 'W' {
+    lon = -lon;
+  }
+  let mut sample = GpsSample::new();
+  sample.set_date_time(Some(SmolStr::from(alloc::format!(
+    "{yr:04}:{mon:02}:{day:02} {hr:02}:{min:02}:{sec:02}"
+  ))));
+  sample.set_latitude(Some(lat));
+  sample.set_longitude(Some(lon));
+  sample.set_speed_kph(Some(spd_raw * MPH_TO_KPH));
+  sample.set_track(Some(dir));
+  if let (Some(x), Some(y), Some(z)) = (ax, ay, az) {
+    sample.set_accelerometer(Some(SmolStr::from(join3(x, y, z))));
+  }
+  if sample.is_empty() {
+    return None;
+  }
+  Some(sample)
+}
+
+// ─────────────────────────── ProcessWolfbox (G900 / Redtiger F9 4K) ────────
+
+/// `ProcessWolfbox` (QuickTimeStream.pl:3615-3676) — Wolfbox G900 and
+/// Redtiger F9 4K Mini Dash Cam binary GPS record.
+///
+/// Layout (bundled QuickTimeStream.pl:3621-3657):
+///   Date/time: 3 × u32 LE at 0x68 (`d, mo, yr`), then 3 × u32 LE at 0xa0
+///   (`h, m, s`). Bundled `unpack('x104V3x44V3')`:
+///     x104 → 0x68, V3 → day/mon/yr (0x68/0x6c/0x70, end at 0x74),
+///     x44  → 0xa0, V3 → hr/min/sec (0xa0/0xa4/0xa8).
+///   Numerator/divisor `i64/i64` pairs at:
+///     0x48 = speed value, 0x50 = speed divisor
+///     0x58 = track value, 0x60 = track divisor
+///     0xb0 = lat value, 0xb8 = lat divisor
+///     0xc0 = lon value, 0xc8 = lon divisor
+///     0xe8 = alt value, 0xf0 = alt divisor
+///   Then `ConvertLatLon` runs on lat/lon (DDDMM.MMMM → decimal degrees).
+///   Speed value is in knots; multiply by `$knotsToKph`.
+///
+/// Bundled requires ≥0xf8 bytes; we mirror.
+pub fn process_wolfbox(data: &[u8], out: &mut QuickTimeStreamMeta) {
+  // QuickTimeStream.pl:3619.
+  if data.len() < 0xf8 {
+    return;
+  }
+  // x104 V3 x44 V3 — date at 0x68 (d,mo,yr), time at 0xa0 (h,m,s).
+  let Some(day) = le_u32(data, 0x68) else {
+    return;
+  };
+  let Some(mon) = le_u32(data, 0x6c) else {
+    return;
+  };
+  let Some(yr) = le_u32(data, 0x70) else { return };
+  let Some(hr) = le_u32(data, 0xa0) else { return };
+  let Some(min) = le_u32(data, 0xa4) else {
+    return;
+  };
+  let Some(sec) = le_u32(data, 0xa8) else {
+    return;
+  };
+  // Value/divisor pairs (i64 each).
+  let div_pair = |p: usize| -> Option<f64> {
+    let v = le_i64(data, p)?;
+    let scl = le_i64(data, p + 8)?;
+    let denom = if scl == 0 { 1.0 } else { scl as f64 };
+    Some(v as f64 / denom)
+  };
+  let Some(spd) = div_pair(0x48) else { return };
+  let Some(trk) = div_pair(0x58) else { return };
+  let Some(mut lat) = div_pair(0xb0) else {
+    return;
+  };
+  let Some(mut lon) = div_pair(0xc0) else {
+    return;
+  };
+  let Some(alt) = div_pair(0xe8) else { return };
+  // ConvertLatLon (QuickTimeStream.pl:3668): DDDMM.MMMM → decimal degrees.
+  lat = convert_lat_lon(lat);
+  lon = convert_lat_lon(lon);
+  let mut sample = GpsSample::new();
+  sample.set_date_time(Some(SmolStr::from(alloc::format!(
+    "{yr:04}:{mon:02}:{day:02} {hr:02}:{min:02}:{sec:02}Z"
+  ))));
+  sample.set_latitude(Some(lat));
+  sample.set_longitude(Some(lon));
+  sample.set_altitude_m(Some(alt));
+  sample.set_speed_kph(Some(spd * KNOTS_TO_KPH));
+  sample.set_track(Some(trk));
+  if !sample.is_empty() {
+    out.push_gps_sample(sample);
+  }
+}
+
+// ===========================================================================
 // Tests
 // ===========================================================================
 
@@ -2774,7 +3898,7 @@ mod tests {
   /// / SampleTime (the brute-force-scan shape).
   fn decode_block(block: &[u8], out: &mut QuickTimeStreamMeta) {
     let mut state = FreeGpsState::new();
-    process_free_gps(block, None, None, None, &mut state, out);
+    process_free_gps(block, None, None, None, &mut state, out, None);
   }
 
   /// Decode one freeGPS block with a `CreateDate` + `SampleTime` in effect —
@@ -2794,6 +3918,7 @@ mod tests {
       None,
       &mut state,
       out,
+      None,
     );
   }
 
@@ -2801,7 +3926,15 @@ mod tests {
   /// Rexing Type-17b test shape.
   fn decode_block_kodak(block: &[u8], kodak_version: &str, out: &mut QuickTimeStreamMeta) {
     let mut state = FreeGpsState::new();
-    process_free_gps(block, None, None, Some(kodak_version), &mut state, out);
+    process_free_gps(
+      block,
+      None,
+      None,
+      Some(kodak_version),
+      &mut state,
+      out,
+      None,
+    );
   }
 
   /// Build a freeGPS block from a `inner` mut buffer that is treated as the
@@ -3114,6 +4247,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     assert_eq!(out.gps_samples().len(), 1);
     assert_eq!(
@@ -3294,6 +4428,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     assert_eq!(out.gps_samples().len(), 1);
     assert!(gp.is_empty());
@@ -3322,6 +4457,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     assert!(
       out.gps_samples().is_empty(),
@@ -3343,6 +4479,7 @@ mod tests {
       true,
       &mut out,
       &mut gp,
+      None,
     );
     assert!(out.is_empty());
     assert!(gp.is_empty());
@@ -3576,7 +4713,7 @@ mod tests {
     // No CreateDate ⇒ no GPSDateTime even with a SampleTime.
     let mut out2 = QuickTimeStreamMeta::new();
     let mut state = FreeGpsState::new();
-    process_free_gps(&block, None, Some(2.0), None, &mut state, &mut out2);
+    process_free_gps(&block, None, Some(2.0), None, &mut state, &mut out2, None);
     assert_eq!(out2.gps_samples().first().unwrap().date_time(), None);
   }
 
@@ -3675,6 +4812,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     assert_eq!(
       out.gps_samples().len(),
@@ -3762,6 +4900,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     // BOTH records must be scanned ⇒ 2 GPS samples (one per record). The
     // pre-fix code produced only 1 (the trailer record was never reached).
@@ -3815,6 +4954,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     // The freeGPS block yields exactly one QuickTime-stream GPS sample.
     assert_eq!(
@@ -3876,6 +5016,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     // Exactly 2 samples — one per record, no duplication from re-scanning the
     // cross-boundary consumed span.
@@ -3929,6 +5070,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     assert_eq!(
       gp.gps_samples().len(),
@@ -3970,6 +5112,7 @@ mod tests {
       false,
       &mut out,
       &mut gp,
+      None,
     );
     assert!(out.gps_samples().is_empty());
   }
@@ -4037,9 +5180,9 @@ mod tests {
 
     let mut state = FreeGpsState::new();
     let mut out = QuickTimeStreamMeta::new();
-    process_free_gps(&block1, None, None, None, &mut state, &mut out);
+    process_free_gps(&block1, None, None, None, &mut state, &mut out, None);
     assert_eq!(out.gps_samples().len(), 2, "block 1 emits both new records");
-    process_free_gps(&block2, None, None, None, &mut state, &mut out);
+    process_free_gps(&block2, None, None, None, &mut state, &mut out, None);
     assert_eq!(
       out.gps_samples().len(),
       3,
@@ -4261,5 +5404,454 @@ mod tests {
       (s2.latitude().expect("lat") - 3.483_191_426_595_05).abs() < 1e-9,
       "non-matching KodakVersion stays default-17"
     );
+  }
+
+  // ─── Process_text (Rove/Kingslim/general) ─────────────────────────────
+
+  #[test]
+  fn process_text_rmc_decimal_degrees_emitted() {
+    // QuickTimeStream.pl:1066-1083 — `$GPRMC` ASCII sentence in raw text.
+    // Sample: "$GPRMC,082138,A,5330.6683,N,00641.9749,W,012.5,87.86,050213,002.1,A"
+    // Lat = (53 + 30.6683/60) = 53.5111... ; Lon = -(6 + 41.9749/60) = -6.69958...
+    let raw = b"$GPRMC,082138.0,A,5330.6683,N,00641.9749,W,012.5,87.86,050213,002.1,A";
+    let mut out = QuickTimeStreamMeta::new();
+    process_text(raw, &mut out);
+    assert_eq!(out.gps_samples().len(), 1);
+    let s = &out.gps_samples()[0];
+    assert!((s.latitude().unwrap() - 53.51113).abs() < 1e-4);
+    assert!((s.longitude().unwrap() + 6.69958).abs() < 1e-4);
+    assert!(s.date_time().unwrap().starts_with("2013:02:05 08:21:38"));
+    // 12.5 knots * 1.852 = 23.15 kph
+    assert!((s.speed_kph().unwrap() - 23.15).abs() < 0.1);
+    assert!((s.track().unwrap() - 87.86).abs() < 0.01);
+  }
+
+  #[test]
+  fn process_text_gga_altitude_decoded() {
+    // QuickTimeStream.pl:1084-1092 — GPGGA sentence with altitude.
+    let raw = b"$GPGGA,123456.0,4721.35197,N,00830.80859,E,1,08,1.2,123.4,M,0.0,M,,";
+    let mut out = QuickTimeStreamMeta::new();
+    process_text(raw, &mut out);
+    assert_eq!(out.gps_samples().len(), 1);
+    let s = &out.gps_samples()[0];
+    assert!((s.altitude_m().unwrap() - 123.4).abs() < 1e-4);
+    assert!((s.latitude().unwrap() - (47.0 + 21.35197 / 60.0)).abs() < 1e-4);
+    assert!((s.longitude().unwrap() - (8.0 + 30.80859 / 60.0)).abs() < 1e-4);
+  }
+
+  #[test]
+  fn process_text_g_sentence_decoded() {
+    // QuickTimeStream.pl:1094-1098 — `$G:2025-01-15 12:34:56-N47.628-W008.514-S25`.
+    let raw = b"$G:2025-01-15 12:34:56-N47.628421-W008.513889-S25";
+    let mut out = QuickTimeStreamMeta::new();
+    process_text(raw, &mut out);
+    assert_eq!(out.gps_samples().len(), 1);
+    let s = &out.gps_samples()[0];
+    assert!((s.latitude().unwrap() - 47.628421).abs() < 1e-5);
+    assert!((s.longitude().unwrap() + 8.513889).abs() < 1e-5);
+    assert!(s.date_time().unwrap().contains("2025:01:15 12:34:56"));
+    assert_eq!(s.speed_kph(), Some(25.0));
+  }
+
+  #[test]
+  fn process_text_truncated_rmc_does_not_emit_sample() {
+    // Truncated mid-sentence — must not produce a GPS fix.
+    let raw = b"$GPRMC,082138.0,A,5330.6683,N";
+    let mut out = QuickTimeStreamMeta::new();
+    process_text(raw, &mut out);
+    assert!(out.gps_samples().is_empty());
+  }
+
+  #[test]
+  fn process_text_corrupt_rmc_does_not_panic() {
+    // Garbage data — must not panic; ideally produces no sample.
+    let raw = b"$GPRMC,XXXX,YYY,ZZZZ";
+    let mut out = QuickTimeStreamMeta::new();
+    process_text(raw, &mut out);
+    // (the fixed-width hr/min parse will fail on `XXXX`; nothing emitted.)
+    assert!(out.gps_samples().is_empty());
+  }
+
+  #[test]
+  fn process_text_rove_xor_aa_binary_block_decoded() {
+    // QuickTimeStream.pl:1175 — the BlueSkySea `\0\0..\xaa\xaa` cipher.
+    // Build a 282-byte buffer whose offset 8 starts with the XOR'd date
+    // "20190820" (0x32 ^ 0xaa = 0x98 etc.). We construct the plaintext and
+    // XOR it back to ciphertext.
+    let mut data = vec![0u8; 282];
+    // BlueSkySea sig: leading `\0\0..\xaa\xaa` at offset 4..6.
+    data[4] = 0xaa;
+    data[5] = 0xaa;
+    // Encrypted date+time `20190820075157` at offset 8.
+    for (i, &c) in b"20190820075157".iter().enumerate() {
+      data[8 + i] = c ^ 0xaa;
+    }
+    // Latitude `N48515873` at offset 38 (9 bytes).
+    for (i, &c) in b"N48515873".iter().enumerate() {
+      data[38 + i] = c ^ 0xaa;
+    }
+    // Longitude `E002197769` at offset 47 (10 bytes).
+    for (i, &c) in b"E002197769".iter().enumerate() {
+      data[47 + i] = c ^ 0xaa;
+    }
+    // Altitude `+0031` at offset 0x39 (5 bytes).
+    for (i, &c) in b"+0031".iter().enumerate() {
+      data[0x39 + i] = c ^ 0xaa;
+    }
+    // Speed `045` at offset 0x3e (3 bytes).
+    for (i, &c) in b"045".iter().enumerate() {
+      data[0x3e + i] = c ^ 0xaa;
+    }
+    let mut out = QuickTimeStreamMeta::new();
+    process_text(&data, &mut out);
+    assert_eq!(out.gps_samples().len(), 1);
+    let s = &out.gps_samples()[0];
+    assert!(s.date_time().unwrap().contains("2019:08:20 07:51:57"));
+    assert!((s.latitude().unwrap() - (48.0 + 515873.0 / 600000.0)).abs() < 1e-4);
+    assert!((s.longitude().unwrap() - (2.0 + 197769.0 / 600000.0)).abs() < 1e-4);
+    assert_eq!(s.altitude_m(), Some(31.0));
+    assert_eq!(s.speed_kph(), Some(45.0));
+  }
+
+  // ─── ProcessFMAS (Vantrue N2S) ────────────────────────────────────────
+
+  #[test]
+  fn process_fmas_decodes_synthetic_record() {
+    // QuickTimeStream.pl:3580-3609. Build a 160-byte sample matching the
+    // bundled `^FMAS\0{4}.{72}SAMM.{36}A/s` regex with placed fields.
+    let mut d = vec![0u8; 160];
+    d[0..8].copy_from_slice(b"FMAS\0\0\0\0");
+    d[80..84].copy_from_slice(b"SAMM");
+    d[120] = b'A';
+    // Date/time block at 0x60: yr=2025 LE u16, mon=6, day=15, hr=14, min=30, sec=45.
+    d[0x60..0x62].copy_from_slice(&2025u16.to_le_bytes());
+    d[0x62] = 6;
+    d[0x63] = 15;
+    d[0x64] = 14;
+    d[0x65] = 30;
+    d[0x66] = 45;
+    // Markers at 0x78..0x7a (AWN): A E N => longitude E, latitude N
+    d[0x78] = b'A';
+    d[0x79] = b'E'; // E/W
+    d[0x7a] = b'N'; // N/S
+    // Longitude: deg=8, min=30, frac=600 → 30.1 minutes
+    d[0x7b] = 8;
+    d[0x7c] = 30;
+    d[0x7d] = 0; // padding zero byte
+    d[0x7e..0x80].copy_from_slice(&600u16.to_le_bytes());
+    // Latitude: deg=47, min=37, frac=4200 → 37.7 minutes
+    d[0x80] = 47;
+    d[0x81] = 37;
+    d[0x82..0x84].copy_from_slice(&4200u16.to_le_bytes());
+    // Speed=50 mph, track=180
+    d[0x84..0x86].copy_from_slice(&50u16.to_le_bytes());
+    d[0x86..0x88].copy_from_slice(&180u16.to_le_bytes());
+    // Acceleration X/Y/Z f32 at 0x6c
+    d[0x6c..0x70].copy_from_slice(&0.1f32.to_le_bytes());
+    d[0x70..0x74].copy_from_slice(&0.2f32.to_le_bytes());
+    d[0x74..0x78].copy_from_slice(&0.3f32.to_le_bytes());
+    let mut out = QuickTimeStreamMeta::new();
+    process_fmas(&d, &mut out);
+    assert_eq!(out.gps_samples().len(), 1);
+    let s = &out.gps_samples()[0];
+    // Lat = 47 + (37 + 4200/6000)/60 ≈ 47.628333
+    let want_lat = 47.0 + (37.0 + 4200.0 / 6000.0) / 60.0;
+    assert!((s.latitude().unwrap() - want_lat).abs() < 1e-6);
+    // Lon = 8 + (30 + 600/6000)/60
+    let want_lon = 8.0 + (30.0 + 600.0 / 6000.0) / 60.0;
+    assert!((s.longitude().unwrap() - want_lon).abs() < 1e-6);
+    assert!(s.date_time().unwrap().contains("2025:06:15 14:30:45"));
+    // 50 mph * 1.60934 = 80.467 kph
+    assert!((s.speed_kph().unwrap() - 80.467).abs() < 0.01);
+    assert_eq!(s.track(), Some(180.0));
+    assert!(s.accelerometer().is_some());
+  }
+
+  #[test]
+  fn process_fmas_short_or_invalid_signature_emits_nothing() {
+    let mut out = QuickTimeStreamMeta::new();
+    process_fmas(&[0u8; 100], &mut out); // too short
+    assert!(out.gps_samples().is_empty());
+    let mut d = vec![0u8; 160];
+    d[0..4].copy_from_slice(b"FFFF"); // wrong sig
+    process_fmas(&d, &mut out);
+    assert!(out.gps_samples().is_empty());
+  }
+
+  // ─── ProcessWolfbox (G900 / Redtiger F9 4K) ───────────────────────────
+
+  #[test]
+  fn process_wolfbox_decodes_synthetic_record() {
+    // QuickTimeStream.pl:3615-3676. 0xf8-byte minimum.
+    let mut d = vec![0u8; 0x100];
+    // Date u32 LE at 0x68/0x6c/0x70 = day=15, mon=6, yr=2025.
+    d[0x68..0x6c].copy_from_slice(&15u32.to_le_bytes());
+    d[0x6c..0x70].copy_from_slice(&6u32.to_le_bytes());
+    d[0x70..0x74].copy_from_slice(&2025u32.to_le_bytes());
+    // Time u32 LE at 0xa0/0xa4/0xa8 = hr=14, min=30, sec=45.
+    d[0xa0..0xa4].copy_from_slice(&14u32.to_le_bytes());
+    d[0xa4..0xa8].copy_from_slice(&30u32.to_le_bytes());
+    d[0xa8..0xac].copy_from_slice(&45u32.to_le_bytes());
+    // Speed value/div (knots * 1000): 25.5 → val 25500, div 1000
+    d[0x48..0x50].copy_from_slice(&25500i64.to_le_bytes());
+    d[0x50..0x58].copy_from_slice(&1000i64.to_le_bytes());
+    // Track val/div: 90.0 → 9000 / 100
+    d[0x58..0x60].copy_from_slice(&9000i64.to_le_bytes());
+    d[0x60..0x68].copy_from_slice(&100i64.to_le_bytes());
+    // Lat val/div: 4737.7053 in DDDMM.MMMM scaled by 1e4 → 47377053 / 10000
+    d[0xb0..0xb8].copy_from_slice(&47377053i64.to_le_bytes());
+    d[0xb8..0xc0].copy_from_slice(&10000i64.to_le_bytes());
+    // Lon val/div: 822.5076 (DDDMM.MMMM for 8°22.5076') → 8225076 / 10000
+    d[0xc0..0xc8].copy_from_slice(&8225076i64.to_le_bytes());
+    d[0xc8..0xd0].copy_from_slice(&10000i64.to_le_bytes());
+    // Alt val/div: 412.5 → 4125 / 10
+    d[0xe8..0xf0].copy_from_slice(&4125i64.to_le_bytes());
+    d[0xf0..0xf8].copy_from_slice(&10i64.to_le_bytes());
+    let mut out = QuickTimeStreamMeta::new();
+    process_wolfbox(&d, &mut out);
+    assert_eq!(out.gps_samples().len(), 1);
+    let s = &out.gps_samples()[0];
+    // ConvertLatLon(4737.7053) = 47 + 37.7053/60 ≈ 47.628421
+    assert!((s.latitude().unwrap() - 47.628421).abs() < 1e-4);
+    // ConvertLatLon(822.5076) = 8 + 22.5076/60 ≈ 8.375127
+    assert!((s.longitude().unwrap() - (8.0 + 22.5076 / 60.0)).abs() < 1e-4);
+    assert_eq!(s.altitude_m(), Some(412.5));
+    // 25.5 knots * 1.852 = 47.226
+    assert!((s.speed_kph().unwrap() - 47.226).abs() < 0.01);
+    assert_eq!(s.track(), Some(90.0));
+    assert!(s.date_time().unwrap().contains("2025:06:15 14:30:45"));
+  }
+
+  #[test]
+  fn process_wolfbox_too_short_emits_nothing() {
+    let mut out = QuickTimeStreamMeta::new();
+    process_wolfbox(&[0u8; 100], &mut out);
+    assert!(out.gps_samples().is_empty());
+  }
+
+  // ─── detect_wolfbox (Condition cascade) ───────────────────────────────
+
+  #[test]
+  fn detect_wolfbox_matches_hyth_marker() {
+    // Bundled regex branch A: 16 ASCII '0' + 4 uppercase chars.
+    let mut d = vec![0u8; 200];
+    for i in 0..16 {
+      d[136 + i] = b'0';
+    }
+    d[152..156].copy_from_slice(b"HYTH");
+    assert!(detect_wolfbox(&d));
+  }
+
+  #[test]
+  fn detect_wolfbox_matches_redtiger_marker() {
+    // Branch B: literal `https://www.redtiger\0`.
+    let mut d = vec![0u8; 200];
+    d[136..157].copy_from_slice(b"https://www.redtiger\0");
+    assert!(detect_wolfbox(&d));
+  }
+
+  #[test]
+  fn detect_wolfbox_rejects_wrong_marker() {
+    let d = vec![0u8; 200];
+    assert!(!detect_wolfbox(&d));
+  }
+
+  // ─── dispatch_gpmd (Condition cascade) ────────────────────────────────
+
+  #[test]
+  fn dispatch_gpmd_routes_kingslim_to_ligogps() {
+    // A faithful Kingslim D4 `gpmd` sample (QuickTimeStream.pl:1874-1888):
+    //   * Condition signature `^.{21}\0\0\0A[NS][EW]` — `\0\0\0` at 21..24,
+    //     `A` at 24, `N` at 25, `W` at 26 (the variant IDENTIFIER only).
+    //   * `LIGOGPSINFO\0` at offset 0x50 (80) — the GPSType-5 fingerprint
+    //     (`.{80}LIGOGPSINFO\0` alternative), routing to `ProcessLigoGPS`.
+    //   * a plain-ASCII LigoGPS record at 0x50+0x14 (100) — `####`-free path
+    //     (LigoGPS.pm:303-307, `^.{4}\d{4}/\d{2}/\d{2} `), flags 0x03 so no
+    //     decryption / no fuzz. The `A`-at-24 raw lat/lon is the
+    //     COMMENTED-OUT secondary (lines 1890-1904) — NOT decoded.
+    // Length must be >= 0x50 + 0x84 = 212 for the Type-5 detector AND
+    // >= 100 + 0x84 = 232 for the record walk; use 240.
+    let mut d = vec![0u8; 240];
+    d[24] = b'A';
+    d[25] = b'N';
+    d[26] = b'W';
+    d[80..92].copy_from_slice(b"LIGOGPSINFO\0");
+    // Plain-ASCII record at offset 100: 4-byte counter + `YYYY/MM/DD ...`.
+    let mut rec = Vec::new();
+    rec.extend_from_slice(&[0, 0, 0, 0]); // counter (consumed by `.{4}`)
+    rec.extend_from_slice(b"2024/01/15 10:00:00 N:45.5 E:170.5 30.0");
+    d.get_mut(100..100 + rec.len())
+      .expect("fixture room for record")
+      .copy_from_slice(&rec);
+
+    let mut out = QuickTimeStreamMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut state = FreeGpsState::new();
+    let matched = dispatch_gpmd(&d, &mut out, &mut lg, &mut state);
+    assert!(matched, "Kingslim Condition should match");
+    // Route reached the GPSType-5 / LigoGPS arm AND decoded the record into
+    // the LigoGPS accumulator (NOT GPSType-14/XBHT, NOT the Type-3/4 freeGPS
+    // arm — those would leave `lg` empty / push to `out`).
+    let s = lg
+      .samples()
+      .first()
+      .expect("Kingslim must decode via GPSType-5 LigoGPS");
+    // N: / E: with magnitudes < 100 ⇒ no DDMM conversion, positive refs.
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+    assert_eq!(s.date_time(), Some("2024:01:15 10:00:00"));
+    // The Kingslim `ProcessFreeGPS` sets `$$et{FoundEmbedded}`
+    // (QuickTimeStream.pl:1650) on the WALK-LEVEL state, suppressing the later
+    // brute-force `mdat` scan.
+    assert!(
+      state.found_embedded(),
+      "Kingslim must set FoundEmbedded on the threaded walk state"
+    );
+  }
+
+  #[test]
+  fn process_free_gps_ligogps_arm_is_binary_only() {
+    // The freeGPS GPSType-5 arm is `LIGOGPSINFO\0` (binary) ONLY
+    // (QuickTimeStream.pl:1843 `/^(.{16}|.{48}|.{80})LIGOGPSINFO\0/`). ExifTool
+    // routes the JSON `LIGOGPSINFO {` form solely through the `udta` `LigoJSON`
+    // Condition (QuickTime.pm:835), NEVER through this freeGPS arm. A JSON
+    // `LIGOGPSINFO {` placed at a freeGPS offset must therefore decode NOTHING
+    // here (the 12th byte is a space, not `\0`, so `detect_type5_ligogps` fails).
+    let json = br#"LIGOGPSINFO {"status": "A", "NS": "N", "EW": "W", "Latitude": "12.5", "Longitude": "34.5"}"#;
+    let mut block = vec![0u8; 16];
+    block[4..12].copy_from_slice(b"freeGPS ");
+    block.extend_from_slice(json);
+    block.resize(block.len().max(96), 0);
+
+    let mut out = QuickTimeStreamMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut state = FreeGpsState::new();
+    process_free_gps(
+      &block,
+      None,
+      None,
+      None,
+      &mut state,
+      &mut out,
+      Some(&mut lg),
+    );
+
+    assert!(
+      lg.samples().is_empty(),
+      "JSON LIGOGPSINFO must NOT decode via the binary freeGPS arm"
+    );
+  }
+
+  #[test]
+  fn dispatch_gpmd_routes_rove_to_process_text() {
+    let mut d = vec![0u8; 300];
+    d[0..8].copy_from_slice(&[0x00, 0x00, 0xf2, 0xe1, 0xf0, 0xee, 0x54, 0x54]);
+    let mut out = QuickTimeStreamMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut state = FreeGpsState::new();
+    assert!(dispatch_gpmd(&d, &mut out, &mut lg, &mut state));
+    // `Process_text` does NOT set `$$et{FoundEmbedded}` — leave it clear.
+    assert!(!state.found_embedded());
+  }
+
+  #[test]
+  fn dispatch_gpmd_routes_fmas() {
+    let mut d = vec![0u8; 160];
+    d[0..8].copy_from_slice(b"FMAS\0\0\0\0");
+    d[80..84].copy_from_slice(b"SAMM");
+    d[120] = b'A';
+    let mut out = QuickTimeStreamMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut state = FreeGpsState::new();
+    assert!(dispatch_gpmd(&d, &mut out, &mut lg, &mut state));
+    // `ProcessFMAS` does NOT set `$$et{FoundEmbedded}` — leave it clear.
+    assert!(!state.found_embedded());
+  }
+
+  #[test]
+  fn dispatch_gpmd_routes_wolfbox() {
+    let mut d = vec![0u8; 0x100];
+    for i in 0..16 {
+      d[136 + i] = b'0';
+    }
+    d[152..156].copy_from_slice(b"HYTH");
+    // Provide valid date/time so the parse doesn't bail.
+    d[0x68..0x6c].copy_from_slice(&15u32.to_le_bytes());
+    d[0x6c..0x70].copy_from_slice(&6u32.to_le_bytes());
+    d[0x70..0x74].copy_from_slice(&2025u32.to_le_bytes());
+    d[0xa0..0xa4].copy_from_slice(&14u32.to_le_bytes());
+    d[0xa4..0xa8].copy_from_slice(&30u32.to_le_bytes());
+    d[0xa8..0xac].copy_from_slice(&45u32.to_le_bytes());
+    // Lat val=0 / div=1 → ConvertLatLon(0)=0; OK for routing test.
+    d[0xb8..0xc0].copy_from_slice(&1i64.to_le_bytes());
+    d[0xc8..0xd0].copy_from_slice(&1i64.to_le_bytes());
+    d[0x50..0x58].copy_from_slice(&1i64.to_le_bytes());
+    d[0x60..0x68].copy_from_slice(&1i64.to_le_bytes());
+    d[0xf0..0xf8].copy_from_slice(&1i64.to_le_bytes());
+    let mut out = QuickTimeStreamMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut state = FreeGpsState::new();
+    assert!(dispatch_gpmd(&d, &mut out, &mut lg, &mut state));
+    // `ProcessWolfbox` does NOT set `$$et{FoundEmbedded}` — leave it clear.
+    assert!(!state.found_embedded());
+  }
+
+  #[test]
+  fn dispatch_gpmd_returns_false_for_gopro_fallback() {
+    // No marker matches → caller routes to GoPro KLV walker.
+    let d = vec![0u8; 256];
+    let mut out = QuickTimeStreamMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut state = FreeGpsState::new();
+    assert!(!dispatch_gpmd(&d, &mut out, &mut lg, &mut state));
+    assert!(!state.found_embedded());
+  }
+
+  // ─── NMEA helpers ─────────────────────────────────────────────────────
+
+  #[test]
+  fn read_dddmm_splits_degrees_and_minutes() {
+    // "4721.35197" — degrees=47, minutes=21.35197
+    let s = b"4721.35197";
+    let mut p = 0;
+    let (d, m) = read_dddmm(s, &mut p).expect("parse ok");
+    assert_eq!(d, 47.0);
+    assert!((m - 21.35197).abs() < 1e-6);
+    assert_eq!(p, 10);
+  }
+
+  #[test]
+  fn read_dddmm_handles_three_digit_degrees() {
+    let s = b"12009.901";
+    let mut p = 0;
+    let (d, m) = read_dddmm(s, &mut p).expect("parse ok");
+    assert_eq!(d, 120.0);
+    assert!((m - 9.901).abs() < 1e-6);
+  }
+
+  #[test]
+  fn read_dddmm_handles_one_digit_minutes_prefix() {
+    let s = b"08.5";
+    let mut p = 0;
+    let (d, m) = read_dddmm(s, &mut p).expect("parse ok");
+    assert_eq!(d, 0.0);
+    assert!((m - 8.5).abs() < 1e-6);
+  }
+
+  #[test]
+  fn dollar_records_iterates_multiple_sentences() {
+    let s = "$GPRMC,1,A,2,N,3,E,4,5,210625\n$GPGGA,1,2,N,3,E,1";
+    let recs: Vec<_> = DollarRecords::new(s).collect();
+    assert_eq!(recs.len(), 2);
+    assert_eq!(recs[0].0, "GPRMC");
+    assert_eq!(recs[1].0, "GPGGA");
+  }
+
+  #[test]
+  fn dollar_records_skips_garbage_dollar_sign() {
+    let s = "$$$$$GPRMC,1";
+    let recs: Vec<_> = DollarRecords::new(s).collect();
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0].0, "GPRMC");
   }
 }

--- a/src/formats/quicktime_stream.rs
+++ b/src/formats/quicktime_stream.rs
@@ -74,7 +74,7 @@ use alloc::{
 use crate::{
   datetime::{convert_datetime, convert_unix_time},
   formats::quicktime_freegps::{self, FreeGpsState},
-  metadata::{GpsSample, MebxSample, QuickTimeStreamMeta},
+  metadata::{GpsSample, MebxSample, ParrotMeta, QuickTimeStreamMeta},
 };
 
 /// QuickTime epoch offset: seconds between 1904-01-01 and 1970-01-01.
@@ -1673,6 +1673,12 @@ struct StreamTrack {
   /// `stsd` MetaFormat — the sample-description format code
   /// (QuickTime.pm:7765-7768).
   meta_format: [u8; 4],
+  /// `stsd` MetaType — the `(application/...)` substring extracted from
+  /// the sample-description entry bytes per QuickTime.pm:7769-7774. Empty
+  /// when no `application/...` string was present. Used by the `mett`
+  /// MetaFormat dispatch to switch the Parrot walker between ARCore-TLV
+  /// and drone-`[EP]\d` modes (Parrot.pm:802-822 vs :823-852).
+  meta_type: alloc::string::String,
   /// `mdhd` MediaTimeScale.
   media_ts: u32,
   /// The `stbl` sample tables.
@@ -1708,11 +1714,14 @@ fn process_samples(
   track: &StreamTrack,
   track_index: u32,
   create_date_raw: Option<u64>,
+  free_gps_state: &mut FreeGpsState,
   out: &mut QuickTimeStreamMeta,
   gopro_out: &mut crate::metadata::GoProMeta,
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
+  parrot_out: &mut ParrotMeta,
+  ligogps_out: &mut crate::metadata::LigoGpsMeta,
 ) -> bool {
   let samples = match expand_samples(&track.ee, track.media_ts) {
     Some(s) => s,
@@ -1749,11 +1758,14 @@ fn process_samples(
       track_index,
       sample,
       create_date_raw,
+      free_gps_state,
       out,
       gopro_out,
       camm_out,
       sony_rtmd_out,
       canon_ctmd_out,
+      parrot_out,
+      &mut *ligogps_out,
     );
   }
   found_embedded
@@ -1763,51 +1775,28 @@ fn process_samples(
 /// the dispatch arms of QuickTimeStream.pl:1467-1578.
 ///
 /// Returns `true` iff the sample ENTERED the GoPro GPMF processor — i.e. a
-/// non-deferred `gpmd` sample — mirroring ExifTool's `$$et{FoundEmbedded} = 1`
-/// set on `ProcessGoPro` entry (GoPro.pm:822), which fires before the KLV loop
-/// and so is independent of extraction success. A deferred `gpmd` variant
-/// (Kingslim/Rove/FMAS/Wolfbox) and the `mebx`/other paths set no
-/// `FoundEmbedded`.
+/// `gpmd` sample that matched no dashcam variant `Condition` and so fell
+/// through to the no-`Condition` `gpmd_GoPro` fallback — mirroring ExifTool's
+/// `$$et{FoundEmbedded} = 1` set on `ProcessGoPro` entry (GoPro.pm:822), which
+/// fires before the KLV loop and so is independent of extraction success. A
+/// matched `gpmd` variant (Kingslim/Rove/FMAS/Wolfbox, decoded in-place via
+/// [`crate::formats::quicktime_freegps::dispatch_gpmd`]) and the `mebx`/other
+/// paths set no `FoundEmbedded`.
 #[must_use]
-/// The non-GoPro `gpmd` MetaFormat variants (QuickTimeStream.pl:181-208):
-/// Kingslim / Rove / FMAS / Wolfbox. Each matches a leading-byte `Condition`
-/// and routes to a processor this port DEFERS (the brute-force `mdat` scan
-/// recovers them instead), so a matching `gpmd` sample must not be dispatched
-/// to the GoPro KLV walker nor set `FoundEmbedded`. Byte-checks use the
-/// checked `.get` form (file-level `deny(indexing_slicing)`).
-fn is_deferred_gpmd_variant(buff: &[u8]) -> bool {
-  // gpmd_Kingslim: `/^.{21}\0\0\0A[NS][EW]/s` (QuickTimeStream.pl:182-184).
-  let kingslim = buff.get(21..24) == Some(&[0, 0, 0][..])
-    && buff.get(24) == Some(&b'A')
-    && matches!(buff.get(25), Some(b'N' | b'S'))
-    && matches!(buff.get(26), Some(b'E' | b'W'));
-  // gpmd_Rove: `/^\0\0\xf2\xe1\xf0\xeeTT/` (QuickTimeStream.pl:189-191).
-  let rove = buff.get(0..8) == Some(&[0x00, 0x00, 0xf2, 0xe1, 0xf0, 0xee, b'T', b'T'][..]);
-  // gpmd_FMAS: `/^FMAS\0\0\0\0/` (QuickTimeStream.pl:196-198).
-  let fmas = buff.get(0..8) == Some(b"FMAS\0\0\0\0".as_slice());
-  // gpmd_Wolfbox: `/^.{136}(0{16}[A-Z]{4}|https:\/\/www.redtiger\0)/s`
-  // (QuickTimeStream.pl:203-205).
-  let wolfbox = (buff
-    .get(136..152)
-    .is_some_and(|s| s.iter().all(|&b| b == b'0'))
-    && buff
-      .get(152..156)
-      .is_some_and(|s| s.iter().all(|&b| b.is_ascii_uppercase())))
-    || buff.get(136..157) == Some(b"https://www.redtiger\0".as_slice());
-  kingslim || rove || fmas || wolfbox
-}
-
 fn decode_one_sample(
   buff: &[u8],
   track: &StreamTrack,
   track_index: u32,
   sample: &Sample,
   create_date_raw: Option<u64>,
+  free_gps_state: &mut FreeGpsState,
   out: &mut QuickTimeStreamMeta,
   gopro_out: &mut crate::metadata::GoProMeta,
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
+  parrot_out: &mut ParrotMeta,
+  ligogps_out: &mut crate::metadata::LigoGpsMeta,
 ) -> bool {
   // The `mebx` MetaFormat (QuickTimeStream.pl:174-180) — Apple timed
   // metadata via the `keys` table. `FoundSomething` records the per-`Doc<N>`
@@ -1890,38 +1879,51 @@ fn decode_one_sample(
     return false;
   }
   // The `gpmd` MetaFormat (QuickTimeStream.pl:181-212) — five condition-
-  // dispatched variants. The fallback (no other Condition matches) is
-  // `gpmd_GoPro`, whose SubDirectory routes the sample bytes into
-  // `Image::ExifTool::GoPro::GPMF`. exifast's GoPro KLV parser is
-  // [`crate::formats::gopro::process_gopro`]. The Kingslim / Rove / FMAS /
-  // Wolfbox variants re-dispatch into ProcessFreeGPS / Process_text /
-  // ProcessFMAS / ProcessWolfbox — DEFERRED at the `gpmd` dispatch level
-  // (the brute-force `mdat` scan already locates Kingslim/Rove/FMAS records
-  // when they're stored in `free`/`mdat` rather than as `gpmd` samples).
+  // dispatched variants. exifast's dispatch mirrors the bundled Condition
+  // cascade in [`crate::formats::quicktime_freegps::dispatch_gpmd`]: the
+  // Kingslim D4 dashcam, Rove Stealth 4K, Vantrue N2S (FMAS), and Wolfbox
+  // G900 / Redtiger F9 4K branches feed the typed [`GpsSample`] vector via
+  // [`crate::formats::quicktime_freegps`]; the unmatched fallback routes
+  // through the GoPro KLV walker
+  // (`Image::ExifTool::GoPro::GPMF`).
   if &track.meta_format == b"gpmd" {
     // QuickTimeStream.pl:181-212 is an ORDERED `Condition` list: Kingslim /
     // Rove / FMAS / Wolfbox each match a leading-byte signature and route to a
     // deferred non-GoPro processor (ProcessFreeGPS / Process_text / ProcessFMAS
     // / ProcessWolfbox); only the no-`Condition` `gpmd_GoPro` fallback reaches
-    // `GoPro::GPMF`. A deferred variant must NOT be parsed as GoPro and must
-    // NOT set `FoundEmbedded` — otherwise its printable FourCC (e.g. `FMAS`)
-    // would be mistaken for a GoPro record and suppress the brute-force `mdat`
-    // scan that actually recovers these records. Mirror the ordered dispatch:
-    // skip a deferred signature, fall through to GoPro only otherwise.
-    if is_deferred_gpmd_variant(buff) {
+    // `GoPro::GPMF`. Decode a matching dashcam variant in-place (the bundled
+    // Condition cascade routes it to its process-proc HERE, during
+    // `ProcessSamples`, not via the later `ScanMediaData` brute-force scan);
+    // fall through to the GoPro KLV walker only when no signature matched.
+    if crate::formats::quicktime_freegps::dispatch_gpmd(buff, out, ligogps_out, free_gps_state) {
+      // A matched dashcam variant is NOT the GoPro GPMF path, so do not set the
+      // GoPro `FoundEmbedded` flag (return `false`). This matches bundled for
+      // Rove (`Process_text`), FMAS (`ProcessFMAS`) and Wolfbox
+      // (`ProcessWolfbox`) — none of those set `$$et{FoundEmbedded}`.
+      //
+      // The Kingslim branch routes to GPSType-5 / `ProcessLigoGPS` (the
+      // `.{80}LIGOGPSINFO` arm, QuickTimeStream.pl:1843-1888) via
+      // `process_free_gps`, which is the bundled `gpmd_Kingslim` process-proc
+      // `ProcessFreeGPS` and sets `$$et{FoundEmbedded} = 1`
+      // (QuickTimeStream.pl:1650). The WALK-LEVEL `free_gps_state` is threaded
+      // into `dispatch_gpmd`, so that flag reaches `extract_stream` and
+      // suppresses the brute-force `mdat` re-scan (QuickTimeStream.pl:3689) — a
+      // real Kingslim file plus stray `freeGPS`-looking `mdat` bytes no longer
+      // double-emits. (The `return false` here is only the GoPro `FoundEmbedded`
+      // channel; the Kingslim `FoundEmbedded` rides `free_gps_state`.)
       return false;
     }
     // The `gpmd_GoPro` fallback — the KLV walker. Run it for EXTRACTION, but
     // the `FoundEmbedded` side-effect is decoupled from extraction success:
     // ExifTool sets `$$et{FoundEmbedded} = 1` on ENTRY to `ProcessGoPro`
     // (GoPro.pm:822), BEFORE the KLV record loop (:831), so it fires for EVERY
-    // non-deferred `gpmd` sample — even one whose payload is zero-filled,
+    // non-variant `gpmd` sample — even one whose payload is zero-filled,
     // truncated, or otherwise extracts nothing. Because `gpmd_GoPro` is the
-    // no-`Condition` fallback (QuickTimeStream.pl:209-212), a non-deferred
-    // `gpmd` sample ALWAYS enters `ProcessGoPro`, so `FoundEmbedded` is always
-    // set ⇒ `ScanMediaData` returns early (QuickTimeStream.pl:3689). Returning
-    // the walker's recognition bool instead would let a corrupt-but-
-    // non-deferred `gpmd` sample leave `FoundEmbedded` unset, and the later
+    // no-`Condition` fallback (QuickTimeStream.pl:209-212), a `gpmd` sample
+    // that matched no variant ALWAYS enters `ProcessGoPro`, so `FoundEmbedded`
+    // is always set ⇒ `ScanMediaData` returns early (QuickTimeStream.pl:3689).
+    // Returning the walker's recognition bool instead would let a corrupt-but-
+    // non-variant `gpmd` sample leave `FoundEmbedded` unset, and the later
     // brute-force `mdat` scan would emit extra GP6/freeGPS tags ExifTool skips.
     // So: extract via the walker, but report `true` UNCONDITIONALLY.
     let _extracted = crate::formats::gopro::process_gopro(buff, gopro_out);
@@ -2032,16 +2034,59 @@ fn decode_one_sample(
     }
     return false;
   }
+  // Parrot `mett` MetaFormat (QuickTimeStream.pl:312-315 — the SubDirectory
+  // route into `Image::ExifTool::Parrot::mett` whose PROCESS_PROC is
+  // `Parrot::Process_mett`). Drone metadata samples (Parrot.pm:23-84)
+  // dispatch by 2-char ID `[EP]\d` to per-version V1/V2/V3 binary tables;
+  // ARCore phone-camera variants dispatch by `MetaType` (an `application/
+  // arcore-*` string extracted from the `stsd` entry by QuickTime.pm:7769-
+  // 7774). `process_mett` carries both walker shapes.
+  //
+  // `ProcessSamples` opens ONE `Doc<N>` per timed sample (`FoundSomething`),
+  // then `Process_mett` `HandleTag`s every record (the P-record GPS + flight
+  // fields, and any concat'd E1 TimeStamp) under it — so all of a sample's tags
+  // share one document (QuickTimeStream.pl:1517-1523; `Process_mett` never bumps
+  // the doc). Mirror the `rtmd` / `CTMD` arms: open the GLOBAL doc (the shared
+  // stream counter, so the ordinal continues across the file's mebx/camm/rtmd/
+  // CTMD/SP3 sources), decode the sample, and stamp that `doc` + `Track<N>` + the
+  // sample-table SampleTime/SampleDuration onto exactly the records this decode
+  // produced (watermark `*_sample_count()` before the call). `Process_mett` does
+  // NOT set `$$et{FoundEmbedded}`, so this returns `false` (no `mdat`-scan
+  // suppression).
+  if &track.meta_format == b"mett" {
+    let meta_type = if track.meta_type.is_empty() {
+      None
+    } else {
+      Some(track.meta_type.as_str())
+    };
+    let gps_start = parrot_out.gps_sample_count();
+    let flight_start = parrot_out.flight_sample_count();
+    let follow_me_start = parrot_out.follow_me_sample_count();
+    let automation_start = parrot_out.automation_sample_count();
+    let doc = out.open_doc();
+    crate::formats::parrot::process_mett(buff, meta_type, parrot_out);
+    parrot_out.stamp_doc_from(
+      gps_start,
+      flight_start,
+      follow_me_start,
+      automation_start,
+      doc,
+      track_index,
+      sample.time,
+      sample.dur,
+    );
+    return false;
+  }
   // NOTE: a real `gps `-HandlerType track is NOT dispatched here — it never
   // reaches `process_samples` ([`is_meta_handler`] excludes `gps `, faithful
   // to ExifTool having no `$eeBox{'gps '}`). The Novatek `gps ` source is the
   // EMPTY-HandlerType `moov`-level box ([`process_moov_gps_box`]), not a track.
   //
-  // Sony `rtmd` / Canon `CTMD` / `tx3g` / …:
-  // DEFERRED — these re-dispatch into other ExifTool modules (Sony.pm,
-  // Canon.pm) or the 850-line ProcessFreeGPS. See module docs +
-  // docs/tracking.md. An unrecognized MetaFormat yields no samples, exactly
-  // as ExifTool's "Unknown $type format" branch (QuickTimeStream.pl:1547).
+  // `tx3g` / …:
+  // DEFERRED — these re-dispatch into other ExifTool modules or the 850-line
+  // ProcessFreeGPS. See module docs + docs/tracking.md. An unrecognized
+  // MetaFormat yields no samples, exactly as ExifTool's "Unknown $type
+  // format" branch (QuickTimeStream.pl:1547).
   let _ = (buff, &track.handler);
   false
 }
@@ -2170,6 +2215,22 @@ fn walk_stsd(data: &[u8], track: &mut StreamTrack) {
     {
       track.meta_format = fmt;
     }
+    // QuickTime.pm:7769-7774 — MetaType is decoded by the per-entry `RawConv`
+    // `$$self{MetaType} = ($val=~/(application[^\0]+)/ ? $1 : undef)` against the
+    // SampleDescription entry bytes starting at offset 8. The assignment runs on
+    // EVERY entry (last-wins) and SETS THE RESULT — including `undef` (clearing
+    // it) when the entry carries no `application/...` run. Faithful: assign
+    // unconditionally per entry, so an earlier `application/arcore-*` entry does
+    // NOT leak its MetaType into a later entry that lacks one (which would make
+    // the Parrot `mett` walker wrongly take the ARCore-TLV path). Mirrors
+    // `meta_format` (also last-wins). A size-8..15 entry has the field absent;
+    // `scan_application_string` over the (possibly empty) body yields "" =
+    // ExifTool's `undef` clear, faithful to the regex matching nothing.
+    if let Some(entry_body) = pos.checked_add(8).and_then(|s| data.get(s..entry_end)) {
+      track.meta_type = scan_application_string(entry_body);
+    } else {
+      track.meta_type = alloc::string::String::new();
+    }
     // Child atoms (the `keys` table) follow the 16-byte SampleDescription
     // header — only present when the entry is large enough to hold them.
     if size >= 16
@@ -2196,6 +2257,33 @@ fn walk_stsd(data: &[u8], track: &mut StreamTrack) {
     pos = entry_end;
   }
   track.meta_keys = merged_keys;
+}
+
+/// QuickTime.pm:7773 — extract the first `application/...` substring
+/// from a `stsd` sample-description entry body, terminated by NUL or
+/// end-of-buffer. Returns an empty string when no match is found.
+/// Faithful: the bundled regex `(application[^\0]+)` matches greedily
+/// from the first occurrence of `"application"` up to (but not
+/// including) the first `\0` byte after that point.
+fn scan_application_string(bytes: &[u8]) -> alloc::string::String {
+  const NEEDLE: &[u8] = b"application";
+  // Sliding window over `bytes` looking for `NEEDLE` (checked via
+  // `windows` so a too-short buffer simply yields no match).
+  let Some(i) = bytes.windows(NEEDLE.len()).position(|w| w == NEEDLE) else {
+    return alloc::string::String::new();
+  };
+  // Run forward from the match start until NUL or end.
+  let mut end = i + NEEDLE.len();
+  while bytes.get(end).is_some_and(|&b| b != 0) {
+    end += 1;
+  }
+  // Faithful to Perl: the regex matches the entire `application[^\0]+`
+  // run as one capture. Stay UTF-8-lossy-tolerant (the typed layer
+  // matches against the byte content via `is_arcore_meta_type`).
+  bytes
+    .get(i..end)
+    .map(|m| alloc::string::String::from_utf8_lossy(m).into_owned())
+    .unwrap_or_default()
 }
 
 /// Walk one `trak`, collecting its `HandlerType`, `MediaTimeScale` and (when
@@ -2264,30 +2352,37 @@ fn walk_trak(data: &[u8], tr_start: usize, tr_end: usize) -> StreamTrack {
 /// freeGPS Type-17b Rexing scaling in [`quicktime_freegps::process_free_gps`]
 /// for the `moov`-level `gps ` offset-box path.
 ///
-/// Returns the decoded [`QuickTimeStreamMeta`] (empty for the common case of a
-/// video with no timed metadata) plus the `FoundEmbedded` flag. `FoundEmbedded`
-/// is `true` iff EITHER a `moov`-level `gps ` offset box dispatched a `freeGPS `
-/// block into [`quicktime_freegps::process_free_gps`] (ExifTool's
-/// `$$et{FoundEmbedded}`, QuickTimeStream.pl:1650) OR a GoPro source entered
-/// `ProcessGoPro` — a `gpmd` GoPro timed-metadata sample OR a `moov/udta/GPMF`
-/// atom (GoPro.pm:822 sets `$$et{FoundEmbedded} = 1` on entry, for both paths).
-/// The caller threads that flag into [`quicktime_freegps::scan_media_data`] so
-/// the brute-force `mdat` scan is suppressed by a real freeGPS decode or a
-/// dispatched GoPro source — NOT by a bare `gps0`/`gsen`/`GPS `/`3gf`/`mebx`
-/// timed-metadata sample (those set no `FoundEmbedded`, so a file carrying one
-/// of them PLUS a buried `freeGPS ` block is still scanned;
-/// QuickTimeStream.pl:967-973 vs :3689).
+/// Returns the `FoundEmbedded` flag, decoding into the caller-owned `out`
+/// [`QuickTimeStreamMeta`] (empty for the common case of a video with no timed
+/// metadata). `out` is passed in (not created here) so it can be created BEFORE
+/// the LigoGPS `udta`/trailer sources, which decode into a SEPARATE
+/// [`crate::metadata::LigoGpsMeta`] yet must continue the SAME global `Doc<N>`
+/// counter this struct owns (`$$et{DOC_COUNT}`); see
+/// [`QuickTimeStreamMeta::doc_counter`]. `FoundEmbedded` is `true` iff EITHER a
+/// `moov`-level `gps ` offset box dispatched a `freeGPS ` block into
+/// [`quicktime_freegps::process_free_gps`] (ExifTool's `$$et{FoundEmbedded}`,
+/// QuickTimeStream.pl:1650) OR a GoPro source entered `ProcessGoPro` — a `gpmd`
+/// GoPro timed-metadata sample OR a `moov/udta/GPMF` atom (GoPro.pm:822 sets
+/// `$$et{FoundEmbedded} = 1` on entry, for both paths). The caller threads that
+/// flag into [`quicktime_freegps::scan_media_data`] so the brute-force `mdat`
+/// scan is suppressed by a real freeGPS decode or a dispatched GoPro source —
+/// NOT by a bare `gps0`/`gsen`/`GPS `/`3gf`/`mebx` timed-metadata sample (those
+/// set no `FoundEmbedded`, so a file carrying one of them PLUS a buried
+/// `freeGPS ` block is still scanned; QuickTimeStream.pl:967-973 vs :3689).
+#[allow(clippy::too_many_arguments)]
 #[must_use]
 pub(crate) fn extract_stream(
   data: &[u8],
   create_date_raw: Option<u64>,
   kodak_version: Option<&str>,
+  out: &mut QuickTimeStreamMeta,
   gopro_out: &mut crate::metadata::GoProMeta,
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
-) -> (QuickTimeStreamMeta, bool) {
-  let mut out = QuickTimeStreamMeta::new();
+  parrot_out: &mut ParrotMeta,
+  ligogps_out: &mut crate::metadata::LigoGpsMeta,
+) -> bool {
   // The freeGPS `$$et{FreeGPS2}` cross-block ring-buffer state shared by the
   // `moov`-level `gps ` offset box (QuickTimeStream.pl:2058). It ALSO carries
   // `$$et{FoundEmbedded}` (QuickTimeStream.pl:1650), set iff a `gps `-box block
@@ -2318,11 +2413,13 @@ pub(crate) fn extract_stream(
           create_date_raw,
           kodak_version,
           &mut free_gps_state,
-          &mut out,
+          &mut *out,
           gopro_out,
           camm_out,
           sony_rtmd_out,
           canon_ctmd_out,
+          parrot_out,
+          ligogps_out,
         );
       }
       // Top-level DuDuBell / VSYS `gps0` (32-byte LE binary GPS records).
@@ -2332,13 +2429,13 @@ pub(crate) fn extract_stream(
       // decodes (it is processed without `-ee` ⇒ the no-`ee` first-fix path).
       b"gps0" => {
         let start = out.gps_sample_count();
-        process_gps0(data.get(ps..body_end).unwrap_or_default(), &mut out);
+        process_gps0(data.get(ps..body_end).unwrap_or_default(), &mut *out);
         out.stamp_gps_origin_from(start, crate::metadata::GpsOrigin::Gps0);
       }
       // Top-level DuDuBell / VSYS `gsen` (3-byte accelerometer triples).
       b"gsen" => {
         let start = out.gps_sample_count();
-        process_gsen(data.get(ps..body_end).unwrap_or_default(), &mut out);
+        process_gsen(data.get(ps..body_end).unwrap_or_default(), &mut *out);
         out.stamp_gps_origin_from(start, crate::metadata::GpsOrigin::Gsen);
       }
       // Top-level Kenwood `GPS ` (36-byte LE inline GPS records) — `-ee`-only
@@ -2349,7 +2446,7 @@ pub(crate) fn extract_stream(
         parse_kenwood_gps(
           data.get(ps..body_end).unwrap_or_default(),
           create_date_raw,
-          &mut out,
+          &mut *out,
         );
         out.stamp_gps_origin_from(start, crate::metadata::GpsOrigin::Kenwood);
         // Kenwood `++DOC_COUNT` per 36-byte record (QuickTimeStream.pl:2565):
@@ -2364,7 +2461,7 @@ pub(crate) fn extract_stream(
       // top-level magic box ExifTool processes without `-ee` ⇒ stamp `ThreeGf`.
       b"3gf " => {
         let start = out.gps_sample_count();
-        process_3gf(data.get(ps..body_end).unwrap_or_default(), &mut out);
+        process_3gf(data.get(ps..body_end).unwrap_or_default(), &mut *out);
         out.stamp_gps_origin_from(start, crate::metadata::GpsOrigin::ThreeGf);
       }
       _ => {}
@@ -2384,8 +2481,7 @@ pub(crate) fn extract_stream(
   // that also carries unreferenced GP6 trailer records is correctly NOT
   // re-scanned (already extracted via the sample / `udta/GPMF` path),
   // matching ExifTool.
-  let found_embedded = free_gps_state.found_embedded() || gopro_found_embedded;
-  (out, found_embedded)
+  free_gps_state.found_embedded() || gopro_found_embedded
 }
 
 /// Decode the `moov`-level Novatek `gps ` box — the offset TABLE that
@@ -2422,6 +2518,7 @@ fn process_moov_gps_box(
   kodak_version: Option<&str>,
   free_gps_state: &mut FreeGpsState,
   out: &mut QuickTimeStreamMeta,
+  ligogps_out: &mut crate::metadata::LigoGpsMeta,
 ) {
   // QuickTimeStream.pl:2544 `elsif ($tag eq 'gps ' and $dataLen > 8)`.
   if payload.len() <= 8 {
@@ -2458,6 +2555,11 @@ fn process_moov_gps_box(
     if buff.get(4..12) == Some(b"freeGPS ".as_slice()) {
       // QuickTimeStream.pl:1559-1564 — `ProcessFreeGPS` with `SampleTime =>
       // $time[$i]`, which is `undef` for this box (no `stts`); see fn docs.
+      // The walk-level `LigoGpsMeta` is threaded in (reborrowed per offset-
+      // table entry) so a `freeGPS `-block-with-`LIGOGPSINFO` in the `moov`
+      // `gps ` offset table (XGODY-style stores its blocks OUTSIDE `mdat`,
+      // QuickTimeStream.pl:1852) routes through the GPSType-5 LigoGPS arm of
+      // `process_free_gps` instead of being dropped.
       quicktime_freegps::process_free_gps(
         buff,
         create_date_raw,
@@ -2465,6 +2567,7 @@ fn process_moov_gps_box(
         kodak_version,
         free_gps_state,
         out,
+        Some(&mut *ligogps_out),
       );
     }
   }
@@ -2530,6 +2633,8 @@ fn walk_moov(
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
+  parrot_out: &mut ParrotMeta,
+  ligogps_out: &mut crate::metadata::LigoGpsMeta,
 ) -> bool {
   let mut gopro_found_embedded = false;
   // ExifTool's `$track` (QuickTime.pm:10353-10354): incremented for EVERY
@@ -2559,11 +2664,14 @@ fn walk_moov(
             &track,
             track_index,
             create_date_raw,
+            free_gps_state,
             out,
             gopro_out,
             camm_out,
             sony_rtmd_out,
             canon_ctmd_out,
+            parrot_out,
+            ligogps_out,
           );
         }
       }
@@ -2587,6 +2695,7 @@ fn walk_moov(
           kodak_version,
           free_gps_state,
           out,
+          ligogps_out,
         );
         out.stamp_gps_origin_from(start, crate::metadata::GpsOrigin::MoovGpsBox);
         // The moov-`gps `-box freeGPS blocks `++DOC_COUNT` per fix
@@ -2652,38 +2761,6 @@ fn is_meta_handler(h: &[u8; 4]) -> bool {
 mod tests {
   use super::*;
 
-  /// R2 finding regression — the deferred non-GoPro `gpmd` variants
-  /// (QuickTimeStream.pl:181-208) must be recognized so they are NOT
-  /// dispatched to the GoPro KLV walker (and so they do not set
-  /// `FoundEmbedded`, which would suppress the brute-force `mdat` scan that
-  /// recovers them). The GoPro fallback (no signature match) must NOT be
-  /// classified as deferred.
-  #[test]
-  fn deferred_gpmd_variants_are_classified() {
-    // gpmd_FMAS: `/^FMAS\0\0\0\0/` (Vantrue N2S). A printable FourCC the
-    // GoPro KLV walker would otherwise mistake for a record.
-    assert!(is_deferred_gpmd_variant(b"FMAS\0\0\0\0\xde\xad\xbe\xef"));
-    // gpmd_Rove: `/^\0\0\xf2\xe1\xf0\xeeTT/`.
-    assert!(is_deferred_gpmd_variant(&[
-      0x00, 0x00, 0xf2, 0xe1, 0xf0, 0xee, b'T', b'T', 0x01, 0x02
-    ]));
-    // gpmd_Kingslim: `/^.{21}\0\0\0A[NS][EW]/s`.
-    let mut kingslim = vec![0xaau8; 21];
-    kingslim.extend_from_slice(&[0, 0, 0, b'A', b'N', b'E']);
-    assert!(is_deferred_gpmd_variant(&kingslim));
-    // gpmd_Wolfbox: `/^.{136}(0{16}[A-Z]{4}|...)/s`.
-    let mut wolfbox = vec![0x11u8; 136];
-    wolfbox.extend_from_slice(b"0000000000000000ABCD");
-    assert!(is_deferred_gpmd_variant(&wolfbox));
-    // gpmd_GoPro fallback — a real GoPro `DEVC` sample is NOT deferred.
-    assert!(!is_deferred_gpmd_variant(
-      b"DEVC\0\x01\x00\x01\x00\x00\x00\x00"
-    ));
-    // Too-short buffers never match (no panic — checked `.get`).
-    assert!(!is_deferred_gpmd_variant(b"FMA"));
-    assert!(!is_deferred_gpmd_variant(&[]));
-  }
-
   /// **R8-B** — `decode_one_sample` sets `FoundEmbedded` (returns `true`) for
   /// ANY non-deferred `gpmd` sample, regardless of whether the GoPro KLV parse
   /// extracted a record. ExifTool sets `$$et{FoundEmbedded} = 1` on ENTRY to
@@ -2710,6 +2787,9 @@ mod tests {
     let mut camm = crate::metadata::CammMeta::new();
     let mut sony = crate::metadata::SonyRtmdMeta::new();
     let mut canon = crate::metadata::CanonCtmdMeta::new();
+    let mut pr = crate::metadata::ParrotMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut free_gps_state = FreeGpsState::new();
 
     // A zero-filled `gpmd` sample: `process_gopro` extracts nothing (the KLV
     // walker bails on the four-NUL tag, GoPro.pm:844) — but it is NOT a
@@ -2723,25 +2803,25 @@ mod tests {
         1,
         &sample,
         None,
+        &mut free_gps_state,
         &mut out,
         &mut gopro,
         &mut camm,
         &mut sony,
-        &mut canon
+        &mut canon,
+        &mut pr,
+        &mut lg
       ),
       "zero-filled non-deferred gpmd still sets FoundEmbedded (ProcessGoPro entry)"
     );
 
     // A `gpmd` sample whose leading tag bytes are non-printable: the walker
     // bails on the tag-char guard (GoPro.pm:833), extracting nothing — but it
-    // is still the non-deferred `gpmd_GoPro` fallback, so `FoundEmbedded` is
-    // set. (All-`\xff` matches none of Kingslim/Rove/FMAS/Wolfbox: Wolfbox
-    // needs `0` bytes at offsets 136-151, which `\xff` fails.)
+    // matches no dashcam variant `Condition`, so it is still the `gpmd_GoPro`
+    // fallback and `FoundEmbedded` is set. (All-`\xff` matches none of
+    // Kingslim/Rove/FMAS/Wolfbox: Wolfbox needs `0` bytes at offsets 136-151,
+    // which `\xff` fails — so `dispatch_gpmd` returns false here.)
     let nonprintable = vec![0xffu8; 64];
-    assert!(
-      !is_deferred_gpmd_variant(&nonprintable),
-      "the non-printable sample is NOT a deferred variant"
-    );
     assert!(
       decode_one_sample(
         &nonprintable,
@@ -2749,19 +2829,24 @@ mod tests {
         1,
         &sample,
         None,
+        &mut free_gps_state,
         &mut out,
         &mut gopro,
         &mut camm,
         &mut sony,
-        &mut canon
+        &mut canon,
+        &mut pr,
+        &mut lg
       ),
       "non-printable non-deferred gpmd still sets FoundEmbedded"
     );
 
-    // No-regression: a DEFERRED variant (FMAS) returns false (NOT GoPro, must
-    // not set FoundEmbedded — preserves the R2/R6 fix).
+    // No-regression: a matched variant (FMAS) returns false (NOT GoPro, must
+    // not set FoundEmbedded — preserves the R2/R6 fix). `dispatch_gpmd` matches
+    // the `FMAS\0\0\0\0` signature and routes to `process_fmas` (which emits
+    // nothing for this 12-byte runt — `decode_fmas` needs >= 160 bytes — but
+    // the dispatch still returns `true`, so `decode_one_sample` returns false).
     let fmas = b"FMAS\0\0\0\0\xde\xad\xbe\xef";
-    assert!(is_deferred_gpmd_variant(fmas));
     assert!(
       !decode_one_sample(
         fmas,
@@ -2769,11 +2854,14 @@ mod tests {
         1,
         &sample,
         None,
+        &mut free_gps_state,
         &mut out,
         &mut gopro,
         &mut camm,
         &mut sony,
-        &mut canon
+        &mut canon,
+        &mut pr,
+        &mut lg
       ),
       "deferred FMAS gpmd does NOT set FoundEmbedded (no regression)"
     );
@@ -2787,11 +2875,14 @@ mod tests {
         1,
         &sample,
         None,
+        &mut free_gps_state,
         &mut out,
         &mut gopro,
         &mut camm,
         &mut sony,
-        &mut canon
+        &mut canon,
+        &mut pr,
+        &mut lg
       ),
       "a valid GoPro DEVC sample sets FoundEmbedded"
     );
@@ -2810,11 +2901,14 @@ mod tests {
         1,
         &sample,
         None,
+        &mut free_gps_state,
         &mut out,
         &mut gopro,
         &mut camm,
         &mut sony,
-        &mut canon
+        &mut canon,
+        &mut pr,
+        &mut lg
       ),
       "a non-gpmd/non-mebx/non-camm track sets no FoundEmbedded"
     );
@@ -2832,11 +2926,14 @@ mod tests {
         1,
         &sample,
         None,
+        &mut free_gps_state,
         &mut out,
         &mut gopro,
         &mut camm,
         &mut sony,
-        &mut canon
+        &mut canon,
+        &mut pr,
+        &mut lg
       ),
       "a camm track does not set FoundEmbedded"
     );
@@ -3402,20 +3499,111 @@ mod tests {
     data.extend_from_slice(&moov);
     let mut gp = crate::metadata::GoProMeta::new();
     let mut cm = crate::metadata::CammMeta::new();
-    let (meta, found_embedded) = extract_stream(
-      &data,
-      None,
-      None,
-      &mut gp,
-      &mut cm,
-      &mut crate::metadata::SonyRtmdMeta::new(),
-      &mut crate::metadata::CanonCtmdMeta::new(),
+    let mut sr = crate::metadata::SonyRtmdMeta::new();
+    let mut cc = crate::metadata::CanonCtmdMeta::new();
+    let mut pr = crate::metadata::ParrotMeta::new();
+    let mut lg = crate::metadata::LigoGpsMeta::new();
+    let mut meta = QuickTimeStreamMeta::new();
+    let found_embedded = extract_stream(
+      &data, None, None, &mut meta, &mut gp, &mut cm, &mut sr, &mut cc, &mut pr, &mut lg,
     );
     assert!(meta.is_empty());
     // No `gps ` box ⇒ ProcessFreeGPS never ran ⇒ FoundEmbedded stays false.
     assert!(!found_embedded);
     assert!(gp.is_empty());
     assert!(cm.is_empty());
+    assert!(sr.is_empty());
+    assert!(cc.is_empty());
+    assert!(pr.is_empty());
+  }
+
+  #[test]
+  fn scan_application_string_extracts_arcore_metatype() {
+    // QuickTime.pm:7773 — the regex `(application[^\0]+)` captures the
+    // run from "application" up to (not including) the first NUL.
+    let mut bytes = alloc::vec![0u8; 4];
+    bytes.extend_from_slice(b"application/arcore-accel");
+    bytes.push(0);
+    bytes.extend_from_slice(b"trailing-bytes");
+    let s = scan_application_string(&bytes);
+    assert_eq!(s, "application/arcore-accel");
+    // No `application` substring ⇒ empty string.
+    let none = scan_application_string(b"random opaque bytes");
+    assert!(none.is_empty());
+    // Runs all the way to end-of-buffer when no NUL is present.
+    let unterminated = scan_application_string(b"application/x-foo");
+    assert_eq!(unterminated, "application/x-foo");
+  }
+
+  /// `walk_stsd` must assign `MetaType` on EVERY
+  /// sample-description entry (QuickTime.pm:7773 `RawConv` `$$self{MetaType} =
+  /// ($val=~/(application[^\0]+)/ ? $1 : undef)`), CLEARING it when an entry
+  /// carries no `application/...` run. A multi-entry `mett` stsd whose EARLIER
+  /// entry is `application/arcore-accel` and whose FINAL entry has no application
+  /// string must end with `meta_type` CLEARED (not leaking the ARCore type) so
+  /// the Parrot `mett` walker takes the normal drone `[EP]\d` path, not the
+  /// ARCore-TLV path. Pre-fix the conditional `if !mt.is_empty()` left the stale
+  /// ARCore MetaType in place.
+  #[test]
+  fn walk_stsd_multi_entry_clears_stale_arcore_metatype() {
+    // Entry 1: a `mett` SampleDescription whose body carries
+    // `application/arcore-accel` (the ARCore MetaType).
+    let mut e1_body = alloc::vec![0u8; 8]; // reserved[6] + data-ref-index[2]
+    e1_body.extend_from_slice(b"application/arcore-accel\0");
+    let e1_len = 8 + e1_body.len(); // [size:4][format:4] + body
+    let mut entry1 = (e1_len as u32).to_be_bytes().to_vec();
+    entry1.extend_from_slice(b"mett");
+    entry1.extend_from_slice(&e1_body);
+
+    // Entry 2: a `mett` SampleDescription whose body has NO `application/...`
+    // run (plain opaque bytes) — ExifTool's RawConv sets MetaType = undef here.
+    let mut e2_body = alloc::vec![0u8; 8];
+    e2_body.extend_from_slice(b"\x01\x02\x03\x04opaque-no-app\0");
+    let e2_len = 8 + e2_body.len();
+    let mut entry2 = (e2_len as u32).to_be_bytes().to_vec();
+    entry2.extend_from_slice(b"mett");
+    entry2.extend_from_slice(&e2_body);
+
+    // stsd body: [version+flags:4][entry-count:4=2] then the two entries.
+    let mut stsd = alloc::vec![0u8; 8];
+    wr(&mut stsd, 4, &2u32.to_be_bytes());
+    stsd.extend_from_slice(&entry1);
+    stsd.extend_from_slice(&entry2);
+
+    let mut track = StreamTrack::default();
+    walk_stsd(&stsd, &mut track);
+
+    // Last-wins format is `mett`; the trailing no-application entry CLEARED the
+    // MetaType the first (ARCore) entry set.
+    assert_eq!(&track.meta_format, b"mett");
+    assert!(
+      track.meta_type.is_empty(),
+      "the trailing non-application entry must CLEAR the stale ARCore MetaType, got {:?}",
+      track.meta_type
+    );
+
+    // And so the Parrot `mett` walker takes the DRONE path (meta_type = None),
+    // decoding a P1 record as drone telemetry rather than the ARCore-TLV path
+    // (which would skip a normal `[EP]\d` record).
+    let meta_type = if track.meta_type.is_empty() {
+      None
+    } else {
+      Some(track.meta_type.as_str())
+    };
+    // A minimal V1 drone record: `[P1][nwords=14]` + 56 bytes (60-byte slot),
+    // with a GPSLatitude at record offset 28 (int32s / 0x100000).
+    let lat_raw = (47.6062_f64 * f64::from(0x10_0000)).round() as i32;
+    let mut p1 = alloc::vec![0u8; 60];
+    p1[0..2].copy_from_slice(b"P1");
+    wr(&mut p1, 2, &14u16.to_be_bytes());
+    p1[28..32].copy_from_slice(&lat_raw.to_be_bytes());
+    let mut pr = ParrotMeta::new();
+    crate::formats::parrot::process_mett(&p1, meta_type, &mut pr);
+    let g = pr
+      .gps_samples()
+      .first()
+      .expect("drone P1 must decode (not the ARCore-TLV path)");
+    assert!((g.latitude().expect("lat") - 47.6062).abs() < 1e-5);
   }
 
   /// Codex R3 — the `moov`-level Novatek `gps ` box (the EMPTY-HandlerType box
@@ -3468,14 +3656,18 @@ mod tests {
 
     let mut gp = crate::metadata::GoProMeta::new();
     let mut cm = crate::metadata::CammMeta::new();
-    let (meta, found_embedded) = extract_stream(
+    let mut meta = QuickTimeStreamMeta::new();
+    let found_embedded = extract_stream(
       &data,
       None,
       None,
+      &mut meta,
       &mut gp,
       &mut cm,
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert_eq!(
       meta.gps_samples().len(),
@@ -3568,14 +3760,18 @@ mod tests {
 
     let mut gp = crate::metadata::GoProMeta::new();
     let mut cm = crate::metadata::CammMeta::new();
-    let (meta, found_embedded) = extract_stream(
+    let mut meta = QuickTimeStreamMeta::new();
+    let found_embedded = extract_stream(
       &data,
       None,
       None,
+      &mut meta,
       &mut gp,
       &mut cm,
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
+      &mut crate::metadata::ParrotMeta::new(),
+      &mut crate::metadata::LigoGpsMeta::new(),
     );
     assert!(
       meta.is_empty(),

--- a/src/metadata/insta360.rs
+++ b/src/metadata/insta360.rs
@@ -749,6 +749,18 @@ pub struct Insta360Meta<'a> {
   /// trailer behind a later LigoGPS/MIE trailer. `0` (unused) when no Insta360
   /// trailer is present; read only alongside [`Self::raw`].
   trail_end: usize,
+  /// The value of the SHARED global document counter (`$$et{DOC_COUNT}`) at the
+  /// moment `ProcessInsta360` begins in `ProcessMOV`'s trailer loop
+  /// (QuickTime.pm:10654-10677) — i.e. AFTER every moov-timed + `udta`-LigoGPS +
+  /// earlier-chain trailer source has bumped it. The deferred `-ee` row decode
+  /// (`decode_all_records`) seeds its running counter from this base, so each
+  /// surfaced Insta360 row gets `Doc<doc_base + N>` (`$$et{DOC_NUM} =
+  /// ++$$et{DOC_COUNT}`, QuickTimeStream.pl:3374/3388/3394/3412) — continuing the
+  /// ONE global sequence instead of restarting at 1. `0` for an Insta360-only
+  /// file (the common case; byte-identical to the pre-unification local 0-based
+  /// counter). The `0x101` identity still inherits the STICKY current doc (Main
+  /// when no timed row preceded it), NOT this base.
+  doc_base: u32,
 }
 
 impl<'a> Insta360Meta<'a> {
@@ -764,6 +776,7 @@ impl<'a> Insta360Meta<'a> {
       head_trailer: None,
       raw: None,
       trail_end: 0,
+      doc_base: 0,
     }
   }
 
@@ -827,6 +840,16 @@ impl<'a> Insta360Meta<'a> {
   #[must_use]
   pub const fn trail_end(&self) -> usize {
     self.trail_end
+  }
+
+  /// The SHARED global document counter (`$$et{DOC_COUNT}`) value at the moment
+  /// `ProcessInsta360` runs in the trailer phase — the base the deferred `-ee`
+  /// row decode adds its per-row ordinals to (see the field doc). `0` for an
+  /// Insta360-only file.
+  #[inline(always)]
+  #[must_use]
+  pub const fn doc_base(&self) -> u32 {
+    self.doc_base
   }
 
   /// `true` when no domain-summary content decoded. The [`Self::trailer`]
@@ -906,6 +929,16 @@ impl<'a> Insta360Meta<'a> {
   #[inline]
   pub const fn set_trail_end(&mut self, trail_end: usize) -> &mut Self {
     self.trail_end = trail_end;
+    self
+  }
+
+  /// Record the SHARED global document-counter base (`$$et{DOC_COUNT}` when
+  /// `ProcessInsta360` begins in the trailer phase) — seeds the deferred `-ee`
+  /// row decode's running counter so each row gets `Doc<doc_base + N>`. See the
+  /// field doc.
+  #[inline]
+  pub const fn set_doc_base(&mut self, doc_base: u32) -> &mut Self {
+    self.doc_base = doc_base;
     self
   }
 

--- a/src/metadata/ligogps.rs
+++ b/src/metadata/ligogps.rs
@@ -1,0 +1,782 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Typed mirror of `Image::ExifTool::LigoGPS` (LigoGPS.pm) — the dashcam
+//! vendor GPS records that some bodies (iiway s1, XGODY 12" 4K, ABASK A8 4K,
+//! Rexing V1GW-4K, Kingslim D4, BlueSkySea DV688, Redtiger F9 4K, Yada
+//! RoadCam Pro 4K BT58189, …) write either as a `freeGPS`/`LIGOGPSINFO`
+//! embedded sample stream OR as a `&&&& `-prefixed trailer at file end.
+//!
+//! ## Provenance
+//!
+//! Faithful port of:
+//!  - `Image::ExifTool::LigoGPS::ProcessLigoGPS` (LigoGPS.pm:289-320) — the
+//!    fixed-stride 0x84-byte record walker;
+//!  - `Image::ExifTool::LigoGPS::DecryptLigoGPS` (LigoGPS.pm:50-99) —
+//!    the per-record byte-cipher with 4 sub-modes driven by the upper 3
+//!    bits of each input byte;
+//!  - `Image::ExifTool::LigoGPS::ParseLigoGPS` (LigoGPS.pm:229-267) — the
+//!    human-readable record parser (`####...DATE TIME N:lat W:lon spd km/h
+//!    A:track H:alt M:magvar x:ax y:ay z:az`);
+//!  - `Image::ExifTool::LigoGPS::UnfuzzLigoGPS` (LigoGPS.pm:38-44) — the
+//!    lat/lon defuzz function;
+//!  - `Image::ExifTool::LigoGPS::ProcessLigoJSON` (LigoGPS.pm:334-398) —
+//!    the JSON-format variant (Yada RoadCam Pro 4K BT58189).
+//!
+//! ## What this sub-port surfaces
+//!
+//! Per LigoGPS.pm:256-265 (binary text records):
+//!  - **`GPSDateTime`** — UTC date+time (`YYYY:MM:DD HH:MM:SS`); the bundled
+//!    `tr/\//:/` normalises the date separators. Stored as
+//!    [`SmolStr`].
+//!  - **`GPSLatitude`** — decimal degrees, signed (post bundled
+//!    `* (($latNeg or $latRef eq 'S') ? -1 : 1)`).
+//!  - **`GPSLongitude`** — decimal degrees, signed (post bundled `* (... eq
+//!    'W')` flip).
+//!  - **`GPSSpeed`** — km/h (post-`* $spdScl` conversion; the scale factor
+//!    is mode-dependent — see [`LigoGpsSample::speed_kph`]).
+//!  - **`GPSTrack`** — bearing degrees (`A:` field, LigoGPS.pm:261).
+//!  - **`GPSAltitude`** — metres (`H:` field, LigoGPS.pm:262).
+//!  - **`MagneticVariation`** — degrees (`M:` field, LigoGPS.pm:263).
+//!  - **`Accelerometer`** — space-joined 3-axis string (`x:` `y:` `z:`
+//!    fields, LigoGPS.pm:265).
+//!
+//! For ProcessLigoJSON (LigoGPS.pm:355-396) the same surface PLUS:
+//!  - **`DateTimeOriginal`** — the dashcam local-time clock (the bundled
+//!    `MYear`/`MMonth`/`MDay`/`MHour`/`MMinute`/`MSecond` fields). Stored
+//!    in addition to `GPSDateTime` (which is the UTC GPS time).
+//!  - **`GPSLatitude2`/`GPSLongitude2`** — the bundled `OLatitude`/
+//!    `OLongitude` fields (LigoGPS.pm:387-388), hemisphere-signed by the
+//!    same `NS`/`EW` refs as the primary lat/lon.
+//!
+//! ## What this sub-port deliberately does NOT decode
+//!
+//! Faithful-walked but unsurfaced:
+//!  - **DecipherLigoGPS cipher discovery (LigoGPS.pm:143-221)** — the
+//!    fallback when `DecryptLigoGPS` cannot decode the encrypted prefix.
+//!    Cipher discovery requires accumulating ≥10 unique seconds-digit
+//!    transitions across multiple records before the cipher table is
+//!    known. Real-world dashcam files always satisfy `DecryptLigoGPS` on
+//!    the first record, so the deciphered fallback is exotic. FOLLOW-UP
+//!    (tracked as a per-port issue).
+//!  - **Sanity-check warnings on out-of-range coordinates (LigoGPS.pm:254)**
+//!    — the bundled emits `LIGOGPSINFO coordinates out of range` and
+//!    drops the sample; we propagate this through the walker's warning
+//!    channel.
+//!
+//! ## D8 compliance
+//!
+//! Every field is private; access through accessors. Setters return
+//! `&mut Self` for chaining. `const fn` where types permit. No public
+//! struct fields; enums newtype/unit-only.
+
+extern crate alloc;
+use alloc::{string::String, vec::Vec};
+
+use smol_str::SmolStr;
+
+use crate::metadata::{GpsLocation, MediaMetadata};
+
+// ===========================================================================
+// LigoSource — which ExifTool dispatch path decoded a record
+// ===========================================================================
+
+/// The ExifTool dispatch path that produced a [`LigoGpsSample`]. The `-ee`
+/// gating differs between the two families (LigoGPS.pm):
+///  - [`LigoSource::UdtaJson`] — the `udta` `LigoJSON` / `GKUData` Conditions
+///    (QuickTime.pm:834-846) routed to `ProcessLigoJSON` (LigoGPS.pm:334-398).
+///    ExifTool processes the FIRST active record EVEN WITHOUT `-ee`, then
+///    `Warn`s + `last`s (LigoGPS.pm:390-393); only `-ee` extracts the rest.
+///  - [`LigoSource::Binary`] — `ProcessLigoGPS` (LigoGPS.pm:289-320), reached
+///    via the file-end `&&&& ` trailer (QuickTime.pm:10658-10668) or a
+///    `freeGPS`-embedded `LIGOGPSINFO\0` sample (QuickTimeStream.pl:1843-1888).
+///    These entry points run ONLY inside the `-ee` trailer / scan pass, so the
+///    binary family is fully `-ee`-gated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LigoSource {
+  /// A `udta` `LigoJSON` / `GKUData` record (`ProcessLigoJSON`). The FIRST
+  /// active such record emits without `-ee`.
+  UdtaJson,
+  /// A binary `ProcessLigoGPS` record (trailer or freeGPS-embedded). Fully
+  /// `-ee`-gated.
+  Binary,
+}
+
+impl LigoSource {
+  /// `true` for the `udta`-JSON / GKU family — the one whose FIRST active
+  /// record emits without `-ee` (LigoGPS.pm:390-393).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn is_udta_json(self) -> bool {
+    matches!(self, Self::UdtaJson)
+  }
+}
+
+// ===========================================================================
+// LigoGpsSample — one decoded record from `ProcessLigoGPS` / `ProcessLigoJSON`
+// ===========================================================================
+
+/// One LigoGPS record decoded from a `####`-prefixed encrypted record
+/// (LigoGPS.pm:229-267 `ParseLigoGPS`) or one element of a JSON record
+/// stream (LigoGPS.pm:334-398 `ProcessLigoJSON`).
+///
+/// Bundled-derived field semantics:
+///  - `date_time` — `tr|/|:|`-normalised `YYYY:MM:DD HH:MM:SS` (UTC); the
+///    JSON variant produces the same shape with a `Z` UTC suffix when
+///    decoded from the GPS-time fields (LigoGPS.pm:359). The textual
+///    binary variant has no suffix (LigoGPS.pm:244).
+///  - `latitude` — signed decimal degrees post `* (($latNeg or $latRef eq
+///    'S') ? -1 : 1)` (LigoGPS.pm:258).
+///  - `longitude` — signed decimal degrees post `* (($lonNeg or $lonRef eq
+///    'W') ? -1 : 1)` (LigoGPS.pm:259).
+///  - `speed_kph` — km/h post `* $spdScl` (LigoGPS.pm:260). `$spdScl` is
+///    `1` (`flags & 0x02` — non-fuzzed text decoded with kph speed),
+///    `1.852` (`flags & 0x01` — non-fuzzed knots → kph), or `1.85407333`
+///    (default — the LigoGPS encryption's odd internal unit). For the
+///    JSON variant `speed_kph = $info{Speed} * $knotsToKph` (LigoGPS.pm:370).
+///  - `track_deg` — bearing degrees (LigoGPS.pm:261).
+///  - `altitude_m` — metres (LigoGPS.pm:262).
+///  - `magnetic_variation` — degrees (LigoGPS.pm:263).
+///  - `accelerometer` — space-joined "ax ay az" (LigoGPS.pm:265 / 373).
+///  - `date_time_local` — only set by `ProcessLigoJSON` from the `M*`
+///    fields (LigoGPS.pm:379) when all six are present.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LigoGpsSample {
+  /// `GPSDateTime` UTC (LigoGPS.pm:256 / 359-360).
+  date_time: Option<SmolStr>,
+  /// `DateTimeOriginal` — dashcam local clock (JSON-only, LigoGPS.pm:379).
+  date_time_local: Option<SmolStr>,
+  /// `GPSLatitude` decimal degrees, signed.
+  latitude: Option<f64>,
+  /// `GPSLongitude` decimal degrees, signed.
+  longitude: Option<f64>,
+  /// `GPSLatitude2` decimal degrees, signed — the JSON `OLatitude` field
+  /// (JSON-only, LigoGPS.pm:387). The bundled documents it as "? same
+  /// values as Latitude/Longitude" (the un-defuzzed original).
+  latitude2: Option<f64>,
+  /// `GPSLongitude2` decimal degrees, signed — the JSON `OLongitude`
+  /// field (JSON-only, LigoGPS.pm:388).
+  longitude2: Option<f64>,
+  /// `GPSSpeed` km/h post-scale.
+  speed_kph: Option<f64>,
+  /// `GPSTrack` bearing degrees.
+  track_deg: Option<f64>,
+  /// `GPSAltitude` metres.
+  altitude_m: Option<f64>,
+  /// `MagneticVariation` degrees.
+  magnetic_variation: Option<f64>,
+  /// `Accelerometer` space-joined "ax ay az".
+  accelerometer: Option<SmolStr>,
+  /// Which ExifTool dispatch path produced this record — gates the no-`ee`
+  /// FIRST-record emission (LigoGPS.pm:390-393, [`LigoSource`]). Defaults to
+  /// [`LigoSource::Binary`] (the fully-`-ee`-gated family).
+  source: LigoSource,
+  /// The 1-based GLOBAL document ordinal (`Doc<N>`) stamped on this record —
+  /// the typed mirror of `$$et{DOC_NUM} = ++$$et{DOC_COUNT}` (LigoGPS.pm:243 /
+  /// :354). Allocated from the SAME shared `QuickTimeStreamMeta` counter as the
+  /// other timed decoders, at the point the record is processed in walk order
+  /// (see [`LigoGpsMeta::stamp_doc_from`]). `None` for unit-built samples; the
+  /// emitter falls back to a per-record running ordinal then.
+  doc: Option<u32>,
+  /// A DOC-BURNING placeholder: a binary record that `ParseLigoGPS` accepted far
+  /// enough to bump `$$et{DOC_NUM} = ++$$et{DOC_COUNT}` (LigoGPS.pm:243) but then
+  /// rejected at the out-of-range sanity check (LigoGPS.pm:254 `($lat > 90 or
+  /// $lon > 180) and ..., return`), so it consumes a global `Doc<N>` yet emits NO
+  /// GPS tags. The emitter [`crate::formats::quicktime`] still advances its
+  /// per-record doc ordinal for it (so the NEXT record's `Doc<N>` is the burned
+  /// slot's successor) but skips all tag emission. `false` for a real sample.
+  suppressed: bool,
+}
+
+impl LigoGpsSample {
+  /// An empty sample (every field `None`).
+  #[inline(always)]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      date_time: None,
+      date_time_local: None,
+      latitude: None,
+      longitude: None,
+      latitude2: None,
+      longitude2: None,
+      speed_kph: None,
+      track_deg: None,
+      altitude_m: None,
+      magnetic_variation: None,
+      accelerometer: None,
+      source: LigoSource::Binary,
+      doc: None,
+      suppressed: false,
+    }
+  }
+
+  /// A DOC-BURNING placeholder for an out-of-range binary record (LigoGPS.pm:243
+  /// bumps `++DOC_COUNT` BEFORE the :254 range-check `return`): it carries no GPS
+  /// fields, only the [`Self::suppressed`] flag, so it consumes one global
+  /// `Doc<N>` ordinal yet emits nothing. `source` stays [`LigoSource::Binary`]
+  /// (the fully-`-ee`-gated family — a binary record is never the no-`ee`
+  /// first-record), so at no-`ee` it is skipped entirely like every other binary
+  /// record.
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn new_suppressed() -> Self {
+    let mut s = Self::new();
+    s.suppressed = true;
+    s
+  }
+
+  /// `true` when this is a doc-burning placeholder (out-of-range binary record)
+  /// — the emitter consumes its `Doc<N>` but emits no tags. See
+  /// [`Self::new_suppressed`].
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn is_suppressed(&self) -> bool {
+    self.suppressed
+  }
+
+  /// `GPSDateTime` UTC.
+  #[inline(always)]
+  #[must_use]
+  pub fn date_time(&self) -> Option<&str> {
+    self.date_time.as_deref()
+  }
+
+  /// `DateTimeOriginal` — dashcam local clock (JSON-only).
+  #[inline(always)]
+  #[must_use]
+  pub fn date_time_local(&self) -> Option<&str> {
+    self.date_time_local.as_deref()
+  }
+
+  /// `GPSLatitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn latitude(&self) -> Option<f64> {
+    self.latitude
+  }
+
+  /// `GPSLongitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn longitude(&self) -> Option<f64> {
+    self.longitude
+  }
+
+  /// `GPSLatitude2` decimal degrees (JSON `OLatitude`).
+  #[inline(always)]
+  #[must_use]
+  pub const fn latitude2(&self) -> Option<f64> {
+    self.latitude2
+  }
+
+  /// `GPSLongitude2` decimal degrees (JSON `OLongitude`).
+  #[inline(always)]
+  #[must_use]
+  pub const fn longitude2(&self) -> Option<f64> {
+    self.longitude2
+  }
+
+  /// `GPSSpeed` km/h.
+  #[inline(always)]
+  #[must_use]
+  pub const fn speed_kph(&self) -> Option<f64> {
+    self.speed_kph
+  }
+
+  /// `GPSTrack` bearing degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn track_deg(&self) -> Option<f64> {
+    self.track_deg
+  }
+
+  /// `GPSAltitude` metres.
+  #[inline(always)]
+  #[must_use]
+  pub const fn altitude_m(&self) -> Option<f64> {
+    self.altitude_m
+  }
+
+  /// `MagneticVariation` degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn magnetic_variation(&self) -> Option<f64> {
+    self.magnetic_variation
+  }
+
+  /// `Accelerometer` space-joined "ax ay az".
+  #[inline(always)]
+  #[must_use]
+  pub fn accelerometer(&self) -> Option<&str> {
+    self.accelerometer.as_deref()
+  }
+
+  /// Which ExifTool dispatch path produced this record ([`LigoSource`]).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn source(&self) -> LigoSource {
+    self.source
+  }
+
+  /// The 1-based GLOBAL `Doc<N>` ordinal stamped on this record, or `None` for
+  /// an unstamped (unit-built) sample.
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn doc(&self) -> Option<u32> {
+    self.doc
+  }
+
+  /// `true` when no field is populated.
+  #[inline(always)]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.date_time.is_none()
+      && self.date_time_local.is_none()
+      && self.latitude.is_none()
+      && self.longitude.is_none()
+      && self.latitude2.is_none()
+      && self.longitude2.is_none()
+      && self.speed_kph.is_none()
+      && self.track_deg.is_none()
+      && self.altitude_m.is_none()
+      && self.magnetic_variation.is_none()
+      && self.accelerometer.is_none()
+  }
+
+  // ── Setters ───────────────────────────────────────────────────────────────
+
+  /// Assign `GPSDateTime`.
+  #[inline(always)]
+  pub fn set_date_time(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.date_time = v;
+    self
+  }
+
+  /// Assign `DateTimeOriginal` (JSON-only).
+  #[inline(always)]
+  pub fn set_date_time_local(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.date_time_local = v;
+    self
+  }
+
+  /// Assign `GPSLatitude`.
+  #[inline(always)]
+  pub const fn set_latitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.latitude = v;
+    self
+  }
+
+  /// Assign `GPSLongitude`.
+  #[inline(always)]
+  pub const fn set_longitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.longitude = v;
+    self
+  }
+
+  /// Assign `GPSLatitude2` (JSON `OLatitude`).
+  #[inline(always)]
+  pub const fn set_latitude2(&mut self, v: Option<f64>) -> &mut Self {
+    self.latitude2 = v;
+    self
+  }
+
+  /// Assign `GPSLongitude2` (JSON `OLongitude`).
+  #[inline(always)]
+  pub const fn set_longitude2(&mut self, v: Option<f64>) -> &mut Self {
+    self.longitude2 = v;
+    self
+  }
+
+  /// Assign `GPSSpeed` in km/h.
+  #[inline(always)]
+  pub const fn set_speed_kph(&mut self, v: Option<f64>) -> &mut Self {
+    self.speed_kph = v;
+    self
+  }
+
+  /// Assign `GPSTrack` bearing degrees.
+  #[inline(always)]
+  pub const fn set_track_deg(&mut self, v: Option<f64>) -> &mut Self {
+    self.track_deg = v;
+    self
+  }
+
+  /// Assign `GPSAltitude` metres.
+  #[inline(always)]
+  pub const fn set_altitude_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.altitude_m = v;
+    self
+  }
+
+  /// Assign `MagneticVariation` degrees.
+  #[inline(always)]
+  pub const fn set_magnetic_variation(&mut self, v: Option<f64>) -> &mut Self {
+    self.magnetic_variation = v;
+    self
+  }
+
+  /// Assign `Accelerometer`.
+  #[inline(always)]
+  pub fn set_accelerometer(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.accelerometer = v;
+    self
+  }
+
+  /// Assign the dispatch [`LigoSource`] (gates the no-`ee` first-record path).
+  #[inline(always)]
+  pub(crate) const fn set_source(&mut self, v: LigoSource) -> &mut Self {
+    self.source = v;
+    self
+  }
+
+  /// Assign the GLOBAL `Doc<N>` ordinal. Used by [`LigoGpsMeta::stamp_doc_from`].
+  #[inline(always)]
+  pub(crate) const fn set_doc(&mut self, v: Option<u32>) -> &mut Self {
+    self.doc = v;
+    self
+  }
+}
+
+impl Default for LigoGpsSample {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ===========================================================================
+// LigoGpsMeta — the host metadata holder for ProcessLigoGPS output
+// ===========================================================================
+
+/// Decoded LigoGPS records — every `####`-prefixed encrypted record that
+/// successfully decrypted (LigoGPS.pm:289-320 `ProcessLigoGPS`) plus every
+/// JSON record decoded from a `LIGOGPSINFO {` JSON variant (LigoGPS.pm:334-
+/// 398 `ProcessLigoJSON`).
+///
+/// `is_empty()` for a non-LigoGPS file (no encrypted records / no JSON
+/// signature at file end).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LigoGpsMeta {
+  /// Decoded GPS samples — one per successfully-parsed record. Order is
+  /// file-order (record walker order).
+  samples: Vec<LigoGpsSample>,
+  /// First warning surfaced by the walker (truncated trailer, decrypt
+  /// failure, coordinate out-of-range, …). Bundled emits multiple
+  /// `$et->Warn(...)` calls; the camera-indexing surface keeps the first.
+  warning: Option<SmolStr>,
+}
+
+impl LigoGpsMeta {
+  /// An empty LigoGPS holder (no samples, no warning).
+  #[inline(always)]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      samples: Vec::new(),
+      warning: None,
+    }
+  }
+
+  /// Decoded GPS samples — file-order.
+  #[inline(always)]
+  #[must_use]
+  pub fn samples(&self) -> &[LigoGpsSample] {
+    &self.samples
+  }
+
+  /// First decoded sample whose `latitude` AND `longitude` are populated.
+  /// Used by the [`MetaProjectInto`] adaptor to populate
+  /// [`MediaMetadata::gps()`] without scanning all samples at projection
+  /// time.
+  #[inline(always)]
+  #[must_use]
+  pub fn first_fix(&self) -> Option<&LigoGpsSample> {
+    self
+      .samples
+      .iter()
+      .find(|s| s.latitude.is_some() && s.longitude.is_some())
+  }
+
+  /// The first walker warning.
+  #[inline(always)]
+  #[must_use]
+  pub fn warning(&self) -> Option<&str> {
+    self.warning.as_deref()
+  }
+
+  /// `true` when no samples AND no warning were recorded.
+  #[inline(always)]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.samples.is_empty() && self.warning.is_none()
+  }
+
+  /// Append a decoded sample. Used by [`crate::formats::ligogps`] only.
+  #[inline(always)]
+  pub fn push_sample(&mut self, s: LigoGpsSample) -> &mut Self {
+    self.samples.push(s);
+    self
+  }
+
+  /// The number of samples decoded so far — a watermark the QuickTime walker
+  /// takes BEFORE decoding one LigoGPS source so it can stamp the GLOBAL
+  /// `Doc<N>` onto exactly the records that source produced (see
+  /// [`Self::stamp_doc_from`]). Mirrors
+  /// [`crate::metadata::QuickTimeStreamMeta::gps_sample_count`].
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn sample_count(&self) -> usize {
+    self.samples.len()
+  }
+
+  /// Stamp the GLOBAL document ordinal onto each sample at or after `start` —
+  /// the records decoded since the walker took its [`Self::sample_count`]
+  /// watermark. `counter` is the CURRENT value of the shared
+  /// `QuickTimeStreamMeta` doc counter (`$$et{DOC_COUNT}`); this bumps it once
+  /// per record (`$$et{DOC_NUM} = ++$$et{DOC_COUNT}`, LigoGPS.pm:243 / :354) in
+  /// the records' append (walk) order and returns the NEW counter value for the
+  /// caller to write back, so LigoGPS docs continue the SAME global sequence as
+  /// every `mebx`/`camm`/`gps0`/freeGPS source in the file (no collision /
+  /// restart). Mirrors
+  /// [`crate::metadata::QuickTimeStreamMeta::stamp_gps_doc_from`]'s
+  /// snapshot-bump-write-back discipline, but takes the counter by value because
+  /// the counter is owned by the stream meta, not here.
+  #[must_use]
+  pub(crate) fn stamp_doc_from(&mut self, start: usize, mut counter: u32) -> u32 {
+    if let Some(slice) = self.samples.get_mut(start..) {
+      for s in slice {
+        counter = counter.saturating_add(1);
+        s.set_doc(Some(counter));
+      }
+    }
+    counter
+  }
+
+  /// Move every sample of `other` to the END of this holder (preserving its
+  /// internal order), keeping THIS holder's warning if set else adopting
+  /// `other`'s (first-wins, matching [`Self::set_warning`]).
+  ///
+  /// Used by the QuickTime walker to land the DEFERRED top-level `udta`-LigoGPS
+  /// records AFTER the moov-timed sources in the shared sample Vec: ExifTool's
+  /// single `ProcessMOV` walk emits the moov-timed metadata BEFORE a top-level
+  /// `udta` that follows it in file order, so the udta records take the HIGHER
+  /// `Doc<N>` ordinals AND appear later in output. Decoding them into a temp
+  /// holder during the Pass-1 atom walk and appending here (after `extract_stream`
+  /// + its inline doc stamp) keeps BOTH the append order and the global doc
+  /// sequence faithful. (See the `parse_inner` phase-order note for the
+  /// documented udta-before-moov limitation.)
+  #[inline]
+  pub(crate) fn append(&mut self, other: Self) -> &mut Self {
+    let Self { samples, warning } = other;
+    self.samples.extend(samples);
+    if self.warning.is_none() {
+      self.warning = warning;
+    }
+    self
+  }
+
+  /// Set the first warning. Faithful to bundled emitting `$et->Warn`
+  /// possibly multiple times — the camera-indexing surface keeps the
+  /// first (last-wins would suppress earlier diagnostics).
+  #[inline(always)]
+  pub fn set_warning(&mut self, w: SmolStr) -> &mut Self {
+    if self.warning.is_none() {
+      self.warning = Some(w);
+    }
+    self
+  }
+}
+
+impl Default for LigoGpsMeta {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ===========================================================================
+// project_into — LigoGPS projection into MediaMetadata
+// ===========================================================================
+
+impl LigoGpsMeta {
+  /// Project LigoGPS records into [`MediaMetadata`].
+  ///
+  /// **CameraInfo:** LigoGPS records carry no Make/Model/Serial/Firmware
+  /// — the format is just GPS telemetry. Bundled (LigoGPS.pm) decodes
+  /// only the GPS/accelerometer fields; the camera identity for a dashcam
+  /// that writes LigoGPS lives in the QuickTime `udta`/Keys path (SP1+SP2
+  /// atoms parsed at the QuickTime SP1 layer). So this projection sets
+  /// no `CameraInfo`.
+  ///
+  /// **CaptureSettings:** not produced — LigoGPS does not carry
+  /// exposure/ISO/aperture (those would live in the parent QuickTime
+  /// container's makernotes).
+  ///
+  /// **GpsLocation:** the FIRST sample with a coordinate pair populates
+  /// `md.gps()`. LigoGPS is **lowest-tier** in the priority chain —
+  /// dashcam vendor GPS shares the same fidelity tier as the
+  /// freeGPS-variants and SP3-stream sources (all are "best-effort
+  /// brute-force-scan dashcam GPS", not on-device hardware GNSS the way
+  /// GoPro/CAMM/Parrot are). The order encoded in
+  /// `quicktime::Meta::media_metadata` reflects this: LigoGPS projects
+  /// AFTER all the higher-priority sources so an LigoGPS-only file
+  /// still gets GPS, but a file with GoPro+LigoGPS prefers GoPro.
+  ///
+  /// **Warnings:** the walker's `warning()` channel (`Unrecognized data in
+  /// LigoGPS trailer` / `LIGOGPSINFO format error` / `LIGOGPSINFO coordinates
+  /// out of range` / …) is NOT pushed into `MediaMetadata` — it carries no
+  /// warnings channel (the original `md.push_warning` path was written against
+  /// an older surface, the same drift the #126 Parrot port hit). The warning
+  /// stays on the typed [`LigoGpsMeta::warning`] surface and IS surfaced in the
+  /// rendered output through the QuickTime per-format diagnostics path
+  /// ([`crate::formats::quicktime::Meta`]'s [`crate::diagnostics::Diagnose`]
+  /// impl) as a DOCUMENT-level `ExifTool:Warning` — faithful, because ExifTool
+  /// raises these LigoGPS warnings with no `SET_GROUP1='LIGO'` in effect (the
+  /// `ParseLigoGPS` warnings precede the LigoGPS.pm:255 `SET_GROUP1`; the
+  /// trailer warning is in the `ProcessMOV` loop), so they are NOT `LIGO`-scoped.
+  pub(crate) fn project_into(&self, md: &mut MediaMetadata) {
+    // ── GpsLocation ──────────────────────────────────────────────────────
+    if md.gps().is_none()
+      && let Some(s) = self.first_fix()
+    {
+      let mut gps = GpsLocation::new();
+      gps
+        .update_latitude(s.latitude())
+        .update_longitude(s.longitude())
+        .update_altitude_m(s.altitude_m())
+        .update_timestamp(s.date_time().map(String::from));
+      md.set_gps(gps);
+    }
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn ligogps_sample_default_is_empty() {
+    let s = LigoGpsSample::default();
+    assert!(s.is_empty());
+    assert!(s.latitude().is_none());
+    assert!(s.longitude().is_none());
+    assert!(s.date_time().is_none());
+  }
+
+  #[test]
+  fn ligogps_sample_setters_round_trip() {
+    let mut s = LigoGpsSample::new();
+    s.set_latitude(Some(31.285065))
+      .set_longitude(Some(-124.759483))
+      .set_altitude_m(Some(46.0))
+      .set_speed_kph(Some(46.93))
+      .set_track_deg(Some(180.0))
+      .set_magnetic_variation(Some(12.5))
+      .set_date_time(Some(SmolStr::new("2022:09:19 12:45:24")))
+      .set_accelerometer(Some(SmolStr::new("-0.000 -0.000 -0.000")));
+    assert!(!s.is_empty());
+    assert_eq!(s.latitude(), Some(31.285065));
+    assert_eq!(s.longitude(), Some(-124.759483));
+    assert_eq!(s.altitude_m(), Some(46.0));
+    assert_eq!(s.speed_kph(), Some(46.93));
+    assert_eq!(s.track_deg(), Some(180.0));
+    assert_eq!(s.magnetic_variation(), Some(12.5));
+    assert_eq!(s.date_time(), Some("2022:09:19 12:45:24"));
+    assert_eq!(s.accelerometer(), Some("-0.000 -0.000 -0.000"));
+  }
+
+  #[test]
+  fn ligogps_meta_empty_by_default() {
+    let m = LigoGpsMeta::default();
+    assert!(m.is_empty());
+    assert!(m.samples().is_empty());
+    assert!(m.first_fix().is_none());
+    assert!(m.warning().is_none());
+  }
+
+  #[test]
+  fn ligogps_meta_first_fix_skips_partial_samples() {
+    let mut m = LigoGpsMeta::new();
+    // First sample has only latitude — should be skipped by `first_fix`.
+    let mut s1 = LigoGpsSample::new();
+    s1.set_latitude(Some(10.0));
+    m.push_sample(s1);
+    // Second sample has BOTH lat/lon — should be the returned fix.
+    let mut s2 = LigoGpsSample::new();
+    s2.set_latitude(Some(20.0)).set_longitude(Some(30.0));
+    m.push_sample(s2);
+    let fix = m.first_fix().expect("first_fix");
+    assert_eq!(fix.latitude(), Some(20.0));
+    assert_eq!(fix.longitude(), Some(30.0));
+  }
+
+  #[test]
+  fn ligogps_meta_warning_first_wins() {
+    let mut m = LigoGpsMeta::new();
+    m.set_warning(SmolStr::new("first"));
+    m.set_warning(SmolStr::new("second"));
+    assert_eq!(m.warning(), Some("first"));
+  }
+
+  #[test]
+  fn project_into_populates_gps_when_first_fix_present() {
+    let mut m = LigoGpsMeta::new();
+    let mut s = LigoGpsSample::new();
+    s.set_latitude(Some(-45.5))
+      .set_longitude(Some(170.5))
+      .set_altitude_m(Some(123.0))
+      .set_date_time(Some(SmolStr::new("2024:01:15 10:00:00")));
+    m.push_sample(s);
+
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    let gps = md.gps().expect("gps populated");
+    assert_eq!(gps.latitude(), Some(-45.5));
+    assert_eq!(gps.longitude(), Some(170.5));
+    assert_eq!(gps.altitude_m(), Some(123.0));
+    assert_eq!(gps.timestamp(), Some("2024:01:15 10:00:00"));
+  }
+
+  #[test]
+  fn project_into_skips_when_gps_already_set() {
+    let mut m = LigoGpsMeta::new();
+    let mut s = LigoGpsSample::new();
+    s.set_latitude(Some(10.0)).set_longitude(Some(20.0));
+    m.push_sample(s);
+
+    let mut md = MediaMetadata::new();
+    // Pre-populate with a higher-priority source.
+    let mut prior = GpsLocation::new();
+    prior
+      .update_latitude(Some(99.0))
+      .update_longitude(Some(88.0));
+    md.set_gps(prior);
+    m.project_into(&mut md);
+    let gps = md.gps().expect("gps still populated");
+    assert_eq!(gps.latitude(), Some(99.0));
+    assert_eq!(gps.longitude(), Some(88.0));
+  }
+
+  #[test]
+  fn warning_is_retained_on_the_typed_surface() {
+    // Warnings do not propagate into `MediaMetadata` (it carries no warnings
+    // channel — the original `md.push_warning` path was written against an older
+    // surface, the same drift #126 Parrot hit). The rendered output surfaces
+    // `warning()` through the QuickTime per-format diagnostics path (a
+    // document-level `ExifTool:Warning`; see `quicktime::Meta`'s `Diagnose`).
+    // Assert here the warning is STORED on the typed surface and that
+    // `project_into` is a safe no-op for it.
+    let mut m = LigoGpsMeta::new();
+    m.set_warning(SmolStr::new("Unrecognized data in LigoGPS trailer"));
+    assert_eq!(m.warning(), Some("Unrecognized data in LigoGPS trailer"));
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    assert!(md.gps().is_none());
+    assert!(md.capture().is_none());
+  }
+}

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -28,6 +28,8 @@ pub(crate) mod crw;
 mod domain;
 mod gopro;
 mod insta360;
+mod ligogps;
+mod parrot;
 #[cfg(feature = "png")]
 pub(crate) mod png;
 pub mod project;
@@ -62,6 +64,13 @@ pub use gopro::{
 pub use insta360::{
   Insta360AccelSample, Insta360ExposureSample, Insta360GpsSample, Insta360Identity, Insta360Meta,
   Insta360VideoTimeSample,
+};
+pub(crate) use ligogps::LigoSource;
+pub use ligogps::{LigoGpsMeta, LigoGpsSample};
+pub use parrot::{
+  ParrotAutomationAnimation, ParrotAutomationSample, ParrotFlightSample, ParrotFlyingState,
+  ParrotFollowMeAnimation, ParrotFollowMeSample, ParrotGpsSample, ParrotMeta, ParrotPilotingMode,
+  ParrotRecordVersion,
 };
 #[cfg(feature = "png")]
 pub use png::{

--- a/src/metadata/parrot.rs
+++ b/src/metadata/parrot.rs
@@ -1,0 +1,2151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Typed mirror of `Image::ExifTool::Parrot::mett` (Parrot.pm:22-84) and the
+//! per-record binary tables `Image::ExifTool::Parrot::V1` / `V2` / `V3` /
+//! `TimeStamp` / `FollowMe` / `Automation` (Parrot.pm:86-660). Faithful port
+//! of `Image::ExifTool::Parrot::Process_mett` (Parrot.pm:791-854) — the
+//! Parrot drone `mett` walker shared by Anafi / Anafi USA / Anafi Ai /
+//! Anafi Thermal / Bebop / Bebop 2 / Disco bodies that write a `mett`
+//! timed-metadata track into MP4.
+//!
+//! ## What this sub-port surfaces (FULL mett parity)
+//!
+//! Per Parrot.pm:86-660, EVERY field of the per-version drone tables
+//! (V1 / V2 / V3) and the extension records (E1 / E2 / E3) is decoded
+//! and emitted (only the ARCore phone-side subtables are walk-and-discard
+//! — see below):
+//!
+//!  - **GPS fix (records `P1` / `P2` / `P3`)** — `GPSLatitude` /
+//!    `GPSLongitude` / `GPSAltitude` / `GPSSatellites` in a fixed-offset
+//!    binary layout. The scaling differs by record version:
+//!     - **V1 (60-byte record)** — Parrot.pm:144-167: lat/lon are
+//!       `int32s / 0x100000` (i.e. ÷ 0x10_0000) at offsets 28 / 32;
+//!       altitude is `(int32s & 0xffffff00) / 0x100` at offset 36
+//!       (low byte holds the SV count).
+//!     - **V2 (56-byte record)** — Parrot.pm:242-265: lat/lon are
+//!       `int32s / 0x400000` at offsets 8 / 12; altitude is the same
+//!       masked shape at offset 16; record CONCAT'd with the E*
+//!       extension records (the bundled walker stretches the V2 size
+//!       from `nwords*4 + 4` to 56 — see Parrot.pm:837-838).
+//!     - **V3 (72-byte record)** — Parrot.pm:383-406: identical lat/
+//!       lon/alt offsets to V2, but the record is 72 bytes including
+//!       extensions (Parrot.pm:838-839).
+//!  - **GNSS velocity vector (V2 / V3)** — `GPSVelocityNorth` /
+//!    `GPSVelocityEast` / `GPSVelocityDown`, `int16s / 0x100` m/s
+//!    (Parrot.pm:266-280 / :407-421). Carried on [`ParrotGpsSample`].
+//!  - **Flight + pose telemetry (records `P1` / `P2` / `P3`)** — battery
+//!    percent, WifiRSSI, AltitudeFromTakeOff (V1), DistanceFromHome (V1),
+//!    Elevation (V2/V3), AirSpeed (V2/V3), DroneYaw/Pitch/Roll (V1),
+//!    CameraPan/CameraTilt (V1/V2), SpeedX/Y/Z (V1), FrameView (V1/V2/V3),
+//!    DroneQuaternion (V2/V3), FrameBaseView (V3), RedBalance/BlueBalance
+//!    (V3), FOV (V3), LinkGoodput/LinkQuality (V3), Binning/Animation,
+//!    ExposureTime, ISO, FlyingState, PilotingMode. Surfaced one
+//!    [`ParrotFlightSample`] per record.
+//!  - **Timestamp extension (record `E1`)** — Parrot.pm:541-551: an
+//!    `int64u` microsecond counter. Recorded as `time_stamp_us`
+//!    on the host [`ParrotFlightSample`].
+//!  - **FollowMe extension (record `E2`)** — Parrot.pm:553-593: the
+//!    follow-me TARGET waypoint (`GPSTargetLatitude` / `Longitude` /
+//!    `Altitude`) plus `Follow-meMode` (BITMASK) and `Follow-meAnimation`.
+//!    Surfaced one [`ParrotFollowMeSample`] per record.
+//!  - **Automation extension (record `E3`)** — Parrot.pm:595-660: the
+//!    framing + destination waypoints (`GPSFramingLatitude` … /
+//!    `GPSDestLatitude` …) plus `AutomationAnimation` and `AutomationFlags`
+//!    (BITMASK). Surfaced one [`ParrotAutomationSample`] per record.
+//!  - **Drone identity** — `mett` does NOT carry Make/Model/Serial/
+//!    Firmware in the per-sample records. Bundled doesn't decode these
+//!    in `Parrot::mett`; Parrot bodies surface their identity through
+//!    the QuickTime `udta/©mod` + `udta/©mak` / Keys path (SP1+SP2).
+//!    The `Make = "Parrot"` projection in [`crate::formats::quicktime`]
+//!    fires whenever any `mett` record decoded — the drone-name string
+//!    (Anafi / Bebop / …) MUST come from the container's udta.
+//!
+//! ## What this sub-port deliberately does NOT decode
+//!
+//! Faithfully but as walked-only (the walker visits, the typed layer
+//! discards):
+//!  - **ARCore phone-camera metadata** (`application/arcore-*` records,
+//!    Parrot.pm:60-83) — Parrot drones also pass through ARCore
+//!    accel/gyro on the controlling phone, but those records are phone-
+//!    side AR data, not drone-side GPS. Walked but discarded (camera-
+//!    indexing scope; flagged separately for a future port).
+//!
+//! ## Projection scope note
+//!
+//! The CAMERA-INDEXING projection into [`MediaMetadata`] still uses only
+//! the drone's own fix + capture settings (Make / GPS / ExposureTime /
+//! ISO). The pose / gimbal / velocity / quaternion / colour-balance / FOV
+//! columns and the E2 / E3 PLANNED-waypoint coordinates are decoded and
+//! EMITTED (full `-ee` parity) but are not projected into the normalized
+//! cross-format domain (they are not the camera's identity or its actual
+//! fix). See [`ParrotMeta::project_into`].
+//!
+//! ## D8 compliance
+//!
+//! Every field is private; access through accessors. Setters return
+//! `&mut Self` for chaining. `const fn` where types permit. Enums are
+//! unit-only (Parrot's `FlyingState` and `PilotingMode` are closed lists
+//! at the bundled level).
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use smol_str::SmolStr;
+
+use crate::metadata::{CameraInfo, CaptureSettings, GpsLocation, MediaMetadata};
+
+// ===========================================================================
+// ParrotFlyingState — Parrot.pm:203-211 (V1) + :329-339 (V2) + :510-520 (V3)
+// ===========================================================================
+
+/// `FlyingState` PrintConv (Parrot.pm:203-211 / :329-339 / :510-520).
+/// V1's range is 0..=5 (`Landed` … `Emergency`); V2 / V3 extend the range
+/// to 0..=8 with `User Takeoff` / `Motor Ramping` / `Emergency Landing`.
+///
+/// The typed layer surfaces the FULL range — a V1 walker can only emit
+/// 0..=5; V2 / V3 walkers can emit any of 0..=8. Unknown numeric values
+/// land in [`ParrotFlyingState::Unknown`] with the raw u8 preserved
+/// (faithful: bundled's `PrintConv` hash returns the raw on miss).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParrotFlyingState {
+  /// Bundled key `0`.
+  Landed,
+  /// Bundled key `1`.
+  TakingOff,
+  /// Bundled key `2`.
+  Hovering,
+  /// Bundled key `3`.
+  Flying,
+  /// Bundled key `4`.
+  Landing,
+  /// Bundled key `5`.
+  Emergency,
+  /// Bundled key `6` (V2 + V3 only).
+  UserTakeoff,
+  /// Bundled key `7` (V2 + V3 only).
+  MotorRamping,
+  /// Bundled key `8` (V2 + V3 only).
+  EmergencyLanding,
+  /// Bundled returned the raw numeric on PrintConv miss — keep the byte.
+  Unknown(u8),
+}
+
+impl ParrotFlyingState {
+  /// Build from the raw 7-bit value (`Mask => 0x7f`). Parrot.pm:202.
+  #[inline]
+  #[must_use]
+  pub const fn from_raw(raw: u8) -> Self {
+    match raw {
+      0 => Self::Landed,
+      1 => Self::TakingOff,
+      2 => Self::Hovering,
+      3 => Self::Flying,
+      4 => Self::Landing,
+      5 => Self::Emergency,
+      6 => Self::UserTakeoff,
+      7 => Self::MotorRamping,
+      8 => Self::EmergencyLanding,
+      n => Self::Unknown(n),
+    }
+  }
+
+  /// Raw 7-bit value (round-trip).
+  #[inline]
+  #[must_use]
+  pub const fn as_u8(self) -> u8 {
+    match self {
+      Self::Landed => 0,
+      Self::TakingOff => 1,
+      Self::Hovering => 2,
+      Self::Flying => 3,
+      Self::Landing => 4,
+      Self::Emergency => 5,
+      Self::UserTakeoff => 6,
+      Self::MotorRamping => 7,
+      Self::EmergencyLanding => 8,
+      Self::Unknown(n) => n,
+    }
+  }
+}
+
+// ===========================================================================
+// ParrotPilotingMode — Parrot.pm:221-227 (V1) + :345-356 (V2) + :526-538 (V3)
+// ===========================================================================
+
+/// `PilotingMode` PrintConv (Parrot.pm:221-227 / :345-356 / :526-538).
+/// V1 keys are 0..=3 (`Manual` … `Follow Me`); V2 / V3 extend to 0..=5 with
+/// `Magic Carpet` / `Move To`. Note V1 calls key 3 "Follow Me" while V2 / V3
+/// call it "Follow Me / Tracking" (same numeric value, just a wider
+/// description — bundled keeps a single PrintConv entry per version).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParrotPilotingMode {
+  /// Bundled key `0`.
+  Manual,
+  /// Bundled key `1`.
+  ReturnHome,
+  /// Bundled key `2`.
+  FlightPlan,
+  /// Bundled key `3` (V1: "Follow Me"; V2 / V3: "Follow Me / Tracking").
+  FollowMe,
+  /// Bundled key `4` (V2 + V3 only).
+  MagicCarpet,
+  /// Bundled key `5` (V2 + V3 only).
+  MoveTo,
+  /// Bundled returned the raw on miss.
+  Unknown(u8),
+}
+
+impl ParrotPilotingMode {
+  /// Build from the raw 7-bit value (`Mask => 0x7f`). Parrot.pm:220.
+  #[inline]
+  #[must_use]
+  pub const fn from_raw(raw: u8) -> Self {
+    match raw {
+      0 => Self::Manual,
+      1 => Self::ReturnHome,
+      2 => Self::FlightPlan,
+      3 => Self::FollowMe,
+      4 => Self::MagicCarpet,
+      5 => Self::MoveTo,
+      n => Self::Unknown(n),
+    }
+  }
+
+  /// Raw 7-bit value (round-trip).
+  #[inline]
+  #[must_use]
+  pub const fn as_u8(self) -> u8 {
+    match self {
+      Self::Manual => 0,
+      Self::ReturnHome => 1,
+      Self::FlightPlan => 2,
+      Self::FollowMe => 3,
+      Self::MagicCarpet => 4,
+      Self::MoveTo => 5,
+      Self::Unknown(n) => n,
+    }
+  }
+}
+
+// ===========================================================================
+// ParrotFollowMeAnimation — Parrot.pm:585-591 (E2 FollowMe)
+// ===========================================================================
+
+/// `Follow-meAnimation` PrintConv (Parrot.pm:585-591). A miss returns the raw
+/// numeric (bundled PrintConv hash with no `OTHER`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParrotFollowMeAnimation {
+  /// Bundled key `0`.
+  None,
+  /// Bundled key `1`.
+  Orbit,
+  /// Bundled key `2`.
+  Boomerang,
+  /// Bundled key `3`.
+  Parabola,
+  /// Bundled key `4`.
+  Zenith,
+  /// Bundled returned the raw numeric on PrintConv miss — keep the byte.
+  Unknown(u8),
+}
+
+impl ParrotFollowMeAnimation {
+  /// Build from the raw int8u value (Parrot.pm:582-592).
+  #[inline]
+  #[must_use]
+  pub const fn from_raw(raw: u8) -> Self {
+    match raw {
+      0 => Self::None,
+      1 => Self::Orbit,
+      2 => Self::Boomerang,
+      3 => Self::Parabola,
+      4 => Self::Zenith,
+      n => Self::Unknown(n),
+    }
+  }
+
+  /// Raw int8u value (round-trip).
+  #[inline]
+  #[must_use]
+  pub const fn as_u8(self) -> u8 {
+    match self {
+      Self::None => 0,
+      Self::Orbit => 1,
+      Self::Boomerang => 2,
+      Self::Parabola => 3,
+      Self::Zenith => 4,
+      Self::Unknown(n) => n,
+    }
+  }
+}
+
+// ===========================================================================
+// ParrotAutomationAnimation — Parrot.pm:633-649 (E3 Automation)
+// ===========================================================================
+
+/// `AutomationAnimation` PrintConv (Parrot.pm:633-649). A miss returns the raw
+/// numeric (bundled PrintConv hash with no `OTHER`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParrotAutomationAnimation {
+  /// Bundled key `0`.
+  None,
+  /// Bundled key `1`.
+  Orbit,
+  /// Bundled key `2`.
+  Boomerang,
+  /// Bundled key `3`.
+  Parabola,
+  /// Bundled key `4`.
+  DollySlide,
+  /// Bundled key `5`.
+  DollyZoom,
+  /// Bundled key `6`.
+  RevealVertical,
+  /// Bundled key `7`.
+  RevealHorizontal,
+  /// Bundled key `8`.
+  Candle,
+  /// Bundled key `9`.
+  FlipFront,
+  /// Bundled key `10`.
+  FlipBack,
+  /// Bundled key `11`.
+  FlipLeft,
+  /// Bundled key `12`.
+  FlipRight,
+  /// Bundled key `13`.
+  TwistUp,
+  /// Bundled key `14`.
+  PositionTwistUp,
+  /// Bundled returned the raw numeric on PrintConv miss — keep the byte.
+  Unknown(u8),
+}
+
+impl ParrotAutomationAnimation {
+  /// Build from the raw int8u value (Parrot.pm:630-650).
+  #[inline]
+  #[must_use]
+  pub const fn from_raw(raw: u8) -> Self {
+    match raw {
+      0 => Self::None,
+      1 => Self::Orbit,
+      2 => Self::Boomerang,
+      3 => Self::Parabola,
+      4 => Self::DollySlide,
+      5 => Self::DollyZoom,
+      6 => Self::RevealVertical,
+      7 => Self::RevealHorizontal,
+      8 => Self::Candle,
+      9 => Self::FlipFront,
+      10 => Self::FlipBack,
+      11 => Self::FlipLeft,
+      12 => Self::FlipRight,
+      13 => Self::TwistUp,
+      14 => Self::PositionTwistUp,
+      n => Self::Unknown(n),
+    }
+  }
+
+  /// Raw int8u value (round-trip).
+  #[inline]
+  #[must_use]
+  pub const fn as_u8(self) -> u8 {
+    match self {
+      Self::None => 0,
+      Self::Orbit => 1,
+      Self::Boomerang => 2,
+      Self::Parabola => 3,
+      Self::DollySlide => 4,
+      Self::DollyZoom => 5,
+      Self::RevealVertical => 6,
+      Self::RevealHorizontal => 7,
+      Self::Candle => 8,
+      Self::FlipFront => 9,
+      Self::FlipBack => 10,
+      Self::FlipLeft => 11,
+      Self::FlipRight => 12,
+      Self::TwistUp => 13,
+      Self::PositionTwistUp => 14,
+      Self::Unknown(n) => n,
+    }
+  }
+}
+
+// ===========================================================================
+// ParrotRecordVersion — which of V1 / V2 / V3 produced the sample
+// ===========================================================================
+
+/// Parrot `mett` record version (Parrot.pm:35-46). The walker only emits
+/// the four-letter IDs `P1` / `P2` / `P3`; a V1 60-byte recording-record
+/// without a leading ID falls through to V1 by the bundled
+/// "no ID and dirEnd == 60" rule (Parrot.pm:827-833).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParrotRecordVersion {
+  /// `P1` — Parrot V1 streaming metadata (Parrot.pm:87-228).
+  V1,
+  /// `P2` — Parrot V2 basic streaming metadata (Parrot.pm:230-369).
+  V2,
+  /// `P3` — Parrot V3 basic streaming metadata (Parrot.pm:371-539).
+  V3,
+}
+
+impl ParrotRecordVersion {
+  /// The id name in the bundled NOTES (`"P1"` / `"P2"` / `"P3"`).
+  #[inline]
+  #[must_use]
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      Self::V1 => "P1",
+      Self::V2 => "P2",
+      Self::V3 => "P3",
+    }
+  }
+}
+
+// ===========================================================================
+// ParrotGpsSample — one decoded GPS fix
+// ===========================================================================
+
+/// One GPS fix decoded from a Parrot `mett` `P1` / `P2` / `P3` record.
+/// Bundled-derived field semantics:
+///
+///  - **V1** (Parrot.pm:144-167): latitude `int32s / 0x100000` at
+///    record offset 28, longitude same scaling at offset 32, altitude
+///    `(int32s & 0xffffff00) / 0x100` at offset 36 (low byte = SV count).
+///  - **V2** (Parrot.pm:242-265): latitude `int32s / 0x400000` at
+///    record offset 8, longitude same at offset 12, altitude
+///    `(int32s & 0xffffff00) / 0x100` at offset 16 (low byte = SV count).
+///  - **V3** (Parrot.pm:383-406): identical offsets / scaling to V2.
+///
+/// All three versions store coordinates in decimal degrees AFTER the
+/// bundled `ValueConv` divisor (no DDDMM.MMMM intermediate). Altitude
+/// is metres after `/ 0x100`. `satellites` is the SV count from the
+/// low byte of the altitude word.
+///
+/// V2 / V3 additionally carry a 3-axis GNSS velocity vector
+/// (`GPSVelocityNorth` / `GPSVelocityEast` / `GPSVelocityDown`,
+/// Parrot.pm:266-280 / :407-421) scaled `int16s / 0x100` (m/s). V1 has no
+/// velocity vector, so those accessors stay `None` for a V1 fix.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParrotGpsSample {
+  /// Which record version produced this fix (`P1` / `P2` / `P3`).
+  version: ParrotRecordVersion,
+  /// `GPSLatitude` decimal degrees (already-scaled by bundled ValueConv).
+  latitude: Option<f64>,
+  /// `GPSLongitude` decimal degrees.
+  longitude: Option<f64>,
+  /// `GPSAltitude` metres (already-scaled by bundled ValueConv).
+  altitude_m: Option<f64>,
+  /// `GPSSatellites` — SV count (low byte of altitude word).
+  satellites: Option<u8>,
+  /// `GPSVelocityNorth` m/s (V2 / V3 — Parrot.pm:266-270 / :407-411).
+  velocity_north_mps: Option<f64>,
+  /// `GPSVelocityEast` m/s (V2 / V3 — Parrot.pm:271-275 / :412-416).
+  velocity_east_mps: Option<f64>,
+  /// `GPSVelocityDown` m/s (V2 / V3 — Parrot.pm:276-280 / :417-421).
+  velocity_down_mps: Option<f64>,
+  /// The 1-based GLOBAL `Doc<N>` ordinal stamped at extraction (the typed
+  /// mirror of `$$et{DOC_NUM} = ++$$et{DOC_COUNT}`, opened once per `mett`
+  /// SAMPLE by `ProcessSamples`). All records of one sample share it. `0` until
+  /// the walker stamps it (and on unit-built samples).
+  doc: u32,
+  /// The 1-based moov `Track<N>` index (`SET_GROUP1 = "Track$num"`). `0` until
+  /// stamped.
+  track_index: u32,
+}
+
+impl ParrotGpsSample {
+  /// Build an empty sample tagged with the given record version.
+  #[inline]
+  #[must_use]
+  pub const fn new(version: ParrotRecordVersion) -> Self {
+    Self {
+      version,
+      latitude: None,
+      longitude: None,
+      altitude_m: None,
+      satellites: None,
+      velocity_north_mps: None,
+      velocity_east_mps: None,
+      velocity_down_mps: None,
+      doc: 0,
+      track_index: 0,
+    }
+  }
+
+  /// The 1-based GLOBAL `Doc<N>` ordinal (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn doc(&self) -> u32 {
+    self.doc
+  }
+
+  /// The 1-based moov `Track<N>` index (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn track_index(&self) -> u32 {
+    self.track_index
+  }
+
+  /// Which record version produced this fix.
+  #[inline(always)]
+  #[must_use]
+  pub const fn version(&self) -> ParrotRecordVersion {
+    self.version
+  }
+
+  /// `GPSLatitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn latitude(&self) -> Option<f64> {
+    self.latitude
+  }
+
+  /// `GPSLongitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn longitude(&self) -> Option<f64> {
+    self.longitude
+  }
+
+  /// `GPSAltitude` metres.
+  #[inline(always)]
+  #[must_use]
+  pub const fn altitude_m(&self) -> Option<f64> {
+    self.altitude_m
+  }
+
+  /// `GPSSatellites` — SV count (Parrot.pm:163-167 / :261-265 / :402-406).
+  #[inline(always)]
+  #[must_use]
+  pub const fn satellites(&self) -> Option<u8> {
+    self.satellites
+  }
+
+  /// `GPSVelocityNorth` m/s (V2 / V3 — Parrot.pm:266-270 / :407-411).
+  #[inline(always)]
+  #[must_use]
+  pub const fn velocity_north_mps(&self) -> Option<f64> {
+    self.velocity_north_mps
+  }
+
+  /// `GPSVelocityEast` m/s (V2 / V3 — Parrot.pm:271-275 / :412-416).
+  #[inline(always)]
+  #[must_use]
+  pub const fn velocity_east_mps(&self) -> Option<f64> {
+    self.velocity_east_mps
+  }
+
+  /// `GPSVelocityDown` m/s (V2 / V3 — Parrot.pm:276-280 / :417-421).
+  #[inline(always)]
+  #[must_use]
+  pub const fn velocity_down_mps(&self) -> Option<f64> {
+    self.velocity_down_mps
+  }
+
+  /// `true` when no coordinate or telemetry field is populated.
+  #[inline]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.latitude.is_none()
+      && self.longitude.is_none()
+      && self.altitude_m.is_none()
+      && self.satellites.is_none()
+      && self.velocity_north_mps.is_none()
+      && self.velocity_east_mps.is_none()
+      && self.velocity_down_mps.is_none()
+  }
+
+  /// Assign `GPSLatitude`.
+  #[inline(always)]
+  pub const fn set_latitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.latitude = v;
+    self
+  }
+
+  /// Assign `GPSLongitude`.
+  #[inline(always)]
+  pub const fn set_longitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.longitude = v;
+    self
+  }
+
+  /// Assign `GPSAltitude` metres.
+  #[inline(always)]
+  pub const fn set_altitude_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.altitude_m = v;
+    self
+  }
+
+  /// Assign `GPSSatellites`.
+  #[inline(always)]
+  pub const fn set_satellites(&mut self, v: Option<u8>) -> &mut Self {
+    self.satellites = v;
+    self
+  }
+
+  /// Assign `GPSVelocityNorth` m/s.
+  #[inline(always)]
+  pub const fn set_velocity_north_mps(&mut self, v: Option<f64>) -> &mut Self {
+    self.velocity_north_mps = v;
+    self
+  }
+
+  /// Assign `GPSVelocityEast` m/s.
+  #[inline(always)]
+  pub const fn set_velocity_east_mps(&mut self, v: Option<f64>) -> &mut Self {
+    self.velocity_east_mps = v;
+    self
+  }
+
+  /// Assign `GPSVelocityDown` m/s.
+  #[inline(always)]
+  pub const fn set_velocity_down_mps(&mut self, v: Option<f64>) -> &mut Self {
+    self.velocity_down_mps = v;
+    self
+  }
+}
+
+// ===========================================================================
+// ParrotFlightSample — telemetry from one P1 / P2 / P3 record
+// ===========================================================================
+
+/// Flight telemetry decoded from one Parrot `mett` `P1` / `P2` / `P3`
+/// record. Mirrors `Image::ExifTool::Parrot::V1` / `V2` / `V3` row
+/// (Parrot.pm:87-539). All fields are optional — a given drone may not
+/// write every field (e.g. V1 has no `Elevation`; V3 adds `RedBalance`).
+///
+/// Bundled-derived field semantics:
+///  - `battery_percent` (Parrot.pm:139-143 / :364-368 / :495-499) —
+///    int8u at offset 27 / 55 / 69, unitless 0..=100.
+///  - `wifi_rssi_dbm` (Parrot.pm:133-138 / :358-363 / :489-494) —
+///    int8s at offset 26 / 54 / 68, dBm.
+///  - `iso` (Parrot.pm:128-132 / :314-318 / :450-454) — int16s/int16u
+///    at offset 24 / 50 / 54.
+///  - `exposure_time_s` (Parrot.pm:121-127 / :307-313 / :443-449) —
+///    int16s/int16u at offset 22 / 48 / 52, ValueConv `$val / 0x100 /
+///    1000`.
+///  - `flying_state` (Parrot.pm:199-211 / :324-339 / :505-520) —
+///    int8u low 7 bits at offset 54 / 52 / 70.
+///  - `piloting_mode` (Parrot.pm:217-227 / :340-356 / :521-538) —
+///    int8u low 7 bits at offset 55 / 53 / 71.
+///  - `altitude_from_takeoff_m` (Parrot.pm:168-173) — int32s scaled
+///    `$val / 0x10000` at V1 offset 40; V2 / V3 don't carry this.
+///  - `distance_from_home_m` (Parrot.pm:174-178) — int32u scaled
+///    `$val / 0x10000` at V1 offset 44; V2 / V3 don't carry this.
+///  - `air_speed_mps` (Parrot.pm:281-286 / :422-427) — int16s scaled
+///    `$val / 0x100`, with bundled `RawConv => '$val < 0 ? undef : $val'`
+///    (Parrot.pm:284 / :425). V1 doesn't carry this field.
+///  - `elevation_m` (Parrot.pm:236-241 / :377-382) — int32s scaled
+///    `$val / 0x10000` at V2 / V3 offset 4. V1 doesn't carry this.
+///  - `time_stamp_us` — concat'd `E1 TimeStamp` extension when present
+///    (Parrot.pm:541-551), int64u microseconds.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParrotFlightSample {
+  /// Which record version produced this sample.
+  version: ParrotRecordVersion,
+  /// `Battery` % (Parrot.pm:139-143 / :364-368 / :495-499).
+  battery_percent: Option<u8>,
+  /// `WifiRSSI` dBm (Parrot.pm:133-138 / :358-363 / :489-494).
+  wifi_rssi_dbm: Option<i8>,
+  /// `ISO` (Parrot.pm:128-132 / :314-318 / :450-454).
+  iso: Option<i32>,
+  /// `ExposureTime` seconds (Parrot.pm:121-127 / :307-313 / :443-449).
+  exposure_time_s: Option<f64>,
+  /// `FlyingState` (Parrot.pm:199-211 / :324-339 / :505-520).
+  flying_state: Option<ParrotFlyingState>,
+  /// `PilotingMode` (Parrot.pm:217-227 / :340-356 / :521-538).
+  piloting_mode: Option<ParrotPilotingMode>,
+  /// `AltitudeFromTakeOff` metres (V1 only — Parrot.pm:168-173).
+  altitude_from_takeoff_m: Option<f64>,
+  /// `DistanceFromHome` metres (V1 only — Parrot.pm:174-178).
+  distance_from_home_m: Option<f64>,
+  /// `AirSpeed` m/s (V2 / V3 — Parrot.pm:281-286 / :422-427).
+  air_speed_mps: Option<f64>,
+  /// `Elevation` metres above ground (V2 / V3 — Parrot.pm:236-241 / :377-382).
+  elevation_m: Option<f64>,
+  /// `DroneYaw` degrees (V1 only — Parrot.pm:91-95). `int16s / 0x1000 * 180 / π`.
+  drone_yaw_deg: Option<f64>,
+  /// `DronePitch` degrees (V1 only — Parrot.pm:96-100).
+  drone_pitch_deg: Option<f64>,
+  /// `DroneRoll` degrees (V1 only — Parrot.pm:101-105).
+  drone_roll_deg: Option<f64>,
+  /// `CameraPan` degrees (V1 @10 / V2 @44 — Parrot.pm:106-110 / :297-301).
+  camera_pan_deg: Option<f64>,
+  /// `CameraTilt` degrees (V1 @12 / V2 @46 — Parrot.pm:111-115 / :302-306).
+  camera_tilt_deg: Option<f64>,
+  /// `SpeedX` (V1 only — Parrot.pm:179-183). `int16s / 0x100`.
+  speed_x: Option<f64>,
+  /// `SpeedY` (V1 only — Parrot.pm:184-188).
+  speed_y: Option<f64>,
+  /// `SpeedZ` (V1 only — Parrot.pm:189-193).
+  speed_z: Option<f64>,
+  /// `FrameView` quaternion `(W,X,Y,Z)` (V1 @14 scaled `/0x1000`,
+  /// V2 @36 / V3 @44 scaled `/0x4000` — Parrot.pm:116-120 / :292-296 / :438-442).
+  frame_view: Option<[f64; 4]>,
+  /// `DroneQuaternion` `(W,X,Y,Z)` (V2 @28 / V3 @28 scaled `/0x4000` —
+  /// Parrot.pm:287-291 / :428-432).
+  drone_quaternion: Option<[f64; 4]>,
+  /// `FrameBaseView` quaternion `(W,X,Y,Z)` without pan/tilt (V3 @36 scaled
+  /// `/0x4000` — Parrot.pm:433-437).
+  frame_base_view: Option<[f64; 4]>,
+  /// `RedBalance` (V3 only — Parrot.pm:455-460). `int16u / 0x4000`.
+  red_balance: Option<f64>,
+  /// `BlueBalance` (V3 only — Parrot.pm:461-466). `int16u / 0x4000`.
+  blue_balance: Option<f64>,
+  /// `FOV` horizontal + vertical field of view, degrees (V3 only —
+  /// Parrot.pm:467-474). `int16u[2]`, each `/0x100`.
+  fov_deg: Option<[f64; 2]>,
+  /// `LinkGoodput` kbit/s (V3 only — Parrot.pm:475-481). `int32u` upper 24 bits.
+  link_goodput_kbitps: Option<u32>,
+  /// `LinkQuality` 0-5 (V3 only — Parrot.pm:482-488). `int32u` low byte.
+  link_quality: Option<u8>,
+  /// `Binning` flag (V1 @54 / V2 @52 / V3 @70, `Mask => 0x80` — high bit of the
+  /// FlyingState byte; Parrot.pm:194-198 / :319-323 / :500-504).
+  binning: Option<u8>,
+  /// `Animation` flag (V1 @55 / V2 @53 / V3 @71, `Mask => 0x80` — high bit of the
+  /// PilotingMode byte; Parrot.pm:212-216 / :340-344 / :521-525).
+  animation: Option<u8>,
+  /// `E1 TimeStamp` microsecond counter (Parrot.pm:541-551).
+  time_stamp_us: Option<u64>,
+  /// The 1-based GLOBAL `Doc<N>` ordinal stamped at extraction (one per `mett`
+  /// SAMPLE — `ProcessSamples` opens it via `FoundSomething`). `0` until stamped.
+  doc: u32,
+  /// The 1-based moov `Track<N>` index. `0` until stamped.
+  track_index: u32,
+  /// The sample-table `SampleTime` (seconds) `ProcessSamples` emits ahead of the
+  /// decoded payload (`ConvertDuration` PrintConv). `None` until stamped.
+  sample_time: Option<f64>,
+  /// The sample-table `SampleDuration` (seconds). `None` until stamped.
+  sample_duration: Option<f64>,
+}
+
+impl ParrotFlightSample {
+  /// Build an empty sample tagged with the given record version.
+  #[inline]
+  #[must_use]
+  pub const fn new(version: ParrotRecordVersion) -> Self {
+    Self {
+      version,
+      battery_percent: None,
+      wifi_rssi_dbm: None,
+      iso: None,
+      exposure_time_s: None,
+      flying_state: None,
+      piloting_mode: None,
+      altitude_from_takeoff_m: None,
+      distance_from_home_m: None,
+      air_speed_mps: None,
+      elevation_m: None,
+      drone_yaw_deg: None,
+      drone_pitch_deg: None,
+      drone_roll_deg: None,
+      camera_pan_deg: None,
+      camera_tilt_deg: None,
+      speed_x: None,
+      speed_y: None,
+      speed_z: None,
+      frame_view: None,
+      drone_quaternion: None,
+      frame_base_view: None,
+      red_balance: None,
+      blue_balance: None,
+      fov_deg: None,
+      link_goodput_kbitps: None,
+      link_quality: None,
+      binning: None,
+      animation: None,
+      time_stamp_us: None,
+      doc: 0,
+      track_index: 0,
+      sample_time: None,
+      sample_duration: None,
+    }
+  }
+
+  /// Which record version produced this sample.
+  #[inline(always)]
+  #[must_use]
+  pub const fn version(&self) -> ParrotRecordVersion {
+    self.version
+  }
+
+  /// The 1-based GLOBAL `Doc<N>` ordinal (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn doc(&self) -> u32 {
+    self.doc
+  }
+
+  /// The 1-based moov `Track<N>` index (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn track_index(&self) -> u32 {
+    self.track_index
+  }
+
+  /// The sample-table `SampleTime` in seconds (`None` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn sample_time(&self) -> Option<f64> {
+    self.sample_time
+  }
+
+  /// The sample-table `SampleDuration` in seconds (`None` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn sample_duration(&self) -> Option<f64> {
+    self.sample_duration
+  }
+
+  /// `Battery` % (0..=100).
+  #[inline(always)]
+  #[must_use]
+  pub const fn battery_percent(&self) -> Option<u8> {
+    self.battery_percent
+  }
+
+  /// `WifiRSSI` dBm.
+  #[inline(always)]
+  #[must_use]
+  pub const fn wifi_rssi_dbm(&self) -> Option<i8> {
+    self.wifi_rssi_dbm
+  }
+
+  /// `ISO`.
+  #[inline(always)]
+  #[must_use]
+  pub const fn iso(&self) -> Option<i32> {
+    self.iso
+  }
+
+  /// `ExposureTime` seconds.
+  #[inline(always)]
+  #[must_use]
+  pub const fn exposure_time_s(&self) -> Option<f64> {
+    self.exposure_time_s
+  }
+
+  /// `FlyingState`.
+  #[inline(always)]
+  #[must_use]
+  pub const fn flying_state(&self) -> Option<ParrotFlyingState> {
+    self.flying_state
+  }
+
+  /// `PilotingMode`.
+  #[inline(always)]
+  #[must_use]
+  pub const fn piloting_mode(&self) -> Option<ParrotPilotingMode> {
+    self.piloting_mode
+  }
+
+  /// `AltitudeFromTakeOff` metres (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn altitude_from_takeoff_m(&self) -> Option<f64> {
+    self.altitude_from_takeoff_m
+  }
+
+  /// `DistanceFromHome` metres (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn distance_from_home_m(&self) -> Option<f64> {
+    self.distance_from_home_m
+  }
+
+  /// `AirSpeed` m/s (V2 / V3).
+  #[inline(always)]
+  #[must_use]
+  pub const fn air_speed_mps(&self) -> Option<f64> {
+    self.air_speed_mps
+  }
+
+  /// `Elevation` metres above ground (V2 / V3).
+  #[inline(always)]
+  #[must_use]
+  pub const fn elevation_m(&self) -> Option<f64> {
+    self.elevation_m
+  }
+
+  /// `DroneYaw` degrees (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn drone_yaw_deg(&self) -> Option<f64> {
+    self.drone_yaw_deg
+  }
+
+  /// `DronePitch` degrees (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn drone_pitch_deg(&self) -> Option<f64> {
+    self.drone_pitch_deg
+  }
+
+  /// `DroneRoll` degrees (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn drone_roll_deg(&self) -> Option<f64> {
+    self.drone_roll_deg
+  }
+
+  /// `CameraPan` degrees (V1 / V2).
+  #[inline(always)]
+  #[must_use]
+  pub const fn camera_pan_deg(&self) -> Option<f64> {
+    self.camera_pan_deg
+  }
+
+  /// `CameraTilt` degrees (V1 / V2).
+  #[inline(always)]
+  #[must_use]
+  pub const fn camera_tilt_deg(&self) -> Option<f64> {
+    self.camera_tilt_deg
+  }
+
+  /// `SpeedX` (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn speed_x(&self) -> Option<f64> {
+    self.speed_x
+  }
+
+  /// `SpeedY` (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn speed_y(&self) -> Option<f64> {
+    self.speed_y
+  }
+
+  /// `SpeedZ` (V1 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn speed_z(&self) -> Option<f64> {
+    self.speed_z
+  }
+
+  /// `FrameView` quaternion `(W,X,Y,Z)` (V1 / V2 / V3).
+  #[inline(always)]
+  #[must_use]
+  pub const fn frame_view(&self) -> Option<[f64; 4]> {
+    self.frame_view
+  }
+
+  /// `DroneQuaternion` `(W,X,Y,Z)` (V2 / V3).
+  #[inline(always)]
+  #[must_use]
+  pub const fn drone_quaternion(&self) -> Option<[f64; 4]> {
+    self.drone_quaternion
+  }
+
+  /// `FrameBaseView` quaternion `(W,X,Y,Z)` without pan/tilt (V3 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn frame_base_view(&self) -> Option<[f64; 4]> {
+    self.frame_base_view
+  }
+
+  /// `RedBalance` (V3 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn red_balance(&self) -> Option<f64> {
+    self.red_balance
+  }
+
+  /// `BlueBalance` (V3 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn blue_balance(&self) -> Option<f64> {
+    self.blue_balance
+  }
+
+  /// `FOV` horizontal + vertical field of view, degrees (V3 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn fov_deg(&self) -> Option<[f64; 2]> {
+    self.fov_deg
+  }
+
+  /// `LinkGoodput` kbit/s (V3 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn link_goodput_kbitps(&self) -> Option<u32> {
+    self.link_goodput_kbitps
+  }
+
+  /// `LinkQuality` 0-5 (V3 only).
+  #[inline(always)]
+  #[must_use]
+  pub const fn link_quality(&self) -> Option<u8> {
+    self.link_quality
+  }
+
+  /// `Binning` flag (high bit of the FlyingState byte).
+  #[inline(always)]
+  #[must_use]
+  pub const fn binning(&self) -> Option<u8> {
+    self.binning
+  }
+
+  /// `Animation` flag (high bit of the PilotingMode byte).
+  #[inline(always)]
+  #[must_use]
+  pub const fn animation(&self) -> Option<u8> {
+    self.animation
+  }
+
+  /// `E1 TimeStamp` microsecond counter.
+  #[inline(always)]
+  #[must_use]
+  pub const fn time_stamp_us(&self) -> Option<u64> {
+    self.time_stamp_us
+  }
+
+  /// `true` when no telemetry field is populated.
+  #[inline]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.battery_percent.is_none()
+      && self.wifi_rssi_dbm.is_none()
+      && self.iso.is_none()
+      && self.exposure_time_s.is_none()
+      && self.flying_state.is_none()
+      && self.piloting_mode.is_none()
+      && self.altitude_from_takeoff_m.is_none()
+      && self.distance_from_home_m.is_none()
+      && self.air_speed_mps.is_none()
+      && self.elevation_m.is_none()
+      && self.drone_yaw_deg.is_none()
+      && self.drone_pitch_deg.is_none()
+      && self.drone_roll_deg.is_none()
+      && self.camera_pan_deg.is_none()
+      && self.camera_tilt_deg.is_none()
+      && self.speed_x.is_none()
+      && self.speed_y.is_none()
+      && self.speed_z.is_none()
+      && self.frame_view.is_none()
+      && self.drone_quaternion.is_none()
+      && self.frame_base_view.is_none()
+      && self.red_balance.is_none()
+      && self.blue_balance.is_none()
+      && self.fov_deg.is_none()
+      && self.link_goodput_kbitps.is_none()
+      && self.link_quality.is_none()
+      && self.binning.is_none()
+      && self.animation.is_none()
+      && self.time_stamp_us.is_none()
+  }
+
+  /// Assign `Battery`.
+  #[inline(always)]
+  pub const fn set_battery_percent(&mut self, v: Option<u8>) -> &mut Self {
+    self.battery_percent = v;
+    self
+  }
+
+  /// Assign `WifiRSSI`.
+  #[inline(always)]
+  pub const fn set_wifi_rssi_dbm(&mut self, v: Option<i8>) -> &mut Self {
+    self.wifi_rssi_dbm = v;
+    self
+  }
+
+  /// Assign `ISO`.
+  #[inline(always)]
+  pub const fn set_iso(&mut self, v: Option<i32>) -> &mut Self {
+    self.iso = v;
+    self
+  }
+
+  /// Assign `ExposureTime`.
+  #[inline(always)]
+  pub const fn set_exposure_time_s(&mut self, v: Option<f64>) -> &mut Self {
+    self.exposure_time_s = v;
+    self
+  }
+
+  /// Assign `FlyingState`.
+  #[inline(always)]
+  pub const fn set_flying_state(&mut self, v: Option<ParrotFlyingState>) -> &mut Self {
+    self.flying_state = v;
+    self
+  }
+
+  /// Assign `PilotingMode`.
+  #[inline(always)]
+  pub const fn set_piloting_mode(&mut self, v: Option<ParrotPilotingMode>) -> &mut Self {
+    self.piloting_mode = v;
+    self
+  }
+
+  /// Assign `AltitudeFromTakeOff` metres.
+  #[inline(always)]
+  pub const fn set_altitude_from_takeoff_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.altitude_from_takeoff_m = v;
+    self
+  }
+
+  /// Assign `DistanceFromHome` metres.
+  #[inline(always)]
+  pub const fn set_distance_from_home_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.distance_from_home_m = v;
+    self
+  }
+
+  /// Assign `AirSpeed` m/s.
+  #[inline(always)]
+  pub const fn set_air_speed_mps(&mut self, v: Option<f64>) -> &mut Self {
+    self.air_speed_mps = v;
+    self
+  }
+
+  /// Assign `Elevation` metres.
+  #[inline(always)]
+  pub const fn set_elevation_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.elevation_m = v;
+    self
+  }
+
+  /// Assign `DroneYaw` degrees.
+  #[inline(always)]
+  pub const fn set_drone_yaw_deg(&mut self, v: Option<f64>) -> &mut Self {
+    self.drone_yaw_deg = v;
+    self
+  }
+
+  /// Assign `DronePitch` degrees.
+  #[inline(always)]
+  pub const fn set_drone_pitch_deg(&mut self, v: Option<f64>) -> &mut Self {
+    self.drone_pitch_deg = v;
+    self
+  }
+
+  /// Assign `DroneRoll` degrees.
+  #[inline(always)]
+  pub const fn set_drone_roll_deg(&mut self, v: Option<f64>) -> &mut Self {
+    self.drone_roll_deg = v;
+    self
+  }
+
+  /// Assign `CameraPan` degrees.
+  #[inline(always)]
+  pub const fn set_camera_pan_deg(&mut self, v: Option<f64>) -> &mut Self {
+    self.camera_pan_deg = v;
+    self
+  }
+
+  /// Assign `CameraTilt` degrees.
+  #[inline(always)]
+  pub const fn set_camera_tilt_deg(&mut self, v: Option<f64>) -> &mut Self {
+    self.camera_tilt_deg = v;
+    self
+  }
+
+  /// Assign `SpeedX`.
+  #[inline(always)]
+  pub const fn set_speed_x(&mut self, v: Option<f64>) -> &mut Self {
+    self.speed_x = v;
+    self
+  }
+
+  /// Assign `SpeedY`.
+  #[inline(always)]
+  pub const fn set_speed_y(&mut self, v: Option<f64>) -> &mut Self {
+    self.speed_y = v;
+    self
+  }
+
+  /// Assign `SpeedZ`.
+  #[inline(always)]
+  pub const fn set_speed_z(&mut self, v: Option<f64>) -> &mut Self {
+    self.speed_z = v;
+    self
+  }
+
+  /// Assign `FrameView` quaternion `(W,X,Y,Z)`.
+  #[inline(always)]
+  pub const fn set_frame_view(&mut self, v: Option<[f64; 4]>) -> &mut Self {
+    self.frame_view = v;
+    self
+  }
+
+  /// Assign `DroneQuaternion` `(W,X,Y,Z)`.
+  #[inline(always)]
+  pub const fn set_drone_quaternion(&mut self, v: Option<[f64; 4]>) -> &mut Self {
+    self.drone_quaternion = v;
+    self
+  }
+
+  /// Assign `FrameBaseView` quaternion `(W,X,Y,Z)`.
+  #[inline(always)]
+  pub const fn set_frame_base_view(&mut self, v: Option<[f64; 4]>) -> &mut Self {
+    self.frame_base_view = v;
+    self
+  }
+
+  /// Assign `RedBalance`.
+  #[inline(always)]
+  pub const fn set_red_balance(&mut self, v: Option<f64>) -> &mut Self {
+    self.red_balance = v;
+    self
+  }
+
+  /// Assign `BlueBalance`.
+  #[inline(always)]
+  pub const fn set_blue_balance(&mut self, v: Option<f64>) -> &mut Self {
+    self.blue_balance = v;
+    self
+  }
+
+  /// Assign `FOV` `(horizontal, vertical)` degrees.
+  #[inline(always)]
+  pub const fn set_fov_deg(&mut self, v: Option<[f64; 2]>) -> &mut Self {
+    self.fov_deg = v;
+    self
+  }
+
+  /// Assign `LinkGoodput` kbit/s.
+  #[inline(always)]
+  pub const fn set_link_goodput_kbitps(&mut self, v: Option<u32>) -> &mut Self {
+    self.link_goodput_kbitps = v;
+    self
+  }
+
+  /// Assign `LinkQuality`.
+  #[inline(always)]
+  pub const fn set_link_quality(&mut self, v: Option<u8>) -> &mut Self {
+    self.link_quality = v;
+    self
+  }
+
+  /// Assign `Binning` flag.
+  #[inline(always)]
+  pub const fn set_binning(&mut self, v: Option<u8>) -> &mut Self {
+    self.binning = v;
+    self
+  }
+
+  /// Assign `Animation` flag.
+  #[inline(always)]
+  pub const fn set_animation(&mut self, v: Option<u8>) -> &mut Self {
+    self.animation = v;
+    self
+  }
+
+  /// Assign `E1 TimeStamp` microsecond counter.
+  #[inline(always)]
+  pub const fn set_time_stamp_us(&mut self, v: Option<u64>) -> &mut Self {
+    self.time_stamp_us = v;
+    self
+  }
+}
+
+// ===========================================================================
+// ParrotFollowMeSample — E2 FollowMe extension (Parrot.pm:553-593)
+// ===========================================================================
+
+/// One `E2` FollowMe extension record (`Image::ExifTool::Parrot::FollowMe`,
+/// Parrot.pm:553-593). Carries the follow-me TARGET waypoint coordinates plus
+/// the mode bitmask and animation. The coordinates have ValueConv but NO
+/// PrintConv (raw decimal degrees / metres in both `-n` and `-j`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParrotFollowMeSample {
+  /// `GPSTargetLatitude` decimal degrees (Parrot.pm:558-562). `int32s / 0x400000`.
+  target_latitude: Option<f64>,
+  /// `GPSTargetLongitude` decimal degrees (Parrot.pm:563-567). `int32s / 0x400000`.
+  target_longitude: Option<f64>,
+  /// `GPSTargetAltitude` metres (Parrot.pm:568-572). `int32s / 0x10000`.
+  target_altitude_m: Option<f64>,
+  /// `Follow-meMode` raw int8u (Parrot.pm:573-581) — rendered via the
+  /// `BITMASK` DecodeBits at emit time. `None` when the byte was absent.
+  mode_flags: Option<u8>,
+  /// `Follow-meAnimation` (Parrot.pm:582-592).
+  animation: Option<ParrotFollowMeAnimation>,
+  /// The 1-based GLOBAL `Doc<N>` ordinal. `0` until stamped.
+  doc: u32,
+  /// The 1-based moov `Track<N>` index. `0` until stamped.
+  track_index: u32,
+  /// The sample-table `SampleTime` (seconds). `None` until stamped.
+  sample_time: Option<f64>,
+  /// The sample-table `SampleDuration` (seconds). `None` until stamped.
+  sample_duration: Option<f64>,
+}
+
+impl ParrotFollowMeSample {
+  /// Build an empty FollowMe sample.
+  #[inline]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      target_latitude: None,
+      target_longitude: None,
+      target_altitude_m: None,
+      mode_flags: None,
+      animation: None,
+      doc: 0,
+      track_index: 0,
+      sample_time: None,
+      sample_duration: None,
+    }
+  }
+
+  /// The 1-based GLOBAL `Doc<N>` ordinal (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn doc(&self) -> u32 {
+    self.doc
+  }
+
+  /// The 1-based moov `Track<N>` index (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn track_index(&self) -> u32 {
+    self.track_index
+  }
+
+  /// The sample-table `SampleTime` in seconds (`None` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn sample_time(&self) -> Option<f64> {
+    self.sample_time
+  }
+
+  /// The sample-table `SampleDuration` in seconds (`None` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn sample_duration(&self) -> Option<f64> {
+    self.sample_duration
+  }
+
+  /// `GPSTargetLatitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn target_latitude(&self) -> Option<f64> {
+    self.target_latitude
+  }
+
+  /// `GPSTargetLongitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn target_longitude(&self) -> Option<f64> {
+    self.target_longitude
+  }
+
+  /// `GPSTargetAltitude` metres.
+  #[inline(always)]
+  #[must_use]
+  pub const fn target_altitude_m(&self) -> Option<f64> {
+    self.target_altitude_m
+  }
+
+  /// `Follow-meMode` raw int8u (rendered via `BITMASK` DecodeBits at emit time).
+  #[inline(always)]
+  #[must_use]
+  pub const fn mode_flags(&self) -> Option<u8> {
+    self.mode_flags
+  }
+
+  /// `Follow-meAnimation`.
+  #[inline(always)]
+  #[must_use]
+  pub const fn animation(&self) -> Option<ParrotFollowMeAnimation> {
+    self.animation
+  }
+
+  /// `true` when no field is populated.
+  #[inline]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.target_latitude.is_none()
+      && self.target_longitude.is_none()
+      && self.target_altitude_m.is_none()
+      && self.mode_flags.is_none()
+      && self.animation.is_none()
+  }
+
+  /// Assign `GPSTargetLatitude`.
+  #[inline(always)]
+  pub const fn set_target_latitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.target_latitude = v;
+    self
+  }
+
+  /// Assign `GPSTargetLongitude`.
+  #[inline(always)]
+  pub const fn set_target_longitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.target_longitude = v;
+    self
+  }
+
+  /// Assign `GPSTargetAltitude` metres.
+  #[inline(always)]
+  pub const fn set_target_altitude_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.target_altitude_m = v;
+    self
+  }
+
+  /// Assign `Follow-meMode` raw int8u.
+  #[inline(always)]
+  pub const fn set_mode_flags(&mut self, v: Option<u8>) -> &mut Self {
+    self.mode_flags = v;
+    self
+  }
+
+  /// Assign `Follow-meAnimation`.
+  #[inline(always)]
+  pub const fn set_animation(&mut self, v: Option<ParrotFollowMeAnimation>) -> &mut Self {
+    self.animation = v;
+    self
+  }
+}
+
+impl Default for ParrotFollowMeSample {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ===========================================================================
+// ParrotAutomationSample — E3 Automation extension (Parrot.pm:595-660)
+// ===========================================================================
+
+/// One `E3` Automation extension record (`Image::ExifTool::Parrot::Automation`,
+/// Parrot.pm:595-660). Carries the framing + destination waypoint coordinates
+/// plus the automation animation and the flags bitmask. The coordinates have
+/// ValueConv but NO PrintConv (raw decimal degrees / metres in both modes).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParrotAutomationSample {
+  /// `GPSFramingLatitude` decimal degrees (Parrot.pm:600-604). `int32s / 0x400000`.
+  framing_latitude: Option<f64>,
+  /// `GPSFramingLongitude` decimal degrees (Parrot.pm:605-609). `int32s / 0x400000`.
+  framing_longitude: Option<f64>,
+  /// `GPSFramingAltitude` metres (Parrot.pm:610-614). `int32s / 0x10000`.
+  framing_altitude_m: Option<f64>,
+  /// `GPSDestLatitude` decimal degrees (Parrot.pm:615-619). `int32s / 0x400000`.
+  dest_latitude: Option<f64>,
+  /// `GPSDestLongitude` decimal degrees (Parrot.pm:620-624). `int32s / 0x400000`.
+  dest_longitude: Option<f64>,
+  /// `GPSDestAltitude` metres (Parrot.pm:625-629). `int32s / 0x10000`.
+  dest_altitude_m: Option<f64>,
+  /// `AutomationAnimation` (Parrot.pm:630-650).
+  animation: Option<ParrotAutomationAnimation>,
+  /// `AutomationFlags` raw int8u (Parrot.pm:651-659) — rendered via the
+  /// `BITMASK` DecodeBits at emit time. `None` when the byte was absent.
+  flags: Option<u8>,
+  /// The 1-based GLOBAL `Doc<N>` ordinal. `0` until stamped.
+  doc: u32,
+  /// The 1-based moov `Track<N>` index. `0` until stamped.
+  track_index: u32,
+  /// The sample-table `SampleTime` (seconds). `None` until stamped.
+  sample_time: Option<f64>,
+  /// The sample-table `SampleDuration` (seconds). `None` until stamped.
+  sample_duration: Option<f64>,
+}
+
+impl ParrotAutomationSample {
+  /// Build an empty Automation sample.
+  #[inline]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      framing_latitude: None,
+      framing_longitude: None,
+      framing_altitude_m: None,
+      dest_latitude: None,
+      dest_longitude: None,
+      dest_altitude_m: None,
+      animation: None,
+      flags: None,
+      doc: 0,
+      track_index: 0,
+      sample_time: None,
+      sample_duration: None,
+    }
+  }
+
+  /// The 1-based GLOBAL `Doc<N>` ordinal (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn doc(&self) -> u32 {
+    self.doc
+  }
+
+  /// The 1-based moov `Track<N>` index (`0` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn track_index(&self) -> u32 {
+    self.track_index
+  }
+
+  /// The sample-table `SampleTime` in seconds (`None` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn sample_time(&self) -> Option<f64> {
+    self.sample_time
+  }
+
+  /// The sample-table `SampleDuration` in seconds (`None` when unstamped).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn sample_duration(&self) -> Option<f64> {
+    self.sample_duration
+  }
+
+  /// `GPSFramingLatitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn framing_latitude(&self) -> Option<f64> {
+    self.framing_latitude
+  }
+
+  /// `GPSFramingLongitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn framing_longitude(&self) -> Option<f64> {
+    self.framing_longitude
+  }
+
+  /// `GPSFramingAltitude` metres.
+  #[inline(always)]
+  #[must_use]
+  pub const fn framing_altitude_m(&self) -> Option<f64> {
+    self.framing_altitude_m
+  }
+
+  /// `GPSDestLatitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn dest_latitude(&self) -> Option<f64> {
+    self.dest_latitude
+  }
+
+  /// `GPSDestLongitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn dest_longitude(&self) -> Option<f64> {
+    self.dest_longitude
+  }
+
+  /// `GPSDestAltitude` metres.
+  #[inline(always)]
+  #[must_use]
+  pub const fn dest_altitude_m(&self) -> Option<f64> {
+    self.dest_altitude_m
+  }
+
+  /// `AutomationAnimation`.
+  #[inline(always)]
+  #[must_use]
+  pub const fn animation(&self) -> Option<ParrotAutomationAnimation> {
+    self.animation
+  }
+
+  /// `AutomationFlags` raw int8u (rendered via `BITMASK` DecodeBits at emit time).
+  #[inline(always)]
+  #[must_use]
+  pub const fn flags(&self) -> Option<u8> {
+    self.flags
+  }
+
+  /// `true` when no field is populated.
+  #[inline]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.framing_latitude.is_none()
+      && self.framing_longitude.is_none()
+      && self.framing_altitude_m.is_none()
+      && self.dest_latitude.is_none()
+      && self.dest_longitude.is_none()
+      && self.dest_altitude_m.is_none()
+      && self.animation.is_none()
+      && self.flags.is_none()
+  }
+
+  /// Assign `GPSFramingLatitude`.
+  #[inline(always)]
+  pub const fn set_framing_latitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.framing_latitude = v;
+    self
+  }
+
+  /// Assign `GPSFramingLongitude`.
+  #[inline(always)]
+  pub const fn set_framing_longitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.framing_longitude = v;
+    self
+  }
+
+  /// Assign `GPSFramingAltitude` metres.
+  #[inline(always)]
+  pub const fn set_framing_altitude_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.framing_altitude_m = v;
+    self
+  }
+
+  /// Assign `GPSDestLatitude`.
+  #[inline(always)]
+  pub const fn set_dest_latitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.dest_latitude = v;
+    self
+  }
+
+  /// Assign `GPSDestLongitude`.
+  #[inline(always)]
+  pub const fn set_dest_longitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.dest_longitude = v;
+    self
+  }
+
+  /// Assign `GPSDestAltitude` metres.
+  #[inline(always)]
+  pub const fn set_dest_altitude_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.dest_altitude_m = v;
+    self
+  }
+
+  /// Assign `AutomationAnimation`.
+  #[inline(always)]
+  pub const fn set_animation(&mut self, v: Option<ParrotAutomationAnimation>) -> &mut Self {
+    self.animation = v;
+    self
+  }
+
+  /// Assign `AutomationFlags` raw int8u.
+  #[inline(always)]
+  pub const fn set_flags(&mut self, v: Option<u8>) -> &mut Self {
+    self.flags = v;
+    self
+  }
+}
+
+impl Default for ParrotAutomationSample {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ===========================================================================
+// ParrotMeta — the aggregate per-track result
+// ===========================================================================
+
+/// The typed result of Parrot `mett` track decoding — the per-format
+/// mirror of what `Process_mett` (Parrot.pm:791-854) emits over every
+/// `mett` sample the walker visits. One walker call yields ONE
+/// [`ParrotMeta`]; multiple `mett` samples in a track accumulate.
+///
+/// Empty (`is_empty()`) when no `mett` track was present or every record
+/// fork failed to decode.
+///
+/// **D8 compliance.** Every field is private; access through the
+/// accessors below.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParrotMeta {
+  /// GPS fixes in source order (per-sample, one per `P1`/`P2`/`P3` record).
+  gps_samples: Vec<ParrotGpsSample>,
+  /// Flight telemetry samples in source order.
+  flight_samples: Vec<ParrotFlightSample>,
+  /// `E2` FollowMe extension records in source order (Parrot.pm:553-593).
+  follow_me_samples: Vec<ParrotFollowMeSample>,
+  /// `E3` Automation extension records in source order (Parrot.pm:595-660).
+  automation_samples: Vec<ParrotAutomationSample>,
+  /// First-only walker warning ("Unexpected length for $metaType record",
+  /// Parrot.pm:808).
+  warning: Option<SmolStr>,
+}
+
+impl ParrotMeta {
+  /// An empty result.
+  #[inline(always)]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      gps_samples: Vec::new(),
+      flight_samples: Vec::new(),
+      follow_me_samples: Vec::new(),
+      automation_samples: Vec::new(),
+      warning: None,
+    }
+  }
+
+  /// All GPS fixes in source order.
+  #[inline(always)]
+  #[must_use]
+  pub fn gps_samples(&self) -> &[ParrotGpsSample] {
+    self.gps_samples.as_slice()
+  }
+
+  /// All flight telemetry samples in source order.
+  #[inline(always)]
+  #[must_use]
+  pub fn flight_samples(&self) -> &[ParrotFlightSample] {
+    self.flight_samples.as_slice()
+  }
+
+  /// All `E2` FollowMe extension records in source order.
+  #[inline(always)]
+  #[must_use]
+  pub fn follow_me_samples(&self) -> &[ParrotFollowMeSample] {
+    self.follow_me_samples.as_slice()
+  }
+
+  /// All `E3` Automation extension records in source order.
+  #[inline(always)]
+  #[must_use]
+  pub fn automation_samples(&self) -> &[ParrotAutomationSample] {
+    self.automation_samples.as_slice()
+  }
+
+  /// The first decoded walker warning.
+  #[inline(always)]
+  #[must_use]
+  pub fn warning(&self) -> Option<&str> {
+    self.warning.as_deref()
+  }
+
+  /// `true` when no record decoded successfully.
+  #[inline(always)]
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.gps_samples.is_empty()
+      && self.flight_samples.is_empty()
+      && self.follow_me_samples.is_empty()
+      && self.automation_samples.is_empty()
+  }
+
+  /// The FIRST GPS sample whose `latitude` AND `longitude` are populated —
+  /// feeds the [`crate::metadata::GpsLocation`] projection.
+  #[inline]
+  #[must_use]
+  pub fn first_fix(&self) -> Option<&ParrotGpsSample> {
+    self
+      .gps_samples
+      .iter()
+      .find(|s| s.latitude.is_some() && s.longitude.is_some())
+  }
+
+  /// Append a GPS sample.
+  #[inline(always)]
+  pub fn push_gps_sample(&mut self, v: ParrotGpsSample) -> &mut Self {
+    self.gps_samples.push(v);
+    self
+  }
+
+  /// Append a flight telemetry sample.
+  #[inline(always)]
+  pub fn push_flight_sample(&mut self, v: ParrotFlightSample) -> &mut Self {
+    self.flight_samples.push(v);
+    self
+  }
+
+  /// Append an `E2` FollowMe extension record.
+  #[inline(always)]
+  pub fn push_follow_me_sample(&mut self, v: ParrotFollowMeSample) -> &mut Self {
+    self.follow_me_samples.push(v);
+    self
+  }
+
+  /// Append an `E3` Automation extension record.
+  #[inline(always)]
+  pub fn push_automation_sample(&mut self, v: ParrotAutomationSample) -> &mut Self {
+    self.automation_samples.push(v);
+    self
+  }
+
+  /// The number of GPS samples decoded so far — a watermark the stream walker
+  /// takes BEFORE one `process_mett` call so it can stamp the `Doc<N>` / track
+  /// coordinates onto exactly the GPS samples that call appended (mirrors
+  /// [`crate::metadata::SonyRtmdMeta::sample_count`]).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn gps_sample_count(&self) -> usize {
+    self.gps_samples.len()
+  }
+
+  /// The number of flight samples decoded so far — the flight-vector watermark
+  /// (the two vectors advance independently when a record yields only one).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn flight_sample_count(&self) -> usize {
+    self.flight_samples.len()
+  }
+
+  /// The number of `E2` FollowMe samples decoded so far — the FollowMe
+  /// watermark (the extension vectors advance independently of the P-records).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn follow_me_sample_count(&self) -> usize {
+    self.follow_me_samples.len()
+  }
+
+  /// The number of `E3` Automation samples decoded so far — the Automation
+  /// watermark.
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn automation_sample_count(&self) -> usize {
+    self.automation_samples.len()
+  }
+
+  /// Stamp the GLOBAL `Doc<N>` ordinal, the `Track<N>` index, and the
+  /// sample-table `SampleTime`/`SampleDuration` (seconds) onto every GPS and
+  /// flight sample at or after the given watermarks — exactly the records ONE
+  /// `process_mett` call appended (mirrors
+  /// [`crate::metadata::SonyRtmdMeta::stamp_doc_from`] +
+  /// `stamp_track_index_from`, fused since `ProcessSamples` opens ONE `Doc<N>`
+  /// per `mett` SAMPLE and `Process_mett` `HandleTag`s every record under it).
+  /// `SampleTime`/`SampleDuration` land on the flight samples (the per-sample
+  /// timing `ProcessSamples` emits ahead of the payload).
+  pub(crate) fn stamp_doc_from(
+    &mut self,
+    gps_start: usize,
+    flight_start: usize,
+    follow_me_start: usize,
+    automation_start: usize,
+    doc: u32,
+    track_index: u32,
+    sample_time: Option<f64>,
+    sample_duration: Option<f64>,
+  ) {
+    if let Some(slice) = self.gps_samples.get_mut(gps_start..) {
+      for s in slice {
+        s.doc = doc;
+        s.track_index = track_index;
+      }
+    }
+    if let Some(slice) = self.flight_samples.get_mut(flight_start..) {
+      for s in slice {
+        s.doc = doc;
+        s.track_index = track_index;
+        s.sample_time = sample_time;
+        s.sample_duration = sample_duration;
+      }
+    }
+    if let Some(slice) = self.follow_me_samples.get_mut(follow_me_start..) {
+      for s in slice {
+        s.doc = doc;
+        s.track_index = track_index;
+        s.sample_time = sample_time;
+        s.sample_duration = sample_duration;
+      }
+    }
+    if let Some(slice) = self.automation_samples.get_mut(automation_start..) {
+      for s in slice {
+        s.doc = doc;
+        s.track_index = track_index;
+        s.sample_time = sample_time;
+        s.sample_duration = sample_duration;
+      }
+    }
+  }
+
+  /// `&mut` to the LAST appended flight sample, or `None` when none
+  /// has been pushed yet. Used by the `E1 TimeStamp` extension arm in
+  /// [`crate::formats::parrot::process_mett`] to attach the timestamp
+  /// to the host P2/P3 sample emitted immediately prior — but ONLY when
+  /// that prior sample was appended in the SAME `process_mett` call (the
+  /// arm guards on a pre-call flight watermark; a standalone E1 in its
+  /// own `mett` sample pushes a fresh sample instead, so the dispatch's
+  /// `stamp_doc_from` assigns it the current `Doc<N>`).
+  ///
+  /// Kept `pub(crate)` to constrain the mutation surface — external
+  /// callers should round-trip through `push_flight_sample` for
+  /// future flight samples.
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn flight_samples_mut_last(&mut self) -> Option<&mut ParrotFlightSample> {
+    self.flight_samples.last_mut()
+  }
+
+  /// Set the FIRST walker warning (subsequent calls are ignored, matching
+  /// bundled's `-j` rendering).
+  #[inline]
+  pub fn set_warning(&mut self, msg: SmolStr) -> &mut Self {
+    if self.warning.is_none() {
+      self.warning = Some(msg);
+    }
+    self
+  }
+}
+
+impl Default for ParrotMeta {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ===========================================================================
+// Parrot mett projection into MediaMetadata
+// ===========================================================================
+
+impl ParrotMeta {
+  /// Project Parrot mett metadata into [`MediaMetadata`].
+  ///
+  /// **CameraInfo:** Make = `"Parrot"` (every body that writes a `mett`
+  /// track with `[EP]\d` records is a Parrot drone — Anafi / Anafi USA /
+  /// Anafi Ai / Anafi Thermal / Bebop / Bebop 2 / Disco). The `mett`
+  /// table itself does NOT carry a Model / SerialNumber record — bundled
+  /// routes Make/Model for Parrot bodies through the QuickTime
+  /// `udta/©mod` + `udta/©mak` path (SP1/SP2 atoms parsed at the
+  /// QuickTime SP1 layer, NOT the `mett` track). So today's projection
+  /// sets only Make="Parrot" when any `mett` record decoded and leaves
+  /// Model/Serial empty for a future SP1/SP2 udta+Keys layer to fill.
+  /// Skipped when a higher-priority source already populated Camera.
+  ///
+  /// **CaptureSettings:** the FIRST P1/P2/P3 flight sample with
+  /// ExposureTime OR ISO populates `md.capture()`. FNumber is not present
+  /// in `mett` records (Parrot drones have a fixed aperture per body).
+  /// Parrot ISO is `int16s`/`int16u`; the typed surface stores `i32` —
+  /// the negative-ISO edge case (V1's `int16s` on a malformed buffer) is
+  /// clamped to None before mapping into `CaptureSettings.iso: u32`.
+  ///
+  /// **GpsLocation:** Parrot mett is on-device-GNSS (drone hardware GPS)
+  /// — same tier as GoPro / Android CAMM in the priority chain. The
+  /// FIRST P1/P2/P3 row with a coordinate pair populates `md.gps()`;
+  /// Parrot.pm's V1/V2/V3 tables don't emit a per-sample GPSDateTime
+  /// (timestamps live on the E1 extension as a microsecond counter, not
+  /// an Exif date+time pair), so `gps.timestamp()` stays `None` here.
+  ///
+  /// **Warnings:** the walker's `warning()` channel (`Unexpected length
+  /// for ARCore mett record` etc.) is surfaced through the per-format
+  /// diagnostics path at emission time — NOT through [`MediaMetadata`]
+  /// (which carries no warnings channel; mirrors the other timed-metadata
+  /// ports). See the `TODO(#126 audit)` below.
+  pub(crate) fn project_into(&self, md: &mut MediaMetadata) {
+    let is_empty = self.is_empty();
+    // ── CameraInfo ─────────────────────────────────────────────────────
+    if md.camera().is_none() && !is_empty {
+      let mut cam = CameraInfo::new();
+      cam.update_make(Some("Parrot".into()));
+      if !cam.is_empty() {
+        md.set_camera(cam);
+      }
+    }
+    // ── CaptureSettings ────────────────────────────────────────────────
+    if md.capture().is_none()
+      && let Some(f) = self
+        .flight_samples()
+        .iter()
+        .find(|s| s.exposure_time_s().is_some() || s.iso().is_some())
+    {
+      let mut cap = CaptureSettings::new();
+      cap.update_exposure_time_s(f.exposure_time_s());
+      // Parrot ISO is `int16s` / `int16u`; clamp the negative-ISO edge
+      // case (V1 int16s on a malformed buffer) to None.
+      cap.update_iso(f.iso().and_then(|v| u32::try_from(v).ok()));
+      if !cap.is_empty() {
+        md.set_capture(cap);
+      }
+    }
+    // ── GpsLocation ────────────────────────────────────────────────────
+    if md.gps().is_none()
+      && let Some(p) = self.first_fix()
+    {
+      let mut gps = GpsLocation::new();
+      gps
+        .update_latitude(p.latitude())
+        .update_longitude(p.longitude())
+        .update_altitude_m(p.altitude_m())
+        .update_timestamp(None);
+      md.set_gps(gps);
+    }
+    // TODO(#126 audit): the walker's `warning()` channel (e.g. "Unexpected
+    // length for ARCore mett record") is NOT propagated here — `MediaMetadata`
+    // has no warnings channel in the current architecture (it was added to
+    // bfb245b against an older `MediaMetadata`). The other timed-metadata
+    // ports (camm / sony_rtmd / canon_ctmd) surface their per-sample warnings
+    // through the per-format diagnostics path at `-ee` emission time; the
+    // cluster faithful-emission audit wires `ParrotMeta::warning()` the same
+    // way. The warning is still STORED on the typed surface (`self.warning()`).
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn empty_meta_is_empty() {
+    let m = ParrotMeta::new();
+    assert!(m.is_empty());
+    assert!(m.gps_samples().is_empty());
+    assert!(m.flight_samples().is_empty());
+    assert!(m.warning().is_none());
+    assert!(m.first_fix().is_none());
+  }
+
+  #[test]
+  fn gps_sample_get_set_roundtrip() {
+    let mut g = ParrotGpsSample::new(ParrotRecordVersion::V2);
+    assert!(g.is_empty());
+    assert_eq!(g.version(), ParrotRecordVersion::V2);
+    g.set_latitude(Some(47.6062));
+    g.set_longitude(Some(-122.3321));
+    g.set_altitude_m(Some(120.5));
+    g.set_satellites(Some(9));
+    assert_eq!(g.latitude(), Some(47.6062));
+    assert_eq!(g.longitude(), Some(-122.3321));
+    assert_eq!(g.altitude_m(), Some(120.5));
+    assert_eq!(g.satellites(), Some(9));
+    assert!(!g.is_empty());
+  }
+
+  #[test]
+  fn flight_sample_get_set_roundtrip() {
+    let mut f = ParrotFlightSample::new(ParrotRecordVersion::V3);
+    assert!(f.is_empty());
+    assert_eq!(f.version(), ParrotRecordVersion::V3);
+    f.set_battery_percent(Some(72));
+    f.set_wifi_rssi_dbm(Some(-60));
+    f.set_iso(Some(400));
+    f.set_exposure_time_s(Some(1.0 / 60.0));
+    f.set_flying_state(Some(ParrotFlyingState::Flying));
+    f.set_piloting_mode(Some(ParrotPilotingMode::Manual));
+    f.set_air_speed_mps(Some(3.5));
+    f.set_elevation_m(Some(50.0));
+    f.set_time_stamp_us(Some(123_456_789));
+    assert_eq!(f.battery_percent(), Some(72));
+    assert_eq!(f.wifi_rssi_dbm(), Some(-60));
+    assert_eq!(f.iso(), Some(400));
+    assert_eq!(f.flying_state(), Some(ParrotFlyingState::Flying));
+    assert_eq!(f.piloting_mode(), Some(ParrotPilotingMode::Manual));
+    assert_eq!(f.air_speed_mps(), Some(3.5));
+    assert_eq!(f.elevation_m(), Some(50.0));
+    assert_eq!(f.time_stamp_us(), Some(123_456_789));
+    assert!(!f.is_empty());
+  }
+
+  #[test]
+  fn flying_state_round_trip() {
+    for (raw, named) in [
+      (0u8, ParrotFlyingState::Landed),
+      (1, ParrotFlyingState::TakingOff),
+      (2, ParrotFlyingState::Hovering),
+      (3, ParrotFlyingState::Flying),
+      (4, ParrotFlyingState::Landing),
+      (5, ParrotFlyingState::Emergency),
+      (6, ParrotFlyingState::UserTakeoff),
+      (7, ParrotFlyingState::MotorRamping),
+      (8, ParrotFlyingState::EmergencyLanding),
+    ] {
+      assert_eq!(ParrotFlyingState::from_raw(raw), named);
+      assert_eq!(named.as_u8(), raw);
+    }
+    // Unknown values preserve the byte.
+    assert_eq!(
+      ParrotFlyingState::from_raw(99),
+      ParrotFlyingState::Unknown(99)
+    );
+    assert_eq!(ParrotFlyingState::Unknown(99).as_u8(), 99);
+  }
+
+  #[test]
+  fn piloting_mode_round_trip() {
+    for (raw, named) in [
+      (0u8, ParrotPilotingMode::Manual),
+      (1, ParrotPilotingMode::ReturnHome),
+      (2, ParrotPilotingMode::FlightPlan),
+      (3, ParrotPilotingMode::FollowMe),
+      (4, ParrotPilotingMode::MagicCarpet),
+      (5, ParrotPilotingMode::MoveTo),
+    ] {
+      assert_eq!(ParrotPilotingMode::from_raw(raw), named);
+      assert_eq!(named.as_u8(), raw);
+    }
+    assert_eq!(
+      ParrotPilotingMode::from_raw(99),
+      ParrotPilotingMode::Unknown(99)
+    );
+  }
+
+  #[test]
+  fn record_version_strings() {
+    assert_eq!(ParrotRecordVersion::V1.as_str(), "P1");
+    assert_eq!(ParrotRecordVersion::V2.as_str(), "P2");
+    assert_eq!(ParrotRecordVersion::V3.as_str(), "P3");
+  }
+
+  #[test]
+  fn first_fix_picks_first_with_lat_and_lon() {
+    let mut m = ParrotMeta::new();
+    // Sample 0: only altitude set (no lat/lon)
+    let mut s0 = ParrotGpsSample::new(ParrotRecordVersion::V1);
+    s0.set_altitude_m(Some(10.0));
+    m.push_gps_sample(s0);
+    // Sample 1: full fix
+    let mut s1 = ParrotGpsSample::new(ParrotRecordVersion::V1);
+    s1.set_latitude(Some(45.0));
+    s1.set_longitude(Some(8.0));
+    m.push_gps_sample(s1);
+    // Sample 2: also full
+    let mut s2 = ParrotGpsSample::new(ParrotRecordVersion::V1);
+    s2.set_latitude(Some(46.0));
+    s2.set_longitude(Some(9.0));
+    m.push_gps_sample(s2);
+    let f = m.first_fix().expect("fix");
+    assert_eq!(f.latitude(), Some(45.0));
+    assert_eq!(f.longitude(), Some(8.0));
+  }
+
+  #[test]
+  fn set_warning_only_first_wins() {
+    let mut m = ParrotMeta::new();
+    m.set_warning(SmolStr::new("first"));
+    m.set_warning(SmolStr::new("second"));
+    assert_eq!(m.warning(), Some("first"));
+  }
+
+  // P3-D project_into round-trips.
+
+  #[test]
+  fn project_into_empty_meta_writes_nothing() {
+    let m = ParrotMeta::new();
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    assert!(md.camera().is_none());
+    assert!(md.gps().is_none());
+    assert!(md.capture().is_none());
+  }
+
+  #[test]
+  fn project_into_populates_camera_make_parrot_when_any_record_decoded() {
+    let mut m = ParrotMeta::new();
+    let mut sample = ParrotGpsSample::new(ParrotRecordVersion::V1);
+    sample.set_latitude(Some(48.85)).set_longitude(Some(2.35));
+    m.push_gps_sample(sample);
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    assert_eq!(md.camera().expect("camera").make(), Some("Parrot"));
+    let gps = md.gps().expect("gps populated");
+    assert_eq!(gps.latitude(), Some(48.85));
+    // Parrot mett doesn't carry per-sample GPSDateTime.
+    assert_eq!(gps.timestamp(), None);
+  }
+
+  #[test]
+  fn warning_is_retained_on_the_typed_surface() {
+    // TODO(#126 audit): warnings no longer propagate into `MediaMetadata`
+    // (it carries no warnings channel — the bfb245b `md.push_warning` path was
+    // written against an older `MediaMetadata`). The cluster faithful-emission
+    // audit surfaces `warning()` through the per-format diagnostics path like
+    // the other timed-metadata ports. For now assert the warning is STORED on
+    // the typed surface and that `project_into` is a safe no-op for it.
+    let mut m = ParrotMeta::new();
+    m.set_warning(SmolStr::new("Unexpected length for ARCore mett record"));
+    assert_eq!(
+      m.warning(),
+      Some("Unexpected length for ARCore mett record")
+    );
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    assert!(md.camera().is_none());
+    assert!(md.gps().is_none());
+    assert!(md.capture().is_none());
+  }
+}

--- a/src/metadata/quicktime_stream.rs
+++ b/src/metadata/quicktime_stream.rs
@@ -727,6 +727,27 @@ impl QuickTimeStreamMeta {
     self.doc_counter
   }
 
+  /// The CURRENT value of the global document counter (`$$et{DOC_COUNT}`) —
+  /// read by the LigoGPS sources (a SEPARATE [`crate::metadata::LigoGpsMeta`]
+  /// struct that does not own this counter) so they can continue the SAME
+  /// global `Doc<N>` sequence as the in-struct sources. Paired with
+  /// [`Self::set_doc_counter`] after the LigoGPS source bumps it once per record
+  /// (`LigoGpsMeta::stamp_doc_from`), mirroring the snapshot-bump-write-back the
+  /// in-struct [`Self::stamp_gps_doc_from`] does internally.
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn doc_counter(&self) -> u32 {
+    self.doc_counter
+  }
+
+  /// Write back the global document counter after a LigoGPS source bumped it
+  /// once per record (see [`Self::doc_counter`]).
+  #[inline(always)]
+  pub(crate) const fn set_doc_counter(&mut self, counter: u32) -> &mut Self {
+    self.doc_counter = counter;
+    self
+  }
+
   /// Stamp the global document ordinal `doc` onto every `mebx` sample at or
   /// after `start` — the records decoded by ONE `process_mebx` invocation (one
   /// timed sample) since the walker took its [`Self::mebx_sample_count`]

--- a/tests/quicktime_stream.rs
+++ b/tests/quicktime_stream.rs
@@ -950,6 +950,160 @@ fn build_mov_with_gpro6_in_mdat() -> Vec<u8> {
   out
 }
 
+// ===========================================================================
+// gpmd dashcam variants — Kingslim / Rove / FMAS / Wolfbox
+// (QuickTimeStream.pl:181-212 Condition cascade)
+// ===========================================================================
+
+#[test]
+fn quicktime_gpmd_rove_dispatch_decodes_xor_aa_block() {
+  // QuickTimeStream.pl:190-194 — `gpmd_Rove` Condition
+  // `^\0\0\xf2\xe1\xf0\xeeTT` re-routes to Process_text → BlueSkySea /
+  // Ambarella XOR-0xAA decoder (1175-1211). The sample bytes carry the
+  // signature + an XOR-encrypted date/lat/lon/spd/alt block.
+  let sample = build_rove_xor_aa_sample();
+  let data = build_mov_with_meta_track(b"gpmd", &sample);
+  let meta = parse_quicktime(&data).expect("recognized");
+  let stream = meta.stream();
+  let samples = stream.gps_samples();
+  assert_eq!(samples.len(), 1, "Rove gpmd must produce one GPS sample");
+  let s = &samples[0];
+  assert!(s.date_time().unwrap().contains("2019:08:20 07:51:57"));
+  assert!((s.latitude().unwrap() - (48.0 + 515873.0 / 600000.0)).abs() < 1e-4);
+  assert!((s.longitude().unwrap() - (2.0 + 197769.0 / 600000.0)).abs() < 1e-4);
+  // MediaMetadata projects the GPS fix.
+  let md = meta.media_metadata();
+  let gps = md.gps().expect("GpsLocation projected from Rove gpmd");
+  assert!(gps.latitude().is_some());
+  assert!(gps.longitude().is_some());
+}
+
+#[test]
+fn quicktime_gpmd_fmas_dispatch_decodes_vantrue_n2s_record() {
+  // QuickTimeStream.pl:196-201 — `gpmd_FMAS` (Vantrue N2S) routes to
+  // ProcessFMAS (3580-3609).
+  let sample = build_fmas_sample();
+  let data = build_mov_with_meta_track(b"gpmd", &sample);
+  let meta = parse_quicktime(&data).expect("recognized");
+  let stream = meta.stream();
+  let samples = stream.gps_samples();
+  assert_eq!(samples.len(), 1, "FMAS gpmd must produce one GPS sample");
+  let s = &samples[0];
+  // Lat 47 + (37 + 4200/6000)/60 ≈ 47.628333
+  let want_lat = 47.0 + (37.0 + 4200.0 / 6000.0) / 60.0;
+  assert!((s.latitude().unwrap() - want_lat).abs() < 1e-6);
+  // 50 mph * 1.60934 = 80.467 kph
+  assert!((s.speed_kph().unwrap() - 80.467).abs() < 0.01);
+  // Projection.
+  let md = meta.media_metadata();
+  assert!(md.gps().is_some());
+}
+
+#[test]
+fn quicktime_gpmd_wolfbox_dispatch_decodes_g900_record() {
+  // QuickTimeStream.pl:203-208 — `gpmd_Wolfbox` routes to ProcessWolfbox
+  // (3615-3676). The Wolfbox G900 marker `00000000HYTH` at offset 152.
+  let sample = build_wolfbox_sample();
+  let data = build_mov_with_meta_track(b"gpmd", &sample);
+  let meta = parse_quicktime(&data).expect("recognized");
+  let stream = meta.stream();
+  let samples = stream.gps_samples();
+  assert_eq!(samples.len(), 1, "Wolfbox gpmd must produce one GPS sample");
+  let s = &samples[0];
+  // ConvertLatLon(4737.7053) ≈ 47.628421
+  assert!((s.latitude().unwrap() - 47.628421).abs() < 1e-4);
+  assert_eq!(s.altitude_m(), Some(412.5));
+  // 25.5 knots * 1.852 = 47.226
+  assert!((s.speed_kph().unwrap() - 47.226).abs() < 0.01);
+}
+
+/// Build a 282-byte Rove `gpmd` sample (Ambarella A12 XOR-0xAA cipher,
+/// matching the bundled `gpmd_Rove` Condition `^\0\0\xf2\xe1\xf0\xeeTT`).
+fn build_rove_xor_aa_sample() -> Vec<u8> {
+  let mut data = vec![0u8; 282];
+  // Ambarella sig: literal `\0\0\xf2\xe1\xf0\xee\x54\x54` at offset 0..8.
+  data[0..8].copy_from_slice(&[0x00, 0x00, 0xf2, 0xe1, 0xf0, 0xee, 0x54, 0x54]);
+  // Encrypted date+time `20190820075157` at offset 8 (XOR'd later via
+  // decode_xor_aa_block).
+  for (i, &c) in b"20190820075157".iter().enumerate() {
+    data[8 + i] = c ^ 0xaa;
+  }
+  for (i, &c) in b"N48515873".iter().enumerate() {
+    data[38 + i] = c ^ 0xaa;
+  }
+  for (i, &c) in b"E002197769".iter().enumerate() {
+    data[47 + i] = c ^ 0xaa;
+  }
+  for (i, &c) in b"+0031".iter().enumerate() {
+    data[0x39 + i] = c ^ 0xaa;
+  }
+  for (i, &c) in b"045".iter().enumerate() {
+    data[0x3e + i] = c ^ 0xaa;
+  }
+  data
+}
+
+/// Build a 160-byte Vantrue N2S FMAS sample.
+fn build_fmas_sample() -> Vec<u8> {
+  let mut d = vec![0u8; 160];
+  d[0..8].copy_from_slice(b"FMAS\0\0\0\0");
+  d[80..84].copy_from_slice(b"SAMM");
+  d[120] = b'A';
+  d[0x60..0x62].copy_from_slice(&2025u16.to_le_bytes());
+  d[0x62] = 6;
+  d[0x63] = 15;
+  d[0x64] = 14;
+  d[0x65] = 30;
+  d[0x66] = 45;
+  d[0x78] = b'A';
+  d[0x79] = b'E';
+  d[0x7a] = b'N';
+  d[0x7b] = 8;
+  d[0x7c] = 30;
+  d[0x7d] = 0;
+  d[0x7e..0x80].copy_from_slice(&600u16.to_le_bytes());
+  d[0x80] = 47;
+  d[0x81] = 37;
+  d[0x82..0x84].copy_from_slice(&4200u16.to_le_bytes());
+  d[0x84..0x86].copy_from_slice(&50u16.to_le_bytes());
+  d[0x86..0x88].copy_from_slice(&180u16.to_le_bytes());
+  d[0x6c..0x70].copy_from_slice(&0.1f32.to_le_bytes());
+  d[0x70..0x74].copy_from_slice(&0.2f32.to_le_bytes());
+  d[0x74..0x78].copy_from_slice(&0.3f32.to_le_bytes());
+  d
+}
+
+/// Build a 0x100-byte Wolfbox G900 sample.
+fn build_wolfbox_sample() -> Vec<u8> {
+  let mut d = vec![0u8; 0x100];
+  for i in 0..16 {
+    d[136 + i] = b'0';
+  }
+  d[152..156].copy_from_slice(b"HYTH");
+  d[0x68..0x6c].copy_from_slice(&15u32.to_le_bytes());
+  d[0x6c..0x70].copy_from_slice(&6u32.to_le_bytes());
+  d[0x70..0x74].copy_from_slice(&2025u32.to_le_bytes());
+  d[0xa0..0xa4].copy_from_slice(&14u32.to_le_bytes());
+  d[0xa4..0xa8].copy_from_slice(&30u32.to_le_bytes());
+  d[0xa8..0xac].copy_from_slice(&45u32.to_le_bytes());
+  // Speed val/div: 25.5 knots
+  d[0x48..0x50].copy_from_slice(&25500i64.to_le_bytes());
+  d[0x50..0x58].copy_from_slice(&1000i64.to_le_bytes());
+  // Track val/div: 90.0
+  d[0x58..0x60].copy_from_slice(&9000i64.to_le_bytes());
+  d[0x60..0x68].copy_from_slice(&100i64.to_le_bytes());
+  // Lat val/div: 4737.7053
+  d[0xb0..0xb8].copy_from_slice(&47377053i64.to_le_bytes());
+  d[0xb8..0xc0].copy_from_slice(&10000i64.to_le_bytes());
+  // Lon val/div: 822.5076
+  d[0xc0..0xc8].copy_from_slice(&8225076i64.to_le_bytes());
+  d[0xc8..0xd0].copy_from_slice(&10000i64.to_le_bytes());
+  // Alt val/div: 412.5
+  d[0xe8..0xf0].copy_from_slice(&4125i64.to_le_bytes());
+  d[0xf0..0xf8].copy_from_slice(&10i64.to_le_bytes());
+  d
+}
+
 /// Build a minimal but valid `.mov` whose moov/udta carries a `GPMF` atom
 /// with a one-DVNM-record DEVC payload.
 fn build_mov_with_gpmf_in_udta() -> Vec<u8> {
@@ -1977,6 +2131,15 @@ fn vec3_le(x: f32, y: f32, z: f32) -> Vec<u8> {
 /// "format" code is `camm`. The track's single sample is `sample_bytes`,
 /// stored at the start of `mdat`.
 fn build_mov_with_camm_track(sample_bytes: &[u8]) -> Vec<u8> {
+  build_mov_with_meta_track(b"camm", sample_bytes)
+}
+
+/// Build a minimal but valid `.mov` whose moov contains ONE metadata `trak`
+/// with the `mhlr/meta` handler and a stsd whose first 4-byte "format" code is
+/// `meta_format` (e.g. `gpmd` / `camm`). The track's single sample is
+/// `sample_bytes`, stored at the start of `mdat`. Mirrors the dispatch path
+/// `ProcessSamples` takes for a timed-metadata `trak`.
+fn build_mov_with_meta_track(meta_format: &[u8; 4], sample_bytes: &[u8]) -> Vec<u8> {
   // ftyp atom: 'qt  '.
   let mut ftyp = 16u32.to_be_bytes().to_vec();
   ftyp.extend_from_slice(b"ftyp");
@@ -2016,12 +2179,12 @@ fn build_mov_with_camm_track(sample_bytes: &[u8]) -> Vec<u8> {
   mdhd.extend_from_slice(&1000u32.to_be_bytes()); // duration
   mdhd.extend_from_slice(&[0u8; 4]); // language+quality
 
-  // stsd — 1 entry whose first 4-byte format code is `camm`.
+  // stsd — 1 entry whose first 4-byte format code is `meta_format`.
   // [version+flags:4][count:4][entry-size:4][format:4][reserved:6][data-ref-index:2]
   let mut stsd_entry = Vec::new();
-  // Entry: size(=16)+format=camm+6 reserved bytes+data-ref-index(=1).
+  // Entry: size(=16)+format+6 reserved bytes+data-ref-index(=1).
   stsd_entry.extend_from_slice(&16u32.to_be_bytes());
-  stsd_entry.extend_from_slice(b"camm");
+  stsd_entry.extend_from_slice(meta_format);
   stsd_entry.extend_from_slice(&[0u8; 6]);
   stsd_entry.extend_from_slice(&1u16.to_be_bytes());
   let mut stsd = Vec::new();
@@ -2234,5 +2397,162 @@ fn extract_embedded_on_emits_timed_gps_tags() {
   assert!(
     obj.contains_key("QuickTime:GPSLatitude"),
     "-ee on must emit the per-sample timed GPS tags"
+  );
+}
+
+// ===========================================================================
+// SP4 — LigoGPS dashcam vendor GPS module + trailer (LigoGPS.pm:1-431,
+// QuickTime.pm:9906-9907 + :10658-10668)
+// ===========================================================================
+
+/// Build a minimal `.mov` with a LigoGPS `&&&& `-prefixed trailer carrying
+/// one plain-ASCII (Redtiger F9 4K format) record. The trailer layout
+/// (QuickTime.pm:10658-10668) is:
+///
+///   [base file: ftyp + moov + mdat]
+///   [trailer body:
+///     [skip atom header: size:u32-BE = body_len, "skip"]
+///     [LIGOGPSINFO\0]
+///     [8 more bytes of preamble incl. \0\0\0\x14 at offset 12]
+///     [0x84 bytes of plain-ASCII record]
+///   ]
+///   [&&&& : 4 bytes]
+///   [trailer_len : u32-LE]
+fn build_mov_with_ligogps_trailer(record_text: &[u8]) -> Vec<u8> {
+  // Reuse the minimal ftyp+moov+mdat from `build_mov_with_freegps_in_mdat`
+  // but discard the freeGPS block so the file is truly plain QuickTime.
+  let mut ftyp = 16u32.to_be_bytes().to_vec();
+  ftyp.extend_from_slice(b"ftyp");
+  ftyp.extend_from_slice(b"qt  ");
+  ftyp.extend_from_slice(&0u32.to_be_bytes());
+
+  let mut mvhd = Vec::new();
+  mvhd.extend_from_slice(&[0u8; 4]);
+  mvhd.extend_from_slice(&[0u8; 8]);
+  mvhd.extend_from_slice(&1000u32.to_be_bytes());
+  mvhd.extend_from_slice(&1000u32.to_be_bytes());
+  mvhd.extend_from_slice(&[0u8; 80]);
+  let mut mvhd_atom = (mvhd.len() as u32 + 8).to_be_bytes().to_vec();
+  mvhd_atom.extend_from_slice(b"mvhd");
+  mvhd_atom.extend_from_slice(&mvhd);
+  let mut moov = (mvhd_atom.len() as u32 + 8).to_be_bytes().to_vec();
+  moov.extend_from_slice(b"moov");
+  moov.extend_from_slice(&mvhd_atom);
+  let mdat_payload = vec![0u8; 16];
+  let mut mdat = (mdat_payload.len() as u32 + 8).to_be_bytes().to_vec();
+  mdat.extend_from_slice(b"mdat");
+  mdat.extend_from_slice(&mdat_payload);
+
+  // Build the trailer payload: LIGOGPSINFO\0 + 8-byte preamble + 0x84 rec.
+  let mut payload = Vec::new();
+  payload.extend_from_slice(b"LIGOGPSINFO\0");
+  // 8 more preamble bytes: bytes [pos-8..pos-4] (pos = 0x14) = [0,0,0,0x14]
+  // triggers the LigoGPS no_fuzz auto-detect for the BlueSkySea-style
+  // firmware (LigoGPS.pm:299).
+  payload.extend_from_slice(&[0, 0, 0, 0x14, 0, 0, 0, 0]);
+  // Build one 0x84-byte record. First 4 bytes are the counter; rest is
+  // the ASCII text payload (null-padded to 0x84).
+  let mut record = Vec::with_capacity(0x84);
+  record.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+  record.extend_from_slice(record_text);
+  while record.len() < 0x84 {
+    record.push(0);
+  }
+  payload.extend_from_slice(&record);
+
+  // Trailer body: skip atom header + payload. QuickTime.pm:10660 reads the
+  // inner LIGOGPSINFO buffer as `$len = Get32u(buff,0) - 16` bytes, so the
+  // skip atom's declared SIZE field must be `16 + payload.len()` to capture the
+  // FULL payload (the `- 16` drops the 8-byte read + an 8-byte inner header).
+  let skip_atom_size = (16 + payload.len()) as u32;
+  let mut body = Vec::with_capacity(8 + payload.len());
+  body.extend_from_slice(&skip_atom_size.to_be_bytes());
+  body.extend_from_slice(b"skip");
+  body.extend_from_slice(&payload);
+
+  // The discovery length (`$$trailer[2]`) is the trailer's byte span: body +
+  // the 8-byte `[&&&&][len]` footer.
+  let trailer_len = (body.len() + 8) as u32;
+
+  // Assemble the file.
+  let mut file = ftyp;
+  file.extend_from_slice(&moov);
+  file.extend_from_slice(&mdat);
+  file.extend_from_slice(&body);
+  file.extend_from_slice(b"&&&&");
+  // `IdentifyTrailers` reads the LigoGPS length as BE `Get32u(buff,36)`
+  // (QuickTime.pm:9907, default `MM` — see `insta360::identify_trailers`).
+  file.extend_from_slice(&trailer_len.to_be_bytes());
+  file
+}
+
+#[test]
+fn quicktime_ligogps_trailer_decodes_plain_ascii_record() {
+  // The Redtiger F9 4K plain-ASCII record format: `[4 bytes counter]
+  // YYYY/MM/DD HH:MM:SS [NS]:lat [EW]:lon spd [optional " km/h"]`.
+  let data = build_mov_with_ligogps_trailer(
+    b"2024/06/15 14:30:00 N:45.500 W:120.500 50.0 km/h A:90.0 H:100.0 x:0 y:0 z:0",
+  );
+  let meta = parse_quicktime(&data).expect("recognized");
+  let ligo = meta.ligogps();
+  assert!(!ligo.is_empty(), "ligogps() must populate");
+  let s = ligo.samples().first().expect("decoded sample");
+  assert_eq!(s.date_time(), Some("2024:06:15 14:30:00"));
+  assert_eq!(s.latitude(), Some(45.5));
+  assert_eq!(s.longitude(), Some(-120.5));
+  assert_eq!(s.speed_kph(), Some(50.0));
+  assert_eq!(s.track_deg(), Some(90.0));
+  assert_eq!(s.altitude_m(), Some(100.0));
+}
+
+#[test]
+fn quicktime_ligogps_trailer_projects_gps_location() {
+  // The decoded sample's lat/lon/altitude/timestamp must surface through
+  // `MediaMetadata::gps()`. Date format in the record body is YYYY/MM/DD
+  // (LigoGPS.pm:244 `tr|/|:|` normalises it to YYYY:MM:DD on output).
+  let data =
+    build_mov_with_ligogps_trailer(b"2024/01/15 10:00:00 N:35.000 E:139.000 30.0 km/h H:50.0");
+  let meta = parse_quicktime(&data).expect("recognized");
+  let md = meta.media_metadata();
+  let gps = md.gps().expect("GpsLocation from LigoGPS");
+  assert!((gps.latitude().unwrap() - 35.000).abs() < 1e-9);
+  assert!((gps.longitude().unwrap() - 139.000).abs() < 1e-9);
+  assert!((gps.altitude_m().unwrap() - 50.0).abs() < 1e-9);
+  assert_eq!(gps.timestamp(), Some("2024:01:15 10:00:00"));
+}
+
+#[test]
+fn quicktime_no_ligogps_trailer_leaves_meta_empty() {
+  // A plain QuickTime file (no LigoGPS trailer) must have an empty
+  // `ligogps()` meta. The signature check is a 4-byte compare at offset
+  // EOF-8.
+  let data = build_mov_with_freegps_in_mdat();
+  let meta = parse_quicktime(&data).expect("recognized");
+  assert!(meta.ligogps().is_empty());
+}
+
+#[test]
+fn quicktime_ligogps_trailer_with_explicit_south_latitude() {
+  // S = negative latitude (LigoGPS.pm:258).
+  let data =
+    build_mov_with_ligogps_trailer(b"2024/12/25 23:59:59 S:33.865 E:151.209 80.0 km/h H:25.0");
+  let meta = parse_quicktime(&data).expect("recognized");
+  let s = meta.ligogps().samples().first().expect("sample");
+  // Latitude is negative (S).
+  assert_eq!(s.latitude(), Some(-33.865));
+  // Longitude is positive (E).
+  assert_eq!(s.longitude(), Some(151.209));
+}
+
+#[test]
+fn quicktime_ligogps_trailer_short_file_silent() {
+  // A file shorter than 40 bytes can't carry the trailer signature; the
+  // scan_trailer fast-path returns silently without warning.
+  let data = vec![0u8; 30];
+  // Must use parse_borrowed direct since this isn't a real QT file.
+  let meta = exifast::formats::quicktime::parse_borrowed(&data);
+  assert!(
+    meta.is_none(),
+    "30-byte all-zero data isn't recognised as QT"
   );
 }


### PR DESCRIPTION
## Summary

Faithfully integrates and **supersedes #107 (freeGPS dashcam variants), #126 (Parrot mett), and #135 (LigoGPS)** into one cluster on the Doc<N> timed-metadata axis — a 1:1 port of ExifTool 13.59.

- **freeGPS gpmd Condition variants** (QuickTimeStream.pl:181-212): Kingslim D4 (→ GPSType-5/LigoGPS), Rove Stealth 4K, Vantrue N2S (FMAS), Wolfbox G900 / Redtiger F9 4K — faithful ordered Condition cascade; the GoPro KLV fallback + `FoundEmbedded` semantics preserved.
- **Parrot drone mett** (Parrot.pm): full V1/V2/V3 + E1/E2/E3 (TimeStamp/FollowMe/Automation) parity — GPS, GPS-velocity, drone pose/quaternion, gimbal pan/tilt, white balance, FOV, speed vectors, follow-me/automation waypoints, BITMASK flags. ARCore `application/*` records are walked-and-discarded (phone-camera AR, out of the camera-metadata scope).
- **LigoGPS** (LigoGPS.pm): the `LIGOGPSINFO` decrypt/unfuzz/parse (default scale 1.524855137), the `&&&&` file-end trailer, the top-level `udta` LigoJSON/GKUData JSON path (ProcessLigoJSON/ProcessGKU), and the freeGPS GPSType-5 hook; GPSLatitude2/GPSLongitude2; per-source `-ee` gating; doc-level warning surfacing.
- **Doc<N> allocation** reworked to ExifTool's canonical single-`ProcessMOV`-walk order (moov-timed → top-level udta → trailer chain → ScanMediaData) on one shared global counter, with the faithful out-of-range doc-burn.

## Verify

- `cargo +stable fmt --check` = 0
- `cargo +stable build --all-features --all-targets -Dwarnings` = 0
- `cargo +stable test --all-features --all-targets` = 0 (**3321 passed**; **521-fixture golden conformance byte-identical**)
- `cargo +stable clippy --all-features` = 0 (no deny-level; residual style warnings are the pre-existing #55/FU-15 backlog)

**Codex adversarial review: APPROVE** — 6 rounds + a deep-audited golden Doc<N> architecture fix; no material findings.

Combines and supersedes #126 and #135.
