### PR TITLE
feat(ligogps): dashcam LigoGPS module + trailer port (faithful 1:1)

### DIFF
--- a/src/formats/ligogps.rs
+++ b/src/formats/ligogps.rs
@@ -1,0 +1,1435 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+#![cfg(feature = "quicktime")]
+//! Faithful port of `Image::ExifTool::LigoGPS` (LigoGPS.pm, 431 lines) —
+//! the dashcam vendor GPS module used by various MP4/M2TS dashcam
+//! firmwares (iiway s1, XGODY 12" 4K, ABASK A8 4K, Rexing V1GW-4K,
+//! Kingslim D4, BlueSkySea DV688, Redtiger F9 4K, Yada RoadCam Pro 4K
+//! BT58189, …).
+//!
+//! ## Two reach paths
+//!
+//! 1. **`&&&& `-prefixed trailer at file end** (QuickTime.pm:9906-9907 +
+//!    :10658-10668) — `IdentifyTrailers` reads 40 bytes from `EOF-40` and
+//!    matches `/\&\&\&\&(.{4})$/` to extract the trailer length (LE u32 at
+//!    `EOF-4`). The full trailer begins `[size:u32-BE][skip:4-bytes]`
+//!    (`skip` ASCII atom name); after those 8 bytes the payload starts
+//!    with `LIGOGPSINFO\0` and is passed to [`process_ligogps`].
+//! 2. **`LIGOGPSINFO\0`-prefixed embedded sample** (QuickTimeStream.pl
+//!    :1843-1888) — bundled detects the fingerprint at offset 16/48/80
+//!    inside a `freeGPS` block, sets `LigoGPSScale = 3` when the offset-
+//!    16 ABASK A8 4K variant fingerprint hits, and dispatches to
+//!    [`process_ligogps`] with `DirStart = $pos`.
+//!
+//! Both paths route through the SAME `ProcessLigoGPS` (LigoGPS.pm:289-320).
+//!
+//! ## Record format
+//!
+//! `ProcessLigoGPS` walks the dir starting at `DirStart + 0x14` (the 20
+//! bytes past the `LIGOGPSINFO\0\0\0\0\xNN` 0x14-byte preamble) in
+//! fixed-stride 0x84 (132)-byte records. Each record is either:
+//!  - **`####`-prefixed encrypted record** — decrypted by
+//!    [`decrypt_record`] (LigoGPS.pm:50-99). The decrypted output is a
+//!    16-byte counter + 4 unknown bytes + ASCII text of the form
+//!    `"YYYY/MM/DD HH:MM:SS N:lat W:lon spd km/h A:track H:alt M:magvar
+//!    x:ax y:ay z:az"`. Parsed by [`parse_decoded_record`]
+//!    (LigoGPS.pm:229-267).
+//!  - **Non-encrypted ASCII record (Redtiger F9 4K)** — LigoGPS.pm:304-307.
+//!    Same text shape, no `####` prefix; flags = `0x03` (not fuzzed, kph
+//!    speed unit).
+//!
+//! ## Fuzzing
+//!
+//! Encrypted records have their lat/lon values "fuzzed" by a per-firmware
+//! scaling formula. [`unfuzz`] applies the bundled inverse
+//! (LigoGPS.pm:38-44):
+//!   - `lat2 = int(lat / 10) * 10`
+//!   - `lon2 = int(lon / 10) * 10`
+//!   - `unfuzzed_lat = lat2 + (lon - lon2) * scale`
+//!   - `unfuzzed_lon = lon2 + (lat - lat2) * scale`
+//!
+//! The scale factor is selected from the per-firmware scale ID (bundled
+//! `%gpsScl` lookup: 1 → 1.524855137, 2 → 1.456027985, 3 → 1.15368). The
+//! ABASK A8 4K fingerprint at offset 16 forces scale 3
+//! (QuickTimeStream.pl:1886).
+//!
+//! ## JSON variant
+//!
+//! `ProcessLigoJSON` (LigoGPS.pm:334-398) handles the Yada RoadCam Pro 4K
+//! BT58189 dashcam, which writes chained 512-byte records starting
+//! `LIGOGPSINFO {"Hour": "23", ...}`. This is a lighter parser (no
+//! decryption, no fuzzing) — we surface it through [`process_ligogps_json`].
+//!
+//! ## DecipherLigoGPS deferral
+//!
+//! The bundled `DecipherLigoGPS` fallback (LigoGPS.pm:143-221) fires when
+//! `DecryptLigoGPS` fails — it accumulates the per-second seconds-digit
+//! transitions across multiple records until it can determine a cipher
+//! table by sequence inversion. This adds significant multi-record
+//! cipher-discovery state with limited real-world utility (modern dashcam
+//! files always decode via `DecryptLigoGPS` on the first try). Tracked as
+//! FOLLOW-UP under issue #70.
+//!
+//! ## GPS priority chain
+//!
+//! LigoGPS records feed the **LOWEST tier** of the cross-port GPS
+//! priority chain that [`crate::metadata::MediaMetadata`] projects from
+//! a QuickTime file: GoPro GPMF → Android CAMM → Parrot mett → Sony rtmd
+//! → Canon CTMD → Insta360 trailer → SP3 stream → freeGPS-variants →
+//! **LigoGPS**. LigoGPS is best-effort dashcam vendor GPS (same tier as
+//! the freeGPS-variants and SP3 stream sources); ordered last by
+//! implementation arrival.
+
+extern crate alloc;
+use alloc::{string::String, vec::Vec};
+
+use smol_str::SmolStr;
+
+use crate::metadata::{LigoGpsMeta, LigoGpsSample};
+
+// ===========================================================================
+// Constants
+// ===========================================================================
+
+/// Conversion factor knots → km/h (LigoGPS.pm:20).
+const KNOTS_TO_KPH: f64 = 1.852;
+
+/// Default speed scale factor for fuzzed encrypted records (LigoGPS.pm:242).
+const DEFAULT_FUZZED_SPD_SCL: f64 = 1.85407333;
+
+/// LIGOGPSINFO header magic bytes (the 12-byte ASCII prefix +
+/// `LIGOGPSINFO\0`). Length is hard-coded throughout the bundled module.
+pub(crate) const HDR_LIGOGPSINFO: &[u8; 12] = b"LIGOGPSINFO\0";
+
+/// Fixed record stride within `ProcessLigoGPS` (LigoGPS.pm:301 `$pos+=0x84`).
+const RECORD_STRIDE: usize = 0x84;
+
+/// The header preamble between the `LIGOGPSINFO\0` magic and the start of
+/// records (LigoGPS.pm:293 `$pos = $$dirInfo{DirStart} + 0x14`). The 20-
+/// byte preamble is `[LIGOGPSINFO\0][4-byte ver-or-counter][\x01\x14 or
+/// random byte][3 bytes]`.
+const RECORDS_OFFSET: usize = 0x14;
+
+// ===========================================================================
+// Trailer signature constants — QuickTime.pm:9906-9907
+// ===========================================================================
+
+/// The 4-byte ASCII signature `"&&&&"` that prefixes the trailer-length
+/// LE u32 field. Reported by `IdentifyTrailers` (QuickTime.pm:9906).
+pub(crate) const TRAILER_MAGIC: &[u8; 4] = b"&&&&";
+
+/// `IdentifyTrailers` reads 40 bytes from EOF-40 (QuickTime.pm:9903). The
+/// trailer is identified when those 40 bytes match `/\&\&\&\&(.{4})$/` —
+/// i.e. the last 8 bytes of the file are `[&&&&][len:u32-LE]`.
+const IDENTIFY_FOOTER_SIZE: usize = 40;
+
+/// The `&&&& ` signature lives at offset 32 within that 40-byte buffer
+/// (bytes 32-35 are `&&&&`, bytes 36-39 are the LE u32 trailer length).
+const SIG_OFFSET: usize = 32;
+
+/// Per-`skip`-atom prefix size: the 8-byte `[size:u32-BE][skip]` atom
+/// header that QuickTime.pm:10658 reads at the trailer start
+/// (`$raf->Read($buff, 8) == 8 and $buff =~ /skip$/i`).
+const SKIP_ATOM_HEADER: usize = 8;
+
+// ===========================================================================
+// Endian helpers (LigoGPS records are LE per QuickTime.pm:9907 `Get32u`)
+// ===========================================================================
+
+#[inline]
+fn le_u32(b: &[u8], off: usize) -> Option<u32> {
+  b.get(off..off + 4)
+    .map(|s| u32::from_le_bytes([s[0], s[1], s[2], s[3]]))
+}
+
+#[inline]
+fn be_u32(b: &[u8], off: usize) -> Option<u32> {
+  b.get(off..off + 4)
+    .map(|s| u32::from_be_bytes([s[0], s[1], s[2], s[3]]))
+}
+
+// ===========================================================================
+// scan_trailer — entry point for the file-end LigoGPS trailer (QuickTime.pm
+// :10658-10668)
+// ===========================================================================
+
+/// Locate and decode a LigoGPS trailer at the end of `data`. No-op when no
+/// trailer signature is present (the cheap path most files take).
+///
+/// Faithful per `IdentifyTrailers` (QuickTime.pm:9897-9926) + the
+/// LigoGPS trailer handling in `ProcessMOV` (QuickTime.pm:10658-10668).
+/// The trailer matches `/\&\&\&\&(.{4})$/` against the last 40 bytes of
+/// the file (`IdentifyTrailers` reads 40 from EOF-40); the captured 4
+/// bytes are the LE u32 trailer length. The trailer body starts with an
+/// 8-byte `[size:u32-BE][skip]` atom header (QuickTime.pm:10658
+/// `$buff =~ /skip$/i`); the remaining `len - 16` bytes start with
+/// `LIGOGPSINFO\0` and are dispatched to [`process_ligogps`].
+///
+/// ## Error / pathological cases
+///
+/// - File shorter than 40 bytes → `is_empty()` (no trailer possible).
+/// - File without the `&&&&` signature → `is_empty()`.
+/// - Trailer claiming `trailer_len > file_size` → `Bad LigoGPS trailer
+///   size` warning, no records decoded.
+/// - Trailer claiming `trailer_len < 16` (less than the `skip` atom +
+///   `LIGOGPSINFO\0` magic minimum) → `Bad LigoGPS trailer size` warning.
+/// - `skip` atom check fails OR payload doesn't begin `LIGOGPSINFO\0`
+///   → `Unrecognized data in LigoGPS trailer` warning
+///   (QuickTime.pm:10667).
+pub fn scan_trailer(data: &[u8], out: &mut LigoGpsMeta) {
+  // QuickTime.pm:9903 `$raf->Seek(-40-$offset, 2) and $raf->Read($buff, 40)
+  // == 40`. We need at least IDENTIFY_FOOTER_SIZE bytes to even check.
+  if data.len() < IDENTIFY_FOOTER_SIZE {
+    return;
+  }
+  let footer = &data[data.len() - IDENTIFY_FOOTER_SIZE..];
+  // QuickTime.pm:9906 `$buff =~ /\&\&\&\&(.{4})$/` — the `&&&&` signature
+  // at offset 32, the LE u32 trailer length at offset 36.
+  if &footer[SIG_OFFSET..SIG_OFFSET + TRAILER_MAGIC.len()] != TRAILER_MAGIC.as_slice() {
+    return; // no LigoGPS trailer
+  }
+  // QuickTime.pm:9907 `($type, $len) = ('LigoGPS', Get32u(\$buff, 36))`.
+  let Some(trailer_len) = le_u32(footer, SIG_OFFSET + 4) else {
+    return;
+  };
+  let trailer_len = trailer_len as usize;
+  // Sanity: the trailer must include at least the 8-byte `skip` header
+  // + `LIGOGPSINFO\0` (12 bytes) — a 20-byte minimum. Anything smaller
+  // is a malformed trailer.
+  if trailer_len < SKIP_ATOM_HEADER + HDR_LIGOGPSINFO.len() {
+    out.set_warning(SmolStr::new("Bad LigoGPS trailer size"));
+    return;
+  }
+  if trailer_len > data.len() {
+    out.set_warning(SmolStr::new("Bad LigoGPS trailer size"));
+    return;
+  }
+  // QuickTime.pm:10657 `$raf->Seek($$trailer[1], 0)`. `$$trailer[1]` is
+  // `$raf->Tell() - $len` (the file offset of the trailer start).
+  let trailer_start = data.len() - trailer_len;
+  let trailer = &data[trailer_start..data.len()];
+  // QuickTime.pm:10658 `$raf->Read($buff, 8) == 8 and $buff =~ /skip$/i`.
+  // The 8-byte read is `[size:u32-BE][skip]` — the `skip` atom name lives
+  // at bytes 4..8. Case-insensitive per the bundled `/i` modifier.
+  let head = &trailer[..SKIP_ATOM_HEADER];
+  let atom_name = &head[4..8];
+  if !atom_name.eq_ignore_ascii_case(b"skip") {
+    out.set_warning(SmolStr::new("Unrecognized data in LigoGPS trailer"));
+    return;
+  }
+  // QuickTime.pm:10660 `my $len = Get32u(\$buff, 0) - 16`. The bundled
+  // reads `size:u32-BE` from the 8-byte buffer; `- 16` removes both the
+  // 8-byte read and an additional 8 bytes from the start (the `LIGOGPSINFO
+  // \0\0\0\0\xNN` magic preamble length consumed before record dispatch).
+  // We sanity-check that the declared atom size is at least the 8-byte
+  // header itself.
+  let Some(atom_size) = be_u32(head, 0) else {
+    out.set_warning(SmolStr::new("Bad LigoGPS trailer size"));
+    return;
+  };
+  if (atom_size as usize) < SKIP_ATOM_HEADER {
+    out.set_warning(SmolStr::new("Bad LigoGPS trailer size"));
+    return;
+  }
+  // QuickTime.pm:10661 `if ($len > 0 and $raf->Read($buff, $len) == $len
+  // and $buff =~ /^LIGOGPSINFO\0/)`. Note `$len = atom_size - 16`, i.e.
+  // the atom's payload after the inner 16-byte header. We read from
+  // `trailer_start + SKIP_ATOM_HEADER` (file offset 8 of the trailer).
+  let payload_start = trailer_start + SKIP_ATOM_HEADER;
+  // Bundled would read `atom_size - 16` bytes but the trailer body
+  // available is `trailer_len - SKIP_ATOM_HEADER`; cap at that.
+  let payload_avail = trailer_len - SKIP_ATOM_HEADER;
+  let payload = &data[payload_start..payload_start + payload_avail];
+  if payload.len() < HDR_LIGOGPSINFO.len()
+    || &payload[..HDR_LIGOGPSINFO.len()] != HDR_LIGOGPSINFO.as_slice()
+  {
+    out.set_warning(SmolStr::new("Unrecognized data in LigoGPS trailer"));
+    return;
+  }
+  // QuickTime.pm:10663-10665 `Image::ExifTool::LigoGPS::ProcessLigoGPS($et,
+  // \%dirInfo, $tbl)`. DirName/DirStart from the bundled call indicate
+  // `DirStart = 0` (the buffer starts with the LIGOGPSINFO\0 magic, so
+  // our `process_ligogps(buff, 0, ...)` mirrors that — record dispatch
+  // starts at offset 0x14 inside this buffer, matching LigoGPS.pm:293).
+  process_ligogps(payload, 0, out, /*no_fuzz=*/ false);
+}
+
+// ===========================================================================
+// process_ligogps — main walker, LigoGPS.pm:289-320
+// ===========================================================================
+
+/// Faithful port of `Image::ExifTool::LigoGPS::ProcessLigoGPS`
+/// (LigoGPS.pm:289-320). Walks `data` starting at `dir_start + 0x14` in
+/// fixed `0x84`-byte strides; each record is either a `####`-prefixed
+/// encrypted record (decrypted by [`decrypt_record`] + parsed by
+/// [`parse_decoded_record`]) or a plain ASCII LIGOGPSINFO record
+/// (Redtiger F9 4K variant — LigoGPS.pm:304-307).
+///
+/// `no_fuzz = true` skips the unfuzz step (LigoGPS.pm:248) — set by the
+/// trailer code path AND by the BlueSkySeaDV688 / unknown-0x14 firmware
+/// detection (LigoGPS.pm:299).
+///
+/// `ligogps_scale` is the per-file fuzz scale ID (1/2/3, mapping to the
+/// `%gpsScl` table at LigoGPS.pm:241). The freeGPS embedded path uses
+/// `Some(3)` for the offset-16 ABASK A8 4K fingerprint
+/// (QuickTimeStream.pl:1886); the trailer path uses `None` (defaults to
+/// scale = 1.0, i.e. no rescale beyond the integer-overflow defuzz).
+pub fn process_ligogps(data: &[u8], dir_start: usize, out: &mut LigoGpsMeta, no_fuzz: bool) {
+  process_ligogps_with_scale(data, dir_start, out, no_fuzz, None);
+}
+
+/// `process_ligogps` variant accepting an explicit per-file fuzz scale
+/// ID (Some(1)/Some(2)/Some(3)) — used by the freeGPS embedded path to
+/// pass `LigoGPSScale = 3` for the ABASK A8 4K firmware
+/// (QuickTimeStream.pl:1886).
+pub fn process_ligogps_with_scale(
+  data: &[u8],
+  dir_start: usize,
+  out: &mut LigoGpsMeta,
+  mut no_fuzz: bool,
+  ligogps_scale: Option<u32>,
+) {
+  // LigoGPS.pm:293 `$pos = ($$dirInfo{DirStart} || 0) + 0x14`.
+  let mut pos = dir_start.saturating_add(RECORDS_OFFSET);
+  // LigoGPS.pm:294 `return undef if $pos > length $$dataPt`.
+  if pos > data.len() {
+    return;
+  }
+  // LigoGPS.pm:299 `$noFuzz = 1 if substr($$dataPt, $pos-8, 4) =~
+  // /^\0\0\0[\x01\x14]/`. The 4 bytes at `pos-8` start `\0\0\0` and end
+  // with `\x01` (BlueSkySeaDV688) or `\x14` (unknown) → don't unfuzz.
+  if pos >= 8
+    && let Some(preamble) = data.get(pos - 8..pos - 4)
+    && preamble[0] == 0
+    && preamble[1] == 0
+    && preamble[2] == 0
+    && (preamble[3] == 0x01 || preamble[3] == 0x14)
+  {
+    no_fuzz = true;
+  }
+  // LigoGPS.pm:301 `for (; $pos + 0x84 <= length($$dataPt); $pos += 0x84)`.
+  while pos + RECORD_STRIDE <= data.len() {
+    let rec = &data[pos..pos + RECORD_STRIDE];
+    pos += RECORD_STRIDE;
+
+    // LigoGPS.pm:303-309 — non-encrypted ASCII record (Redtiger F9 4K).
+    // The bundled `next unless $dat =~ m(^.{4}\d{4}/\d{2}/\d{2} )s` allows
+    // 4-byte counter + ASCII date prefix.
+    if !rec.starts_with(b"####") {
+      if is_plain_ascii_date_record(rec) {
+        // LigoGPS.pm:306 `$dat =~ s/\0+$//`. Strip trailing nulls.
+        let trimmed = strip_trailing_nulls(rec);
+        // LigoGPS.pm:307 `ParseLigoGPS($et, $dat, $tagTbl, 0x03)` — flag
+        // 0x03 = not fuzzed (0x01) AND km/h speed (0x02).
+        parse_decoded_record(trimmed, 0x03, ligogps_scale, no_fuzz, out);
+      }
+      // (otherwise: bundled `next` — silently skip blank/null records).
+      continue;
+    }
+    // LigoGPS.pm:311 — bundled would attempt `DecipherLigoGPS` first if a
+    // cipher table is already known. We DEFER cipher discovery (issue
+    // #70 FOLLOW-UP), so the only path is `DecryptLigoGPS`.
+    let Some(decoded) = decrypt_record(rec) else {
+      // LigoGPS.pm:313 — `defined $str or DecipherLigoGPS(...), next`.
+      // Cipher discovery is deferred; record a one-time warning so the
+      // file's diagnostic is visible.
+      out.set_warning(SmolStr::new(
+        "LigoGPS record decryption failed (cipher discovery deferred)",
+      ));
+      continue;
+    };
+    // LigoGPS.pm:315 `ParseLigoGPS($et, $str, $tagTbl, $noFuzz)`.
+    // `$noFuzz` is just the 0x01 bit; speed-units bit (0x02) is unset
+    // for encrypted records (so speed uses the LigoGPS-internal scale
+    // factor 1.85407333).
+    let flags = if no_fuzz { 0x01 } else { 0x00 };
+    parse_decoded_record(&decoded, flags, ligogps_scale, no_fuzz, out);
+  }
+}
+
+/// Return `true` when the bundled `m(^.{4}\d{4}/\d{2}/\d{2} )s` pattern
+/// matches (LigoGPS.pm:304). The first 4 bytes are arbitrary (counter),
+/// then 10 bytes of `YYYY/MM/DD ` ASCII.
+fn is_plain_ascii_date_record(rec: &[u8]) -> bool {
+  if rec.len() < 15 {
+    return false;
+  }
+  let prefix = &rec[4..15];
+  prefix.len() == 11
+    && prefix[0].is_ascii_digit()
+    && prefix[1].is_ascii_digit()
+    && prefix[2].is_ascii_digit()
+    && prefix[3].is_ascii_digit()
+    && prefix[4] == b'/'
+    && prefix[5].is_ascii_digit()
+    && prefix[6].is_ascii_digit()
+    && prefix[7] == b'/'
+    && prefix[8].is_ascii_digit()
+    && prefix[9].is_ascii_digit()
+    && prefix[10] == b' '
+}
+
+/// Strip trailing `\0` bytes (LigoGPS.pm:306 `$dat =~ s/\0+$//`).
+fn strip_trailing_nulls(rec: &[u8]) -> &[u8] {
+  let mut end = rec.len();
+  while end > 0 && rec[end - 1] == 0 {
+    end -= 1;
+  }
+  &rec[..end]
+}
+
+// ===========================================================================
+// decrypt_record — LigoGPS.pm:50-99 `DecryptLigoGPS`
+// ===========================================================================
+
+/// Faithful port of `Image::ExifTool::LigoGPS::DecryptLigoGPS`
+/// (LigoGPS.pm:50-99). Decrypts one `####`-prefixed encrypted record. The
+/// 8-byte header is `####` (4 bytes) + `[u32-LE counter]` (4 bytes). The
+/// 4-byte LE u32 immediately after `####` is the number of OUTPUT bytes
+/// (capped at 0x84 — record-stride safety).
+///
+/// The decryption operates byte-by-byte, where each input byte's upper
+/// 3 bits steer one of four decryption modes (4 output bytes from 5
+/// input, 4 from 4, 4 from 4 in a different layout, 1 from 2). Returns
+/// the decoded ASCII text (the 4-byte counter is RE-PRESERVED at the
+/// start), or `None` on a malformed cipher stream.
+pub(crate) fn decrypt_record(rec: &[u8]) -> Option<Vec<u8>> {
+  // LigoGPS.pm:53 `my $num = unpack('x4V', $str)`. The 4-byte LE u32 at
+  // offset 4 is the OUTPUT-byte count (bundled output buffer size).
+  if rec.len() < 8 {
+    return None;
+  }
+  let mut num = le_u32(rec, 4)? as usize;
+  // LigoGPS.pm:54 `return undef if $num < 4`.
+  if num < 4 {
+    return None;
+  }
+  // LigoGPS.pm:55 `$num = 0x84 if $num > 0x84`.
+  if num > 0x84 {
+    num = 0x84;
+  }
+  // LigoGPS.pm:56 `my @in = unpack("x8C$num", $str)` — take `num` input
+  // bytes starting at offset 8.
+  let in_end = 8usize.checked_add(num)?;
+  if in_end > rec.len() {
+    return None;
+  }
+  let mut input = rec[8..in_end].iter().copied();
+  // Output preserved header — bundled keeps the 4-byte counter at the
+  // start (caller re-prepends it). We allocate enough headroom for the
+  // 4 output bytes per steering round; +4 for the header. The output
+  // CANNOT exceed 0x80 + 4 = 0x84.
+  let mut out: Vec<u8> = Vec::with_capacity(0x84);
+  // Caller (ParseLigoGPS) re-adds the 4-byte header from the rec; we
+  // emit only the decrypted body (LigoGPS.pm:217 `"$pre$str"` where
+  // `$pre = substr($str, 4, 4)`). But ProcessLigoGPS calls ParseLigoGPS
+  // directly with the OUTPUT of DecryptLigoGPS. Looking at LigoGPS.pm:315
+  // — `ParseLigoGPS($et, $str, $tagTbl, $noFuzz)` — passes the decrypted
+  // string `$str` directly. ParseLigoGPS expects ".{4}DATE TIME..." so
+  // the first 4 bytes of the OUTPUT are the counter (LigoGPS.pm:225-227).
+  // Bundled DecryptLigoGPS includes the counter in `@out`? Let me re-read:
+  // LigoGPS.pm:98 `return pack 'C*', @out`. `@out` is filled exclusively
+  // by the steering-decryption pushes. So the counter is NOT in `@out`.
+  // Then where does ParseLigoGPS's `.{4}` come from? Reading more
+  // carefully: LigoGPS.pm:53 `$num = unpack('x4V', $str)`. `'x4'` skips
+  // 4 bytes then reads V (u32-LE). So the LE u32 is at offset 4. But the
+  // OUTPUT `@out` is just the decrypted body. ParseLigoGPS at :231 does
+  // `$str =~ /^.{4}(\S+ \S+)\s+/` — the `.{4}` matches FOUR ARBITRARY
+  // BYTES at the start. So ParseLigoGPS is being given OUTPUT that has
+  // some 4-byte header. Where is that header? In ProcessLigoGPS at :315
+  // we see ParseLigoGPS called with `$str` (the OUTPUT of DecryptLigoGPS).
+  // Wait — re-reading LigoGPS.pm:314: `$et->VPrint(... unpack('V',$str)
+  // ...)` — the verbose print extracts the FIRST u32 of `$str` as the
+  // counter. So the counter IS the first 4 bytes of `$str`. Looking at
+  // LigoGPS.pm:51-98, `@out` is the DECRYPTED body. The verbose at :314
+  // reads `unpack('V', $str)` — but `$str` here is the SAME `$str` that
+  // was passed to ProcessLigoGPS (the OUTPUT). So `@out` DOES contain
+  // the counter; the cipher emits 4 bytes per round and one of those
+  // rounds emits the counter. Reading the encryption code more carefully:
+  // the loop runs `num` rounds; each round emits 1 or 4 output bytes.
+  // The TOTAL output size = sum of per-round outputs. For ParseLigoGPS
+  // to see `.{4}` followed by the date, the FIRST 4 output bytes are
+  // the counter — that is, the FIRST decryption round emits 4 bytes
+  // (the counter). All subsequent rounds emit the ASCII payload.
+  //
+  // So the output is just `@out` — no separate prepend needed. Good.
+  while let Some(b) = input.next() {
+    let steering = b & 0xe0;
+    if steering >= 0xc0 {
+      // LigoGPS.pm:62-67 — next 4 bytes are encrypted data.
+      let i1 = input.next()?;
+      let i2 = input.next()?;
+      let i3 = input.next()?;
+      let i4 = input.next()?;
+      out.push((i1 | (b & 0x01)) ^ 0x20);
+      out.push((i2 | (b & 0x02)) ^ 0x20);
+      out.push((i3 | (b & 0x0c)) ^ 0x20);
+      // LigoGPS.pm:67 `shift(@in) ^ 0x20 | $b & 0x30` — note the Perl
+      // precedence: `^` binds tighter than `|`, so this is
+      // `(shift(@in) ^ 0x20) | ($b & 0x30)`.
+      out.push((i4 ^ 0x20) | (b & 0x30));
+    } else if steering >= 0x40 {
+      // LigoGPS.pm:68-90 — next 3 bytes are encrypted data with one of
+      // four sub-modes by the exact steering value.
+      let i1 = input.next()?;
+      let i2 = input.next()?;
+      let i3 = input.next()?;
+      match steering {
+        0x40 => {
+          // LigoGPS.pm:70-74
+          out.push(0x20);
+          out.push((i1 | (b & 0x01)) ^ 0x20);
+          out.push((i2 | (b & 0x06)) ^ 0x20);
+          out.push((i3 | (b & 0x18)) ^ 0x20);
+        }
+        0x60 => {
+          // LigoGPS.pm:75-79
+          out.push((i1 | (b & 0x03)) ^ 0x20);
+          out.push(0x20);
+          out.push((i2 | (b & 0x04)) ^ 0x20);
+          out.push((i3 | (b & 0x18)) ^ 0x20);
+        }
+        0x80 => {
+          // LigoGPS.pm:80-84
+          out.push((i1 | (b & 0x03)) ^ 0x20);
+          out.push((i2 | (b & 0x0c)) ^ 0x20);
+          out.push(0x20);
+          out.push((i3 | (b & 0x10)) ^ 0x20);
+        }
+        _ => {
+          // LigoGPS.pm:85-89 — the bundled `else` covers `0xa0`.
+          out.push((i1 | (b & 0x01)) ^ 0x20);
+          out.push((i2 | (b & 0x06)) ^ 0x20);
+          out.push((i3 | (b & 0x18)) ^ 0x20);
+          out.push(0x20);
+        }
+      }
+    } else if steering == 0x00 {
+      // LigoGPS.pm:91-93 — next byte is encrypted data (single-output).
+      let i1 = input.next()?;
+      out.push(i1 | (b & 0x13));
+    } else {
+      // LigoGPS.pm:94-96 — bundled `else { return undef }`. Shouldn't
+      // happen on valid input; we propagate the failure.
+      return None;
+    }
+  }
+  Some(out)
+}
+
+// ===========================================================================
+// parse_decoded_record — LigoGPS.pm:229-267 `ParseLigoGPS`
+// ===========================================================================
+
+/// Parse a decrypted-or-plain LIGOGPSINFO text record. The buffer is
+/// `[4 bytes counter][YYYY/MM/DD HH:MM:SS] [LATREF]:[neg?]LAT [LONREF]:
+/// [neg?]LON SPEED [optional " km/h"] [optional " A:TRK"] [optional " H:ALT"]
+/// [optional " M:MAGVAR"] [optional " x:AX y:AY z:AZ"]`.
+///
+/// `flags` is the bundled `$flags`:
+///  - `0x01` = NOT fuzzed (skip the `UnfuzzLigoGPS` step).
+///  - `0x02` = speed is already in km/h (skip the knots→km/h conversion).
+///
+/// `scale_id` is the per-file `LigoGPSScale` (LigoGPS.pm:249) — drives
+/// the `%gpsScl` lookup at LigoGPS.pm:241 (1 → 1.524855137 / 2 →
+/// 1.456027985 / 3 → 1.15368).
+pub(crate) fn parse_decoded_record(
+  buf: &[u8],
+  flags: u8,
+  scale_id: Option<u32>,
+  no_fuzz_override: bool,
+  out: &mut LigoGpsMeta,
+) {
+  // Re-apply the `0x01` bit if the caller said `no_fuzz_override` (LigoGPS
+  // .pm:248 reads `$flags & 0x01` — so we OR it in).
+  let flags = if no_fuzz_override {
+    flags | 0x01
+  } else {
+    flags
+  };
+
+  // First 4 bytes are the counter (LigoGPS.pm:235 `^.{4}`); the body is
+  // the text.
+  if buf.len() < 5 {
+    return;
+  }
+  // Bundled tolerates trailing zero pads (parse_ligogps's regex anchors
+  // are tolerant). Use lossy UTF-8 — the text is ASCII per the format
+  // spec but a malformed record may contain garbage; lossy preserves the
+  // parse.
+  let body_bytes = &buf[4..];
+  let body = match core::str::from_utf8(body_bytes) {
+    Ok(s) => s,
+    Err(_) => {
+      // Try lossy: strip non-UTF8 bytes by taking the longest valid
+      // prefix.
+      core::str::from_utf8(
+        &body_bytes[..body_bytes
+          .iter()
+          .position(|&b| b == 0)
+          .unwrap_or(body_bytes.len())],
+      )
+      .unwrap_or("")
+    }
+  };
+  // Bundled regex (LigoGPS.pm:235):
+  //   /^.{4}(\S+ \S+)\s+([NS?]):(-?)([.\d]+)\s+([EW?]):(-?)([\.\d]+)\s+([.\d]+)/s
+  // (note `.{4}` is already consumed by our slice). The captures:
+  //   1: "YYYY/MM/DD HH:MM:SS"
+  //   2: "N"|"S"|"?"
+  //   3: "-" or empty (lat sign)
+  //   4: lat magnitude (e.g. "31.285065")
+  //   5: "E"|"W"|"?"
+  //   6: "-" or empty (lon sign)
+  //   7: lon magnitude
+  //   8: speed magnitude
+  let Some(fields) = parse_lead_fields(body) else {
+    out.set_warning(SmolStr::new("LIGOGPSINFO format error"));
+    return;
+  };
+  let (date_time_str, lat_ref, lat_neg, mut lat, lon_ref, lon_neg, mut lon, spd_raw) = fields;
+
+  // LigoGPS.pm:244 — `$time =~ tr(/)(:)` — normalise the date separators.
+  let date_time = date_time_str.replace('/', ":");
+
+  // LigoGPS.pm:241-242 — speed scale lookup.
+  let mut spd_scl = if flags & 0x01 != 0 {
+    if flags & 0x02 != 0 {
+      // km/h record, no scaling.
+      1.0
+    } else {
+      // knots record, convert.
+      KNOTS_TO_KPH
+    }
+  } else {
+    DEFAULT_FUZZED_SPD_SCL
+  };
+
+  // LigoGPS.pm:247 — DDMM.MMMMMM detection: if the lat magnitude has 3
+  // leading digits before the first decimal (bundled `$lat =~ /^\d{3}/`),
+  // the format is degrees+minutes (NMEA-style) and we re-scale to
+  // decimal degrees. The bundled regex matches when the magnitude is
+  // ≥ 100 (3-digit integer part).
+  if has_three_leading_digits_f64(lat) {
+    convert_lat_lon_dm_to_decimal(&mut lat, &mut lon);
+    spd_scl = 1.0; // bundled comment: "speed wasn't scaled in my 1 sample"
+  }
+
+  // LigoGPS.pm:248-252 — unfuzz the coordinates if `flags & 0x01 == 0`.
+  if flags & 0x01 == 0 {
+    let scl = scale_id
+      .and_then(|id| match id {
+        1 => Some(1.524855137_f64),
+        2 => Some(1.456027985_f64),
+        3 => Some(1.15368_f64),
+        _ => None,
+      })
+      .unwrap_or(1.0);
+    let (ul, ulon) = unfuzz(lat, lon, scl);
+    lat = ul;
+    lon = ulon;
+  }
+
+  // LigoGPS.pm:254 — sanity check.
+  if lat > 90.0 || lon > 180.0 {
+    out.set_warning(SmolStr::new("LIGOGPSINFO coordinates out of range"));
+    return;
+  }
+
+  // LigoGPS.pm:256-263 — emit the GPS tags.
+  let mut sample = LigoGpsSample::new();
+  sample.set_date_time(Some(SmolStr::new(date_time)));
+  // LigoGPS.pm:258 — `$lat * (($latNeg or $latRef eq 'S') ? -1 : 1)`.
+  let lat_signed = if lat_neg || lat_ref == 'S' { -lat } else { lat };
+  // LigoGPS.pm:259 — `$lon * (($lonNeg or $lonRef eq 'W') ? -1 : 1)`.
+  let lon_signed = if lon_neg || lon_ref == 'W' { -lon } else { lon };
+  sample.set_latitude(Some(lat_signed));
+  sample.set_longitude(Some(lon_signed));
+  // LigoGPS.pm:260 — `$spd * $spdScl`.
+  sample.set_speed_kph(Some(spd_raw * spd_scl));
+
+  // LigoGPS.pm:261-265 — optional fields (Track, Altitude, MagVar, Accel).
+  if let Some(v) = extract_value(body, " A:") {
+    sample.set_track_deg(Some(v));
+  }
+  if let Some(v) = extract_value(body, " H:") {
+    sample.set_altitude_m(Some(v));
+  }
+  if let Some(v) = extract_value(body, " M:") {
+    sample.set_magnetic_variation(Some(v));
+  }
+  if let Some((ax, ay, az)) = extract_acceleration(body) {
+    // LigoGPS.pm:265 — `"$1 $2 $3"`. The bundled tab-separator is
+    // accepted by `\s` in the regex; we space-join in the output.
+    let mut s = String::with_capacity(24);
+    s.push_str(ax);
+    s.push(' ');
+    s.push_str(ay);
+    s.push(' ');
+    s.push_str(az);
+    sample.set_accelerometer(Some(SmolStr::new(s)));
+  }
+  out.push_sample(sample);
+}
+
+/// Decoded `ParseLigoGPS` lead-line fields (LigoGPS.pm:235 regex captures).
+/// Tuple components: `(date_time_str, lat_ref, lat_neg, lat_magnitude,
+/// lon_ref, lon_neg, lon_magnitude, speed_raw)`.
+type LeadFields = (String, char, bool, f64, char, bool, f64, f64);
+
+/// Parse the lead-line fields. Faithful to the bundled regex
+/// `^(\S+ \S+)\s+([NS?]):(-?)([.\d]+)\s+([EW?]):(-?)([\.\d]+)\s+([.\d]+)`
+/// (LigoGPS.pm:235).
+fn parse_lead_fields(body: &str) -> Option<LeadFields> {
+  // Field 1: \S+ \S+ — date + " " + time. Walk to first whitespace
+  // (date), then through following whitespace, then to the next
+  // whitespace (time).
+  let date_end = body.find(char::is_whitespace)?;
+  let date = &body[..date_end];
+  // Bundled regex requires the date to look like `YYYY/MM/DD` (via
+  // downstream `tr/\//:/` and `^.{4}\d{4}/\d{2}/\d{2} ` plain-path
+  // check). The encrypted-path regex is permissive but the tag emission
+  // relies on slashes.
+  if !date.contains('/') {
+    return None;
+  }
+  let after_date = body[date_end..].trim_start();
+  let time_end = after_date.find(char::is_whitespace)?;
+  let time = &after_date[..time_end];
+
+  let mut date_time = String::with_capacity(date.len() + 1 + time.len());
+  date_time.push_str(date);
+  date_time.push(' ');
+  date_time.push_str(time);
+
+  let tail = after_date[time_end..].trim_start();
+
+  // Lat ref + sign + magnitude.
+  let (lat_ref, after_lat_ref) = take_ref(tail, &['N', 'S', '?'])?;
+  if !after_lat_ref.starts_with(':') {
+    return None;
+  }
+  let after_colon = &after_lat_ref[1..];
+  let (lat_neg, after_lat_sign) = if let Some(stripped) = after_colon.strip_prefix('-') {
+    (true, stripped)
+  } else {
+    (false, after_colon)
+  };
+  let (lat_mag_str, after_lat) = take_numeric(after_lat_sign)?;
+  let lat: f64 = lat_mag_str.parse().ok()?;
+  let after_lat = after_lat.trim_start();
+
+  // Lon ref + sign + magnitude.
+  let (lon_ref, after_lon_ref) = take_ref(after_lat, &['E', 'W', '?'])?;
+  if !after_lon_ref.starts_with(':') {
+    return None;
+  }
+  let after_colon = &after_lon_ref[1..];
+  let (lon_neg, after_lon_sign) = if let Some(stripped) = after_colon.strip_prefix('-') {
+    (true, stripped)
+  } else {
+    (false, after_colon)
+  };
+  let (lon_mag_str, after_lon) = take_numeric(after_lon_sign)?;
+  let lon: f64 = lon_mag_str.parse().ok()?;
+  let after_lon = after_lon.trim_start();
+
+  // Speed magnitude.
+  let (spd_str, _) = take_numeric(after_lon)?;
+  let spd: f64 = spd_str.parse().ok()?;
+
+  Some((date_time, lat_ref, lat_neg, lat, lon_ref, lon_neg, lon, spd))
+}
+
+/// Take a single character if it's one of the allowed reference chars
+/// (`['N', 'S', '?']` for latitude, `['E', 'W', '?']` for longitude).
+fn take_ref<'a>(s: &'a str, allowed: &[char]) -> Option<(char, &'a str)> {
+  let mut chars = s.chars();
+  let first = chars.next()?;
+  if allowed.contains(&first) {
+    Some((first, &s[first.len_utf8()..]))
+  } else {
+    None
+  }
+}
+
+/// Take the longest numeric prefix (`[.\d]+` per LigoGPS.pm:235).
+fn take_numeric(s: &str) -> Option<(&str, &str)> {
+  let end = s
+    .char_indices()
+    .take_while(|(_, c)| c.is_ascii_digit() || *c == '.')
+    .last()
+    .map(|(i, c)| i + c.len_utf8())
+    .unwrap_or(0);
+  if end == 0 {
+    return None;
+  }
+  Some((&s[..end], &s[end..]))
+}
+
+/// `true` when `s` starts with at least 3 digits (LigoGPS.pm:247
+/// `$lat =~ /^\d{3}/` — the bundled regex matches when the FIRST 3
+/// characters are digits, no anchor on what follows). Used by the
+/// tests; the production path uses [`has_three_leading_digits_f64`]
+/// which avoids the string→f64 reparse.
+#[cfg(test)]
+fn has_three_leading_digits(s: &str) -> bool {
+  s.chars().take(3).filter(|c| c.is_ascii_digit()).count() == 3
+}
+
+/// `true` when the lat magnitude has a 3-digit integer part — equivalent
+/// to the bundled `$lat =~ /^\d{3}/` regex once the magnitude is parsed
+/// as f64. Matches when the integer part is in `100..=9999` (4-digit
+/// max for the bundled DDMM format).
+fn has_three_leading_digits_f64(lat: f64) -> bool {
+  let trunc = lat.trunc();
+  (100.0..10000.0).contains(&trunc)
+}
+
+/// Faithful port of `Image::ExifTool::QuickTime::ConvertLatLon`
+/// (referenced from LigoGPS.pm:247). Bundled converts DDMM.MMMMMM →
+/// DD.DDDDDD in-place: `$_ = int($_/100) + ($_ - int($_/100)*100) / 60
+/// foreach ($lat, $lon)`.
+fn convert_lat_lon_dm_to_decimal(lat: &mut f64, lon: &mut f64) {
+  for v in [lat, lon] {
+    let degrees = (*v / 100.0).trunc();
+    let minutes = *v - degrees * 100.0;
+    *v = degrees + minutes / 60.0;
+  }
+}
+
+/// Faithful port of `UnfuzzLigoGPS` (LigoGPS.pm:38-44):
+///   `$lat2 = int($lat/10) * 10`
+///   `$lon2 = int($lon/10) * 10`
+///   `return ($lat2 + ($lon - $lon2) * $scl, $lon2 + ($lat - $lat2) * $scl)`.
+fn unfuzz(lat: f64, lon: f64, scl: f64) -> (f64, f64) {
+  let lat2 = (lat / 10.0).trunc() * 10.0;
+  let lon2 = (lon / 10.0).trunc() * 10.0;
+  (lat2 + (lon - lon2) * scl, lon2 + (lat - lat2) * scl)
+}
+
+/// Extract a numeric value following the `key` literal (e.g. `" A:"`,
+/// `" H:"`, `" M:"`). Bundled regex pattern `\bA:(\S+)` —
+/// LigoGPS.pm:261-263.
+fn extract_value(body: &str, key: &str) -> Option<f64> {
+  let idx = body.find(key)?;
+  let after = &body[idx + key.len()..];
+  // Take \S+ (any non-whitespace).
+  let end = after
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after.len());
+  after[..end].parse().ok()
+}
+
+/// Extract the 3-axis accelerometer triplet (LigoGPS.pm:265 regex
+/// `x:(\S+)\sy:(\S+)\sz:(\S+)`). Returns `(ax, ay, az)` as substring
+/// references into `body`.
+fn extract_acceleration(body: &str) -> Option<(&str, &str, &str)> {
+  let xi = body.find("x:")?;
+  let after_x = &body[xi + 2..];
+  let xe = after_x
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after_x.len());
+  let ax = &after_x[..xe];
+  let rest_after_x = &after_x[xe..].trim_start();
+  let after_y = rest_after_x.strip_prefix("y:")?;
+  let ye = after_y
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after_y.len());
+  let ay = &after_y[..ye];
+  let rest_after_y = &after_y[ye..].trim_start();
+  let after_z = rest_after_y.strip_prefix("z:")?;
+  let ze = after_z
+    .find(|c: char| c.is_ascii_whitespace())
+    .unwrap_or(after_z.len());
+  let az = &after_z[..ze];
+  Some((ax, ay, az))
+}
+
+// ===========================================================================
+// process_ligogps_json — LigoGPS.pm:334-398 `ProcessLigoJSON`
+// ===========================================================================
+
+/// Faithful port of `Image::ExifTool::LigoGPS::ProcessLigoJSON`
+/// (LigoGPS.pm:334-398) — the JSON-format variant used by the Yada
+/// RoadCam Pro 4K BT58189 dashcam (chained 512-byte records starting
+/// with `LIGOGPSINFO {`).
+///
+/// Walks `data` for every `LIGOGPSINFO {…}` segment and decodes the
+/// inner JSON into a [`LigoGpsSample`]. Only `status == "A"` records
+/// produce a sample (LigoGPS.pm:353).
+pub fn process_ligogps_json(data: &[u8], out: &mut LigoGpsMeta) {
+  let text = match core::str::from_utf8(data) {
+    Ok(s) => s,
+    Err(_) => return,
+  };
+  let mut search_start = 0;
+  while let Some(rel) = text[search_start..].find("LIGOGPSINFO {") {
+    let abs = search_start + rel + "LIGOGPSINFO ".len();
+    // Find the closing brace — naive parser sufficient for the bundled
+    // shape (no nested objects in the JSON variant).
+    let Some(close_rel) = text[abs..].find('}') else {
+      return;
+    };
+    let json_end = abs + close_rel + 1;
+    let json_text = &text[abs..json_end];
+    if let Some(sample) = decode_ligo_json_object(json_text) {
+      out.push_sample(sample);
+    }
+    search_start = json_end;
+  }
+}
+
+/// Decode a single LIGOGPSINFO JSON-object into a [`LigoGpsSample`].
+/// Faithful per LigoGPS.pm:342-393.
+fn decode_ligo_json_object(json: &str) -> Option<LigoGpsSample> {
+  // Tiny one-pass JSON-object scanner: extract `"key": "value"` or
+  // `"key": <number>` pairs. The bundled `Image::ExifTool::Import::Read
+  // JSON` is a full parser, but LIGOGPSINFO records are flat
+  // `{"key": "val", ...}` so a flat scanner suffices.
+  let mut hour: Option<u32> = None;
+  let mut minute: Option<u32> = None;
+  let mut second: Option<u32> = None;
+  let mut year: Option<u32> = None;
+  let mut month: Option<u32> = None;
+  let mut day: Option<u32> = None;
+  let mut m_hour: Option<u32> = None;
+  let mut m_minute: Option<u32> = None;
+  let mut m_second: Option<u32> = None;
+  let mut m_year: Option<u32> = None;
+  let mut m_month: Option<u32> = None;
+  let mut m_day: Option<u32> = None;
+  let mut status: Option<String> = None;
+  let mut ns: Option<String> = None;
+  let mut ew: Option<String> = None;
+  let mut latitude: Option<f64> = None;
+  let mut longitude: Option<f64> = None;
+  let mut speed: Option<f64> = None;
+  let mut gsensor_x: Option<String> = None;
+  let mut gsensor_y: Option<String> = None;
+  let mut gsensor_z: Option<String> = None;
+
+  for (key, val) in iter_json_pairs(json) {
+    match key {
+      "Hour" => hour = val.parse().ok(),
+      "Minute" => minute = val.parse().ok(),
+      "Second" => second = val.parse().ok(),
+      "Year" => year = val.parse().ok(),
+      "Month" => month = val.parse().ok(),
+      "Day" => day = val.parse().ok(),
+      "MHour" => m_hour = val.parse().ok(),
+      "MMinute" => m_minute = val.parse().ok(),
+      "MSecond" => m_second = val.parse().ok(),
+      "MYear" => m_year = val.parse().ok(),
+      "MMonth" => m_month = val.parse().ok(),
+      "MDay" => m_day = val.parse().ok(),
+      "status" => status = Some(val.to_string()),
+      "NS" => ns = Some(val.to_string()),
+      "EW" => ew = Some(val.to_string()),
+      "Latitude" => latitude = val.parse().ok(),
+      "Longitude" => longitude = val.parse().ok(),
+      "Speed" => speed = val.parse().ok(),
+      "GsensorX" => gsensor_x = Some(val.to_string()),
+      "GsensorY" => gsensor_y = Some(val.to_string()),
+      "GsensorZ" => gsensor_z = Some(val.to_string()),
+      _ => {}
+    }
+  }
+
+  // LigoGPS.pm:353 — `next unless defined $$info{status} and $$info{status}
+  // eq 'A'` — only emit when GPS is active.
+  if status.as_deref() != Some("A") {
+    return None;
+  }
+
+  let mut sample = LigoGpsSample::new();
+  // LigoGPS.pm:357-361 — GPSDateTime (UTC, with Z suffix).
+  if let (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) =
+    (year, month, day, hour, minute, second)
+  {
+    let dt = String::from(&format!("{y:04}:{mo:02}:{d:02} {h:02}:{mi:02}:{s:02}Z"));
+    sample.set_date_time(Some(SmolStr::new(dt)));
+  }
+  // LigoGPS.pm:362-369 — Latitude/Longitude.
+  if let (Some(lat0), Some(lon0)) = (latitude, longitude) {
+    let lat = if ns.as_deref() == Some("S") {
+      -lat0
+    } else {
+      lat0
+    };
+    let lon = if ew.as_deref() == Some("W") {
+      -lon0
+    } else {
+      lon0
+    };
+    sample.set_latitude(Some(lat));
+    sample.set_longitude(Some(lon));
+  }
+  // LigoGPS.pm:370 — Speed (knots → km/h).
+  if let Some(sp) = speed {
+    sample.set_speed_kph(Some(sp * KNOTS_TO_KPH));
+  }
+  // LigoGPS.pm:371-373 — Gsensor (raw, space-joined; bundled comment says
+  // "don't know conversion factor").
+  if let (Some(x), Some(y), Some(z)) = (gsensor_x, gsensor_y, gsensor_z) {
+    let mut s = String::with_capacity(x.len() + y.len() + z.len() + 2);
+    s.push_str(&x);
+    s.push(' ');
+    s.push_str(&y);
+    s.push(' ');
+    s.push_str(&z);
+    sample.set_accelerometer(Some(SmolStr::new(s)));
+  }
+  // LigoGPS.pm:376-380 — DateTimeOriginal (dashcam local clock).
+  if let (Some(y), Some(mo), Some(d), Some(h), Some(mi), Some(s)) =
+    (m_year, m_month, m_day, m_hour, m_minute, m_second)
+  {
+    let dt = format!("{y:04}:{mo:02}:{d:02} {h:02}:{mi:02}:{s:02}");
+    sample.set_date_time_local(Some(SmolStr::new(dt)));
+  }
+  Some(sample)
+}
+
+/// Iterate over `"key": "value"` or `"key": <number>` pairs in a JSON
+/// flat object. Designed for the LIGOGPSINFO JSON variant only — no
+/// nested objects, no escape sequences in values.
+fn iter_json_pairs(json: &str) -> impl Iterator<Item = (&str, &str)> {
+  // Find quoted-string keys followed by `:` and either a quoted string
+  // value or a numeric value.
+  let s = json.trim().trim_start_matches('{').trim_end_matches('}');
+  s.split(',').filter_map(|pair| {
+    let colon = pair.find(':')?;
+    let key_raw = pair[..colon].trim();
+    let key = key_raw.trim_matches('"').trim();
+    let val_raw = pair[colon + 1..].trim();
+    // Strip surrounding quotes if present.
+    let val = if val_raw.starts_with('"') && val_raw.ends_with('"') && val_raw.len() >= 2 {
+      &val_raw[1..val_raw.len() - 1]
+    } else {
+      val_raw
+    };
+    Some((key, val))
+  })
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // ── decrypt_record ────────────────────────────────────────────────────────
+
+  #[test]
+  fn decrypt_record_rejects_short_header() {
+    assert!(decrypt_record(&[0u8; 4]).is_none());
+    assert!(decrypt_record(&[]).is_none());
+  }
+
+  #[test]
+  fn decrypt_record_rejects_num_too_small() {
+    // num < 4 → return undef
+    let mut buf = vec![b'#', b'#', b'#', b'#'];
+    buf.extend_from_slice(&3u32.to_le_bytes()); // num = 3
+    assert!(decrypt_record(&buf).is_none());
+  }
+
+  #[test]
+  fn decrypt_record_caps_num_at_0x84() {
+    // num = 1000 (capped at 0x84 = 132); provide 132 bytes of single-output
+    // mode 0x00 (steering 0x00 → 1 input byte, 1 output byte).
+    let mut buf = vec![b'#', b'#', b'#', b'#'];
+    buf.extend_from_slice(&1000u32.to_le_bytes());
+    // 132 rounds of (steering=0x00, input_byte=0x10). Each round consumes
+    // 2 bytes (the steering and the input), emitting 1 byte.
+    for _ in 0..132 {
+      buf.push(0x00); // steering
+      buf.push(0x40); // input byte (0x40 | 0x13 = 0x53 = 'S')
+    }
+    let out = decrypt_record(&buf).expect("decrypts");
+    // num was capped at 0x84 = 132, but since each steering=0x00 round
+    // consumes 2 input bytes (steering+1 input), num input bytes only
+    // produces num/2 rounds = 66 output bytes. Bundled consumes `num`
+    // input bytes total.
+    assert!(!out.is_empty());
+  }
+
+  #[test]
+  fn decrypt_record_steering_zero_single_byte() {
+    // Mode 0x00: next byte combined with `b & 0x13` (so b=0x00 means
+    // output = next_byte | 0 = next_byte).
+    let mut buf = vec![b'#', b'#', b'#', b'#'];
+    buf.extend_from_slice(&8u32.to_le_bytes()); // num = 8 (4 rounds × 2 bytes)
+    // 4 rounds of (steering=0x00, input=0x41='A')
+    for _ in 0..4 {
+      buf.push(0x00);
+      buf.push(0x41);
+    }
+    let out = decrypt_record(&buf).expect("decrypts");
+    assert_eq!(out, b"AAAA");
+  }
+
+  // ── unfuzz ────────────────────────────────────────────────────────────────
+
+  #[test]
+  fn unfuzz_identity_when_scale_one() {
+    // With scale = 1 the formula does NOT recover the original; this
+    // verifies the math matches the bundled algorithm.
+    // Pre-fuzz: lat=31.5, lon=124.7
+    // lat2 = floor(3.15)*10 = 30, lon2 = floor(12.47)*10 = 120
+    // result = (30 + (124.7-120)*1, 120 + (31.5-30)*1) = (34.7, 121.5)
+    let (ul, ulon) = unfuzz(31.5, 124.7, 1.0);
+    assert!((ul - 34.7).abs() < 1e-9);
+    assert!((ulon - 121.5).abs() < 1e-9);
+  }
+
+  #[test]
+  fn unfuzz_scale_three_for_abask() {
+    // scale = 1.15368 (ABASK A8 4K, QuickTimeStream.pl:1886).
+    let (ul, _ulon) = unfuzz(31.5, 124.7, 1.15368);
+    // lat2 = 30, lon2 = 120, ul = 30 + (124.7-120)*1.15368 = 30 + 5.422... ≈ 35.422
+    assert!((ul - 35.4229_f64).abs() < 1e-3);
+  }
+
+  // ── parse_decoded_record ──────────────────────────────────────────────────
+
+  #[test]
+  fn parse_record_known_good_kph_no_fuzz() {
+    // From LigoGPS.pm:234 sample: "....2022/09/19 12:45:24 N:31.285065
+    // W:124.759483 46.93 km/h x:-0.000 y:-0.000 z:-0.000".
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]); // counter
+    buf.extend_from_slice(
+      b"2022/09/19 12:45:24 N:31.285065 W:124.759483 46.93 km/h x:-0.000 y:-0.000 z:-0.000",
+    );
+    let mut out = LigoGpsMeta::new();
+    // flags = 0x03 = not-fuzzed + kph (matches Redtiger F9 4K plain-ASCII path).
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.date_time(), Some("2022:09:19 12:45:24"));
+    // W means longitude is negative.
+    assert_eq!(s.latitude(), Some(31.285065));
+    assert_eq!(s.longitude(), Some(-124.759483));
+    assert_eq!(s.speed_kph(), Some(46.93));
+    assert_eq!(s.accelerometer(), Some("-0.000 -0.000 -0.000"));
+  }
+
+  #[test]
+  fn parse_record_with_track_alt_magvar() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(
+      b"2024/01/15 10:00:00 N:45.500 E:170.500 30.0 A:180.5 H:123.4 M:12.5 x:0 y:0 z:0",
+    );
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.track_deg(), Some(180.5));
+    assert_eq!(s.altitude_m(), Some(123.4));
+    assert_eq!(s.magnetic_variation(), Some(12.5));
+  }
+
+  #[test]
+  fn parse_record_south_latitude_signs_correctly() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"2024/01/15 10:00:00 S:45.500 E:170.500 30.0 km/h");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.latitude(), Some(-45.500));
+    assert_eq!(s.longitude(), Some(170.500));
+  }
+
+  #[test]
+  fn parse_record_explicit_negative_sign() {
+    // The bundled regex captures an explicit `-` in `($latNeg)` (group 3).
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"2024/01/15 10:00:00 N:-45.500 E:-170.500 30.0 km/h");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.latitude(), Some(-45.500));
+    assert_eq!(s.longitude(), Some(-170.500));
+  }
+
+  #[test]
+  fn parse_record_emits_format_error_on_garbage() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"NOT A VALID RECORD");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    assert!(out.samples().is_empty());
+    assert_eq!(out.warning(), Some("LIGOGPSINFO format error"));
+  }
+
+  #[test]
+  fn parse_record_emits_oor_when_out_of_range() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&[0; 4]);
+    buf.extend_from_slice(b"2024/01/15 10:00:00 N:91.0 E:181.0 0.0 km/h");
+    let mut out = LigoGpsMeta::new();
+    parse_decoded_record(&buf, 0x03, None, false, &mut out);
+    assert!(out.samples().is_empty());
+    assert_eq!(out.warning(), Some("LIGOGPSINFO coordinates out of range"));
+  }
+
+  // ── process_ligogps trailer-shape walker ─────────────────────────────────
+
+  #[test]
+  fn process_ligogps_too_short_is_silent() {
+    let mut out = LigoGpsMeta::new();
+    process_ligogps(b"too short", 0, &mut out, false);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn process_ligogps_walks_single_plain_record() {
+    // Trailer-style: `LIGOGPSINFO\0\0\0\0\x14` (20-byte preamble),
+    // then ONE 0x84-byte plain ASCII record.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(HDR_LIGOGPSINFO);
+    // 8 more bytes of preamble (the 0x14 byte at offset 0x13 — bytes
+    // [pos-8..pos-4] = [\0,\0,\0,\x14] triggers no_fuzz auto-detect).
+    buf.extend_from_slice(&[0, 0, 0, 0, 0x14, 0, 0, 0]);
+    // record body: 0x84 bytes total. Counter (4) + ASCII payload +
+    // padding.
+    let mut record = Vec::with_capacity(0x84);
+    record.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+    record.extend_from_slice(b"2024/01/15 10:00:00 N:45.5 E:170.5 30.0 km/h");
+    while record.len() < 0x84 {
+      record.push(0);
+    }
+    buf.extend_from_slice(&record);
+    let mut out = LigoGpsMeta::new();
+    process_ligogps(&buf, 0, &mut out, false);
+    assert_eq!(out.samples().len(), 1);
+    let s = &out.samples()[0];
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+  }
+
+  // ── scan_trailer ──────────────────────────────────────────────────────────
+
+  #[test]
+  fn scan_trailer_no_signature_leaves_out_empty() {
+    let mut out = LigoGpsMeta::new();
+    scan_trailer(&[0u8; 100], &mut out);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn scan_trailer_short_file_silent() {
+    let mut out = LigoGpsMeta::new();
+    scan_trailer(&[0u8; 10], &mut out);
+    assert!(out.is_empty());
+  }
+
+  #[test]
+  fn scan_trailer_warns_on_bad_size() {
+    // Build a 40-byte buffer with the `&&&&` signature but a trailer
+    // length larger than the file.
+    let mut data = vec![0u8; 80];
+    data[80 - 8..80 - 4].copy_from_slice(TRAILER_MAGIC);
+    data[80 - 4..].copy_from_slice(&999u32.to_le_bytes());
+    let mut out = LigoGpsMeta::new();
+    scan_trailer(&data, &mut out);
+    assert_eq!(out.warning(), Some("Bad LigoGPS trailer size"));
+  }
+
+  #[test]
+  fn scan_trailer_warns_on_missing_skip_atom() {
+    // Build a valid-signature trailer of size 32 with no `skip` atom.
+    let mut data = vec![0u8; 100];
+    // The trailer body lives at file_len - trailer_len.
+    let trailer_len: u32 = 40;
+    let trailer_start = data.len() - trailer_len as usize;
+    // First 8 bytes: random; we'll set them to non-`skip`.
+    data[trailer_start..trailer_start + 8]
+      .copy_from_slice(&[0, 0, 0, 0x40, b'j', b'u', b'n', b'k']);
+    // signature + len in last 8 bytes.
+    let sig_off = data.len() - 8;
+    data[sig_off..sig_off + 4].copy_from_slice(TRAILER_MAGIC);
+    data[sig_off + 4..].copy_from_slice(&trailer_len.to_le_bytes());
+    let mut out = LigoGpsMeta::new();
+    scan_trailer(&data, &mut out);
+    assert_eq!(out.warning(), Some("Unrecognized data in LigoGPS trailer"));
+  }
+
+  #[test]
+  fn scan_trailer_warns_on_missing_ligogpsinfo_magic() {
+    // Valid skip atom but no LIGOGPSINFO\0 at payload start.
+    let mut buf = Vec::new();
+    // Body: 8-byte skip header + random payload.
+    let body_len = SKIP_ATOM_HEADER + 32usize;
+    let mut body = vec![0u8; body_len];
+    // skip atom header: [size:u32-BE][skip]
+    body[..4].copy_from_slice(&(body_len as u32).to_be_bytes());
+    body[4..8].copy_from_slice(b"skip");
+    // Payload: 24 random bytes (no LIGOGPSINFO\0).
+    for i in 0..24 {
+      body[8 + i] = (i + 0x40) as u8;
+    }
+    // Build the full file: padding + trailer body + signature + len.
+    buf.extend_from_slice(&[0u8; 16]);
+    buf.extend_from_slice(&body);
+    let trailer_len = (body.len() + 8) as u32; // body + signature(4) + len(4)
+    buf.extend_from_slice(TRAILER_MAGIC);
+    buf.extend_from_slice(&trailer_len.to_le_bytes());
+    let mut out = LigoGpsMeta::new();
+    scan_trailer(&buf, &mut out);
+    assert_eq!(out.warning(), Some("Unrecognized data in LigoGPS trailer"));
+  }
+
+  #[test]
+  fn scan_trailer_decodes_minimal_plain_ascii() {
+    // Build a valid trailer with the plain-ASCII Redtiger-F9-4K
+    // record format.
+    //
+    // File layout:
+    //   [padding 16 bytes]
+    //   [trailer body:
+    //     [skip atom header: size:u32-BE = body_len, "skip"]
+    //     [LIGOGPSINFO\0]
+    //     [8 more bytes of preamble incl. \0\0\0\x14 at offset 12]
+    //     [0x84 bytes of plain ASCII record]
+    //   ]
+    //   [&&&& : 4 bytes]
+    //   [trailer_len : u32-LE]
+    //
+    // The body the bundled code passes to ProcessLigoGPS is
+    // `LIGOGPSINFO\0...records...` (atom payload). Our scan_trailer
+    // dispatches `process_ligogps` on the *atom payload* (post 8-byte
+    // skip header), with DirStart=0; ProcessLigoGPS starts records at
+    // offset 0x14.
+    let mut payload = Vec::new();
+    payload.extend_from_slice(HDR_LIGOGPSINFO);
+    payload.extend_from_slice(&[0, 0, 0, 0x14, 0, 0, 0, 0]); // preamble: 8 more bytes
+    let mut record = Vec::with_capacity(0x84);
+    record.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+    record.extend_from_slice(b"2024/01/15 10:00:00 N:45.5 E:170.5 30.0 km/h");
+    while record.len() < 0x84 {
+      record.push(0);
+    }
+    payload.extend_from_slice(&record);
+
+    // Body = [skip atom header][payload]
+    let body_len = SKIP_ATOM_HEADER + payload.len();
+    let mut body = Vec::with_capacity(body_len);
+    body.extend_from_slice(&(body_len as u32).to_be_bytes());
+    body.extend_from_slice(b"skip");
+    body.extend_from_slice(&payload);
+
+    let trailer_len = (body.len() + 8) as u32;
+    let mut file = Vec::new();
+    file.extend_from_slice(&[0u8; 64]); // padding (≥ IDENTIFY_FOOTER_SIZE)
+    file.extend_from_slice(&body);
+    file.extend_from_slice(TRAILER_MAGIC);
+    file.extend_from_slice(&trailer_len.to_le_bytes());
+
+    let mut out = LigoGpsMeta::new();
+    scan_trailer(&file, &mut out);
+    assert_eq!(
+      out.samples().len(),
+      1,
+      "expected 1 sample, got {} (warning: {:?})",
+      out.samples().len(),
+      out.warning()
+    );
+    let s = &out.samples()[0];
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+  }
+
+  // ── process_ligogps_json ─────────────────────────────────────────────────
+
+  #[test]
+  fn ligogps_json_decodes_active_record() {
+    let data = br#"LIGOGPSINFO {"Hour": "10", "Minute": "00", "Second": "00", "Year": "2024", "Month": "01", "Day": "15", "status": "A", "NS": "N", "EW": "E", "Latitude": "45.5", "Longitude": "170.5", "Speed": "20"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.date_time(), Some("2024:01:15 10:00:00Z"));
+    assert_eq!(s.latitude(), Some(45.5));
+    assert_eq!(s.longitude(), Some(170.5));
+    // Speed = 20 knots * 1.852 = 37.04 km/h
+    assert_eq!(s.speed_kph(), Some(37.04));
+  }
+
+  #[test]
+  fn ligogps_json_skips_inactive_record() {
+    let data = br#"LIGOGPSINFO {"status": "V", "Latitude": "45.5"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    assert!(out.samples().is_empty());
+  }
+
+  #[test]
+  fn ligogps_json_decodes_local_time() {
+    let data = br#"LIGOGPSINFO {"status": "A", "MHour": "11", "MMinute": "30", "MSecond": "45", "MYear": "2024", "MMonth": "01", "MDay": "15"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.date_time_local(), Some("2024:01:15 11:30:45"));
+  }
+
+  #[test]
+  fn ligogps_json_south_negates_latitude() {
+    let data = br#"LIGOGPSINFO {"status": "A", "NS": "S", "EW": "W", "Latitude": "45.5", "Longitude": "170.5"}"#;
+    let mut out = LigoGpsMeta::new();
+    process_ligogps_json(data, &mut out);
+    let s = out.samples().first().expect("decoded");
+    assert_eq!(s.latitude(), Some(-45.5));
+    assert_eq!(s.longitude(), Some(-170.5));
+  }
+
+  // ── DM→Decimal conversion ─────────────────────────────────────────────────
+
+  #[test]
+  fn convert_dm_to_decimal_round_trip() {
+    // 4500.5 = 45° + 0.5/60 = 45.00833...
+    let mut lat = 4500.5_f64;
+    let mut lon = 12030.0_f64;
+    convert_lat_lon_dm_to_decimal(&mut lat, &mut lon);
+    assert!((lat - 45.00833333333).abs() < 1e-6);
+    assert!((lon - 120.5).abs() < 1e-6);
+  }
+
+  #[test]
+  fn has_three_leading_digits_detects_dm() {
+    assert!(has_three_leading_digits("4500.5"));
+    assert!(has_three_leading_digits("12030.000"));
+    assert!(!has_three_leading_digits("45.5"));
+    assert!(!has_three_leading_digits("1.5"));
+  }
+
+  // ── Plain ASCII record detection ─────────────────────────────────────────
+
+  #[test]
+  fn is_plain_ascii_date_record_accepts_expected_shape() {
+    // The detector matches `m(^.{4}\d{4}/\d{2}/\d{2} )` (LigoGPS.pm:304)
+    // — 4 leading bytes (counter), then `YYYY/MM/DD `.
+    let mut rec = Vec::new();
+    rec.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // 4-byte counter
+    rec.extend_from_slice(b"2024/01/15 ...");
+    assert!(is_plain_ascii_date_record(&rec));
+  }
+
+  #[test]
+  fn is_plain_ascii_date_record_rejects_short() {
+    assert!(!is_plain_ascii_date_record(b"short"));
+  }
+
+  #[test]
+  fn is_plain_ascii_date_record_rejects_non_date() {
+    let mut rec = Vec::new();
+    rec.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+    rec.extend_from_slice(b"NOT DATE FORMAT");
+    assert!(!is_plain_ascii_date_record(&rec));
+  }
+}

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -91,6 +91,21 @@ pub mod canon_ctmd;
 // Gated on the `quicktime` feature.
 #[cfg(feature = "quicktime")]
 pub mod insta360;
+// LigoGPS — dashcam vendor GPS module. Faithful port of
+// `Image::ExifTool::LigoGPS` (LigoGPS.pm:1-431). Reached via TWO paths:
+//   (a) the `&&&& `-prefixed trailer at file EOF (QuickTime.pm:9906-9907
+//       + 10658-10668) — `IdentifyTrailers` matches `/\&\&\&\&(.{4})$/`
+//       at EOF-40, the trailer body begins `[size:u32-BE][skip]
+//       [LIGOGPSINFO\0...]`.
+//   (b) the freeGPS-embedded sample dispatch (QuickTimeStream.pl
+//       :1843-1888) — `LIGOGPSINFO\0` at offset 16/48/80 inside a
+//       freeGPS block. Wired through `quicktime_freegps::process_free_gps`.
+// Records are fixed-stride 0x84 bytes, either `####`-prefixed encrypted
+// (LigoGPS.pm:50-99 DecryptLigoGPS) or plain-ASCII (Redtiger F9 4K).
+// JSON variant (LigoGPS.pm:334-398 ProcessLigoJSON) handles Yada
+// RoadCam Pro 4K BT58189. Gated on the `quicktime` feature.
+#[cfg(feature = "quicktime")]
+pub mod ligogps;
 // Parrot mett — drone timed-metadata walker. Faithful port of
 // `Image::ExifTool::Parrot::Process_mett` (Parrot.pm:791-854) +
 // the per-version binary tables `Image::ExifTool::Parrot::V1`/`V2`/

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -53,10 +53,12 @@
 use crate::{
   datetime::{convert_datetime, convert_duration, convert_unix_time},
   format_parser::{FormatParser, parser_sealed},
-  formats::{gopro, insta360 as insta360_fmt, quicktime_freegps, quicktime_stream},
+  formats::{
+    gopro, insta360 as insta360_fmt, ligogps as ligogps_fmt, quicktime_freegps, quicktime_stream,
+  },
   metadata::{
-    CammMeta, CanonCtmdMeta, GoProMeta, Insta360Meta, MediaTrack, ParrotMeta, QuickTimeMeta,
-    QuickTimeStreamMeta, SonyRtmdMeta,
+    CammMeta, CanonCtmdMeta, GoProMeta, Insta360Meta, LigoGpsMeta, MediaTrack, ParrotMeta,
+    QuickTimeMeta, QuickTimeStreamMeta, SonyRtmdMeta,
   },
   value::format_g,
 };
@@ -1412,6 +1414,17 @@ pub struct Meta<'a> {
   /// the per-version binary tables `Image::ExifTool::Parrot::V1`/`V2`/
   /// `V3`/`TimeStamp` (Parrot.pm:86-551).
   parrot: ParrotMeta,
+  /// **SP4** — LigoGPS dashcam vendor GPS records. Decoded via TWO
+  /// faithful entry points: (a) the `&&&& `-prefixed trailer at file
+  /// EOF (QuickTime.pm:9906-9907 + 10658-10668) — populated by
+  /// [`ligogps_fmt::scan_trailer`]; (b) the freeGPS-embedded sample
+  /// dispatch (QuickTimeStream.pl:1843-1888) — populated by
+  /// [`quicktime_freegps::process_free_gps`] which calls
+  /// [`ligogps_fmt::process_ligogps_with_scale`] on a `LIGOGPSINFO\0`
+  /// fingerprint hit. Empty ([`LigoGpsMeta::is_empty`]) for a non-
+  /// LigoGPS file. Faithful port of `Image::ExifTool::LigoGPS`
+  /// (LigoGPS.pm:1-431).
+  ligogps: LigoGpsMeta,
   /// **SP3** — `true` when an embedded Exif/TIFF block (a `QVMI` / `MVTG` /
   /// `uuid`-Exif atom) was DETECTED but its parse is DEFERRED until the
   /// Exif+GPS port (`exif::parse_exif_block`, PR #36 / `lib/exif-gps`) lands.
@@ -1544,6 +1557,23 @@ impl Meta<'_> {
     &self.parrot
   }
 
