### PR TITLE
fix(tagmap): drop unused #[cfg(test)] errors() accessor

### DIFF
--- a/src/tagmap.rs
+++ b/src/tagmap.rs
@@ -239,12 +239,6 @@ impl TagMap {
     &self.warnings
   }
 
-  /// All recorded errors in call order (test-only read-back).
-  #[cfg(test)]
-  pub(crate) fn errors(&self) -> &[String] {
-    &self.errors
-  }
-
   /// Look up an emitted tag's [`TagValue`] by `(group, name)` — the
   /// `"<group>:<name>"` key (test-only read-back, mirrors the retired
   /// `MapTagWriter::get`). `None` if never emitted.


### PR DESCRIPTION
Removes the dead `#[cfg(test)] TagMap::errors()` accessor (zero callers since the #30 lib-first redesign). Sibling `warnings()` is kept (15 test callers). Pure cleanup — main CI is already green, so this is hygiene, not an unblock. Verified: `cargo +stable fmt --all -- --check` = 0; CI to confirm clippy/test/build.