### PR TITLE
fix(canon): faithful FILE_TYPE==CRW transcription for ShotInfo ExposureTime (#164 R5 follow-up)

### DIFF
--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -332,7 +332,9 @@ impl MakerNotesCanon {
 /// behaviour, since Canon's MakerNotes inherit the parent's `Base`).
 #[must_use]
 pub fn parse(blob: &[u8], parent_order: ByteOrder) -> (MakerNotesCanon, Vec<VendorEmission>) {
-  parse_in_tiff(blob, 0, blob.len(), parent_order, true, None)
+  // Standalone-blob convenience entry: no parent container context, so
+  // `model`/`file_type` are `None` (the FILE_TYPE-keyed CRW clause is off).
+  parse_in_tiff(blob, 0, blob.len(), parent_order, true, None, None)
 }
 
 /// Parse with the parent TIFF context.
@@ -343,6 +345,12 @@ pub fn parse(blob: &[u8], parent_order: ByteOrder) -> (MakerNotesCanon, Vec<Vend
 /// inherits the parent `Base`). `model` is the parent body's
 /// `$$self{Model}` (from IFD0), used to evaluate the FocalLength
 /// FocalPlaneX/YSize `Condition` (`Canon.pm:2735-2739`).
+///
+/// `file_type` is the container's detected `$$self{FILE_TYPE}` — threaded
+/// into `Canon::ShotInfo` position 22's RawConv (`Canon.pm:2977`/`:2990`),
+/// which keeps a raw-0 ExposureTime only for a CRW container. `None` when the
+/// container type is unknown; the embedded JPEG/PNG callers pass `None` (a
+/// JPEG/PNG container is never "CRW", so the CRW clause is correctly false).
 #[must_use]
 pub fn parse_in_tiff(
   tiff_data: &[u8],
@@ -351,6 +359,7 @@ pub fn parse_in_tiff(
   parent_order: ByteOrder,
   print_conv: bool,
   model: Option<&str>,
+  file_type: Option<&str>,
 ) -> (MakerNotesCanon, Vec<VendorEmission>) {
   let mut typed = MakerNotesCanon::new();
   let mut emissions: Vec<VendorEmission> = Vec::new();
@@ -480,7 +489,9 @@ pub fn parse_in_tiff(
         }
         SubTable::ShotInfo => {
           let blob_bytes = reserialize_int_array(&entry.value, parent_order);
-          let (si, em) = shot_info::parse(&blob_bytes, parent_order, print_conv, model);
+          // Thread the container `$$self{FILE_TYPE}` into ShotInfo position
+          // 22's RawConv (CRW-allows-0, `Canon.pm:2977`/`:2990`).
+          let (si, em) = shot_info::parse(&blob_bytes, parent_order, print_conv, model, file_type);
           if !si.is_empty() {
             typed.shot_info = Some(si);
           }
@@ -602,9 +613,11 @@ pub fn parse_into_metadata(
   into: &mut Metadata,
 ) {
   let group = Group::new("MakerNotes", "MakerNotes");
-  // Standalone-blob entry point — no parent `$$self{Model}` context, so
-  // the FocalPlaneX/YSize `Condition` evaluates as for an undef Model.
-  let (_typed, emissions) = parse_in_tiff(blob, 0, blob.len(), parent_order, print_conv, None);
+  // Standalone-blob entry point — no parent `$$self{Model}` / `$$self{FILE_TYPE}`
+  // context, so the FocalPlaneX/YSize `Condition` and the ShotInfo pos-22
+  // CRW clause both evaluate as for an undef container.
+  let (_typed, emissions) =
+    parse_in_tiff(blob, 0, blob.len(), parent_order, print_conv, None, None);
   for e in emissions {
     // Unknown-suppression is the engine's job; this raw `Metadata`-sink
     // helper applies it inline so it matches the default-output contract.
@@ -852,6 +865,7 @@ mod tests {
       ByteOrder::Little,
       true,
       Some("Canon EOS-1D Mark IV"),
+      None,
     );
     let v = emissions
       .iter()
@@ -915,6 +929,7 @@ mod tests {
       ByteOrder::Little,
       true,
       Some("Canon EOS 5D Mark II"),
+      None,
     );
     // First arm: SerialInfo, raw (un-stripped) blob.
     assert!(
@@ -944,6 +959,7 @@ mod tests {
       ByteOrder::Little,
       true,
       Some("Canon EOS 5D"),
+      None,
     );
     assert!(emissions.iter().any(|e| e.name() == "SerialInfo"));
     assert!(!emissions.iter().any(|e| e.name() == "InternalSerialNumber"));
@@ -963,6 +979,7 @@ mod tests {
       ByteOrder::Little,
       true,
       Some("Canon EOS 50D"),
+      None,
     );
     assert!(!emissions.iter().any(|e| e.name() == "SerialInfo"));
     assert_eq!(typed.internal_serial_number(), Some("ABC123"));

--- a/src/exif/makernotes/vendors/canon/shot_info.rs
+++ b/src/exif/makernotes/vendors/canon/shot_info.rs
@@ -60,11 +60,15 @@
 //!   `$$self{Model} =~ /\b(20D|350D|REBEL XT|Kiss Digital N)\b/` and uses
 //!   `ValueConv => 'exp(-CanonEv*log2)*1000/32'`; the default branch uses
 //!   `'exp(-CanonEv*log2)'` (identical to TargetExposureTime). Both share
-//!   `PrintConv => PrintExposureTime` and `RawConv => '($val or FILE_TYPE eq
-//!   "CRW") ? $val : undef'`. **`$$self{FILE_TYPE}` is not threaded into the
-//!   Canon parser**, so the CRW-allows-0 clause is approximated as
-//!   "0 ⇒ undef" — faithful for every non-CRW container (JPG/CR2/TIFF/MOV);
-//!   a raw-0 ExposureTime in a `.crw` would be suppressed here (flagged).
+//!   `PrintConv => PrintExposureTime` and `RawConv => '($val or
+//!   $$self{FILE_TYPE} eq "CRW") ? $val : undef'`. The container
+//!   `$$self{FILE_TYPE}` IS threaded through ([`parse`]'s `file_type`), so the
+//!   CRW-allows-0 clause is a faithful transcription: a raw-0 ExposureTime is
+//!   kept only when `file_type == Some("CRW")` (`"0 is valid in a CRW image
+//!   (=1s, D60 sample)"`) and dropped for every non-CRW container
+//!   (JPG/CR2/TIFF/MOV). Because the port has no CIFF/CRW parser, every
+//!   reachable container is non-CRW today, so the emitted output is unchanged;
+//!   only the gate is now spelled faithfully.
 //!
 //! ## ValueConv that needs `CanonEv` / the aperture conv
 //!
@@ -644,12 +648,19 @@ fn matches_word(haystack: &str, token: &str) -> bool {
 /// `model` is the resolved Canon model NAME (from `%canonModelID`) — the
 /// bundled Conditions key on `$$self{Model}`, and the resolved name is
 /// the faithful stand-in (e.g. `"EOS 20D"`).
+///
+/// `file_type` is the container's detected `$$self{FILE_TYPE}` (`Some("CRW")`
+/// for a CIFF/CRW raw, `Some("JPEG")`/`Some("CR2")`/… otherwise, `None` when
+/// unknown). It is read ONLY by position 22's RawConv (`Canon.pm:2977`/`:2990`):
+/// a raw-0 ExposureTime is kept when the container is a CRW (`"0 is valid in a
+/// CRW image (=1s, D60 sample)"`).
 #[must_use]
 pub fn parse(
   data: &[u8],
   order: ByteOrder,
   print_conv: bool,
   model: Option<&str>,
+  file_type: Option<&str>,
 ) -> (CanonShotInfo, Vec<(SmolStr, TagValue)>) {
   let mut typed = CanonShotInfo::new();
   let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
@@ -988,13 +999,16 @@ pub fn parse(
   }
 
   // Position 22 — ExposureTime (model-conditional list, `Canon.pm:2967-
-  // 2997`). RawConv `($val or FILE_TYPE eq "CRW") ? $val : undef`: 0 ⇒ undef
-  // for every non-CRW container (FILE_TYPE is not threaded here — see the
-  // module-doc faithfulness note). FIRST branch (20D/350D/REBEL XT/Kiss
-  // Digital N) ValueConv `exp(-CanonEv($val)*log(2))*1000/32`; default branch
-  // `exp(-CanonEv($val)*log(2))`. Both PrintConv `PrintExposureTime`.
+  // 2997`). RawConv `($val or $$self{FILE_TYPE} eq "CRW") ? $val : undef`:
+  // emit unless `$val == 0` AND the container is not a CRW (`"0 is valid in a
+  // CRW image (=1s, D60 sample)"`, `Canon.pm:2974-2976`). Both the FIRST
+  // branch (20D/350D/REBEL XT/Kiss Digital N, ValueConv
+  // `exp(-CanonEv($val)*log(2))*1000/32`) and the default branch
+  // (`exp(-CanonEv($val)*log(2))`) carry the SAME RawConv, so the single
+  // `raw != 0 || file_type == Some("CRW")` gate covers both. Both PrintConv
+  // `PrintExposureTime`.
   if let Some(raw) = read_i16(data, 22, order)
-    && raw != 0
+    && (raw != 0 || file_type == Some("CRW"))
   {
     let v = if is_20d_350d_family(model) {
       exposure_time_from_apex(raw) * 1000.0 / 32.0
@@ -1143,7 +1157,7 @@ mod tests {
     ];
     let data = blob(&words);
     let model = Some("EOS Digital Rebel / 300D / Kiss Digital");
-    let (typed, em) = parse(&data, ByteOrder::Little, true, model);
+    let (typed, em) = parse(&data, ByteOrder::Little, true, model, None);
 
     // --- Newly-ported positions (oracled vs ExifTool 13.59 Perl) ---
     // pos1 AutoISO raw=0 → exp(0)*100 = 100 → "100".
@@ -1257,7 +1271,7 @@ mod tests {
       let mut words = [0i16; 18];
       words[17] = raw;
       let data = blob(&words);
-      let (_t, em) = parse(&data, ByteOrder::Little, true, None);
+      let (_t, em) = parse(&data, ByteOrder::Little, true, None, None);
       assert_eq!(
         find(&em, "AEBBracketValue"),
         Some(TagValue::Str(want.into())),
@@ -1273,7 +1287,7 @@ mod tests {
     words[19] = -1; // bytes 0xffff → as int16u = 65535.
     words[20] = 546;
     let data = blob(&words);
-    let (typed, em) = parse(&data, ByteOrder::Little, true, None);
+    let (typed, em) = parse(&data, ByteOrder::Little, true, None, None);
     assert_eq!(
       find(&em, "FocusDistanceUpper"),
       Some(TagValue::Str("inf".into()))
@@ -1293,7 +1307,7 @@ mod tests {
     words[19] = 0; // upper = 0 → RawConv undef.
     words[20] = 546;
     let data = blob(&words);
-    let (_typed, em) = parse(&data, ByteOrder::Little, true, None);
+    let (_typed, em) = parse(&data, ByteOrder::Little, true, None, None);
     assert_eq!(find(&em, "FocusDistanceUpper"), None);
     assert_eq!(find(&em, "FocusDistanceLower"), None);
   }
@@ -1307,7 +1321,7 @@ mod tests {
     let data = blob(&words);
 
     // EOS 5D → emitted.
-    let (typed, em) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"));
+    let (typed, em) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(
       find(&em, "CameraTemperature"),
       Some(TagValue::Str("22 C".into()))
@@ -1315,12 +1329,18 @@ mod tests {
     assert_eq!(typed.camera_temperature_c(), Some(22));
 
     // EOS-1D → excluded by `!~ /EOS-1DS?$/`.
-    let (typed2, em2) = parse(&data, ByteOrder::Little, true, Some("EOS-1D"));
+    let (typed2, em2) = parse(&data, ByteOrder::Little, true, Some("EOS-1D"), None);
     assert_eq!(find(&em2, "CameraTemperature"), None);
     assert_eq!(typed2.camera_temperature_c(), None);
 
     // Non-EOS (PowerShot) → excluded.
-    let (_t3, em3) = parse(&data, ByteOrder::Little, true, Some("PowerShot A570 IS"));
+    let (_t3, em3) = parse(
+      &data,
+      ByteOrder::Little,
+      true,
+      Some("PowerShot A570 IS"),
+      None,
+    );
     assert_eq!(find(&em3, "CameraTemperature"), None);
   }
 
@@ -1332,16 +1352,22 @@ mod tests {
     words[33] = 0;
     let data = blob(&words);
     // PowerShot → 0 kept.
-    let (typed, em) = parse(&data, ByteOrder::Little, true, Some("PowerShot A570 IS"));
+    let (typed, em) = parse(
+      &data,
+      ByteOrder::Little,
+      true,
+      Some("PowerShot A570 IS"),
+      None,
+    );
     assert_eq!(find(&em, "FlashOutput"), Some(TagValue::I64(0)));
     assert_eq!(typed.flash_output(), Some(0));
     // EOS with 0 → dropped.
-    let (_t2, em2) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"));
+    let (_t2, em2) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(find(&em2, "FlashOutput"), None);
     // EOS with nonzero → kept.
     words[33] = 200;
     let data2 = blob(&words);
-    let (_t3, em3) = parse(&data2, ByteOrder::Little, true, Some("EOS 5D"));
+    let (_t3, em3) = parse(&data2, ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(find(&em3, "FlashOutput"), Some(TagValue::I64(200)));
   }
 
@@ -1352,14 +1378,14 @@ mod tests {
     words[7] = 1; // WhiteBalance = Daylight.
     words[28] = 1; // NDFilter = On.
     let data = blob(&words);
-    let (_typed, em) = parse(&data, ByteOrder::Little, false, None);
+    let (_typed, em) = parse(&data, ByteOrder::Little, false, None, None);
     assert_eq!(find(&em, "WhiteBalance"), Some(TagValue::I64(1)));
     assert_eq!(find(&em, "NDFilter"), Some(TagValue::I64(1)));
   }
 
   #[test]
   fn short_blob_yields_empty() {
-    let (typed, em) = parse(&[0, 0], ByteOrder::Little, true, None);
+    let (typed, em) = parse(&[0, 0], ByteOrder::Little, true, None, None);
     assert!(typed.is_empty());
     assert!(em.is_empty());
   }
@@ -1374,7 +1400,7 @@ mod tests {
     words[1] = 96; // AutoISO
     words[2] = 200; // BaseISO
     let data = blob(&words);
-    let (typed, em) = parse(&data, ByteOrder::Little, true, None);
+    let (typed, em) = parse(&data, ByteOrder::Little, true, None, None);
     // -j: Perl `%.0f` rounds the (799.999…) float to "800".
     assert_eq!(find(&em, "AutoISO"), Some(TagValue::Str("800".into())));
     assert_eq!(find(&em, "BaseISO"), Some(TagValue::Str("238".into())));
@@ -1386,7 +1412,7 @@ mod tests {
     // -n: post-ValueConv numbers (whole→I64, fractional→F64).
     words[1] = 200;
     let data2 = blob(&words);
-    let (_t, em2) = parse(&data2, ByteOrder::Little, false, None);
+    let (_t, em2) = parse(&data2, ByteOrder::Little, false, None, None);
     let auto_iso_200 = (200.0_f64 / 32.0 * std::f64::consts::LN_2).exp() * 100.0;
     assert_eq!(find(&em2, "AutoISO"), Some(TagValue::F64(auto_iso_200)));
 
@@ -1395,7 +1421,7 @@ mod tests {
     z[1] = 0;
     z[2] = 0;
     let dataz = blob(&z);
-    let (_tz, emz) = parse(&dataz, ByteOrder::Little, true, None);
+    let (_tz, emz) = parse(&dataz, ByteOrder::Little, true, None, None);
     assert_eq!(find(&emz, "AutoISO"), Some(TagValue::Str("100".into())));
     assert_eq!(find(&emz, "BaseISO"), None);
   }
@@ -1407,15 +1433,15 @@ mod tests {
     let mut words = [0i16; 4];
     words[3] = 32;
     let data = blob(&words);
-    let (typed, em) = parse(&data, ByteOrder::Little, true, None);
+    let (typed, em) = parse(&data, ByteOrder::Little, true, None, None);
     assert_eq!(find(&em, "MeasuredEV"), Some(TagValue::Str("6.00".into())));
     assert_eq!(typed.measured_ev(), Some(6.0));
     // raw 0 → 5.00 (not dropped).
     let z = [0i16; 4];
-    let (_t, emz) = parse(&blob(&z), ByteOrder::Little, true, None);
+    let (_t, emz) = parse(&blob(&z), ByteOrder::Little, true, None, None);
     assert_eq!(find(&emz, "MeasuredEV"), Some(TagValue::Str("5.00".into())));
     // -n: 6 (whole).
-    let (_t2, emn) = parse(&data, ByteOrder::Little, false, None);
+    let (_t2, emn) = parse(&data, ByteOrder::Little, false, None, None);
     assert_eq!(find(&emn, "MeasuredEV"), Some(TagValue::I64(6)));
   }
 
@@ -1428,7 +1454,7 @@ mod tests {
     words[4] = 160; // TargetAperture
     words[21] = 96; // FNumber
     let data = blob(&words);
-    let (typed, em) = parse(&data, ByteOrder::Little, true, None);
+    let (typed, em) = parse(&data, ByteOrder::Little, true, None, None);
     assert_eq!(
       find(&em, "TargetAperture"),
       Some(TagValue::Str("5.7".into()))
@@ -1439,7 +1465,7 @@ mod tests {
     assert_eq!(typed.target_aperture(), Some(aperture_160));
 
     // -n: ValueConv float.
-    let (_t, emn) = parse(&data, ByteOrder::Little, false, None);
+    let (_t, emn) = parse(&data, ByteOrder::Little, false, None, None);
     assert_eq!(
       find(&emn, "TargetAperture"),
       Some(TagValue::F64(aperture_160))
@@ -1447,13 +1473,13 @@ mod tests {
 
     // RawConv gates: TargetAperture raw 0 dropped, FNumber raw 0 dropped.
     let z = [0i16; 22];
-    let (_tz, emz) = parse(&blob(&z), ByteOrder::Little, true, None);
+    let (_tz, emz) = parse(&blob(&z), ByteOrder::Little, true, None, None);
     assert_eq!(find(&emz, "TargetAperture"), None);
     assert_eq!(find(&emz, "FNumber"), None);
     // TargetAperture raw -32 (<=0) dropped too.
     let mut neg = [0i16; 22];
     neg[4] = -32;
-    let (_tn, emneg) = parse(&blob(&neg), ByteOrder::Little, true, None);
+    let (_tn, emneg) = parse(&blob(&neg), ByteOrder::Little, true, None, None);
     assert_eq!(find(&emneg, "TargetAperture"), None);
   }
 
@@ -1465,14 +1491,14 @@ mod tests {
     let mut words = [0i16; 6];
     words[5] = 160;
     let data = blob(&words);
-    let (typed, em) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"));
+    let (typed, em) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(
       find(&em, "TargetExposureTime"),
       Some(TagValue::Str("1/32".into()))
     );
     assert_eq!(typed.target_exposure_time(), Some(0.03125));
     // -n: 0.03125.
-    let (_t, emn) = parse(&data, ByteOrder::Little, false, Some("EOS 5D"));
+    let (_t, emn) = parse(&data, ByteOrder::Little, false, Some("EOS 5D"), None);
     assert_eq!(
       find(&emn, "TargetExposureTime"),
       Some(TagValue::F64(0.03125))
@@ -1481,17 +1507,23 @@ mod tests {
     // raw <= -1000 → dropped regardless of model.
     let mut bad = [0i16; 6];
     bad[5] = -32768i16; // -32768 < -1000.
-    let (_tb, emb) = parse(&blob(&bad), ByteOrder::Little, true, Some("EOS 5D"));
+    let (_tb, emb) = parse(&blob(&bad), ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(find(&emb, "TargetExposureTime"), None);
 
     // raw 0: kept for EOS/PowerShot (→ exp(0)=1s → "1"), dropped otherwise.
     let z = [0i16; 6];
-    let (_tz, emz) = parse(&blob(&z), ByteOrder::Little, true, Some("EOS 5D"));
+    let (_tz, emz) = parse(&blob(&z), ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(
       find(&emz, "TargetExposureTime"),
       Some(TagValue::Str("1".into()))
     );
-    let (_tu, emu) = parse(&blob(&z), ByteOrder::Little, true, Some("Some Webcam"));
+    let (_tu, emu) = parse(
+      &blob(&z),
+      ByteOrder::Little,
+      true,
+      Some("Some Webcam"),
+      None,
+    );
     assert_eq!(find(&emu, "TargetExposureTime"), None);
   }
 
@@ -1503,7 +1535,7 @@ mod tests {
     words[6] = 16; // ExposureCompensation
     words[15] = -16; // FlashExposureComp
     let data = blob(&words);
-    let (typed, em) = parse(&data, ByteOrder::Little, true, None);
+    let (typed, em) = parse(&data, ByteOrder::Little, true, None, None);
     assert_eq!(
       find(&em, "ExposureCompensation"),
       Some(TagValue::Str("+1/2".into()))
@@ -1515,7 +1547,7 @@ mod tests {
     assert_eq!(typed.exposure_compensation(), Some(0.5));
     assert_eq!(typed.flash_exposure_comp(), Some(-0.5));
     // -n: bare CanonEv values.
-    let (_t, emn) = parse(&data, ByteOrder::Little, false, None);
+    let (_t, emn) = parse(&data, ByteOrder::Little, false, None, None);
     assert_eq!(find(&emn, "ExposureCompensation"), Some(TagValue::F64(0.5)));
   }
 
@@ -1525,13 +1557,13 @@ mod tests {
     for (raw, want) in [(0i16, "Off"), (1, "Night Scene"), (2, "On"), (3, "None")] {
       let mut words = [0i16; 9];
       words[8] = raw;
-      let (_t, em) = parse(&blob(&words), ByteOrder::Little, true, None);
+      let (_t, em) = parse(&blob(&words), ByteOrder::Little, true, None, None);
       assert_eq!(find(&em, "SlowShutter"), Some(TagValue::Str(want.into())));
     }
     // unknown → "Unknown (9)".
     let mut words = [0i16; 9];
     words[8] = 9;
-    let (_t, em) = parse(&blob(&words), ByteOrder::Little, true, None);
+    let (_t, em) = parse(&blob(&words), ByteOrder::Little, true, None, None);
     assert_eq!(
       find(&em, "SlowShutter"),
       Some(TagValue::Str("Unknown (9)".into()))
@@ -1543,18 +1575,18 @@ mod tests {
   fn optical_zoom_code() {
     let mut words = [0i16; 11];
     words[10] = 8;
-    let (_t, em) = parse(&blob(&words), ByteOrder::Little, true, None);
+    let (_t, em) = parse(&blob(&words), ByteOrder::Little, true, None, None);
     assert_eq!(
       find(&em, "OpticalZoomCode"),
       Some(TagValue::Str("n/a".into()))
     );
     // raw 3 → 3 (int even in -j).
     words[10] = 3;
-    let (_t2, em2) = parse(&blob(&words), ByteOrder::Little, true, None);
+    let (_t2, em2) = parse(&blob(&words), ByteOrder::Little, true, None, None);
     assert_eq!(find(&em2, "OpticalZoomCode"), Some(TagValue::I64(3)));
     // -n raw 8 → 8.
     words[10] = 8;
-    let (_t3, em3) = parse(&blob(&words), ByteOrder::Little, false, None);
+    let (_t3, em3) = parse(&blob(&words), ByteOrder::Little, false, None, None);
     assert_eq!(find(&em3, "OpticalZoomCode"), Some(TagValue::I64(8)));
   }
 
@@ -1566,7 +1598,7 @@ mod tests {
   fn af_points_in_focus_print_hex() {
     let mut words = [0i16; 15];
     words[14] = 0x3002u16 as i16; // "Center"
-    let (typed, em) = parse(&blob(&words), ByteOrder::Little, true, Some("EOS 5D"));
+    let (typed, em) = parse(&blob(&words), ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(
       find(&em, "AFPointsInFocus"),
       Some(TagValue::Str("Center".into()))
@@ -1574,18 +1606,24 @@ mod tests {
     assert_eq!(typed.af_points_in_focus(), Some("Center"));
     // unmatched → "Unknown (0x1234)".
     words[14] = 0x1234;
-    let (_t, em2) = parse(&blob(&words), ByteOrder::Little, true, Some("EOS 5D"));
+    let (_t, em2) = parse(&blob(&words), ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(
       find(&em2, "AFPointsInFocus"),
       Some(TagValue::Str("Unknown (0x1234)".into()))
     );
     // RawConv drops 0.
     words[14] = 0;
-    let (_t2, em3) = parse(&blob(&words), ByteOrder::Little, true, Some("EOS 5D"));
+    let (_t2, em3) = parse(&blob(&words), ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(find(&em3, "AFPointsInFocus"), None);
     // -n: raw decimal int (0x3002 = 12290).
     words[14] = 0x3002u16 as i16;
-    let (_t3, em4) = parse(&blob(&words), ByteOrder::Little, false, Some("EOS 5D"));
+    let (_t3, em4) = parse(
+      &blob(&words),
+      ByteOrder::Little,
+      false,
+      Some("EOS 5D"),
+      None,
+    );
     assert_eq!(find(&em4, "AFPointsInFocus"), Some(TagValue::I64(12290)));
   }
 
@@ -1599,7 +1637,7 @@ mod tests {
     let data = blob(&words);
 
     // 20D branch.
-    let (typed, em) = parse(&data, ByteOrder::Little, true, Some("EOS 20D"));
+    let (typed, em) = parse(&data, ByteOrder::Little, true, Some("EOS 20D"), None);
     assert_eq!(find(&em, "ExposureTime"), Some(TagValue::Str("3.9".into())));
     assert_eq!(typed.exposure_time(), Some(3.90625));
     // Kiss Digital N branch (word-boundary token match).
@@ -1608,6 +1646,7 @@ mod tests {
       ByteOrder::Little,
       true,
       Some("EOS Digital Rebel XT / 350D / Kiss Digital N"),
+      None,
     );
     assert_eq!(
       find(&emk, "ExposureTime"),
@@ -1615,7 +1654,7 @@ mod tests {
     );
 
     // Default branch (5D is NOT in the 20D family).
-    let (_td, emd) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"));
+    let (_td, emd) = parse(&data, ByteOrder::Little, true, Some("EOS 5D"), None);
     assert_eq!(
       find(&emd, "ExposureTime"),
       Some(TagValue::Str("1/8".into()))
@@ -1623,16 +1662,118 @@ mod tests {
     // A "350D" substring inside a larger word must NOT match (\b). The
     // resolved names always delimit the token, so e.g. "X350DZ" stays
     // default — guards the word-boundary helper.
-    let (_tx, emx) = parse(&data, ByteOrder::Little, true, Some("PowerShot X350DZ"));
+    let (_tx, emx) = parse(
+      &data,
+      ByteOrder::Little,
+      true,
+      Some("PowerShot X350DZ"),
+      None,
+    );
     assert_eq!(
       find(&emx, "ExposureTime"),
       Some(TagValue::Str("1/8".into()))
     );
 
-    // RawConv drops 0 (non-CRW approximation).
+    // RawConv drops a raw-0 for a non-CRW container (`file_type = None`):
+    // `($val or FILE_TYPE eq "CRW")` is false.
     let z = [0i16; 23];
-    let (_tz, emz) = parse(&blob(&z), ByteOrder::Little, true, Some("EOS 20D"));
+    let (_tz, emz) = parse(&blob(&z), ByteOrder::Little, true, Some("EOS 20D"), None);
     assert_eq!(find(&emz, "ExposureTime"), None);
+  }
+
+  /// Position-22 ExposureTime RawConv `($val or $$self{FILE_TYPE} eq "CRW") ?
+  /// $val : undef` (`Canon.pm:2977`/`:2990`, BOTH branches): a raw-0
+  /// ExposureTime is EMITTED for a CRW container ("0 is valid in a CRW image
+  /// (=1s, D60 sample)") and DROPPED for every non-CRW container.
+  ///
+  /// Oracled against bundled 13.59 (`perl exiftool`): `CanonEv(0) = 0`, so the
+  /// DEFAULT branch ValueConv `exp(-CanonEv(0)*log(2)) = 1` → PrintExposureTime
+  /// "1"; the 20D branch ValueConv `…*1000/32 = 31.25` → PrintExposureTime
+  /// "31.2".
+  #[test]
+  fn exposure_time_pos22_crw_keeps_raw_zero() {
+    let z = [0i16; 23]; // pos-22 raw = 0.
+
+    // --- CRW container: raw-0 IS emitted (the `FILE_TYPE eq "CRW"` clause). ---
+    // Default branch (5D is not in the 20D family): exp(0) = 1.
+    let (typed_d, em_d) = parse(
+      &blob(&z),
+      ByteOrder::Little,
+      true,
+      Some("EOS 5D"),
+      Some("CRW"),
+    );
+    assert_eq!(find(&em_d, "ExposureTime"), Some(TagValue::Str("1".into())));
+    assert_eq!(typed_d.exposure_time(), Some(1.0));
+    // -n (ValueConv numeric): 1.0 is whole → I64(1).
+    let (_td_n, em_d_n) = parse(
+      &blob(&z),
+      ByteOrder::Little,
+      false,
+      Some("EOS 5D"),
+      Some("CRW"),
+    );
+    assert_eq!(find(&em_d_n, "ExposureTime"), Some(TagValue::I64(1)));
+
+    // 20D branch: exp(0)*1000/32 = 31.25 → PrintExposureTime "31.2".
+    let (typed_2, em_2) = parse(
+      &blob(&z),
+      ByteOrder::Little,
+      true,
+      Some("EOS 20D"),
+      Some("CRW"),
+    );
+    assert_eq!(
+      find(&em_2, "ExposureTime"),
+      Some(TagValue::Str("31.2".into()))
+    );
+    assert_eq!(typed_2.exposure_time(), Some(31.25));
+    // -n: 31.25 is fractional → F64(31.25).
+    let (_t2_n, em_2_n) = parse(
+      &blob(&z),
+      ByteOrder::Little,
+      false,
+      Some("EOS 20D"),
+      Some("CRW"),
+    );
+    assert_eq!(find(&em_2_n, "ExposureTime"), Some(TagValue::F64(31.25)));
+
+    // --- Non-CRW containers: raw-0 is DROPPED (both branches, -j and -n). ---
+    for ft in [Some("CR2"), Some("JPEG"), Some("TIFF"), None] {
+      for model in [Some("EOS 5D"), Some("EOS 20D")] {
+        for pc in [true, false] {
+          let (_t, em) = parse(&blob(&z), ByteOrder::Little, pc, model, ft);
+          assert_eq!(
+            find(&em, "ExposureTime"),
+            None,
+            "raw-0 ExposureTime must be dropped for file_type={ft:?} model={model:?} pc={pc}"
+          );
+        }
+      }
+    }
+
+    // A NONZERO raw is unaffected by file_type (CRW vs non-CRW identical).
+    let mut nz = [0i16; 23];
+    nz[22] = 96; // default branch → "1/8".
+    let (_tc, em_crw) = parse(
+      &blob(&nz),
+      ByteOrder::Little,
+      true,
+      Some("EOS 5D"),
+      Some("CRW"),
+    );
+    let (_tj, em_jpg) = parse(
+      &blob(&nz),
+      ByteOrder::Little,
+      true,
+      Some("EOS 5D"),
+      Some("JPEG"),
+    );
+    assert_eq!(
+      find(&em_crw, "ExposureTime"),
+      Some(TagValue::Str("1/8".into()))
+    );
+    assert_eq!(find(&em_crw, "ExposureTime"), find(&em_jpg, "ExposureTime"));
   }
 
   /// CameraType (pos 26) hash + AutoRotate (pos 27) hash with RawConv
@@ -1644,7 +1785,7 @@ mod tests {
     words[27] = 2; // AutoRotate → "Rotate 180"
     words[29] = 20; // SelfTimer2 → 2.0
     let data = blob(&words);
-    let (typed, em) = parse(&data, ByteOrder::Little, true, None);
+    let (typed, em) = parse(&data, ByteOrder::Little, true, None, None);
     assert_eq!(
       find(&em, "CameraType"),
       Some(TagValue::Str("Compact".into()))
@@ -1662,14 +1803,14 @@ mod tests {
     let mut neg = [0i16; 30];
     neg[27] = -1;
     neg[29] = -5;
-    let (_tn, emn) = parse(&blob(&neg), ByteOrder::Little, true, None);
+    let (_tn, emn) = parse(&blob(&neg), ByteOrder::Little, true, None, None);
     assert_eq!(find(&emn, "AutoRotate"), None);
     assert_eq!(find(&emn, "SelfTimer2"), None);
 
     // CameraType unknown → "Unknown (7)".
     let mut u = [0i16; 30];
     u[26] = 7;
-    let (_tu, emu) = parse(&blob(&u), ByteOrder::Little, true, None);
+    let (_tu, emu) = parse(&blob(&u), ByteOrder::Little, true, None, None);
     assert_eq!(
       find(&emu, "CameraType"),
       Some(TagValue::Str("Unknown (7)".into()))

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -644,6 +644,18 @@ pub struct ExifMeta<'a> {
   /// `None`, faithful to bundled gating the emit on the OUTER file type
   /// being "TIFF" (`Parent='TIFF'`, `ExifTool.pm:8704`).
   multi_page_count: Option<u32>,
+  /// The container's detected FILE_TYPE (`$$self{FILE_TYPE}`) — `Some("CRW")`
+  /// for a CIFF/CRW raw, the standalone-TIFF candidate's `Parent`
+  /// (`"TIFF"`/`"DNG"`/`"NEF"`/`"CR2"`/…) for a standalone TIFF, `None` for an
+  /// embedded Exif block (JPEG `APP1`, PNG `eXIf`) or when unknown. WRITE-ONLY
+  /// inside the engine except for ONE faithful read: `Canon::ShotInfo`
+  /// position 22's RawConv (`Canon.pm:2977`/`:2990`) keeps a raw-0
+  /// ExposureTime only when the container is a CRW. It does NOT affect any
+  /// other tag — the Canon decoder threads it through to that single gate at
+  /// MakerNote-capture time. (Because the port has no CIFF/CRW parser, no
+  /// reachable input is a CRW, so the pos-22 behaviour — hence all output —
+  /// is unchanged; only the gate is now spelled faithfully.)
+  file_type: Option<smol_str::SmolStr>,
 }
 
 impl<'a> ExifMeta<'a> {
@@ -696,6 +708,18 @@ impl<'a> ExifMeta<'a> {
     self.multi_page_count
   }
 
+  /// The container's detected FILE_TYPE (`$$self{FILE_TYPE}`) — see the field
+  /// docs. `Some("CRW")` for a CIFF/CRW raw, the candidate `Parent`
+  /// (`"TIFF"`/`"DNG"`/…) for a standalone TIFF, `None` for an embedded Exif
+  /// block (JPEG `APP1`, PNG `eXIf`) or when unknown. The sole faithful
+  /// consumer is `Canon::ShotInfo` position 22's CRW-allows-0 RawConv
+  /// (`Canon.pm:2977`/`:2990`); it does not influence any other output.
+  #[must_use]
+  #[inline]
+  pub fn file_type(&self) -> Option<&str> {
+    self.file_type.as_deref()
+  }
+
   /// The first entry whose resolved name matches `name` (a small ergonomic
   /// helper for the common "probe one tag" library use, e.g. `Make`).
   #[must_use]
@@ -736,6 +760,11 @@ impl<'a> ExifMeta<'a> {
       byte_order,
       maker_note,
       multi_page_count: None,
+      // A JPEG container's `APP1` Exif block is embedded — `$$self{FILE_TYPE}`
+      // is the JPEG ("JPEG"), never "CRW", so the ShotInfo pos-22 CRW clause is
+      // correctly off. We model that as `None` (no CRW), matching the embedded
+      // `parse_exif_block` path.
+      file_type: None,
     }
   }
 
@@ -793,7 +822,13 @@ impl FormatParser for ProcessExif {
   /// `tiff_type_is_tiff = true` so the multi-page `File:PageCount`
   /// synthesis (`ExifTool.pm:8756-8757`) is active.
   fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
-    Ok(parse_tiff(data, /* tiff_type_is_tiff */ true))
+    // Direct standalone-TIFF lib entry: no candidate `Parent` context (the
+    // engine path through `AnyParser::Exif` carries the real type via
+    // `parse_standalone_tiff_with_base`), so `file_type = None`. A `.tif` is
+    // never a CRW, so the ShotInfo pos-22 CRW clause is correctly off.
+    Ok(parse_tiff(
+      data, /* tiff_type_is_tiff */ true, /* file_type */ None,
+    ))
   }
 }
 
@@ -806,7 +841,11 @@ impl FormatParser for ProcessExif {
 /// Returns `Err` only for Rust-level fatal modes (none today — every bad
 /// input is `Ok(None)`, faithful to `DoProcessTIFF` `return 0`).
 pub fn parse_borrowed(data: &[u8]) -> Result<Option<ExifMeta<'_>>, Error> {
-  Ok(parse_tiff(data, /* tiff_type_is_tiff */ true))
+  // Direct standalone-TIFF lib entry — no candidate `Parent`, so `file_type =
+  // None` (see [`ProcessExif::parse`]).
+  Ok(parse_tiff(
+    data, /* tiff_type_is_tiff */ true, /* file_type */ None,
+  ))
 }
 
 /// **Reusable entry — the QuickTime/RIFF/MakerNotes seam.** Parse a raw
@@ -833,7 +872,12 @@ pub fn parse_borrowed(data: &[u8]) -> Result<Option<ExifMeta<'_>>, Error> {
 /// marker, IFD0 offset < 8 — `ExifTool.pm:8645`).
 #[must_use]
 pub fn parse_exif_block(block: &[u8]) -> Option<ExifMeta<'_>> {
-  parse_tiff(block, /* tiff_type_is_tiff */ false)
+  // Embedded Exif block (QuickTime/RIFF/PNG/MakerNotes seam) — the container's
+  // `$$self{FILE_TYPE}` is the OUTER type, never "CRW", so `file_type = None`
+  // (the ShotInfo pos-22 CRW clause stays off).
+  parse_tiff(
+    block, /* tiff_type_is_tiff */ false, /* file_type */ None,
+  )
 }
 
 /// Like [`parse_exif_block`], but for an Exif/TIFF block that does NOT start at
@@ -849,7 +893,11 @@ pub fn parse_exif_block(block: &[u8]) -> Option<ExifMeta<'_>> {
 /// is OFF — see [`parse_exif_block`].
 #[must_use]
 pub fn parse_exif_block_with_base(block: &[u8], base: u32) -> Option<ExifMeta<'_>> {
-  parse_tiff_with_base(block, base, /* tiff_type_is_tiff */ false)
+  // Embedded Exif block (JPEG `APP1`, etc.) — the OUTER container type is never
+  // "CRW", so `file_type = None` (the ShotInfo pos-22 CRW clause stays off).
+  parse_tiff_with_base(
+    block, base, /* tiff_type_is_tiff */ false, /* file_type */ None,
+  )
 }
 
 /// Like [`parse_exif_block_with_base`], but for the standalone-TIFF dispatch
@@ -866,13 +914,25 @@ pub fn parse_exif_block_with_base(block: &[u8], base: u32) -> Option<ExifMeta<'_
 /// `header_skip` `base` for the "scan past unknown header for TIFF" detector
 /// candidate (`ExifTool.pm:3026-3034`). The `MultiPage` flag itself comes from
 /// the SubfileType / OldSubfileType `RawConv` (`Exif.pm:456`/`:473`).
+///
+/// `file_type` is that same candidate `Parent` (`$$self{FILE_TYPE}`,
+/// `ExifTool.pm:8715`) — stored on the resulting [`ExifMeta`] and threaded to
+/// the Canon MakerNote decoder for the `Canon::ShotInfo` pos-22 CRW-allows-0
+/// RawConv (`Canon.pm:2977`/`:2990`). The engine dispatch passes
+/// `Some(parent_type)`; it is WRITE-ONLY apart from that single pos-22 read.
+/// (A standalone TIFF/RAW is never a CRW — the CRW path is the unported CIFF
+/// front-end — so this changes no output today.)
 #[must_use]
-pub fn parse_standalone_tiff_with_base(
-  block: &[u8],
+pub fn parse_standalone_tiff_with_base<'a>(
+  block: &'a [u8],
   base: u32,
   tiff_type_is_tiff: bool,
-) -> Option<ExifMeta<'_>> {
-  parse_tiff_with_base(block, base, tiff_type_is_tiff)
+  file_type: Option<&str>,
+) -> Option<ExifMeta<'a>> {
+  // The returned `ExifMeta<'a>` borrows ONLY from `block` (the IFD bytes); the
+  // `file_type` is copied into an owned `SmolStr` inside `parse_tiff_with_base`,
+  // so its lifetime is independent and need not appear in the return type.
+  parse_tiff_with_base(block, base, tiff_type_is_tiff, file_type)
 }
 
 // ===========================================================================
@@ -898,8 +958,12 @@ pub fn parse_standalone_tiff_with_base(
 /// classic walker would misdecode it. We cleanly skip it (return `None`) rather
 /// than emit garbage — see [`parse_tiff_with_base`]. A full BigTIFF walker is a
 /// deferred port.
-fn parse_tiff(data: &[u8], tiff_type_is_tiff: bool) -> Option<ExifMeta<'_>> {
-  parse_tiff_with_base(data, 0, tiff_type_is_tiff)
+fn parse_tiff<'a>(
+  data: &'a [u8],
+  tiff_type_is_tiff: bool,
+  file_type: Option<&str>,
+) -> Option<ExifMeta<'a>> {
+  parse_tiff_with_base(data, 0, tiff_type_is_tiff, file_type)
 }
 
 /// Parse a TIFF block whose start sits at file offset `base` (`$$dirInfo{Base}`).
@@ -917,7 +981,20 @@ fn parse_tiff(data: &[u8], tiff_type_is_tiff: bool) -> Option<ExifMeta<'_>> {
 /// the emission via `Parent` ('PNG' / 'APP1' / 'QuickTime' / 'RIFF'), which
 /// stays the outer container's name and never becomes "TIFF" in those
 /// recursive `ProcessTIFF` calls.
-fn parse_tiff_with_base(data: &[u8], base: u32, tiff_type_is_tiff: bool) -> Option<ExifMeta<'_>> {
+///
+/// `file_type` is the container's detected `$$self{FILE_TYPE}` — stored on the
+/// resulting [`ExifMeta`] and threaded to the Canon MakerNote decoder for the
+/// `Canon::ShotInfo` pos-22 CRW-allows-0 RawConv (`Canon.pm:2977`/`:2990`).
+/// The standalone-TIFF dispatch passes the candidate `Parent`
+/// (`"TIFF"`/`"DNG"`/…); the embedded-block callers pass `None` (a JPEG/PNG
+/// container is never "CRW"). It is otherwise WRITE-ONLY — it changes no
+/// other tag, and no reachable input is a CRW today (no CIFF/CRW parser).
+fn parse_tiff_with_base<'a>(
+  data: &'a [u8],
+  base: u32,
+  tiff_type_is_tiff: bool,
+  file_type: Option<&str>,
+) -> Option<ExifMeta<'a>> {
   // `length $$dataPt < 8` — the TIFF header is 8 bytes.
   if data.len() < 8 {
     return None;
@@ -947,6 +1024,10 @@ fn parse_tiff_with_base(data: &[u8], base: u32, tiff_type_is_tiff: bool) -> Opti
     return None;
   }
 
+  // The container `$$self{FILE_TYPE}` — owned once so it can be both threaded
+  // to the Canon MakerNote decoder (the pos-22 CRW gate, read at walk time)
+  // and stored on the resulting `ExifMeta`.
+  let file_type: Option<smol_str::SmolStr> = file_type.map(smol_str::SmolStr::new);
   let mut w = Walker {
     data,
     order,
@@ -963,6 +1044,7 @@ fn parse_tiff_with_base(data: &[u8], base: u32, tiff_type_is_tiff: bool) -> Opti
     active_ifd_offsets: Vec::new(),
     page_count: 0,
     multi_page: false,
+    file_type: file_type.clone(),
   };
   // Walk the IFD0 → IFD1 chain (the next-IFD pointer). ExifIFD/GPS/Interop
   // are reached as SubDirectories from inside the walk.
@@ -994,6 +1076,7 @@ fn parse_tiff_with_base(data: &[u8], base: u32, tiff_type_is_tiff: bool) -> Opti
     byte_order: Some(order),
     maker_note: w.maker_note,
     multi_page_count,
+    file_type,
   })
 }
 
@@ -1102,6 +1185,9 @@ fn parse_tiff_with_base_shared<'a>(
     // is gated to the standalone-TIFF dispatch (`tiff_type_is_tiff`).
     page_count: 0,
     multi_page: false,
+    // Embedded block (PNG `eXIf`): `$$self{FILE_TYPE}` is "PNG", never "CRW",
+    // so the ShotInfo pos-22 CRW clause is off — model it as `None`.
+    file_type: None,
   };
   w.walk_ifd_chain(ifd0_offset, IfdKind::Ifd0);
 
@@ -1114,6 +1200,8 @@ fn parse_tiff_with_base_shared<'a>(
     // Embedded block (PNG `eXIf`): never the standalone-TIFF dispatch, so no
     // synthesized `File:PageCount`.
     multi_page_count: None,
+    // Embedded block (PNG `eXIf`) — never "CRW" (see the Walker field above).
+    file_type: None,
   };
   (Some(meta), cycle_guard_warnings)
 }
@@ -1268,6 +1356,13 @@ struct Walker<'a, 'g> {
   /// reached (`$$self{PageCount} > 1`). Gates the `File:PageCount`
   /// emission at `ExifTool.pm:8757`.
   multi_page: bool,
+  /// The container's detected `$$self{FILE_TYPE}` (`ExifTool.pm:8715`).
+  /// Threaded into the Canon MakerNote decoder so `Canon::ShotInfo` position
+  /// 22's RawConv (`Canon.pm:2977`/`:2990`) can keep a raw-0 ExposureTime for
+  /// a CRW container. `None` for an embedded Exif block (PNG `eXIf`, JPEG
+  /// `APP1` — never "CRW") or when the type is unknown. WRITE-ONLY apart from
+  /// that single pos-22 read; it influences no other tag.
+  file_type: Option<smol_str::SmolStr>,
 }
 
 impl Walker<'_, '_> {
@@ -2131,15 +2226,18 @@ impl Walker<'_, '_> {
               }
               makernotes::Vendor::Canon => {
                 // Canon: parse using the parent TIFF context so
-                // out-of-line offsets resolve correctly.
+                // out-of-line offsets resolve correctly. Thread the container
+                // `$$self{FILE_TYPE}` for the `Canon::ShotInfo` pos-22
+                // CRW-allows-0 RawConv (`Canon.pm:2977`/`:2990`).
                 let mn_offset = value_offset;
                 let mn_len = read_len;
                 let model = self.captured_model.as_deref();
+                let file_type = self.file_type.as_deref();
                 let (typed_pc, emi_pc) = makernotes::vendors::canon::parse_in_tiff(
-                  self.data, mn_offset, mn_len, self.order, true, model,
+                  self.data, mn_offset, mn_len, self.order, true, model, file_type,
                 );
                 let (_typed_vc, emi_vc) = makernotes::vendors::canon::parse_in_tiff(
-                  self.data, mn_offset, mn_len, self.order, false, model,
+                  self.data, mn_offset, mn_len, self.order, false, model, file_type,
                 );
                 meta.set_canon(typed_pc);
                 cached_pc = emi_pc;
@@ -4771,6 +4869,7 @@ mod tests {
       active_ifd_offsets: Vec::new(),
       page_count: 0,
       multi_page: false,
+      file_type: None,
     }
   }
 

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -2042,9 +2042,11 @@ impl AnyParser {
         // `IsOffset` tags absolute). Pre-fix this arm only matched a `SOI` at
         // byte 0, so a recoverable/edited JPEG with a small unknown header was
         // detected then mis-rejected into a `File format error`.
-        // Exif/TIFF is a leaf format — `shared` and `ext` are unused, and the
-        // `p` unit dispatcher is bypassed for the base-aware entry below.
-        let _ = (p, shared, ext);
+        // Exif/TIFF is a leaf format — `shared` is unused, and the `p` unit
+        // dispatcher is bypassed for the base-aware entry below. `ext` IS used
+        // by the standalone-TIFF arm: it feeds the finalized-`FILE_TYPE`
+        // computation (the sub-type-by-ext promotion).
+        let _ = (p, shared);
         let body = bytes.get(header_skip..).unwrap_or(&[]);
         if body.len() >= 2 && body[0] == 0xff && body[1] == 0xd8 {
           return Ok(
@@ -2062,9 +2064,35 @@ impl AnyParser {
         // — so a multi-page RAW does NOT gain a non-bundled `File:PageCount`.
         let base = u32::try_from(header_skip).unwrap_or(u32::MAX);
         let tiff_type_is_tiff = tiff_parent_type == Some("TIFF");
+        // Thread the FINALIZED `$$self{FILE_TYPE}` — the SAME string the engine
+        // emits as `File:FileType` — as the container file type, so the
+        // `Canon::ShotInfo` pos-22 CRW-allows-0 RawConv (`Canon.pm:2977`/
+        // `:2990`, which keys on `$$self{FILE_TYPE} eq "CRW"`) checks the RIGHT
+        // variable. It is the candidate `Parent` run through `DoProcessTIFF`'s
+        // `$t`/`SetFileType` rule (ExifTool.pm:8685-8694) + the sub-type-by-ext
+        // promotion — NOT the bare `Parent` (`tiff_parent_type`). The two
+        // diverge for a `.crw`-named TIFF-magic file: its `Parent` is `"CRW"`
+        // (the uppercased ext) but its finalized `FILE_TYPE` is `"TIFF"` (CRW's
+        // base module is `CanonRaw`, not TIFF, and `"CRW"` lacks a `RAW`
+        // substring, so `$t` is undef ⇒ stays `"TIFF"`). The standalone-TIFF
+        // base type is always `"TIFF"` (the only candidate `file_type()` that
+        // maps to `AnyParser::Exif`). The result is provably never `"CRW"` (no
+        // CIFF/CRW front-end; `CRW` is never a TIFF-base/RAW promotion), so the
+        // CRW branch stays correctly dead — but the gate now checks the right
+        // value, and the `.crw`-named-TIFF case matches bundled.
+        // `$$dirInfo{Parent} || ''` (ExifTool.pm:8685) — a missing candidate
+        // Parent (dotless / embedded TIFF) is the empty string ⇒ `$t` undef ⇒
+        // the finalized name stays the detected `"TIFF"`.
+        let file_type =
+          crate::parser::finalized_tiff_file_type("TIFF", tiff_parent_type.unwrap_or(""), ext);
         Ok(
-          crate::exif::parse_standalone_tiff_with_base(body, base, tiff_type_is_tiff)
-            .map(AnyMeta::Exif),
+          crate::exif::parse_standalone_tiff_with_base(
+            body,
+            base,
+            tiff_type_is_tiff,
+            Some(&file_type),
+          )
+          .map(AnyMeta::Exif),
         )
       }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,6 +92,40 @@ struct FileTypeTriplet {
   mime_type: String,
 }
 
+/// The resolved `$fileType` NAME — the string ExifTool ultimately stores as
+/// `File:FileType` (ExifTool.pm:9684-9692). It is the explicit `file_type` arg
+/// (the `SetFileType($ft)` argument) or `base_type` when none, AFTER the
+/// sub-type-by-ext promotion (ExifTool.pm:9686-9692). Borrows from its inputs
+/// (no allocation, no `apply`), so it can be reused both by [`resolve_file_type`]
+/// (which then resolves the MIME + extension triplet) and by
+/// [`finalized_tiff_file_type`] (which needs ONLY the name to thread the
+/// finalized `$$self{FILE_TYPE}` into the standalone-TIFF parse). This is the
+/// computation that makes `File:FileType` and the threaded container type ONE
+/// value — e.g. a `.crw`-named TIFF resolves to `"TIFF"` here (CRW's base module
+/// is `CanonRaw`, not TIFF, and `"CRW"` has no `RAW` substring — see
+/// [`finalized_tiff_file_type`]), never `"CRW"`.
+fn resolved_file_type_name<'a>(
+  base_type: &'a str,
+  file_type: Option<&'a str>,
+  ext: Option<&'a str>,
+) -> &'a str {
+  // ExifTool.pm:9684 `$fileType or $fileType = $baseType`.
+  let mut ft: &str = file_type.unwrap_or(base_type);
+  // ExifTool.pm:9686-9692 — handle sub-types identified by extension.
+  if let Some(ext) = ext {
+    if ext != ft {
+      let f = crate::filetype::file_type_lookup_root(ft);
+      let e = crate::filetype::file_type_lookup_root(ext);
+      if let (Some(fr), Some(er)) = (f, e) {
+        if fr == er && (fr == ft || !crate::filetype::file_type_lookup_defined(fr)) {
+          ft = ext;
+        }
+      }
+    }
+  }
+  ft
+}
+
 /// Pure `SetFileType` resolution (ExifTool.pm:9677-9706) — the COMPUTATION
 /// half of [`ParseContext::set_file_type`], factored out so both the writer
 /// path (legacy) and the typed serde path ([`extract_info`]) share ONE
@@ -110,20 +144,10 @@ fn resolve_file_type(
   ext: Option<&str>,
   print_conv: bool,
 ) -> FileTypeTriplet {
-  // ExifTool.pm:9684 `$fileType or $fileType = $baseType`.
-  let mut ft: &str = file_type.unwrap_or(base_type);
-  // ExifTool.pm:9686-9692 — handle sub-types identified by extension.
-  if let Some(ext) = ext {
-    if ext != ft {
-      let f = crate::filetype::file_type_lookup_root(ft);
-      let e = crate::filetype::file_type_lookup_root(ext);
-      if let (Some(fr), Some(er)) = (f, e) {
-        if fr == er && (fr == ft || !crate::filetype::file_type_lookup_defined(fr)) {
-          ft = ext;
-        }
-      }
-    }
-  }
+  // ExifTool.pm:9684-9692 — the resolved `$fileType` NAME (the explicit arg or
+  // base, then the sub-type-by-ext promotion). Shared with the standalone-TIFF
+  // dispatch so `File:FileType` and the threaded `$$self{FILE_TYPE}` agree.
+  let ft: &str = resolved_file_type_name(base_type, file_type, ext);
   // ExifTool.pm:9693 `$mimeType or $mimeType = $mimeType{$fileType}`.
   let mut mime = mime_type(ft);
   // ExifTool.pm:9695 base-type MIME fallback (TIFF excluded).
@@ -178,24 +202,67 @@ fn tiff_finalize_file_type(
   ext: Option<&str>,
   print_conv: bool,
 ) -> FileTypeTriplet {
-  // ExifTool.pm:8685 `if ($fileType and ...)` — an empty Parent (dotless /
-  // embedded TIFF) skips the re-finalization; bundled keeps the bare
-  // detected `"TIFF"` from the detection-time `SetFileType()`.
+  // ExifTool.pm:8685-8690 `$t = ($baseType eq 'TIFF' or $fileType =~ /RAW/) ?
+  // $fileType : undef` (the empty-Parent guard ⇒ `None`). ExifTool.pm:8693
+  // `$self->SetFileType($t)` — `$$self{FILE_TYPE}` stays the detection `$type`
+  // (`base_type`), the explicit arg is `$t`.
+  let t = tiff_finalized_type_arg(parent_type);
+  resolve_file_type(base_type, t, ext, print_conv)
+}
+
+/// The `$t` argument `DoProcessTIFF` feeds to `SetFileType` (ExifTool.pm:8685-
+/// 8690) — the COMPUTATION shared by [`tiff_finalize_file_type`] (which then
+/// resolves the full `File:*` triplet) and [`finalized_tiff_file_type`] (which
+/// composes it with the ext promotion to get the finalized `$$self{FILE_TYPE}`
+/// NAME). `None` for an empty `parent_type` (dotless / embedded TIFF — the
+/// `if ($fileType ...)` guard at ExifTool.pm:8685 is false, so bundled never
+/// re-finalizes, keeping the detection-time bare `"TIFF"`), or when the parent's
+/// base module is not `TIFF` AND `parent_type` has no `RAW` substring; otherwise
+/// `Some(parent_type)`. (Perl's `$baseType` here is the base MODULE of
+/// `$fileType`==`parent_type`, computed below — NOT the outer detection
+/// `$$self{FILE_TYPE}`.) Borrows `parent_type`.
+#[cfg(feature = "exif")]
+fn tiff_finalized_type_arg(parent_type: &str) -> Option<&str> {
+  // ExifTool.pm:8685 `if ($fileType and ...)` — an empty Parent skips the
+  // re-finalization (⇒ `$t` undef).
   if parent_type.is_empty() {
-    return resolve_file_type(base_type, None, ext, print_conv);
+    return None;
   }
   // ExifTool.pm:8687-8689 `$baseType` = first module of `$fileType`'s row.
   let base_module = crate::filetype::file_type_base_module(parent_type);
   // ExifTool.pm:8690 `$t = ($baseType eq 'TIFF' or $fileType =~ /RAW/) ?
   // $fileType : undef`.
-  let t: Option<&str> = if base_module == "TIFF" || parent_type.contains("RAW") {
+  if base_module == "TIFF" || parent_type.contains("RAW") {
     Some(parent_type)
   } else {
     None
-  };
-  // ExifTool.pm:8693 `$self->SetFileType($t)` — `$$self{FILE_TYPE}` stays
-  // the detection `$type` (`base_type`), the explicit arg is `$t`.
-  resolve_file_type(base_type, t, ext, print_conv)
+  }
+}
+
+/// The FINALIZED `$$self{FILE_TYPE}` NAME for a standalone-TIFF parse — the
+/// exact string [`extract_info`] emits as `File:FileType` (so the two never
+/// diverge). It is [`resolved_file_type_name`] applied to the
+/// [`tiff_finalized_type_arg`] `$t`: e.g. a plain `.tif` ⇒ `"TIFF"`, a TIFF-
+/// rooted RAW subtype (`.nef`/`.cr2`/…) ⇒ that subtype (`"NEF"`/`"CR2"`/…), and
+/// crucially a `.crw`-named TIFF ⇒ `"TIFF"` — because `CRW`'s base module is
+/// `CanonRaw` (NOT `TIFF`) and `"CRW"` has no `RAW` substring, so
+/// [`tiff_finalized_type_arg`] returns `None` ⇒ the name stays the detected
+/// `base_type` (`"TIFF"`), never `"CRW"`.
+///
+/// This is the value the engine threads into the standalone-TIFF parse as the
+/// container `$$self{FILE_TYPE}` (the `Canon::ShotInfo` pos-22 CRW-allows-0
+/// RawConv, Canon.pm:2977/:2990, keys on it) — provably never `"CRW"` in the
+/// port (there is no CIFF/CRW front-end, and `CRW` is never a TIFF-base/RAW
+/// promotion), so the CRW branch stays correctly dead while the gate now checks
+/// the RIGHT variable.
+#[cfg(feature = "exif")]
+pub(crate) fn finalized_tiff_file_type(
+  base_type: &str,
+  parent_type: &str,
+  ext: Option<&str>,
+) -> String {
+  let t = tiff_finalized_type_arg(parent_type);
+  resolved_file_type_name(base_type, t, ext).to_string()
 }
 
 /// Pure `OverrideFileType` resolution (ExifTool.pm:9712-9730) — the
@@ -1026,6 +1093,51 @@ mod tests {
     );
   }
 
+  /// The finalized `$$self{FILE_TYPE}` NAME ([`finalized_tiff_file_type`]) —
+  /// the value the standalone-TIFF dispatch threads as the container type for
+  /// the `Canon::ShotInfo` pos-22 CRW-allows-0 RawConv — must EQUAL the
+  /// `File:FileType` ([`tiff_finalize_file_type`]`.file_type`) for every
+  /// candidate `Parent`, and is **provably never `"CRW"`**.
+  ///
+  /// The load-bearing case (Codex R6 bug): a `.crw`-named TIFF-magic file. Its
+  /// candidate `Parent` is `"CRW"` (the uppercased extension), but its finalized
+  /// `FILE_TYPE` is `"TIFF"` — `CRW`'s base module is `CanonRaw` (NOT `TIFF`)
+  /// and `"CRW"` has no `RAW` substring, so `DoProcessTIFF`'s `$t` is undef ⇒ the
+  /// name stays the detected `"TIFF"`. Threading the bare `Parent` (the bug) would
+  /// wrongly fire the CRW branch (keep a raw-0 ExposureTime); threading this
+  /// finalized type does NOT.
+  #[cfg(feature = "exif")]
+  #[test]
+  fn finalized_tiff_file_type_never_crw_and_matches_filetype() {
+    // (candidate Parent, ext) ⇒ finalized FILE_TYPE. Includes the .crw-named
+    // TIFF (Parent "CRW" ⇒ "TIFF"), a plain .tif, TIFF-rooted RAW subtypes
+    // (promote), a non-TIFF-root parent (X3F ⇒ stays TIFF), and the empty /
+    // dotless Parent.
+    for (parent, ext, want) in [
+      ("CRW", Some("CRW"), "TIFF"), // the bug: Parent "CRW" but FILE_TYPE "TIFF".
+      ("TIFF", Some("TIFF"), "TIFF"),
+      ("NEF", Some("NEF"), "NEF"),
+      ("CR2", Some("CR2"), "CR2"),
+      ("3FR", Some("3FR"), "3FR"),
+      ("RAW", Some("RAW"), "RAW"),
+      ("X3F", Some("X3F"), "TIFF"), // non-TIFF-root, no RAW substring ⇒ $t undef.
+      ("", None, "TIFF"),           // dotless / embedded ⇒ guard false ⇒ "TIFF".
+    ] {
+      let finalized = finalized_tiff_file_type("TIFF", parent, ext);
+      assert_eq!(
+        finalized, want,
+        "finalized FILE_TYPE for Parent={parent:?} ext={ext:?}"
+      );
+      assert_ne!(finalized, "CRW", "the finalized FILE_TYPE is never CRW");
+      // It MUST equal the `File:FileType` the engine emits (same computation).
+      let emitted = tiff_finalize_file_type("TIFF", parent, ext, true).file_type;
+      assert_eq!(
+        finalized, emitted,
+        "finalized FILE_TYPE must match File:FileType for Parent={parent:?}"
+      );
+    }
+  }
+
   #[test]
   fn set_file_type_base_mime_fallback_and_tiff_exclusion() {
     // ExifTool.pm:9695 `$mimeType = $mimeType{$baseType} unless $mimeType or
@@ -1042,6 +1154,95 @@ mod tests {
     // Sanity: base TIFF, no override ⇒ image/tiff directly.
     let t3 = resolve_file_type("TIFF", None, None, true);
     assert_eq!(t3.mime_type, "image/tiff");
+  }
+
+  /// END-TO-END regression for the Codex R6 bug: a `.crw`-named TIFF-magic
+  /// file must finalize to `File:FileType == "TIFF"` (NOT "CRW"), so the
+  /// container `$$self{FILE_TYPE}` threaded into `Canon::ShotInfo` position
+  /// 22's RawConv (`Canon.pm:2977`/`:2990`) is "TIFF" ⇒ a raw-0 ExposureTime is
+  /// DROPPED (the `FILE_TYPE eq "CRW"` clause is false), matching bundled.
+  ///
+  /// Before the fix, the engine threaded the candidate `Parent` ("CRW" for a
+  /// `.crw` name) instead of the finalized `FILE_TYPE` ("TIFF"), so the CRW
+  /// branch wrongly fired and KEPT the raw-0 ExposureTime — this test would
+  /// fail (an `…:ExposureTime` key would be present).
+  ///
+  /// The fixture is a minimal little-endian TIFF: IFD0 = Make "Canon\0" +
+  /// ExifIFD pointer; ExifIFD = a `0x927C` MakerNote; the MakerNote is a Canon
+  /// IFD with one `ShotInfo` (tag `0x0004`, int16[23], all zero ⇒ pos-22 raw 0,
+  /// stored out-of-line at an absolute file offset — Canon inherits base 0).
+  #[cfg(all(feature = "json", feature = "exif"))]
+  #[test]
+  fn crw_named_tiff_finalizes_to_tiff_and_drops_shotinfo_exposuretime() {
+    // Little-endian TIFF. Offsets (absolute, base 0):
+    //   0   header: "II" 0x2a 0x00, IFD0 = 8
+    //   8   IFD0 (2 entries): 8..38
+    //   38  Make string "Canon\0": 38..44
+    //   44  ExifIFD (1 entry): 44..62
+    //   62  MakerNote = Canon IFD (1 entry): 62..80
+    //   80  ShotInfo int16[23] = 46 bytes of zero: 80..126
+    let mut t: Vec<u8> = Vec::new();
+    t.extend_from_slice(&[b'I', b'I', 0x2a, 0x00]); // II, magic 42
+    t.extend_from_slice(&8u32.to_le_bytes()); // IFD0 @ 8
+    // --- IFD0 @ 8 (2 entries) ---
+    t.extend_from_slice(&2u16.to_le_bytes());
+    // Make (0x010f) ASCII(2) count=6 ⇒ out-of-line @ 38.
+    t.extend_from_slice(&0x010fu16.to_le_bytes());
+    t.extend_from_slice(&2u16.to_le_bytes());
+    t.extend_from_slice(&6u32.to_le_bytes());
+    t.extend_from_slice(&38u32.to_le_bytes());
+    // ExifIFD (0x8769) LONG(4) count=1 ⇒ value = 44.
+    t.extend_from_slice(&0x8769u16.to_le_bytes());
+    t.extend_from_slice(&4u16.to_le_bytes());
+    t.extend_from_slice(&1u32.to_le_bytes());
+    t.extend_from_slice(&44u32.to_le_bytes());
+    t.extend_from_slice(&0u32.to_le_bytes()); // IFD0 next = 0
+    debug_assert_eq!(t.len(), 38);
+    // --- Make string @ 38 ---
+    t.extend_from_slice(b"Canon\x00");
+    debug_assert_eq!(t.len(), 44);
+    // --- ExifIFD @ 44 (1 entry: MakerNote) ---
+    t.extend_from_slice(&1u16.to_le_bytes());
+    // MakerNote (0x927c) UNDEF(7) count=64 ⇒ value @ 62 (the Canon IFD: 62..126).
+    t.extend_from_slice(&0x927cu16.to_le_bytes());
+    t.extend_from_slice(&7u16.to_le_bytes());
+    t.extend_from_slice(&64u32.to_le_bytes());
+    t.extend_from_slice(&62u32.to_le_bytes());
+    t.extend_from_slice(&0u32.to_le_bytes()); // ExifIFD next = 0
+    debug_assert_eq!(t.len(), 62);
+    // --- MakerNote = Canon IFD @ 62 (1 entry: ShotInfo) ---
+    t.extend_from_slice(&1u16.to_le_bytes());
+    // ShotInfo (0x0004) int16(3) count=23 ⇒ out-of-line @ 80 (absolute).
+    t.extend_from_slice(&0x0004u16.to_le_bytes());
+    t.extend_from_slice(&3u16.to_le_bytes());
+    t.extend_from_slice(&23u32.to_le_bytes());
+    t.extend_from_slice(&80u32.to_le_bytes());
+    t.extend_from_slice(&0u32.to_le_bytes()); // Canon IFD next = 0
+    debug_assert_eq!(t.len(), 80);
+    // --- ShotInfo int16[23] all zero @ 80 (pos-22 raw = 0) ---
+    t.extend_from_slice(&[0u8; 46]);
+    debug_assert_eq!(t.len(), 126);
+
+    let obj = engine_obj("x.crw", &t, true);
+    // The `.crw`-named TIFF-magic file finalizes to FileType "TIFF" (NOT "CRW").
+    assert_eq!(
+      obj.get("File:FileType").and_then(|v| v.as_str()),
+      Some("TIFF"),
+      "a .crw-named TIFF-magic file must finalize to FileType TIFF"
+    );
+    // The Make round-tripped (proves the Canon MakerNote dispatch ran).
+    assert_eq!(
+      obj.get("IFD0:Make").and_then(|v| v.as_str()),
+      Some("Canon"),
+      "IFD0:Make should be Canon (the Canon vendor dispatch keys on it)"
+    );
+    // The raw-0 ShotInfo ExposureTime is DROPPED (FILE_TYPE is "TIFF", not
+    // "CRW") — NO key bears an ExposureTime name.
+    let exposure_keys: Vec<&String> = obj.keys().filter(|k| k.contains("ExposureTime")).collect();
+    assert!(
+      exposure_keys.is_empty(),
+      "raw-0 ShotInfo ExposureTime must be DROPPED for a TIFF (non-CRW) container, got: {exposure_keys:?}"
+    );
   }
 
   #[cfg(feature = "json")]

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -2634,6 +2634,7 @@ fn canon_afinfo2_0x26_all_zero_is_suppressed() {
     ByteOrder::Little,
     true,
     Some("Canon EOS 60D"),
+    None,
   );
   // No AFInfo2 leaves emitted, and the typed AF surface stays unset.
   assert!(
@@ -2671,6 +2672,7 @@ fn canon_afinfo2_0x26_only_first_word_zero_is_not_suppressed() {
     ByteOrder::Little,
     true,
     Some("Canon EOS 60D"),
+    None,
   );
   assert!(
     em.iter()
@@ -2718,6 +2720,7 @@ fn canon_afinfo3_0x3c_dispatches_to_afinfo2_and_suppresses_primary() {
     ByteOrder::Little,
     true,
     Some("Canon PowerShot G1 X Mark II"),
+    None,
   );
   let find = |n: &str| em.iter().find(|e| e.name() == n).map(|e| e.value().clone());
   assert_eq!(


### PR DESCRIPTION
Closes the one open Codex finding from #164 R5. ShotInfo position 22 ExposureTime RawConv is `($val or $$self{FILE_TYPE} eq "CRW") ? $val : undef` (Canon.pm:2977/:2990). The merged #164 hardcoded the non-CRW branch without checking FILE_TYPE; this threads the container `$$self{FILE_TYPE}` end-to-end (ExifMeta.file_type + Walker, candidate Parent on the standalone path / None embedded) into canon::parse_in_tiff → shot_info::parse, and gates pos-22 on `raw != 0 || file_type == Some("CRW")` (both branches). No reachable container is CRW today (no CIFF/CRW parser, #182) so output is unchanged — conformance 267 byte-identical — but the code is now a faithful transcription. New CRW raw-0 regression test (-j/-n) with oracle-confirmed values.