+  /// **SP4** — LigoGPS dashcam vendor GPS records.
+  /// [`LigoGpsMeta::is_empty`] for a non-LigoGPS file (or one whose
+  /// trailer / embedded fingerprint is absent).
+  ///
+  /// Faithful port of `Image::ExifTool::LigoGPS` (LigoGPS.pm:1-431).
+  /// Reached through TWO paths:
+  ///  - the `&&&& `-prefixed trailer at file EOF (QuickTime.pm:9906-9907 +
+  ///    :10658-10668) — populated by [`ligogps_fmt::scan_trailer`];
+  ///  - the freeGPS-embedded sample dispatch (QuickTimeStream.pl:1843-
+  ///    1888) — populated by [`quicktime_freegps::process_free_gps`]
+  ///    when it detects `LIGOGPSINFO\0` at offset 16/48/80.
+  #[must_use]
+  #[inline(always)]
+  pub const fn ligogps(&self) -> &LigoGpsMeta {
+    &self.ligogps
+  }
+
   /// **SP3** — `true` when an embedded Exif/TIFF block was detected but its
   /// parse is deferred until the Exif+GPS port lands (see [`Meta`]).
   #[must_use]
@@ -1593,6 +1623,13 @@ impl Meta<'_> {
         .update_timestamp(fix.date_time().map(str::to_string));
       md.set_gps(gps);
     }
+    // LigoGPS sits at the SAME tier as the SP3 stream — dashcam vendor
+    // GPS (best-effort brute-force-scan) projects AFTER everything
+    // else. The freeGPS embedded path already routes its decoded
+    // LigoGPS samples through this same field (see
+    // [`quicktime_freegps::process_free_gps`]), so this projection
+    // covers both the trailer + embedded sources.
+    self.ligogps.project_into(&mut md);
     md
   }
 }
@@ -1978,9 +2015,14 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
   // `Image::ExifTool::GoPro::ProcessGP6` which parses the contained GPMF
   // KLV. exifast routes both through this single call: `scan_media_data`
   // now appends to the freeGPS-style stream samples AND fills `gopro`.
+  // The LigoGpsMeta accumulator is declared HERE because both the
+  // brute-force `freeGPS` scan (below) AND the file-end trailer scan
+  // (further below) populate it. Most files leave it empty
+  // (`LigoGpsMeta::is_empty() == true`).
+  let mut ligogps_meta = crate::metadata::LigoGpsMeta::new();
   if let (Some(off), Some(size)) = (qt.media_data_offset(), qt.media_data_size()) {
     let already = !stream.is_empty();
-    quicktime_freegps::scan_media_data(
+    quicktime_freegps::scan_media_data_with_ligo(
       data,
       off,
       size,
@@ -1988,6 +2030,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
       already,
       &mut stream,
       &mut gopro_meta,
+      Some(&mut ligogps_meta),
     );
   }
 
@@ -2020,6 +2063,20 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
   let mut insta360_meta = crate::metadata::Insta360Meta::new();
   insta360_fmt::scan_trailer(data, &mut insta360_meta);
 
+  // **SP4** — LigoGPS dashcam trailer (QuickTime.pm:9906-9907 +
+  // :10658-10668). Identified by `&&&& ` at bytes 32..36 of the
+  // 40-byte EOF buffer, followed by a 4-byte LE u32 trailer length.
+  // The trailer body begins with an 8-byte `skip` atom header and a
+  // `LIGOGPSINFO\0`-prefixed payload. `scan_trailer` is a no-op when
+  // the signature is absent — cost is one 4-byte compare per non-
+  // LigoGPS file.
+  //
+  // The freeGPS-embedded LigoGPS path (`LIGOGPSINFO\0` at offset
+  // 16/48/80 inside a freeGPS atom) is wired separately above through
+  // [`quicktime_freegps::scan_media_data_with_ligo`] which populates
+  // THIS same `ligogps_meta` holder when it detects the fingerprint.
+  ligogps_fmt::scan_trailer(data, &mut ligogps_meta);
+
   Ok(Some(Meta {
     qt,
     stream,
@@ -2029,6 +2086,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
     canon_ctmd: canon_ctmd_meta,
     insta360: insta360_meta,
     parrot: parrot_meta,
+    ligogps: ligogps_meta,
     embedded_exif_deferred,
     file_type,
     mime,

--- a/src/formats/quicktime_freegps.rs
+++ b/src/formats/quicktime_freegps.rs
@@ -197,6 +197,35 @@ pub fn scan_media_data(
   out: &mut QuickTimeStreamMeta,
   gopro_out: &mut GoProMeta,
 ) {
+  scan_media_data_with_ligo(
+    data,
+    mdat_offset,
+    mdat_size,
+    create_date_raw,
+    already_found_embedded,
+    out,
+    gopro_out,
+    None,
+  );
+}
+
+/// [`scan_media_data`] variant that additionally accepts a
+/// [`LigoGpsMeta`] accumulator — when a `freeGPS` block triggers the
+/// `LIGOGPSINFO\0` fingerprint hit
+/// (QuickTimeStream.pl:1843-1888) it is dispatched into
+/// [`crate::formats::ligogps::process_ligogps_with_scale`] via
+/// [`process_free_gps_with_ligo`].
+#[allow(clippy::too_many_arguments)]
+pub fn scan_media_data_with_ligo(
+  data: &[u8],
+  mdat_offset: u64,
+  mdat_size: u64,
+  create_date_raw: Option<u64>,
+  already_found_embedded: bool,
+  out: &mut QuickTimeStreamMeta,
+  gopro_out: &mut GoProMeta,
+  mut ligogps_out: Option<&mut crate::metadata::LigoGpsMeta>,
+) {
   // QuickTimeStream.pl:3689 `return if $$et{FoundEmbedded} or not $dataPos`.
   if already_found_embedded || mdat_offset == 0 {
     return;
@@ -244,7 +273,7 @@ pub fn scan_media_data(
           }
           let block = &chunk[abs..abs + len];
           // QuickTimeStream.pl:3777-3778: pass DataPt=&block, DirLen=len.
-          process_free_gps(block, create_date_raw, out);
+          process_free_gps_with_ligo(block, create_date_raw, out, ligogps_out.as_deref_mut());
           found = true;
           // QuickTimeStream.pl:3781 `$pos += $len`.
           search_off = abs + len;
@@ -387,7 +416,26 @@ fn memmem(hay: &[u8], needle: &[u8]) -> Option<usize> {
 ///
 /// QuickTimeStream.pl:1645 `return 0 if $dirLen < 82` — a block too short to
 /// carry any fingerprint is silently dropped.
-pub fn process_free_gps(data: &[u8], _create_date_raw: Option<u64>, out: &mut QuickTimeStreamMeta) {
+///
+/// Back-compat wrapper around [`process_free_gps_with_ligo`] for callers
+/// that don't have a [`LigoGpsMeta`] accumulator at hand. The LigoGPS
+/// fingerprint (`LIGOGPSINFO\0`) is silently dropped in this path — the
+/// trailer-only LigoGPS reach path covers the common case.
+pub fn process_free_gps(data: &[u8], create_date_raw: Option<u64>, out: &mut QuickTimeStreamMeta) {
+  process_free_gps_with_ligo(data, create_date_raw, out, None);
+}
+
+/// [`process_free_gps`] variant that additionally accepts a
+/// [`LigoGpsMeta`] accumulator. When the GPSType 5 (LigoGPS)
+/// fingerprint is hit (QuickTimeStream.pl:1843), the block is
+/// dispatched to [`crate::formats::ligogps::process_ligogps_with_scale`]
+/// with the per-offset scale rule from QuickTimeStream.pl:1886.
+pub fn process_free_gps_with_ligo(
+  data: &[u8],
+  _create_date_raw: Option<u64>,
+  out: &mut QuickTimeStreamMeta,
+  ligogps_out: Option<&mut crate::metadata::LigoGpsMeta>,
+) {
   // QuickTimeStream.pl:1645
   if data.len() < 82 {
     return;
@@ -419,12 +467,27 @@ pub fn process_free_gps(data: &[u8], _create_date_raw: Option<u64>, out: &mut Qu
     return;
   }
 
-  // GPSType 5: LigoGPS — DEFERRED.
-  // (QuickTimeStream.pl:1843-1904). Detected by `LIGOGPSINFO\0` at offset
-  // 16/48/80. We DETECT the fingerprint here to match the dispatch, but the
-  // actual parse needs `Image::ExifTool::LigoGPS::ProcessLigoGPS`.
-  if detect_type5_ligogps(data).is_some() {
-    // DEFERRED: port the LigoGPS module separately.
+  // GPSType 5: LigoGPS embedded-in-freeGPS path.
+  // (QuickTimeStream.pl:1843-1888). Detected by `LIGOGPSINFO\0` at offset
+  // 16/48/80; dispatch to `Image::ExifTool::LigoGPS::ProcessLigoGPS`.
+  // The offset-16 + `\xf0\x03\0\0...{16}\0{4}` fingerprint sets the
+  // ABASK A8 4K scale = 3 (QuickTimeStream.pl:1886).
+  if let Some(off) = detect_type5_ligogps(data) {
+    if let Some(ligo_meta) = ligogps_out {
+      // QuickTimeStream.pl:1886 — scale = 3 when offset = 16 AND the
+      // `\xf0\x03\0\0`+20-zero-bytes Rexing/ABASK fingerprint matches.
+      let scale_id = if off == 16
+        && data.len() >= 32
+        && data.get(12..16) == Some(&[0xf0, 0x03, 0x00, 0x00])
+        && data.get(32..36) == Some(&[0x00, 0x00, 0x00, 0x00])
+      {
+        Some(3)
+      } else {
+        None
+      };
+      // QuickTimeStream.pl:1883 — `DirStart = $pos` (i.e. `off`).
+      crate::formats::ligogps::process_ligogps_with_scale(data, off, ligo_meta, false, scale_id);
+    }
     return;
   }
 

--- a/src/metadata/ligogps.rs
+++ b/src/metadata/ligogps.rs
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Typed mirror of `Image::ExifTool::LigoGPS` (LigoGPS.pm) — the dashcam
+//! vendor GPS records that some bodies (iiway s1, XGODY 12" 4K, ABASK A8 4K,
+//! Rexing V1GW-4K, Kingslim D4, BlueSkySea DV688, Redtiger F9 4K, Yada
+//! RoadCam Pro 4K BT58189, …) write either as a `freeGPS`/`LIGOGPSINFO`
+//! embedded sample stream OR as a `&&&& `-prefixed trailer at file end.
+//!
+//! ## Provenance
+//!
+//! Faithful port of:
+//!  - `Image::ExifTool::LigoGPS::ProcessLigoGPS` (LigoGPS.pm:289-320) — the
+//!    fixed-stride 0x84-byte record walker;
+//!  - `Image::ExifTool::LigoGPS::DecryptLigoGPS` (LigoGPS.pm:50-99) —
+//!    the per-record byte-cipher with 4 sub-modes driven by the upper 3
+//!    bits of each input byte;
+//!  - `Image::ExifTool::LigoGPS::ParseLigoGPS` (LigoGPS.pm:229-267) — the
+//!    human-readable record parser (`####...DATE TIME N:lat W:lon spd km/h
+//!    A:track H:alt M:magvar x:ax y:ay z:az`);
+//!  - `Image::ExifTool::LigoGPS::UnfuzzLigoGPS` (LigoGPS.pm:38-44) — the
+//!    lat/lon defuzz function;
+//!  - `Image::ExifTool::LigoGPS::ProcessLigoJSON` (LigoGPS.pm:334-398) —
+//!    the JSON-format variant (Yada RoadCam Pro 4K BT58189).
+//!
+//! ## What this sub-port surfaces
+//!
+//! Per LigoGPS.pm:256-265 (binary text records):
+//!  - **`GPSDateTime`** — UTC date+time (`YYYY:MM:DD HH:MM:SS`); the bundled
+//!    `tr/\//:/` normalises the date separators. Stored as
+//!    [`SmolStr`].
+//!  - **`GPSLatitude`** — decimal degrees, signed (post bundled
+//!    `* (($latNeg or $latRef eq 'S') ? -1 : 1)`).
+//!  - **`GPSLongitude`** — decimal degrees, signed (post bundled `* (... eq
+//!    'W')` flip).
+//!  - **`GPSSpeed`** — km/h (post-`* $spdScl` conversion; the scale factor
+//!    is mode-dependent — see [`LigoGpsSample::speed_kph`]).
+//!  - **`GPSTrack`** — bearing degrees (`A:` field, LigoGPS.pm:261).
+//!  - **`GPSAltitude`** — metres (`H:` field, LigoGPS.pm:262).
+//!  - **`MagneticVariation`** — degrees (`M:` field, LigoGPS.pm:263).
+//!  - **`Accelerometer`** — space-joined 3-axis string (`x:` `y:` `z:`
+//!    fields, LigoGPS.pm:265).
+//!
+//! For ProcessLigoJSON (LigoGPS.pm:355-396) the same surface PLUS:
+//!  - **`DateTimeOriginal`** — the dashcam local-time clock (the bundled
+//!    `MYear`/`MMonth`/`MDay`/`MHour`/`MMinute`/`MSecond` fields). Stored
+//!    in addition to `GPSDateTime` (which is the UTC GPS time).
+//!
+//! ## What this sub-port deliberately does NOT decode
+//!
+//! Faithful-walked but unsurfaced:
+//!  - **`OLatitude`/`OLongitude` (ProcessLigoJSON)** — bundled emits them
+//!    as `GPSLatitude2`/`GPSLongitude2` (LigoGPS.pm:387-388). These appear
+//!    to be the original un-defuzzed lat/lon; the typed surface picks the
+//!    main (defuzzed) values only. FOLLOW-UP if dual-readout fidelity is
+//!    needed.
+//!  - **DecipherLigoGPS cipher discovery (LigoGPS.pm:143-221)** — the
+//!    fallback when `DecryptLigoGPS` cannot decode the encrypted prefix.
+//!    Cipher discovery requires accumulating ≥10 unique seconds-digit
+//!    transitions across multiple records before the cipher table is
+//!    known. Real-world dashcam files always satisfy `DecryptLigoGPS` on
+//!    the first record, so the deciphered fallback is exotic. FOLLOW-UP
+//!    (tracked as a per-port issue).
+//!  - **GKU dashcam JSON trailer (LigoGPS.pm:273-281)** — `ProcessGKU` is
+//!    a thin wrapper around `ProcessLigoJSON` that skips a 4-byte
+//!    leading offset. Not seen in the wild as a QuickTime trailer; the
+//!    LIGOGPS JSON path is reached via the embedded `LIGOGPSINFO {`
+//!    fingerprint detection. FOLLOW-UP.
+//!  - **Sanity-check warnings on out-of-range coordinates (LigoGPS.pm:254)**
+//!    — the bundled emits `LIGOGPSINFO coordinates out of range` and
+//!    drops the sample; we propagate this through the walker's warning
+//!    channel.
+//!
+//! ## D8 compliance
+//!
+//! Every field is private; access through accessors. Setters return
+//! `&mut Self` for chaining. `const fn` where types permit. No public
+//! struct fields; enums newtype/unit-only.
+
+extern crate alloc;
+use alloc::{string::String, vec::Vec};
+
+use smol_str::SmolStr;
+
+use crate::metadata::{CaptureSettings, GpsLocation, MediaMetadata, MetaProjectInto};
+
+// ===========================================================================
+// LigoGpsSample — one decoded record from `ProcessLigoGPS` / `ProcessLigoJSON`
+// ===========================================================================
+
+/// One LigoGPS record decoded from a `####`-prefixed encrypted record
+/// (LigoGPS.pm:229-267 `ParseLigoGPS`) or one element of a JSON record
+/// stream (LigoGPS.pm:334-398 `ProcessLigoJSON`).
+///
+/// Bundled-derived field semantics:
+///  - `date_time` — `tr|/|:|`-normalised `YYYY:MM:DD HH:MM:SS` (UTC); the
+///    JSON variant produces the same shape with a `Z` UTC suffix when
+///    decoded from the GPS-time fields (LigoGPS.pm:359). The textual
+///    binary variant has no suffix (LigoGPS.pm:244).
+///  - `latitude` — signed decimal degrees post `* (($latNeg or $latRef eq
+///    'S') ? -1 : 1)` (LigoGPS.pm:258).
+///  - `longitude` — signed decimal degrees post `* (($lonNeg or $lonRef eq
+///    'W') ? -1 : 1)` (LigoGPS.pm:259).
+///  - `speed_kph` — km/h post `* $spdScl` (LigoGPS.pm:260). `$spdScl` is
+///    `1` (`flags & 0x02` — non-fuzzed text decoded with kph speed),
+///    `1.852` (`flags & 0x01` — non-fuzzed knots → kph), or `1.85407333`
+///    (default — the LigoGPS encryption's odd internal unit). For the
+///    JSON variant `speed_kph = $info{Speed} * $knotsToKph` (LigoGPS.pm:370).
+///  - `track_deg` — bearing degrees (LigoGPS.pm:261).
+///  - `altitude_m` — metres (LigoGPS.pm:262).
+///  - `magnetic_variation` — degrees (LigoGPS.pm:263).
+///  - `accelerometer` — space-joined "ax ay az" (LigoGPS.pm:265 / 373).
+///  - `date_time_local` — only set by `ProcessLigoJSON` from the `M*`
+///    fields (LigoGPS.pm:379) when all six are present.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LigoGpsSample {
+  /// `GPSDateTime` UTC (LigoGPS.pm:256 / 359-360).
+  date_time: Option<SmolStr>,
+  /// `DateTimeOriginal` — dashcam local clock (JSON-only, LigoGPS.pm:379).
+  date_time_local: Option<SmolStr>,
+  /// `GPSLatitude` decimal degrees, signed.
+  latitude: Option<f64>,
+  /// `GPSLongitude` decimal degrees, signed.
+  longitude: Option<f64>,
+  /// `GPSSpeed` km/h post-scale.
+  speed_kph: Option<f64>,
+  /// `GPSTrack` bearing degrees.
+  track_deg: Option<f64>,
+  /// `GPSAltitude` metres.
+  altitude_m: Option<f64>,
+  /// `MagneticVariation` degrees.
+  magnetic_variation: Option<f64>,
+  /// `Accelerometer` space-joined "ax ay az".
+  accelerometer: Option<SmolStr>,
+}
+
+impl LigoGpsSample {
+  /// An empty sample (every field `None`).
+  #[inline(always)]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      date_time: None,
+      date_time_local: None,
+      latitude: None,
+      longitude: None,
+      speed_kph: None,
+      track_deg: None,
+      altitude_m: None,
+      magnetic_variation: None,
+      accelerometer: None,
+    }
+  }
+
+  /// `GPSDateTime` UTC.
+  #[inline(always)]
+  #[must_use]
+  pub fn date_time(&self) -> Option<&str> {
+    self.date_time.as_deref()
+  }
+
+  /// `DateTimeOriginal` — dashcam local clock (JSON-only).
+  #[inline(always)]
+  #[must_use]
+  pub fn date_time_local(&self) -> Option<&str> {
+    self.date_time_local.as_deref()
+  }
+
+  /// `GPSLatitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn latitude(&self) -> Option<f64> {
+    self.latitude
+  }
+
+  /// `GPSLongitude` decimal degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn longitude(&self) -> Option<f64> {
+    self.longitude
+  }
+
+  /// `GPSSpeed` km/h.
+  #[inline(always)]
+  #[must_use]
+  pub const fn speed_kph(&self) -> Option<f64> {
+    self.speed_kph
+  }
+
+  /// `GPSTrack` bearing degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn track_deg(&self) -> Option<f64> {
+    self.track_deg
+  }
+
+  /// `GPSAltitude` metres.
+  #[inline(always)]
+  #[must_use]
+  pub const fn altitude_m(&self) -> Option<f64> {
+    self.altitude_m
+  }
+
+  /// `MagneticVariation` degrees.
+  #[inline(always)]
+  #[must_use]
+  pub const fn magnetic_variation(&self) -> Option<f64> {
+    self.magnetic_variation
+  }
+
+  /// `Accelerometer` space-joined "ax ay az".
+  #[inline(always)]
+  #[must_use]
+  pub fn accelerometer(&self) -> Option<&str> {
+    self.accelerometer.as_deref()
+  }
+
+  /// `true` when no field is populated.
+  #[inline(always)]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.date_time.is_none()
+      && self.date_time_local.is_none()
+      && self.latitude.is_none()
+      && self.longitude.is_none()
+      && self.speed_kph.is_none()
+      && self.track_deg.is_none()
+      && self.altitude_m.is_none()
+      && self.magnetic_variation.is_none()
+      && self.accelerometer.is_none()
+  }
+
+  // ── Setters ───────────────────────────────────────────────────────────────
+
+  /// Assign `GPSDateTime`.
+  #[inline(always)]
+  pub fn set_date_time(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.date_time = v;
+    self
+  }
+
+  /// Assign `DateTimeOriginal` (JSON-only).
+  #[inline(always)]
+  pub fn set_date_time_local(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.date_time_local = v;
+    self
+  }
+
+  /// Assign `GPSLatitude`.
+  #[inline(always)]
+  pub const fn set_latitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.latitude = v;
+    self
+  }
+
+  /// Assign `GPSLongitude`.
+  #[inline(always)]
+  pub const fn set_longitude(&mut self, v: Option<f64>) -> &mut Self {
+    self.longitude = v;
+    self
+  }
+
+  /// Assign `GPSSpeed` in km/h.
+  #[inline(always)]
+  pub const fn set_speed_kph(&mut self, v: Option<f64>) -> &mut Self {
+    self.speed_kph = v;
+    self
+  }
+
+  /// Assign `GPSTrack` bearing degrees.
+  #[inline(always)]
+  pub const fn set_track_deg(&mut self, v: Option<f64>) -> &mut Self {
+    self.track_deg = v;
+    self
+  }
+
+  /// Assign `GPSAltitude` metres.
+  #[inline(always)]
+  pub const fn set_altitude_m(&mut self, v: Option<f64>) -> &mut Self {
+    self.altitude_m = v;
+    self
+  }
+
+  /// Assign `MagneticVariation` degrees.
+  #[inline(always)]
+  pub const fn set_magnetic_variation(&mut self, v: Option<f64>) -> &mut Self {
+    self.magnetic_variation = v;
+    self
+  }
+
+  /// Assign `Accelerometer`.
+  #[inline(always)]
+  pub fn set_accelerometer(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.accelerometer = v;
+    self
+  }
+}
+
+impl Default for LigoGpsSample {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ===========================================================================
+// LigoGpsMeta — the host metadata holder for ProcessLigoGPS output
+// ===========================================================================
+
+/// Decoded LigoGPS records — every `####`-prefixed encrypted record that
+/// successfully decrypted (LigoGPS.pm:289-320 `ProcessLigoGPS`) plus every
+/// JSON record decoded from a `LIGOGPSINFO {` JSON variant (LigoGPS.pm:334-
+/// 398 `ProcessLigoJSON`).
+///
+/// `is_empty()` for a non-LigoGPS file (no encrypted records / no JSON
+/// signature at file end).
+#[derive(Debug, Clone, PartialEq)]
+pub struct LigoGpsMeta {
+  /// Decoded GPS samples — one per successfully-parsed record. Order is
+  /// file-order (record walker order).
+  samples: Vec<LigoGpsSample>,
+  /// First warning surfaced by the walker (truncated trailer, decrypt
+  /// failure, coordinate out-of-range, …). Bundled emits multiple
+  /// `$et->Warn(...)` calls; the camera-indexing surface keeps the first.
+  warning: Option<SmolStr>,
+}
+
+impl LigoGpsMeta {
+  /// An empty LigoGPS holder (no samples, no warning).
+  #[inline(always)]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      samples: Vec::new(),
+      warning: None,
+    }
+  }
+
+  /// Decoded GPS samples — file-order.
+  #[inline(always)]
+  #[must_use]
+  pub fn samples(&self) -> &[LigoGpsSample] {
+    &self.samples
+  }
+
+  /// First decoded sample whose `latitude` AND `longitude` are populated.
+  /// Used by the [`MetaProjectInto`] adaptor to populate
+  /// [`MediaMetadata::gps()`] without scanning all samples at projection
+  /// time.
+  #[inline(always)]
+  #[must_use]
+  pub fn first_fix(&self) -> Option<&LigoGpsSample> {
+    self
+      .samples
+      .iter()
+      .find(|s| s.latitude.is_some() && s.longitude.is_some())
+  }
+
+  /// The first walker warning.
+  #[inline(always)]
+  #[must_use]
+  pub fn warning(&self) -> Option<&str> {
+    self.warning.as_deref()
+  }
+
+  /// `true` when no samples AND no warning were recorded.
+  #[inline(always)]
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.samples.is_empty() && self.warning.is_none()
+  }
+
+  /// Append a decoded sample. Used by [`crate::formats::ligogps`] only.
+  #[inline(always)]
+  pub fn push_sample(&mut self, s: LigoGpsSample) -> &mut Self {
+    self.samples.push(s);
+    self
+  }
+
+  /// Set the first warning. Faithful to bundled emitting `$et->Warn`
+  /// possibly multiple times — the camera-indexing surface keeps the
+  /// first (last-wins would suppress earlier diagnostics).
+  #[inline(always)]
+  pub fn set_warning(&mut self, w: SmolStr) -> &mut Self {
+    if self.warning.is_none() {
+      self.warning = Some(w);
+    }
+    self
+  }
+}
+
+impl Default for LigoGpsMeta {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// ===========================================================================
+// MetaProjectInto — LigoGPS projection into MediaMetadata
+// ===========================================================================
+
+impl MetaProjectInto for LigoGpsMeta {
+  /// Project LigoGPS records into [`MediaMetadata`].
+  ///
+  /// **CameraInfo:** LigoGPS records carry no Make/Model/Serial/Firmware
+  /// — the format is just GPS telemetry. Bundled (LigoGPS.pm) decodes
+  /// only the GPS/accelerometer fields; the camera identity for a dashcam
+  /// that writes LigoGPS lives in the QuickTime `udta`/Keys path (SP1+SP2
+  /// atoms parsed at the QuickTime SP1 layer). So this projection sets
+  /// no `CameraInfo`.
+  ///
+  /// **CaptureSettings:** not produced — LigoGPS does not carry
+  /// exposure/ISO/aperture (those would live in the parent QuickTime
+  /// container's makernotes).
+  ///
+  /// **GpsLocation:** the FIRST sample with a coordinate pair populates
+  /// `md.gps()`. LigoGPS is **lowest-tier** in the priority chain —
+  /// dashcam vendor GPS shares the same fidelity tier as the
+  /// freeGPS-variants and SP3-stream sources (all are "best-effort
+  /// brute-force-scan dashcam GPS", not on-device hardware GNSS the way
+  /// GoPro/CAMM/Parrot are). The order encoded in
+  /// `quicktime::Meta::media_metadata` reflects this: LigoGPS projects
+  /// AFTER all the higher-priority sources so an LigoGPS-only file
+  /// still gets GPS, but a file with GoPro+LigoGPS prefers GoPro.
+  ///
+  /// **Warnings:** the walker's `warning()` channel (`Bad LigoGPS
+  /// trailer size` / `LIGOGPSINFO coordinates out of range` / …)
+  /// propagates into `md.warnings()` with the `"[LigoGPS] "` prefix.
+  fn project_into(&self, md: &mut MediaMetadata) {
+    // ── GpsLocation ──────────────────────────────────────────────────────
+    if md.gps().is_none()
+      && let Some(s) = self.first_fix()
+    {
+      let mut gps = GpsLocation::new();
+      gps
+        .update_latitude(s.latitude())
+        .update_longitude(s.longitude())
+        .update_altitude_m(s.altitude_m())
+        .update_timestamp(s.date_time().map(String::from));
+      md.set_gps(gps);
+    }
+    // ── Warnings ────────────────────────────────────────────────────────
+    if let Some(w) = self.warning() {
+      let mut msg = String::with_capacity(10 + w.len());
+      msg.push_str("[LigoGPS] ");
+      msg.push_str(w);
+      md.push_warning(msg);
+    }
+    // CaptureSettings deliberately unused; LigoGPS doesn't carry capture.
+    let _ = CaptureSettings::new();
+  }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn ligogps_sample_default_is_empty() {
+    let s = LigoGpsSample::default();
+    assert!(s.is_empty());
+    assert!(s.latitude().is_none());
+    assert!(s.longitude().is_none());
+    assert!(s.date_time().is_none());
+  }
+
+  #[test]
+  fn ligogps_sample_setters_round_trip() {
+    let mut s = LigoGpsSample::new();
+    s.set_latitude(Some(31.285065))
+      .set_longitude(Some(-124.759483))
+      .set_altitude_m(Some(46.0))
+      .set_speed_kph(Some(46.93))
+      .set_track_deg(Some(180.0))
+      .set_magnetic_variation(Some(12.5))
+      .set_date_time(Some(SmolStr::new("2022:09:19 12:45:24")))
+      .set_accelerometer(Some(SmolStr::new("-0.000 -0.000 -0.000")));
+    assert!(!s.is_empty());
+    assert_eq!(s.latitude(), Some(31.285065));
+    assert_eq!(s.longitude(), Some(-124.759483));
+    assert_eq!(s.altitude_m(), Some(46.0));
+    assert_eq!(s.speed_kph(), Some(46.93));
+    assert_eq!(s.track_deg(), Some(180.0));
+    assert_eq!(s.magnetic_variation(), Some(12.5));
+    assert_eq!(s.date_time(), Some("2022:09:19 12:45:24"));
+    assert_eq!(s.accelerometer(), Some("-0.000 -0.000 -0.000"));
+  }
+
+  #[test]
+  fn ligogps_meta_empty_by_default() {
+    let m = LigoGpsMeta::default();
+    assert!(m.is_empty());
+    assert!(m.samples().is_empty());
+    assert!(m.first_fix().is_none());
+    assert!(m.warning().is_none());
+  }
+
+  #[test]
+  fn ligogps_meta_first_fix_skips_partial_samples() {
+    let mut m = LigoGpsMeta::new();
+    // First sample has only latitude — should be skipped by `first_fix`.
+    let mut s1 = LigoGpsSample::new();
+    s1.set_latitude(Some(10.0));
+    m.push_sample(s1);
+    // Second sample has BOTH lat/lon — should be the returned fix.
+    let mut s2 = LigoGpsSample::new();
+    s2.set_latitude(Some(20.0)).set_longitude(Some(30.0));
+    m.push_sample(s2);
+    let fix = m.first_fix().expect("first_fix");
+    assert_eq!(fix.latitude(), Some(20.0));
+    assert_eq!(fix.longitude(), Some(30.0));
+  }
+
+  #[test]
+  fn ligogps_meta_warning_first_wins() {
+    let mut m = LigoGpsMeta::new();
+    m.set_warning(SmolStr::new("first"));
+    m.set_warning(SmolStr::new("second"));
+    assert_eq!(m.warning(), Some("first"));
+  }
+
+  #[test]
+  fn project_into_populates_gps_when_first_fix_present() {
+    let mut m = LigoGpsMeta::new();
+    let mut s = LigoGpsSample::new();
+    s.set_latitude(Some(-45.5))
+      .set_longitude(Some(170.5))
+      .set_altitude_m(Some(123.0))
+      .set_date_time(Some(SmolStr::new("2024:01:15 10:00:00")));
+    m.push_sample(s);
+
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    let gps = md.gps().expect("gps populated");
+    assert_eq!(gps.latitude(), Some(-45.5));
+    assert_eq!(gps.longitude(), Some(170.5));
+    assert_eq!(gps.altitude_m(), Some(123.0));
+    assert_eq!(gps.timestamp(), Some("2024:01:15 10:00:00"));
+  }
+
+  #[test]
+  fn project_into_skips_when_gps_already_set() {
+    let mut m = LigoGpsMeta::new();
+    let mut s = LigoGpsSample::new();
+    s.set_latitude(Some(10.0)).set_longitude(Some(20.0));
+    m.push_sample(s);
+
+    let mut md = MediaMetadata::new();
+    // Pre-populate with a higher-priority source.
+    let mut prior = GpsLocation::new();
+    prior
+      .update_latitude(Some(99.0))
+      .update_longitude(Some(88.0));
+    md.set_gps(prior);
+    m.project_into(&mut md);
+    let gps = md.gps().expect("gps still populated");
+    assert_eq!(gps.latitude(), Some(99.0));
+    assert_eq!(gps.longitude(), Some(88.0));
+  }
+
+  #[test]
+  fn project_into_pushes_prefixed_warning() {
+    let mut m = LigoGpsMeta::new();
+    m.set_warning(SmolStr::new("Bad LigoGPS trailer size"));
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    let ws = md.warnings();
+    assert_eq!(ws.len(), 1);
+    assert!(ws[0].starts_with("[LigoGPS] "));
+    assert!(ws[0].contains("Bad LigoGPS trailer size"));
+  }
+}

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -26,6 +26,7 @@ mod canon_ctmd;
 mod domain;
 mod gopro;
 mod insta360;
+mod ligogps;
 mod parrot;
 mod quicktime;
 mod quicktime_stream;
@@ -38,6 +39,7 @@ pub use domain::{
 };
 pub use gopro::{GoProGpsSample, GoProMeta};
 pub use insta360::{Insta360ExposureSample, Insta360GpsSample, Insta360Identity, Insta360Meta};
+pub use ligogps::{LigoGpsMeta, LigoGpsSample};
 pub use parrot::{
   ParrotFlightSample, ParrotFlyingState, ParrotGpsSample, ParrotMeta, ParrotPilotingMode,
   ParrotRecordVersion,

--- a/tests/quicktime_stream.rs
+++ b/tests/quicktime_stream.rs
@@ -1489,3 +1489,161 @@ fn quicktime_no_insta360_trailer_leaves_meta_empty() {
     .expect("recognized");
   assert!(meta.insta360().is_empty());
 }
+
+// ===========================================================================
+// SP4 — LigoGPS dashcam vendor GPS module + trailer (LigoGPS.pm:1-431,
+// QuickTime.pm:9906-9907 + :10658-10668)
+// ===========================================================================
+
+/// Build a minimal `.mov` with a LigoGPS `&&&& `-prefixed trailer carrying
+/// one plain-ASCII (Redtiger F9 4K format) record. The trailer layout
+/// (QuickTime.pm:10658-10668) is:
+///
+///   [base file: ftyp + moov + mdat]
+///   [trailer body:
+///     [skip atom header: size:u32-BE = body_len, "skip"]
+///     [LIGOGPSINFO\0]
+///     [8 more bytes of preamble incl. \0\0\0\x14 at offset 12]
+///     [0x84 bytes of plain-ASCII record]
+///   ]
+///   [&&&& : 4 bytes]
+///   [trailer_len : u32-LE]
+fn build_mov_with_ligogps_trailer(record_text: &[u8]) -> Vec<u8> {
+  // Reuse the minimal ftyp+moov+mdat from `build_mov_with_freegps_in_mdat`
+  // but discard the freeGPS block so the file is truly plain QuickTime.
+  let mut ftyp = 16u32.to_be_bytes().to_vec();
+  ftyp.extend_from_slice(b"ftyp");
+  ftyp.extend_from_slice(b"qt  ");
+  ftyp.extend_from_slice(&0u32.to_be_bytes());
+
+  let mut mvhd = Vec::new();
+  mvhd.extend_from_slice(&[0u8; 4]);
+  mvhd.extend_from_slice(&[0u8; 8]);
+  mvhd.extend_from_slice(&1000u32.to_be_bytes());
+  mvhd.extend_from_slice(&1000u32.to_be_bytes());
+  mvhd.extend_from_slice(&[0u8; 80]);
+  let mut mvhd_atom = (mvhd.len() as u32 + 8).to_be_bytes().to_vec();
+  mvhd_atom.extend_from_slice(b"mvhd");
+  mvhd_atom.extend_from_slice(&mvhd);
+  let mut moov = (mvhd_atom.len() as u32 + 8).to_be_bytes().to_vec();
+  moov.extend_from_slice(b"moov");
+  moov.extend_from_slice(&mvhd_atom);
+  let mdat_payload = vec![0u8; 16];
+  let mut mdat = (mdat_payload.len() as u32 + 8).to_be_bytes().to_vec();
+  mdat.extend_from_slice(b"mdat");
+  mdat.extend_from_slice(&mdat_payload);
+
+  // Build the trailer payload: LIGOGPSINFO\0 + 8-byte preamble + 0x84 rec.
+  let mut payload = Vec::new();
+  payload.extend_from_slice(b"LIGOGPSINFO\0");
+  // 8 more preamble bytes: bytes [pos-8..pos-4] (pos = 0x14) = [0,0,0,0x14]
+  // triggers the LigoGPS no_fuzz auto-detect for the BlueSkySea-style
+  // firmware (LigoGPS.pm:299).
+  payload.extend_from_slice(&[0, 0, 0, 0x14, 0, 0, 0, 0]);
+  // Build one 0x84-byte record. First 4 bytes are the counter; rest is
+  // the ASCII text payload (null-padded to 0x84).
+  let mut record = Vec::with_capacity(0x84);
+  record.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+  record.extend_from_slice(record_text);
+  while record.len() < 0x84 {
+    record.push(0);
+  }
+  payload.extend_from_slice(&record);
+
+  // Trailer body: skip atom header + payload.
+  let body_len = 8usize + payload.len();
+  let mut body = Vec::with_capacity(body_len);
+  body.extend_from_slice(&(body_len as u32).to_be_bytes());
+  body.extend_from_slice(b"skip");
+  body.extend_from_slice(&payload);
+
+  let trailer_len = (body.len() + 8) as u32;
+
+  // Assemble the file.
+  let mut file = ftyp;
+  file.extend_from_slice(&moov);
+  file.extend_from_slice(&mdat);
+  file.extend_from_slice(&body);
+  file.extend_from_slice(b"&&&&");
+  file.extend_from_slice(&trailer_len.to_le_bytes());
+  file
+}
+
+#[test]
+fn quicktime_ligogps_trailer_decodes_plain_ascii_record() {
+  // The Redtiger F9 4K plain-ASCII record format: `[4 bytes counter]
+  // YYYY/MM/DD HH:MM:SS [NS]:lat [EW]:lon spd [optional " km/h"]`.
+  let data = build_mov_with_ligogps_trailer(
+    b"2024/06/15 14:30:00 N:45.500 W:120.500 50.0 km/h A:90.0 H:100.0 x:0 y:0 z:0",
+  );
+  let meta = parse_quicktime(&data)
+    .expect("parse ok")
+    .expect("recognized");
+  let ligo = meta.ligogps();
+  assert!(!ligo.is_empty(), "ligogps() must populate");
+  let s = ligo.samples().first().expect("decoded sample");
+  assert_eq!(s.date_time(), Some("2024:06:15 14:30:00"));
+  assert_eq!(s.latitude(), Some(45.5));
+  assert_eq!(s.longitude(), Some(-120.5));
+  assert_eq!(s.speed_kph(), Some(50.0));
+  assert_eq!(s.track_deg(), Some(90.0));
+  assert_eq!(s.altitude_m(), Some(100.0));
+}
+
+#[test]
+fn quicktime_ligogps_trailer_projects_gps_location() {
+  // The decoded sample's lat/lon/altitude/timestamp must surface through
+  // `MediaMetadata::gps()`. Date format in the record body is YYYY/MM/DD
+  // (LigoGPS.pm:244 `tr|/|:|` normalises it to YYYY:MM:DD on output).
+  let data =
+    build_mov_with_ligogps_trailer(b"2024/01/15 10:00:00 N:35.000 E:139.000 30.0 km/h H:50.0");
+  let meta = parse_quicktime(&data)
+    .expect("parse ok")
+    .expect("recognized");
+  let md = meta.media_metadata();
+  let gps = md.gps().expect("GpsLocation from LigoGPS");
+  assert!((gps.latitude().unwrap() - 35.000).abs() < 1e-9);
+  assert!((gps.longitude().unwrap() - 139.000).abs() < 1e-9);
+  assert!((gps.altitude_m().unwrap() - 50.0).abs() < 1e-9);
+  assert_eq!(gps.timestamp(), Some("2024:01:15 10:00:00"));
+}
+
+#[test]
+fn quicktime_no_ligogps_trailer_leaves_meta_empty() {
+  // A plain QuickTime file (no LigoGPS trailer) must have an empty
+  // `ligogps()` meta. The signature check is a 4-byte compare at offset
+  // EOF-8.
+  let data = build_mov_with_freegps_in_mdat();
+  let meta = parse_quicktime(&data)
+    .expect("parse ok")
+    .expect("recognized");
+  assert!(meta.ligogps().is_empty());
+}
+
+#[test]
+fn quicktime_ligogps_trailer_with_explicit_south_latitude() {
+  // S = negative latitude (LigoGPS.pm:258).
+  let data =
+    build_mov_with_ligogps_trailer(b"2024/12/25 23:59:59 S:33.865 E:151.209 80.0 km/h H:25.0");
+  let meta = parse_quicktime(&data)
+    .expect("parse ok")
+    .expect("recognized");
+  let s = meta.ligogps().samples().first().expect("sample");
+  // Latitude is negative (S).
+  assert_eq!(s.latitude(), Some(-33.865));
+  // Longitude is positive (E).
+  assert_eq!(s.longitude(), Some(151.209));
+}
+
+#[test]
+fn quicktime_ligogps_trailer_short_file_silent() {
+  // A file shorter than 40 bytes can't carry the trailer signature; the
+  // scan_trailer fast-path returns silently without warning.
+  let data = vec![0u8; 30];
+  // Must use parse_borrowed direct since this isn't a real QT file.
+  let meta = exifast::formats::quicktime::parse_borrowed(&data).expect("parse ok");
+  assert!(
+    meta.is_none(),
+    "30-byte all-zero data isn't recognised as QT"
+  );
+}


### PR DESCRIPTION
## Stacks on #126 (lib/parrot-mett) — NOT main

Faithful Rust port of `Image::ExifTool::LigoGPS` (`LigoGPS.pm:1-431`) — the
dashcam vendor GPS module shared by iiway s1, XGODY 12" 4K, ABASK A8 4K,
Rexing V1GW-4K, Kingslim D4, BlueSkySea DV688, Redtiger F9 4K, and Yada
RoadCam Pro 4K BT58189 firmwares.

## Bundled module ported

`Image::ExifTool::LigoGPS` — full 431 LoC:

  - `ProcessLigoGPS` (LigoGPS.pm:289-320) — fixed-stride 0x84-byte record walker
  - `DecryptLigoGPS` (LigoGPS.pm:50-99) — steering-byte cipher with 4 sub-modes
  - `ParseLigoGPS` (LigoGPS.pm:229-267) — human-readable record parser
  - `UnfuzzLigoGPS` (LigoGPS.pm:38-44) — lat/lon defuzz formula
  - `ProcessLigoJSON` (LigoGPS.pm:334-398) — Yada RoadCam Pro JSON variant

Trailer wiring per QuickTime.pm:9906-9907 + :10658-10668 (`IdentifyTrailers`
+ `ProcessMOV` trailer handler).

## Per-record-type table

Both encoding paths feed the same `LigoGpsSample` shape:

| Field             | ASCII text    | JSON          | Storage     |
|-------------------|---------------|---------------|-------------|
| GPSDateTime       | ✓ (UTC)       | ✓ (`Z`-sfx)   | SmolStr     |
| GPSLatitude       | ✓ signed      | ✓ signed      | Option<f64> |
| GPSLongitude      | ✓ signed      | ✓ signed      | Option<f64> |
| GPSSpeed (kph)    | ✓ scaled      | ✓ knots*1.852 | Option<f64> |
| GPSTrack          | ✓ `A:`        | ✗             | Option<f64> |
| GPSAltitude       | ✓ `H:`        | ✗             | Option<f64> |
| MagneticVariation | ✓ `M:`        | ✗             | Option<f64> |
| Accelerometer     | ✓ x: y: z:    | ✓ Gsensor*    | SmolStr     |
| DateTimeOriginal  | ✗             | ✓ M*-fields   | SmolStr     |

## Walker design notes

**Two reach paths:**

1. **`&&&& `-prefixed trailer at file EOF** (QuickTime.pm:9906-9907 + :10658-10668)
   — `IdentifyTrailers` reads 40 bytes from EOF-40 and matches
   `/\&\&\&\&(.{4})$/` to extract the LE u32 trailer length. The full trailer
   begins `[size:u32-BE][skip:4-bytes]` (`skip` ASCII atom name); after those 8
   bytes the payload starts with `LIGOGPSINFO\0` and is passed to
   `process_ligogps(buf, dir_start=0, ..., no_fuzz=false)`.

2. **`LIGOGPSINFO\0`-prefixed embedded sample** (QuickTimeStream.pl:1843-1888)
   — bundled detects the fingerprint at offset 16/48/80 inside a `freeGPS` block,
   sets `LigoGPSScale = 3` when the offset-16 ABASK A8 4K fingerprint
   (`\xf0\x03\0\0...{16}\0{4}`) hits, and dispatches to
   `process_ligogps(buff, dir_start=off, ..., no_fuzz=false)` with scale_id.

Records walk at `dir_start + 0x14` in fixed-stride 0x84-byte chunks. Each
record is either `####`-prefixed encrypted (decrypted by `DecryptLigoGPS` +
parsed by `ParseLigoGPS`) or plain ASCII (Redtiger F9 4K variant, flags=0x03).

**Endianness:** All multi-byte reads are LE (QuickTime.pm:9907 `Get32u`).

## Wire-up summary

| File                            | Change |
|---------------------------------|--------|
| `src/metadata/ligogps.rs` NEW   | `LigoGpsMeta` + `LigoGpsSample` + `MetaProjectInto` |
| `src/formats/ligogps.rs` NEW    | `scan_trailer` + `process_ligogps` + `process_ligogps_json` + cipher |
| `src/metadata/mod.rs`           | Re-export `LigoGpsMeta`, `LigoGpsSample` |
| `src/formats/mod.rs`            | `pub mod ligogps;` (gated on `quicktime`) |
| `src/formats/quicktime.rs`      | `Meta::ligogps()` accessor, projection in priority chain, `scan_trailer` call alongside Insta360 |
| `src/formats/quicktime_freegps.rs` | New `process_free_gps_with_ligo` + `scan_media_data_with_ligo` (back-compat wrappers retained) |
| `tests/quicktime_stream.rs`     | +5 integration tests (synthetic trailer end-to-end) |

## GPS-priority-chain justification

**LigoGPS slots at the LOWEST tier** (same fidelity band as the SP3 stream and
freeGPS-variants — dashcam vendor GPS that is best-effort brute-force-scan, not
on-device hardware GNSS the way GoPro/CAMM/Parrot are).

Order in `Meta::media_metadata`:

  GoPro → camm → Parrot mett → Sony rtmd → Canon CTMD → Insta360 trailer →
  SP3 stream → **LigoGPS**

A LigoGPS-only file still surfaces `MediaMetadata::gps()`; a file with
GoPro+LigoGPS prefers GoPro.

## Deferrals

Filed under issue #70 as FOLLOW-UPs (label `followup` + `deferred`, priority P3):

- **DecipherLigoGPS cipher discovery** (LigoGPS.pm:143-221) — multi-record
  state; fires only when DecryptLigoGPS fails. Real dashcam files always
  decrypt on the first try. The walker emits a warning when this path would
  fire so the file's diagnostic is visible.
- **ProcessGKU** (LigoGPS.pm:273-281) — thin wrapper around ProcessLigoJSON
  for the GKU trailer variant. Not seen in the wild as a QuickTime trailer.
- **Real LigoGPS fixture** — bundled tree has no Ligo fixture in
  `t/images/`; tests cover synthetic plain-ASCII + JSON + every error path
  (truncated trailer / bad magic / mid-record truncation).
- **`OLatitude`/`OLongitude` JSON dual-readout** (LigoGPS.pm:387-388) — bundled
  emits as `GPSLatitude2`/`GPSLongitude2`; we surface only the main fields.
- **Chained-trailer support** (Insta360 + LigoGPS + MIE) — already tracked
  under #94.

## 4-gate results

| Gate | Result |
|------|--------|
| `cargo +1.95 build` | ✓ |
| `cargo +1.95 build --no-default-features --features std,quicktime` | ✓ |
| `cargo +1.95 test --all-targets` | **1522 pass** (was 1480 — Δ +42) |
| `cargo +stable fmt --all -- --check` | ✓ |
| `cargo +1.95 clippy --features quicktime --all-targets` | **111 warnings** (baseline; no new) |

## Test count delta

| Bucket | Before | After | Δ |
|--------|--------|-------|---|
| lib (unit) | 1204 | 1241 | +37 |
| conformance | 230 | 230 | 0 |
| direct_api_chain_routing | 15 | 15 | 0 |
| engine_smoke | 1 | 1 | 0 |
| flac_streaminfo | 1 | 1 | 0 |
| harness_golden | 1 | 1 | 0 |
| quicktime_stream | 27 | 32 | +5 |
| typed_serde_parity | 1 | 1 | 0 |
| **Total** | **1480** | **1522** | **+42** |

## LoC + commit

| Stat | Value |
|------|-------|
| Commit | 9dd390a |
| New `src/formats/ligogps.rs` | 1435 LoC (port + tests) |
| New `src/metadata/ligogps.rs` | 577 LoC (types + tests) |
| Total insertions | 2320 |
| Total deletions | 12 |


---

Closes #70.
