### PR TITLE
perf+fix(golden-v2): Phase A — robustness (DoS budgets, fuzz, catch_unwind) + dead-scaffolding cleanup + emission performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ rust_out
 
 # Internal planning docs (specs/plans) — kept local, not published
 /docs/
+
+# cargo-fuzz (Golden-v2 3b) — build artifacts, generated corpus, crash inputs
+/fuzz/target/
+/fuzz/corpus/
+/fuzz/artifacts/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,14 @@ tempfile = "3"
 # Golden-v2 Contract 3b — randomized no-panic gate over the public parse
 # entry points (`tests/no_panic.rs`). Dev-only; no runtime/feature impact.
 proptest = "1"
+# Golden-v2 C4 — `benches/extract.rs` throughput baselines for the perf
+# contract. `default-features = false` drops criterion's `rayon`/`plotters`
+# pull-in (we only need the timing loop); dev-only, no runtime/feature impact.
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "extract"
+harness = false
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,6 +239,9 @@ thiserror   = { version = "2", default-features = false }
 # `serde_json` is a normal (optional) dependency above; under the `json`
 # feature it is in scope for tests too. Not duplicated here.
 tempfile = "3"
+# Golden-v2 Contract 3b — randomized no-panic gate over the public parse
+# entry points (`tests/no_panic.rs`). Dev-only; no runtime/feature impact.
+proptest = "1"
 
 [profile.bench]
 opt-level = 3

--- a/benches/extract.rs
+++ b/benches/extract.rs
@@ -22,6 +22,7 @@ const FIXTURES: &[&str] = &[
   "MakerNotes_Canon.jpg",
   "ID3v2_4_big.mp3",
   "QuickTime_frea_rexing17b.mov",
+  "Real.ra",
 ];
 
 fn bench_extract(c: &mut Criterion) {

--- a/benches/extract.rs
+++ b/benches/extract.rs
@@ -5,7 +5,7 @@
 //! tracks wall-clock so a CPU regression (an extra parse pass, an O(n²) scan)
 //! shows up in `cargo bench` too. Not wired into CI — a developer aid.
 
-use criterion::{criterion_group, Criterion};
+use criterion::{Criterion, criterion_group};
 use std::hint::black_box;
 
 /// Read a fixture's bytes.
@@ -42,11 +42,21 @@ fn bench_extract(c: &mut Criterion) {
   for &name in FIXTURES {
     let bytes = fixture_bytes(name);
     ei.bench_function(format!("{name}/-j"), |b| {
-      b.iter(|| black_box(exifast::parser::extract_info(black_box(name), black_box(&bytes), true)));
+      b.iter(|| {
+        black_box(exifast::parser::extract_info(
+          black_box(name),
+          black_box(&bytes),
+          true,
+        ))
+      });
     });
     ei.bench_function(format!("{name}/-n"), |b| {
       b.iter(|| {
-        black_box(exifast::parser::extract_info(black_box(name), black_box(&bytes), false))
+        black_box(exifast::parser::extract_info(
+          black_box(name),
+          black_box(&bytes),
+          false,
+        ))
       });
     });
   }

--- a/benches/extract.rs
+++ b/benches/extract.rs
@@ -1,0 +1,73 @@
+//! Golden-v2 C4 — extraction throughput bench over the representative fixtures.
+//!
+//! Mirrors `tests/alloc_budget.rs`'s fixture set. The alloc-count harness is the
+//! load-bearing perf guard (allocation pressure is the indexer KPI); this bench
+//! tracks wall-clock so a CPU regression (an extra parse pass, an O(n²) scan)
+//! shows up in `cargo bench` too. Not wired into CI — a developer aid.
+
+use criterion::{criterion_group, Criterion};
+use std::hint::black_box;
+
+/// Read a fixture's bytes.
+fn fixture_bytes(name: &str) -> Vec<u8> {
+  let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+    .join("tests")
+    .join("fixtures")
+    .join(name);
+  std::fs::read(&path).unwrap_or_else(|e| panic!("read fixture {name}: {e}"))
+}
+
+const FIXTURES: &[&str] = &[
+  "MakerNotes_Apple.jpg",
+  "MakerNotes_Canon.jpg",
+  "ID3v2_4_big.mp3",
+  "QuickTime_frea_rexing17b.mov",
+];
+
+fn bench_extract(c: &mut Criterion) {
+  // `media_metadata` — detect + parse + project (mode-independent typed path).
+  let mut mm = c.benchmark_group("media_metadata");
+  for &name in FIXTURES {
+    let bytes = fixture_bytes(name);
+    mm.bench_function(name, |b| {
+      b.iter(|| black_box(exifast::media_metadata(black_box(&bytes))));
+    });
+  }
+  mm.finish();
+
+  // `extract_info` — the JSON render path, both modes (a MakerNote fixture
+  // decodes only the requested mode's vendor body after P0).
+  let mut ei = c.benchmark_group("extract_info");
+  for &name in FIXTURES {
+    let bytes = fixture_bytes(name);
+    ei.bench_function(format!("{name}/-j"), |b| {
+      b.iter(|| black_box(exifast::parser::extract_info(black_box(name), black_box(&bytes), true)));
+    });
+    ei.bench_function(format!("{name}/-n"), |b| {
+      b.iter(|| {
+        black_box(exifast::parser::extract_info(black_box(name), black_box(&bytes), false))
+      });
+    });
+  }
+  ei.finish();
+}
+
+criterion_group!(benches, bench_extract);
+
+// A hand-written `main` (instead of `criterion_main!`) so the harness is inert
+// under `cargo test --all-targets -- <args>`: that runs every target, including
+// this bench, passing libtest flags (`--skip gen_golden`) that criterion's
+// (default-features-trimmed) CLI parser rejects. `cargo bench` passes `--bench`;
+// `cargo test` does NOT — so when `--bench` is absent we exit 0 without touching
+// criterion's arg parser, keeping the conformance gate command working while
+// still running the real timing loop under `cargo bench`.
+fn main() {
+  if !std::env::args().any(|a| a == "--bench") {
+    // Invoked by `cargo test` (or `--list` etc.) — nothing to do; exit clean.
+    return;
+  }
+  // `criterion_group!`'s generated `benches()` builds a `Criterion` from the
+  // CLI args (here only `--bench`), runs every registered bench, and prints the
+  // final summary.
+  benches();
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+# Golden-v2 Contract 3b — cargo-fuzz (libFuzzer) targets for the public parse
+# entry points. This is a SEPARATE crate (not a workspace member of the root
+# `exifast` Cargo.toml, which declares no `[workspace]`), so the ordinary
+# `cargo build`/`cargo test` never compiles it. Run with a nightly toolchain:
+#   cargo +nightly fuzz run parse_bytes
+[package]
+name = "exifast-fuzz"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+exifast = { path = "..", features = ["std", "json", "all-formats"] }
+
+[[bin]]
+name = "parse_bytes"
+path = "fuzz_targets/parse_bytes.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "media_metadata"
+path = "fuzz_targets/media_metadata.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "parse_exif_block"
+path = "fuzz_targets/parse_exif_block.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/media_metadata.rs
+++ b/fuzz/fuzz_targets/media_metadata.rs
@@ -1,0 +1,5 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+fuzz_target!(|data: &[u8]| {
+    let _ = exifast::media_metadata(data);
+});

--- a/fuzz/fuzz_targets/parse_bytes.rs
+++ b/fuzz/fuzz_targets/parse_bytes.rs
@@ -1,0 +1,5 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+fuzz_target!(|data: &[u8]| {
+    let _ = exifast::parse_bytes(data);
+});

--- a/fuzz/fuzz_targets/parse_exif_block.rs
+++ b/fuzz/fuzz_targets/parse_exif_block.rs
@@ -1,0 +1,5 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+fuzz_target!(|data: &[u8]| {
+    let _ = exifast::parse_exif_block(data);
+});

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -128,15 +128,13 @@ pub(crate) fn run_emission<T: Taggable>(meta: &T, mode: ConvMode, out: &mut crat
     if e.unknown() {
       continue;
     }
-    let tag = e.into_tag();
-    // `write_value` is infallible (`Result<(), Infallible>`); the sink keys on
-    // the family-1 group (`exiftool:2948` — only family-1 reaches the `-G1`
-    // key) and owns the dedup.
-    let _ = out.write_value(
-      tag.group_ref().family1(),
-      tag.name(),
-      tag.value_ref().clone(),
-    );
+    // MOVE the value out of the owned `Tag` (P3 — no `value_ref().clone()`); the
+    // group + name are borrowed from the moved-out parts for the `write_value`
+    // call. `write_value` is infallible (`Result<(), Infallible>`); the sink
+    // keys on the family-1 group (`exiftool:2948` — only family-1 reaches the
+    // `-G1` key) and owns the dedup.
+    let (group, name, value) = e.into_tag().into_parts();
+    let _ = out.write_value(group.family1(), name.as_str(), value);
   }
 }
 

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -466,10 +466,7 @@ enum MakerNoteValueConvDecode<'a> {
   /// `%Main` route did not match — its PrintConv decode produced none either).
   None,
   /// Apple — `parse_with_print_conv(blob, order, ·)`.
-  Apple {
-    blob: &'a [u8],
-    order: ByteOrder,
-  },
+  Apple { blob: &'a [u8], order: ByteOrder },
   /// Canon — `parse_in_tiff(data, mn_offset, mn_len, order, ·, model, file_type)`.
   Canon {
     data: &'a [u8],

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -815,20 +815,19 @@ impl parser_sealed::Sealed for ProcessExif {}
 impl FormatParser for ProcessExif {
   type Meta<'a> = ExifMeta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
   /// Dispatched by [`crate::format_parser::any_parser_for`] when
   /// `File:FileType == "TIFF"` — the standalone-TIFF entry. Sets
   /// `tiff_type_is_tiff = true` so the multi-page `File:PageCount`
   /// synthesis (`ExifTool.pm:8756-8757`) is active.
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     // Direct standalone-TIFF lib entry: no candidate `Parent` context (the
     // engine path through `AnyParser::Exif` carries the real type via
     // `parse_standalone_tiff_with_base`), so `file_type = None`. A `.tif` is
     // never a CRW, so the ShotInfo pos-22 CRW clause is correctly off.
-    Ok(parse_tiff(
+    parse_tiff(
       data, /* tiff_type_is_tiff */ true, /* file_type */ None,
-    ))
+    )
   }
 }
 
@@ -836,16 +835,16 @@ impl FormatParser for ProcessExif {
 /// `TIFF_TYPE` is "TIFF" (`ExifTool.pm:8704`), so a multi-page TIFF emits
 /// `File:PageCount` (`ExifTool.pm:8757`).
 ///
-/// # Errors
-///
-/// Returns `Err` only for Rust-level fatal modes (none today — every bad
-/// input is `Ok(None)`, faithful to `DoProcessTIFF` `return 0`).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<ExifMeta<'_>>, Error> {
+/// Returns `None` when `data` is not a valid TIFF header (`DoProcessTIFF`
+/// `return 0`); a malformed TIFF surfaces its diagnostics as `Warn`/`Error`
+/// tags on the returned [`ExifMeta`], never as a fatal error.
+#[must_use]
+pub fn parse_borrowed(data: &[u8]) -> Option<ExifMeta<'_>> {
   // Direct standalone-TIFF lib entry — no candidate `Parent`, so `file_type =
   // None` (see [`ProcessExif::parse`]).
-  Ok(parse_tiff(
+  parse_tiff(
     data, /* tiff_type_is_tiff */ true, /* file_type */ None,
-  ))
+  )
 }
 
 /// **Reusable entry — the QuickTime/RIFF/MakerNotes seam.** Parse a raw
@@ -3817,18 +3816,6 @@ fn join_floats(vals: &[f64]) -> String {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for Exif/TIFF parsing. Currently empty — every bad
-/// input produces `Ok(None)` (faithful to `DoProcessTIFF` `return 0`) or is
-/// walked past silently (an unknown tag / format / out-of-range offset).
-/// Reserved for future I/O-fallible wrappers.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Unit tests
 // ===========================================================================
 
@@ -3860,7 +3847,7 @@ mod tests {
   #[test]
   fn rejects_short_buffer() {
     assert!(parse_exif_block(b"MM\0").is_none());
-    assert!(parse_borrowed(b"").unwrap().is_none());
+    assert!(parse_borrowed(b"").is_none());
   }
 
   #[test]
@@ -4236,7 +4223,7 @@ mod tests {
     t.extend_from_slice(&[0x00, 0x00, 0x00, 0x02]); // value = 2 (single page of multi-page)
     t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next IFD = 0
     // Standalone entry: emits `multi_page_count = Some(2)`.
-    let meta = parse_borrowed(&t).unwrap().expect("valid TIFF");
+    let meta = parse_borrowed(&t).expect("valid TIFF");
     assert_eq!(meta.multi_page_count(), Some(2));
     // Embedded entry on the same bytes: `multi_page_count = None` (the
     // `TIFF_TYPE == 'TIFF'` gate at ExifTool.pm:8757 is off).
@@ -4256,7 +4243,7 @@ mod tests {
     t.extend_from_slice(&[0x00, 0xfe, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01]); // SubfileType LONG count=1
     t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // value = 0 (full-resolution)
     t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next IFD = 0
-    let meta = parse_borrowed(&t).unwrap().expect("valid TIFF");
+    let meta = parse_borrowed(&t).expect("valid TIFF");
     assert_eq!(meta.multi_page_count(), None);
   }
 
@@ -4281,7 +4268,7 @@ mod tests {
     t.extend_from_slice(&[0x00, 0xff, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01]);
     t.extend_from_slice(&[0x00, 0x03, 0x00, 0x00]); // value SHORT=3
     t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next IFD = 0
-    let meta = parse_borrowed(&t).unwrap().expect("valid TIFF");
+    let meta = parse_borrowed(&t).expect("valid TIFF");
     assert_eq!(meta.multi_page_count(), Some(2));
   }
 
@@ -4302,7 +4289,7 @@ mod tests {
     t.extend_from_slice(&[0x00, 0xfe, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01]);
     t.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
     t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
-    let meta = parse_borrowed(&t).unwrap().expect("valid TIFF");
+    let meta = parse_borrowed(&t).expect("valid TIFF");
     assert_eq!(meta.multi_page_count(), None);
   }
 

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -446,6 +446,213 @@ enum ResolvedConv {
 // MakerNote capture — the deferred-vendor-parsing seam
 // ===========================================================================
 
+/// How to recompute a captured MakerNote's `-n` (ValueConv) vendor emissions on
+/// demand — Golden-v2 P0 single-mode decode. The eager walk decodes each vendor
+/// body ONCE (PrintConv), keeping the typed slot + the PrintConv emissions; this
+/// captures the per-vendor decode INPUTS so the (rarely-needed) `-n` emissions
+/// can be re-derived only when asked, instead of eagerly decoding the body a
+/// second time and caching a result the `-j`/typed path never reads.
+///
+/// All inputs are `Copy` (the borrowed parent slice `&'a [u8]`, offsets, byte
+/// order, `BaseRule`) or cheap owned `SmolStr` (the captured Make/Model/FileType,
+/// which the walker owns and drops — so they must be retained here). Each
+/// variant mirrors the eager PrintConv decode's call at the walk site; the
+/// vendor decoders are deterministic across the PrintConv flag (the gated ones
+/// route identically), so [`Self::recompute`] yields the SAME emissions the old
+/// eager `-n` cache held.
+#[derive(Debug, Clone)]
+enum MakerNoteValueConvDecode<'a> {
+  /// No `-n` emissions (vendor has no body parser yet, or a gated vendor whose
+  /// `%Main` route did not match — its PrintConv decode produced none either).
+  None,
+  /// Apple — `parse_with_print_conv(blob, order, ·)`.
+  Apple {
+    blob: &'a [u8],
+    order: ByteOrder,
+  },
+  /// Canon — `parse_in_tiff(data, mn_offset, mn_len, order, ·, model, file_type)`.
+  Canon {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    order: ByteOrder,
+    model: Option<smol_str::SmolStr>,
+    file_type: Option<smol_str::SmolStr>,
+  },
+  /// Sony — `parse_main_gated(data, mn_offset, mn_len, body_off, order, ·, make, model)`.
+  Sony {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    body_off: usize,
+    order: ByteOrder,
+    make: Option<smol_str::SmolStr>,
+    model: Option<smol_str::SmolStr>,
+  },
+  /// Panasonic — `parse_main_gated(data, mn_offset, mn_len, order, ·, model, base_rule)`.
+  Panasonic {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    order: ByteOrder,
+    model: Option<smol_str::SmolStr>,
+    base_rule: makernotes::BaseRule,
+  },
+  /// Leica1 — `parse_leica1_gated(data, mn_offset, mn_len, body_off, order, ·, make, model)`.
+  Leica1 {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    body_off: usize,
+    order: ByteOrder,
+    make: Option<smol_str::SmolStr>,
+    model: Option<smol_str::SmolStr>,
+  },
+  /// Leica10 — `parse_leica10_gated(data, mn_offset, mn_len, body_off, order, ·, model)`.
+  Leica10 {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    body_off: usize,
+    order: ByteOrder,
+    model: Option<smol_str::SmolStr>,
+  },
+  /// DJI — `parse_in_tiff(data, mn_offset, mn_len, order, ·)`.
+  Dji {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    order: ByteOrder,
+  },
+}
+
+#[cfg(feature = "alloc")]
+impl MakerNoteValueConvDecode<'_> {
+  /// Re-run the vendor decoder for `-n` (ValueConv) and return its emissions.
+  /// The gated variants `.expect(...)` a `Some` result — faithful to the eager
+  /// walk's invariant that a route which matched in PrintConv matches in
+  /// ValueConv too (same gate, PrintConv-independent).
+  #[must_use]
+  fn recompute(&self) -> std::vec::Vec<makernotes::VendorEmission> {
+    use makernotes::vendors::{apple, canon, dji, panasonic, sony};
+    match self {
+      MakerNoteValueConvDecode::None => std::vec::Vec::new(),
+      MakerNoteValueConvDecode::Apple { blob, order } => {
+        apple::parse_with_print_conv(blob, *order, false).1
+      }
+      MakerNoteValueConvDecode::Canon {
+        data,
+        mn_offset,
+        mn_len,
+        order,
+        model,
+        file_type,
+      } => {
+        canon::parse_in_tiff(
+          data,
+          *mn_offset,
+          *mn_len,
+          *order,
+          false,
+          model.as_deref(),
+          file_type.as_deref(),
+        )
+        .1
+      }
+      MakerNoteValueConvDecode::Sony {
+        data,
+        mn_offset,
+        mn_len,
+        body_off,
+        order,
+        make,
+        model,
+      } => {
+        sony::parse_main_gated(
+          data,
+          *mn_offset,
+          *mn_len,
+          *body_off,
+          *order,
+          false,
+          make.as_deref(),
+          model.as_deref(),
+        )
+        .expect("routes_to_main is deterministic across print_conv")
+        .1
+      }
+      MakerNoteValueConvDecode::Panasonic {
+        data,
+        mn_offset,
+        mn_len,
+        order,
+        model,
+        base_rule,
+      } => {
+        panasonic::parse_main_gated(
+          data,
+          *mn_offset,
+          *mn_len,
+          *order,
+          false,
+          model.as_deref(),
+          *base_rule,
+        )
+        .expect("routes_to_main is deterministic across print_conv")
+        .1
+      }
+      MakerNoteValueConvDecode::Leica1 {
+        data,
+        mn_offset,
+        mn_len,
+        body_off,
+        order,
+        make,
+        model,
+      } => {
+        panasonic::parse_leica1_gated(
+          data,
+          *mn_offset,
+          *mn_len,
+          *body_off,
+          *order,
+          false,
+          make.as_deref(),
+          model.as_deref(),
+        )
+        .expect("routes_to_leica1 is deterministic across print_conv")
+        .1
+      }
+      MakerNoteValueConvDecode::Leica10 {
+        data,
+        mn_offset,
+        mn_len,
+        body_off,
+        order,
+        model,
+      } => {
+        panasonic::parse_leica10_gated(
+          data,
+          *mn_offset,
+          *mn_len,
+          *body_off,
+          *order,
+          false,
+          model.as_deref(),
+        )
+        .expect("routes_to_leica10 is deterministic across print_conv")
+        .1
+      }
+      MakerNoteValueConvDecode::Dji {
+        data,
+        mn_offset,
+        mn_len,
+        order,
+      } => dji::parse_in_tiff(data, *mn_offset, *mn_len, *order, false).1,
+    }
+  }
+}
+
 /// The raw MakerNote (0x927c) blob captured by the Exif walker, together
 /// with the Phase-1 dispatch outcome (vendor identification +
 /// `SubDirectory` directives — see [`makernotes::dispatch`]).
@@ -474,11 +681,22 @@ pub struct MakerNote<'a> {
   /// plus the `Unknown => 1` flag (the emission engine suppresses the
   /// Unknown ones; the legacy `serialize_tags` path filters them on read).
   /// Computed once at walk time so the serializer doesn't need to
-  /// re-resolve out-of-line offsets against the TIFF block.
+  /// re-resolve out-of-line offsets against the TIFF block. The PrintConv
+  /// decode ALSO yields the typed vendor [`MakerNotesMeta`] slot, which the
+  /// domain projection / dispatch tests read, so it stays EAGER.
   cached_emissions_print_conv: std::vec::Vec<makernotes::VendorEmission>,
-  /// Same as [`cached_emissions_print_conv`] but for `-n` (post-
-  /// ValueConv raw) mode.
-  cached_emissions_value_conv: std::vec::Vec<makernotes::VendorEmission>,
+  /// How to recompute the `-n` (post-ValueConv raw) emissions ON DEMAND —
+  /// Golden-v2 P0 single-mode decode. The eager walk decodes the vendor body
+  /// ONCE (PrintConv, above); the ValueConv emissions are needed only by the
+  /// `-n` serialize path, so instead of eagerly decoding the body a SECOND
+  /// time and caching the result (one wasted decode per parse — `-j`/the typed
+  /// API never reads it), this captures the decode INPUTS (the borrowed parent
+  /// slice + offsets/order/model/… — all `Copy` or cheap owned `SmolStr`s) and
+  /// re-runs the vendor decoder for `-n` only when [`emissions_value_conv`] is
+  /// actually called. The vendor decoders are deterministic across the
+  /// PrintConv flag (the gated ones route identically), so the recomputed `-n`
+  /// emissions are byte-identical to the old eager cache.
+  value_conv_decode: MakerNoteValueConvDecode<'a>,
   /// The FAMILY-1 group under which the cached emissions serialize. Almost
   /// always [`Vendor::group1()`](makernotes::Vendor::group1) of
   /// [`Self::vendor`] (`Apple`/`Canon`/`Sony`/`Panasonic`), but the
@@ -572,11 +790,19 @@ impl<'a> MakerNote<'a> {
     &self.cached_emissions_print_conv
   }
 
-  /// `-n` mode emissions.
+  /// The Phase-2 vendor emissions in `-n` (post-ValueConv raw) mode, decoded ON
+  /// DEMAND (Golden-v2 P0). Unlike [`Self::emissions_print_conv`] (eagerly
+  /// cached because the PrintConv decode also yields the typed vendor slot),
+  /// the `-n` emissions are re-derived from the stored decode inputs only when
+  /// this is called — so a `-j`/typed-only consumer never pays the second
+  /// vendor-body decode. Returns an OWNED `Vec` (the result is freshly built).
+  /// Byte-identical to the old eager `-n` cache (the vendor decoders are
+  /// deterministic across the PrintConv flag). Empty for vendors with no body
+  /// parser yet (Phase 3/4) and for a gated vendor whose `%Main` route did not
+  /// match (its PrintConv decode produced no emissions either).
   #[must_use]
-  #[inline(always)]
-  pub fn emissions_value_conv(&self) -> &[makernotes::VendorEmission] {
-    &self.cached_emissions_value_conv
+  pub fn emissions_value_conv(&self) -> std::vec::Vec<makernotes::VendorEmission> {
+    self.value_conv_decode.recompute()
   }
 
   /// The FAMILY-1 group under which the cached emissions serialize. Equal to
@@ -2195,14 +2421,17 @@ impl Walker<'_, '_> {
               self.captured_model.as_deref(),
               None,
             );
-            // Phase 2: parse Apple/Canon vendor bodies here. The walker
-            // pre-computes BOTH PrintConv (-j) and ValueConv (-n)
-            // emissions while it still has access to the parent TIFF
-            // block (Canon's out-of-line value offsets resolve against
-            // the parent TIFF block, not the captured blob).
+            // Phase 2: parse the Apple/Canon/Sony/Panasonic/Leica/DJI vendor
+            // body here. P0 single-mode decode: the walker decodes the body
+            // ONCE for PrintConv (-j) — yielding the typed slot + the cached
+            // PrintConv emissions — and records the decode INPUTS needed to
+            // re-derive the ValueConv (-n) emissions on demand (instead of
+            // eagerly decoding the body a second time). The decode runs here so
+            // out-of-line value offsets resolve against the parent TIFF block
+            // (Canon/Sony/Panasonic), not the captured blob.
             let mut meta = makernotes::MakerNotesMeta::from_detected(detected);
             let mut cached_pc = std::vec::Vec::<makernotes::VendorEmission>::new();
-            let mut cached_vc = std::vec::Vec::<makernotes::VendorEmission>::new();
+            let mut value_conv_decode = MakerNoteValueConvDecode::None;
             // The family-1 group for the cached emissions. Defaults to the
             // dispatched vendor's `group1()`; the cross-table Leica10 arm
             // below overrides it to `"Panasonic"` (its tags ARE
@@ -2217,11 +2446,12 @@ impl Walker<'_, '_> {
                 // faithful here.
                 let (typed_pc, emi_pc) =
                   makernotes::vendors::apple::parse_with_print_conv(bytes, self.order, true);
-                let (_typed_vc, emi_vc) =
-                  makernotes::vendors::apple::parse_with_print_conv(bytes, self.order, false);
                 meta.set_apple(typed_pc);
                 cached_pc = emi_pc;
-                cached_vc = emi_vc;
+                value_conv_decode = MakerNoteValueConvDecode::Apple {
+                  blob: bytes,
+                  order: self.order,
+                };
               }
               makernotes::Vendor::Canon => {
                 // Canon: parse using the parent TIFF context so
@@ -2235,12 +2465,16 @@ impl Walker<'_, '_> {
                 let (typed_pc, emi_pc) = makernotes::vendors::canon::parse_in_tiff(
                   self.data, mn_offset, mn_len, self.order, true, model, file_type,
                 );
-                let (_typed_vc, emi_vc) = makernotes::vendors::canon::parse_in_tiff(
-                  self.data, mn_offset, mn_len, self.order, false, model, file_type,
-                );
                 meta.set_canon(typed_pc);
                 cached_pc = emi_pc;
-                cached_vc = emi_vc;
+                value_conv_decode = MakerNoteValueConvDecode::Canon {
+                  data: self.data,
+                  mn_offset,
+                  mn_len,
+                  order: self.order,
+                  model: model.map(smol_str::SmolStr::new),
+                  file_type: file_type.map(smol_str::SmolStr::new),
+                };
               }
               // Sony: dispatcher gives us body_offset (12 for the
               // SONY DSC/CAM/MOBILE/VHAB/TF1 variants, 0 for headerless
@@ -2279,13 +2513,17 @@ impl Walker<'_, '_> {
                 if let Some((typed_pc, emi_pc)) = makernotes::vendors::sony::parse_main_gated(
                   self.data, mn_offset, mn_len, body_off, self.order, true, make, model,
                 ) {
-                  let (_typed_vc, emi_vc) = makernotes::vendors::sony::parse_main_gated(
-                    self.data, mn_offset, mn_len, body_off, self.order, false, make, model,
-                  )
-                  .expect("routes_to_main is deterministic across print_conv");
                   meta.set_sony(typed_pc);
                   cached_pc = emi_pc;
-                  cached_vc = emi_vc;
+                  value_conv_decode = MakerNoteValueConvDecode::Sony {
+                    data: self.data,
+                    mn_offset,
+                    mn_len,
+                    body_off,
+                    order: self.order,
+                    make: make.map(smol_str::SmolStr::new),
+                    model: model.map(smol_str::SmolStr::new),
+                  };
                 }
               }
               // Panasonic has THREE dispatch variants (`MakerNotes.pm:
@@ -2316,13 +2554,16 @@ impl Walker<'_, '_> {
                 if let Some((typed_pc, emi_pc)) = makernotes::vendors::panasonic::parse_main_gated(
                   self.data, mn_offset, mn_len, self.order, true, model, base_rule,
                 ) {
-                  let (_typed_vc, emi_vc) = makernotes::vendors::panasonic::parse_main_gated(
-                    self.data, mn_offset, mn_len, self.order, false, model, base_rule,
-                  )
-                  .expect("routes_to_main is deterministic across print_conv");
                   meta.set_panasonic(typed_pc);
                   cached_pc = emi_pc;
-                  cached_vc = emi_vc;
+                  value_conv_decode = MakerNoteValueConvDecode::Panasonic {
+                    data: self.data,
+                    mn_offset,
+                    mn_len,
+                    order: self.order,
+                    model: model.map(smol_str::SmolStr::new),
+                    base_rule,
+                  };
                 }
               }
               // Leica — cross-vendor routing. The dispatcher collapses all
@@ -2373,29 +2614,46 @@ impl Walker<'_, '_> {
                 let leica1 = makernotes::vendors::panasonic::parse_leica1_gated(
                   self.data, mn_offset, mn_len, body_off, self.order, true, make, model,
                 );
+                // P0: capture which Leica route matched (Leica1 vs Leica10) so
+                // the `-n` emissions are re-derived through the SAME gated
+                // parser. The PrintConv decode determines the route; ValueConv
+                // is deferred to that route's `recompute`.
                 let parsed = match leica1 {
-                  Some((typed_pc, emi_pc)) => {
-                    let (_typed_vc, emi_vc) = makernotes::vendors::panasonic::parse_leica1_gated(
-                      self.data, mn_offset, mn_len, body_off, self.order, false, make, model,
-                    )
-                    .expect("routes_to_leica1 is deterministic across print_conv");
-                    Some((typed_pc, emi_pc, emi_vc))
-                  }
+                  Some((typed_pc, emi_pc)) => Some((
+                    typed_pc,
+                    emi_pc,
+                    MakerNoteValueConvDecode::Leica1 {
+                      data: self.data,
+                      mn_offset,
+                      mn_len,
+                      body_off,
+                      order: self.order,
+                      make: make.map(smol_str::SmolStr::new),
+                      model: model.map(smol_str::SmolStr::new),
+                    },
+                  )),
                   None => makernotes::vendors::panasonic::parse_leica10_gated(
                     self.data, mn_offset, mn_len, body_off, self.order, true, model,
                   )
                   .map(|(typed_pc, emi_pc)| {
-                    let (_typed_vc, emi_vc) = makernotes::vendors::panasonic::parse_leica10_gated(
-                      self.data, mn_offset, mn_len, body_off, self.order, false, model,
+                    (
+                      typed_pc,
+                      emi_pc,
+                      MakerNoteValueConvDecode::Leica10 {
+                        data: self.data,
+                        mn_offset,
+                        mn_len,
+                        body_off,
+                        order: self.order,
+                        model: model.map(smol_str::SmolStr::new),
+                      },
                     )
-                    .expect("routes_to_leica10 is deterministic across print_conv");
-                    (typed_pc, emi_pc, emi_vc)
                   }),
                 };
-                if let Some((typed_pc, emi_pc, emi_vc)) = parsed {
+                if let Some((typed_pc, emi_pc, vc_decode)) = parsed {
                   meta.set_panasonic(typed_pc);
                   cached_pc = emi_pc;
-                  cached_vc = emi_vc;
+                  value_conv_decode = vc_decode;
                   // Both the Leica1 and Leica10 tags ARE `%Panasonic::Main`
                   // tags ⇒ bundled emits them under the `Panasonic` family-1
                   // group.
@@ -2412,12 +2670,14 @@ impl Walker<'_, '_> {
                 let (typed_pc, emi_pc) = makernotes::vendors::dji::parse_in_tiff(
                   self.data, mn_offset, mn_len, self.order, true,
                 );
-                let (_typed_vc, emi_vc) = makernotes::vendors::dji::parse_in_tiff(
-                  self.data, mn_offset, mn_len, self.order, false,
-                );
                 meta.set_dji(typed_pc);
                 cached_pc = emi_pc;
-                cached_vc = emi_vc;
+                value_conv_decode = MakerNoteValueConvDecode::Dji {
+                  data: self.data,
+                  mn_offset,
+                  mn_len,
+                  order: self.order,
+                };
               }
               _ => {}
             }
@@ -2425,7 +2685,7 @@ impl Walker<'_, '_> {
               bytes,
               meta,
               cached_emissions_print_conv: cached_pc,
-              cached_emissions_value_conv: cached_vc,
+              value_conv_decode,
               emission_group1,
             });
           }
@@ -2684,19 +2944,25 @@ impl ExifMeta<'_> {
     // `Panasonic` for the cross-table Leica10 route); other vendors fall back
     // to `"MakerNotes"` and emit nothing here yet (empty cached emissions).
     let group1 = mn.emission_group1();
-    let emissions = if print_conv {
-      mn.emissions_print_conv()
-    } else {
-      mn.emissions_value_conv()
+    // `-j` reads the eagerly-cached PrintConv emissions (borrowed); `-n` decodes
+    // the vendor body ONCE on demand (P0 — owned `Vec`). A shared push folds
+    // either slice into `out`.
+    let push = |out: &mut std::vec::Vec<crate::emit::EmittedTag>,
+                emissions: &[makernotes::VendorEmission]| {
+      out.reserve(emissions.len());
+      for e in emissions {
+        out.push(crate::emit::EmittedTag::new(
+          crate::value::Group::new("MakerNotes", group1),
+          smol_str::SmolStr::new(e.name()),
+          e.value().clone(),
+          e.unknown(),
+        ));
+      }
     };
-    out.reserve(emissions.len());
-    for e in emissions {
-      out.push(crate::emit::EmittedTag::new(
-        crate::value::Group::new("MakerNotes", group1),
-        smol_str::SmolStr::new(e.name()),
-        e.value().clone(),
-        e.unknown(),
-      ));
+    if print_conv {
+      push(out, mn.emissions_print_conv());
+    } else {
+      push(out, &mn.emissions_value_conv());
     }
   }
 }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -2631,27 +2631,25 @@ fn sub_dir_for(tag_id: u16, kind: IfdKind) -> Option<SubDirKind> {
 
 #[cfg(feature = "alloc")]
 impl ExifMeta<'_> {
-  /// Render this `ExifMeta`'s EXIF/GPS [`ExifEntry`] tags into a
-  /// [`Vec<EmittedTag>`](crate::emit::EmittedTag) for the requested
-  /// [`ConvMode`](crate::emit::ConvMode) — the golden-pattern parallel to the
-  /// `emit_entry` loop in [`serialize_tags`](Self::serialize_tags).
+  /// Push this `ExifMeta`'s EXIF/GPS [`ExifEntry`] tags into `out` for the
+  /// requested [`ConvMode`](crate::emit::ConvMode) — the golden-pattern parallel
+  /// to the `emit_entry` loop in [`serialize_tags`](Self::serialize_tags).
   ///
   /// Each entry is converted by the SAME `emit_entry`/`emit_exif_value`/
   /// `emit_gps_value` logic the production path uses, but written into an
   /// [`EmittedTagSink`] (which produces the identical [`TagValue`]) instead of
-  /// the [`TagMap`](crate::tagmap::TagMap). The result carries
+  /// the [`TagMap`](crate::tagmap::TagMap). The pushed tags carry
   /// `Group{family0:"EXIF", family1:<IfdName>}`, `unknown:false`.
   ///
-  /// **EXIF entries only**: the `File:ExifByteOrder` and `File:PageCount` tags
-  /// are prepended by [`tags`](crate::emit::Taggable::tags) (not here), and the
-  /// `ExifTool:Warning` messages stay a separate channel drained by
-  /// `AnyMeta::drain_diagnostics`. The MakerNote vendor emissions are appended
-  /// separately by [`tags`](crate::emit::Taggable::tags) via
-  /// [`push_maker_note_tags`](Self::push_maker_note_tags). So this is the
-  /// EXIF (`IFD0`/`ExifIFD`/`GPS`/`IFD1`/…) tag stream.
-  #[must_use]
-  fn emitted_exif_tags(&self, print_conv: bool) -> std::vec::Vec<crate::emit::EmittedTag> {
-    let mut sink = EmittedTagSink::new();
+  /// Writes DIRECTLY into the caller's `out` buffer (P2 — no per-call temp `Vec`
+  /// that [`tags`](crate::emit::Taggable::tags) then has to move). **EXIF
+  /// entries only**: the `File:ExifByteOrder`/`File:PageCount` prefix + the
+  /// MakerNote vendor emissions are pushed by [`tags`](crate::emit::Taggable::tags)
+  /// into the SAME `out`; the `ExifTool:Warning` messages stay a separate channel
+  /// drained by `AnyMeta::drain_diagnostics`.
+  fn push_exif_tags(&self, print_conv: bool, out: &mut std::vec::Vec<crate::emit::EmittedTag>) {
+    out.reserve(self.entries.len());
+    let mut sink = EmittedTagSink::new(out);
     // The byte order threaded to `emit_entry` for `ConvertExifText`'s UTF-16
     // 'Unknown' guess — identical to `serialize_tags`'s `entry_order`. `None`
     // only for a JPEG accepted without a parsed Exif block, which then has NO
@@ -2662,7 +2660,6 @@ impl ExifMeta<'_> {
       // `emit_entry` into the `EmittedTagSink` is infallible (`Infallible`).
       let Ok(()) = emit_entry(entry, entry_order, print_conv, &mut sink);
     }
-    sink.tags
   }
 
   /// Append the captured MakerNote's cached vendor emissions to `out` as
@@ -2771,7 +2768,7 @@ impl crate::emit::Taggable for ExifMeta<'_> {
         false,
       ));
     }
-    tags.append(&mut self.emitted_exif_tags(print_conv));
+    self.push_exif_tags(print_conv, &mut tags);
     self.push_maker_note_tags(print_conv, &mut tags);
     tags.into_iter()
   }
@@ -2907,19 +2904,21 @@ impl ExifSink for crate::tagmap::TagMap {
 /// Drives [`ExifMeta::tags`]; the engine ([`run_emission`](crate::emit::run_emission))
 /// then applies Unknown-suppression (a no-op here) + the sink dedup.
 #[cfg(feature = "alloc")]
-struct EmittedTagSink {
-  /// The collected EXIF [`EmittedTag`]s, in emission order.
-  tags: std::vec::Vec<crate::emit::EmittedTag>,
+struct EmittedTagSink<'v> {
+  /// The destination [`EmittedTag`] buffer (borrowed) — the EXIF emitters push
+  /// in emission order. Borrowing (rather than owning) lets [`ExifMeta::tags`]
+  /// fill ONE `Vec` in place (the `File:ExifByteOrder`/`PageCount` prefix, the
+  /// IFD entries via this sink, and the MakerNote vendor tags), eliminating the
+  /// per-call temp `Vec` the EXIF-entry pass used to allocate + move (P2).
+  tags: &'v mut std::vec::Vec<crate::emit::EmittedTag>,
 }
 
 #[cfg(feature = "alloc")]
-impl EmittedTagSink {
-  /// An empty collector.
+impl<'v> EmittedTagSink<'v> {
+  /// Wrap a destination buffer.
   #[inline(always)]
-  const fn new() -> Self {
-    Self {
-      tags: std::vec::Vec::new(),
-    }
+  fn new(tags: &'v mut std::vec::Vec<crate::emit::EmittedTag>) -> Self {
+    Self { tags }
   }
 
   /// Push one rendered [`EmittedTag`] — `Group{family0:"EXIF", family1:group}`,
@@ -2936,7 +2935,7 @@ impl EmittedTagSink {
 }
 
 #[cfg(feature = "alloc")]
-impl ExifSink for EmittedTagSink {
+impl ExifSink for EmittedTagSink<'_> {
   #[inline(always)]
   fn write_str(
     &mut self,

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -40,12 +40,15 @@ pub(crate) mod parser_sealed {
 /// formats take a richer struct with shared mutable state), and `Error`.
 ///
 /// `parse` returns:
-/// - `Ok(Some(meta))` — this is the format; here are the tags. (Perl `return 1`)
-/// - `Ok(None)`       — not this format, try the next detection candidate.
+/// - `Some(meta)` — this is the format; here are the tags. (Perl `return 1`)
+/// - `None`       — not this format, try the next detection candidate.
 ///   (Perl `return 0`)
-/// - `Err(e)`         — Rust-level fatal (not Perl-modeled — Perl uses
-///   `$et->Warn`/`$et->Error` which are recorded as tags in `Meta` regardless
-///   of return).
+///
+/// There is no fallible variant: every ported format models a malformed
+/// input as either a rejected candidate (`None`) or a `Meta` carrying a
+/// `Warn`/`Error` tag (Perl `$et->Warn`/`$et->Error` are recorded as tags
+/// in `Meta` regardless of return) — never a Rust-level `Err`. The contract
+/// is therefore `Option`, not `Result` (Golden-v2 §4).
 ///
 /// IMPORTANT: side effects on the shared [`SharedFlags`] (held inside the
 /// per-format `Context`) PERSIST regardless of return value, faithful to
@@ -84,15 +87,11 @@ pub trait FormatParser: parser_sealed::Sealed {
   type Context<'a>
   where
     Self: 'a;
-  /// Rust-level fatal error (distinct from Perl `Warn`/`Error` tags, which
-  /// belong to `Meta` and surface through the typed `serialize_tags` emission
-  /// into [`crate::tagmap::TagMap`]).
-  type Error;
 
   /// Run the parser on a per-format `Context`. The returned `Meta<'a>`
   /// borrows from the same `'a` as the input `Context`. See trait docs for
   /// return value semantics.
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Self::Error>;
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>>;
 }
 
 /// Cross-format shared state. Threaded through chained parsers
@@ -1713,151 +1712,6 @@ const _: () = {
   }
 };
 
-// ===========================================================================
-// AnyError — closed-set error from `AnyParser::parse_any` + `parse_bytes`
-// ===========================================================================
-
-/// Aggregate Rust-level fatal error from the closed [`AnyParser`] dispatch.
-///
-/// One variant wraps each format's [`FormatParser::Error`]; conversions
-/// from the per-format `XxxError` types are provided via `From` impls so
-/// the per-arm dispatch in [`AnyParser::parse_any`] can write
-/// `.map_err(Into::into)`.
-///
-/// Most format errors today are uninhabited (no variants — see e.g.
-/// [`crate::formats::moi::Error`]); the `From` impls for those formats
-/// translate into unreachable matches that `rustc` constant-folds out at
-/// monomorphization. The structure exists so future I/O-fallible parsers
-/// can add fatal modes without changing the public `AnyError` shape.
-///
-/// `#[non_exhaustive]` matches [`AnyParser`] / [`AnyMeta`]: consumers
-/// cannot exhaustively match on this enum across crate-feature combos —
-/// new format arms (or new variants on existing errors) are additive
-/// within the crate, but no caller can rely on a fixed set.
-///
-/// §5: derived via `thiserror` (`Display` + `core::error::Error`, no-std
-/// clean — was a `std`-only hand-written `impl std::error::Error`). Each
-/// wrapped source is `#[from]` (which implies `#[source]`): thiserror
-/// generates the per-arm `From<XxxError>` conversion AND threads the wrapped
-/// error through `source()`, so the dispatch in [`AnyParser::parse_any`] can
-/// write `.map_err(Into::into)` for free. This was a Wave-1 forward item: it
-/// became possible once the Wave-2 sweep gave every format error a
-/// `#[derive(thiserror::Error)]` `core::error::Error` impl in all feature
-/// tiers (the `#[from]`-implied `XxxError: core::error::Error` bound is now
-/// satisfied unconditionally, not just under `std`). `#[from]` works even on
-/// the uninhabited (empty-enum) format errors — thiserror emits a
-/// `From<Empty>` whose body is type-correct but never callable, which `rustc`
-/// constant-folds out at monomorphization.
-#[non_exhaustive]
-#[derive(Debug, Clone, thiserror::Error)]
-pub enum AnyError {
-  /// MOI fatal-error wrapper.
-  #[cfg(feature = "moi")]
-  #[error("MOI: {0}")]
-  Moi(#[from] crate::formats::moi::Error),
-  /// AAC fatal-error wrapper.
-  #[cfg(feature = "aac")]
-  #[error("AAC: {0}")]
-  Aac(#[from] crate::formats::aac::Error),
-  /// DV fatal-error wrapper.
-  #[cfg(feature = "dv")]
-  #[error("DV: {0}")]
-  Dv(#[from] crate::formats::dv::Error),
-  /// Audible (AA) fatal-error wrapper.
-  #[cfg(feature = "audible")]
-  #[error("AA: {0}")]
-  Aa(#[from] crate::formats::audible::Error),
-  /// Canon CRW fatal-error wrapper.
-  #[cfg(feature = "crw")]
-  #[error("CRW: {0}")]
-  Crw(#[from] crate::formats::crw::Error),
-  /// Red R3D fatal-error wrapper.
-  #[cfg(feature = "red")]
-  #[error("R3D: {0}")]
-  R3d(#[from] crate::formats::red::Error),
-  /// ID3 fatal-error wrapper.
-  #[cfg(feature = "id3")]
-  #[error("ID3: {0}")]
-  Id3(#[from] crate::formats::id3::Id3Error),
-  /// MP3 fatal-error wrapper.
-  #[cfg(feature = "mp3")]
-  #[error("MP3: {0}")]
-  Mp3(#[from] crate::formats::id3::Mp3Error),
-  /// AIFF fatal-error wrapper.
-  #[cfg(feature = "aiff")]
-  #[error("AIFF: {0}")]
-  Aiff(#[from] crate::formats::aiff::Error),
-  /// APE fatal-error wrapper.
-  #[cfg(feature = "ape")]
-  #[error("APE: {0}")]
-  Ape(#[from] crate::formats::ape::Error),
-  /// DSF fatal-error wrapper.
-  #[cfg(feature = "dsf")]
-  #[error("DSF: {0}")]
-  Dsf(#[from] crate::formats::dsf::Error),
-  /// FLAC fatal-error wrapper.
-  #[cfg(feature = "flac")]
-  #[error("FLAC: {0}")]
-  Flac(#[from] crate::formats::flac::Error),
-  /// H264 fatal-error wrapper.
-  #[cfg(feature = "h264")]
-  #[error("H264: {0}")]
-  H264(#[from] crate::formats::h264::H264Error),
-  /// Flash FLV fatal-error wrapper.
-  #[cfg(feature = "flash")]
-  #[error("FLV: {0}")]
-  Flv(#[from] crate::formats::flash::Error),
-  /// Ogg fatal-error wrapper.
-  #[cfg(feature = "ogg")]
-  #[error("OGG: {0}")]
-  Ogg(#[from] crate::formats::ogg::Error),
-  /// PNG fatal-error wrapper.
-  #[cfg(feature = "png")]
-  #[error("PNG: {0}")]
-  Png(#[from] crate::formats::png::Error),
-  /// Real (RM/RA/RAM/RPM) fatal-error wrapper.
-  #[cfg(feature = "real")]
-  #[error("Real: {0}")]
-  Real(#[from] crate::formats::real::RealError),
-  /// MPEG audio fatal-error wrapper.
-  #[cfg(feature = "mpeg-audio")]
-  #[error("MPEG-audio: {0}")]
-  MpegAudio(#[from] crate::formats::mpeg::AudioError),
-  /// MPC fatal-error wrapper.
-  #[cfg(feature = "mpc")]
-  #[error("MPC: {0}")]
-  Mpc(#[from] crate::formats::mpc::Error),
-  /// WavPack fatal-error wrapper.
-  #[cfg(feature = "wavpack")]
-  #[error("WV: {0}")]
-  Wv(#[from] crate::formats::wavpack::Error),
-  /// Matroska fatal-error wrapper.
-  #[cfg(feature = "matroska")]
-  #[error("Matroska: {0}")]
-  Matroska(#[from] crate::formats::matroska::Error),
-  /// QuickTime fatal-error wrapper.
-  #[cfg(feature = "quicktime")]
-  #[error("QuickTime: {0}")]
-  QuickTime(#[from] crate::formats::quicktime::Error),
-  /// MXF fatal-error wrapper.
-  #[cfg(feature = "mxf")]
-  #[error("MXF: {0}")]
-  Mxf(#[from] crate::formats::mxf::MxfError),
-  /// PLIST fatal-error wrapper.
-  #[cfg(feature = "plist")]
-  #[error("PLIST: {0}")]
-  Plist(#[from] crate::formats::plist::Error),
-  /// Exif/TIFF fatal-error wrapper.
-  #[cfg(feature = "exif")]
-  #[error("Exif: {0}")]
-  Exif(#[from] crate::exif::Error),
-  /// RIFF fatal-error wrapper. Currently empty (every bad input is `Ok(None)`)
-  /// but kept for thiserror-`From` symmetry with the other formats.
-  #[cfg(feature = "riff")]
-  #[error("RIFF: {0}")]
-  Riff(#[from] crate::formats::riff::RiffError),
-}
-
 // R3 F1: the bespoke `id3v2_prefix_end` helper has been removed. The
 // previous dispatch arm computed an ID3v2-header offset, skipped past the
 // prefix, and reparsed the OGG body — but never emitted the ID3 directory
@@ -1899,13 +1753,11 @@ impl AnyParser {
   /// (bundled's `TIFF_TYPE eq 'TIFF'`, `ExifTool.pm:8715`/`:8767`); every other
   /// arm ignores it. `None` ⇒ gate off (no synthesized PageCount).
   ///
-  /// # Errors
-  ///
-  /// Returns [`AnyError`] when the dispatched per-format parser raises a
-  /// Rust-level fatal. Most ported formats today have no fatal modes
-  /// (uninhabited `XxxError` enums), so the `Err` branch is unreachable
-  /// in practice; the structure is in place for future I/O-fallible
-  /// parsers.
+  /// Returns `Some(meta)` for the first parser that accepts `bytes`, or
+  /// `None` to reject this candidate. No ported format has a Rust-level
+  /// fatal mode — a malformed input is either rejected (`None`) or accepted
+  /// with a `Warn`/`Error` tag recorded in the `Meta` — so the contract is
+  /// `Option`, not `Result` (Golden-v2 §4).
   ///
   /// `ext` borrows on an INDEPENDENT (elided) lifetime — distinct from
   /// `bytes`. Only `bytes` drives the returned `AnyMeta<'a>`; no dispatch arm
@@ -1921,7 +1773,7 @@ impl AnyParser {
     ext: Option<&str>,
     header_skip: usize,
     tiff_parent_type: Option<&str>,
-  ) -> Result<Option<AnyMeta<'a>>, AnyError> {
+  ) -> Option<AnyMeta<'a>> {
     // No-format build (Codex CF3): `AnyParser` has no variants, so the
     // `match` below is empty and the parameters are unused. Discard them
     // to keep the no-format tier warning-clean.
@@ -1964,30 +1816,22 @@ impl AnyParser {
       #[cfg(feature = "moi")]
       AnyParser::Moi(p) => {
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Moi))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Moi)
       }
       #[cfg(feature = "aac")]
       AnyParser::Aac(p) => {
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Aac))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Aac)
       }
       #[cfg(feature = "dv")]
       AnyParser::Dv(p) => {
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Dv))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Dv)
       }
       #[cfg(feature = "audible")]
       AnyParser::Aa(p) => {
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Aa))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Aa)
       }
       #[cfg(feature = "crw")]
       AnyParser::Crw(p) => {
@@ -1998,16 +1842,12 @@ impl AnyParser {
         // (faithful to `ProcessCanonRaw` dispatching `CanonRaw::Main`
         // SubDirectory records into `Image::ExifTool::Canon`).
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Crw))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Crw)
       }
       #[cfg(feature = "red")]
       AnyParser::R3D(p) => {
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::R3d))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::R3d)
       }
       // Chained formats dispatch via their **decoupled** `*_borrowed` /
       // `*_owned` entries: `shared` borrows independently of `bytes`, so the
@@ -2020,22 +1860,17 @@ impl AnyParser {
         let _ = (p, ext);
         // ID3 typed Meta is mode-locked; the closed dispatch stages `-j`.
         crate::formats::id3::parse_id3_borrowed(bytes, Some(shared), /* print_conv */ true)
-          .map(|o| o.map(AnyMeta::Id3))
-          .map_err(Into::into)
+          .map(AnyMeta::Id3)
       }
       #[cfg(feature = "mp3")]
       AnyParser::Mp3(p) => {
         let _ = p;
-        crate::formats::id3::parse_mp3_borrowed(bytes, ext, shared)
-          .map(|o| o.map(AnyMeta::Mp3))
-          .map_err(Into::into)
+        crate::formats::id3::parse_mp3_borrowed(bytes, ext, shared).map(AnyMeta::Mp3)
       }
       #[cfg(feature = "aiff")]
       AnyParser::Aiff(p) => {
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Aiff))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Aiff)
       }
       #[cfg(feature = "ape")]
       AnyParser::Ape(p) => {
@@ -2045,23 +1880,19 @@ impl AnyParser {
         // returned `ape::Meta`, so the typed `parse_any` path emits the complete
         // `File:ID3Size` + `ID3v2_*`/`ID3v1` + `MAC:*` + `APE:*` tag set —
         // matching the engine `ProcessApe::process`. (`ape` pulls `id3`.)
-        Ok(crate::formats::ape::parse_full_chained(bytes, shared).map(AnyMeta::Ape))
+        crate::formats::ape::parse_full_chained(bytes, shared).map(AnyMeta::Ape)
       }
       #[cfg(feature = "dsf")]
       AnyParser::Dsf(p) => {
         let _ = (p, ext, &mut *shared);
         // DSF's typed parse uses only `data`; the ID3v2 trailer scan range
         // is exposed on the Meta for the caller to dispatch.
-        crate::formats::dsf::parse_borrowed(bytes)
-          .map(|o| o.map(AnyMeta::Dsf))
-          .map_err(Into::into)
+        crate::formats::dsf::parse_borrowed(bytes).map(AnyMeta::Dsf)
       }
       #[cfg(feature = "flac")]
       AnyParser::Flac(p) => {
         let _ = (p, ext);
-        crate::formats::flac::parse_borrowed(bytes, shared)
-          .map(|o| o.map(AnyMeta::Flac))
-          .map_err(Into::into)
+        crate::formats::flac::parse_borrowed(bytes, shared).map(AnyMeta::Flac)
       }
       #[cfg(feature = "h264")]
       AnyParser::H264(p) => {
@@ -2069,18 +1900,14 @@ impl AnyParser {
         // dispatch is unreachable in practice. It is wired for a future
         // M2TS / MPEG port that resolves an `AnyParser::H264` directly.
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::H264))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::H264)
       }
       #[cfg(feature = "flash")]
       AnyParser::Flv(p) => {
         let _ = (p, shared, ext);
         // FLV is a leaf format (no cross-format chain): ignore `shared`
         // and `ext`. The typed `parse_borrowed` accepts only a byte slice.
-        crate::formats::flash::parse_borrowed(bytes)
-          .map(|o| o.map(AnyMeta::Flv))
-          .map_err(Into::into)
+        crate::formats::flash::parse_borrowed(bytes).map(AnyMeta::Flv)
       }
       #[cfg(feature = "ogg")]
       AnyParser::Ogg(p) => {
@@ -2102,13 +1929,9 @@ impl AnyParser {
         // the same `SharedFlags`'s `DoneID3` already set, mirroring
         // bundled `unless ($$et{DoneID3})` recursion guard).
         // (`ogg` requires `id3` in Cargo.toml.)
-        let chained =
-          crate::formats::ogg::parse_full_chained(bytes, shared, /* print_conv */ true)?
-            .filter(|m| m.success());
-        if let Some(m) = chained {
-          return Ok(Some(AnyMeta::Ogg(m)));
-        }
-        Ok(None)
+        crate::formats::ogg::parse_full_chained(bytes, shared, /* print_conv */ true)
+          .filter(|m| m.success())
+          .map(AnyMeta::Ogg)
       }
       #[cfg(feature = "png")]
       AnyParser::Png(p) => {
@@ -2120,9 +1943,7 @@ impl AnyParser {
         // `ProcessPNG → ProcessTIFF → ProcessExif` dispatch chain at
         // PNG.pm:1391).
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Png))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Png)
       }
       #[cfg(feature = "real")]
       AnyParser::Real(p) => {
@@ -2139,9 +1960,7 @@ impl AnyParser {
         // `FormatParser::parse` has no extension channel, so the dispatch
         // uses the extension-aware `parse_with_ext` entry instead.
         let _ = (p, shared);
-        crate::formats::real::parse_with_ext(bytes, ext)
-          .map(|o| o.map(AnyMeta::Real))
-          .map_err(Into::into)
+        crate::formats::real::parse_with_ext(bytes, ext).map(AnyMeta::Real)
       }
       #[cfg(feature = "mpeg-audio")]
       AnyParser::MpegAudio(p) => {
@@ -2156,9 +1975,7 @@ impl AnyParser {
         let _ = (p, &mut *shared);
         let ext = ext.unwrap_or("");
         let mp3 = !ext.eq_ignore_ascii_case("MUS");
-        crate::formats::mpeg::parse_borrowed(bytes, mp3, ext)
-          .map(|o| o.map(AnyMeta::MpegAudio))
-          .map_err(Into::into)
+        crate::formats::mpeg::parse_borrowed(bytes, mp3, ext).map(AnyMeta::MpegAudio)
       }
       #[cfg(feature = "mpc")]
       AnyParser::Mpc(p) => {
@@ -2169,7 +1986,7 @@ impl AnyParser {
         // `parse_borrowed` which dropped both chains.
         // (`mpc` requires `id3` + `ape` in Cargo.toml so this `cfg(all)`
         // arm is the only one — the bare `parse_borrowed` is gone.)
-        Ok(crate::formats::mpc::parse_full_chained(bytes, shared).map(AnyMeta::Mpc))
+        crate::formats::mpc::parse_full_chained(bytes, shared).map(AnyMeta::Mpc)
       }
       #[cfg(feature = "wavpack")]
       AnyParser::Wv(p) => {
@@ -2178,14 +1995,12 @@ impl AnyParser {
         // trailer chain (WavPack.pm:100-103 `APE::ProcessAPE`). The
         // pre-fix arm called `parse_borrowed` which dropped the chain.
         // (`wavpack` requires `id3` + `ape` in Cargo.toml.)
-        Ok(crate::formats::wavpack::parse_full_chained(bytes, shared).map(AnyMeta::Wv))
+        crate::formats::wavpack::parse_full_chained(bytes, shared).map(AnyMeta::Wv)
       }
       #[cfg(feature = "matroska")]
       AnyParser::Matroska(p) => {
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Matroska))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Matroska)
       }
       #[cfg(feature = "quicktime")]
       AnyParser::QuickTime(p) => {
@@ -2195,27 +2010,21 @@ impl AnyParser {
         // The leaf `FormatParser::parse` has no extension channel, so the
         // dispatch uses the extension-aware `parse_with_ext` entry instead.
         let _ = (p, shared);
-        crate::formats::quicktime::parse_with_ext(bytes, ext)
-          .map(|o| o.map(AnyMeta::QuickTime))
-          .map_err(Into::into)
+        crate::formats::quicktime::parse_with_ext(bytes, ext).map(AnyMeta::QuickTime)
       }
       #[cfg(feature = "mxf")]
       AnyParser::Mxf(p) => {
         // MXF is a leaf format (Engine-only, no chained state): `shared`
         // and `ext` are unused.
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Mxf))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Mxf)
       }
       #[cfg(feature = "plist")]
       AnyParser::Plist(p) => {
         // PLIST is a leaf format (no cross-format chains); `shared` / `ext`
         // are unused. The parser detects the binary vs XML encoding itself.
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Plist))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Plist)
       }
       #[cfg(feature = "exif")]
       AnyParser::Exif(p) => {
@@ -2262,9 +2071,8 @@ impl AnyParser {
         let _ = (p, shared);
         let body = bytes.get(header_skip..).unwrap_or(&[]);
         if body.len() >= 2 && body[0] == 0xff && body[1] == 0xd8 {
-          return Ok(
-            crate::exif::jpeg::parse_jpeg_exif_with_base(body, header_skip).map(AnyMeta::Exif),
-          );
+          return crate::exif::jpeg::parse_jpeg_exif_with_base(body, header_skip)
+            .map(AnyMeta::Exif);
         }
         // A standalone TIFF — at byte 0 normally, or at `bytes[header_skip..]`
         // for the detector's terminal TIFF-after-unknown-header candidate.
@@ -2298,24 +2106,20 @@ impl AnyParser {
         // the finalized name stays the detected `"TIFF"`.
         let file_type =
           crate::parser::finalized_tiff_file_type("TIFF", tiff_parent_type.unwrap_or(""), ext);
-        Ok(
-          crate::exif::parse_standalone_tiff_with_base(
-            body,
-            base,
-            tiff_type_is_tiff,
-            Some(&file_type),
-          )
-          .map(AnyMeta::Exif),
+        crate::exif::parse_standalone_tiff_with_base(
+          body,
+          base,
+          tiff_type_is_tiff,
+          Some(&file_type),
         )
+        .map(AnyMeta::Exif)
       }
       #[cfg(feature = "riff")]
       AnyParser::Riff(p) => {
         // RIFF is a leaf format (no chained state today): `shared` and
         // `ext` are unused.
         let _ = (shared, ext);
-        p.parse(bytes)
-          .map(|o| o.map(AnyMeta::Riff))
-          .map_err(Into::into)
+        p.parse(bytes).map(AnyMeta::Riff)
       }
     }
   }
@@ -2527,8 +2331,8 @@ mod tests {
     let result = parser.parse_any(bytes, &mut shared, None, 0, None);
     // The exact `Some`/`None` outcome depends on the MOI parser's
     // acceptance rules for a 16-byte buffer; this test just verifies the
-    // dispatch doesn't panic and produces an `Ok(_)` result.
-    assert!(result.is_ok());
+    // dispatch doesn't panic and routes through the closed `AnyMeta` enum.
+    let _ = result;
   }
 
   /// Codex C-R3-1: `parse_any` decouples the transient `ext` borrow from the
@@ -2549,25 +2353,12 @@ mod tests {
     let meta = {
       // `ext` is a short-lived String dropped at the end of this block.
       let ext: String = String::from("MP3");
-      let m = parser
-        .parse_any(&bytes, &mut shared, Some(ext.as_str()), 0, None)
-        .expect("ok");
+      let m = parser.parse_any(&bytes, &mut shared, Some(ext.as_str()), 0, None);
       // `ext` drops here; `m` must remain valid (it borrows only `bytes`).
       m
     };
     // Use the meta after `ext` is gone — proves the decoupling.
     let _ = meta.is_some();
-  }
-
-  /// `AnyError` formats nicely via `Display`. Most format errors are
-  /// uninhabited, so the variant constructors aren't constructible — but
-  /// the `Display` impl compiles, which is what matters.
-  #[test]
-  fn any_error_implements_display() {
-    fn _accepts_display<E: core::fmt::Display>(_: &E) {}
-    fn _check_any_error(e: &AnyError) {
-      _accepts_display(e);
-    }
   }
 
   /// `Rendered` serializes a typed `AnyMeta`'s FORMAT tags to a flat
@@ -2588,7 +2379,6 @@ mod tests {
     let mut shared = SharedFlags::new();
     let meta = parser
       .parse_any(&data, &mut shared, Some("AAC"), 0, None)
-      .expect("parse ok")
       .expect("AAC recognized");
 
     // -j (PrintConv): a flat object of AAC:* tags; no SourceFile / File:* /
@@ -2637,9 +2427,8 @@ mod tests {
 /// impl FormatParser for ForeignParser {
 ///   type Meta = ();
 ///   type Context<'a> = &'a [u8];
-///   type Error = ();
-///   fn parse<'a>(&self, _ctx: &'a [u8]) -> Result<Option<()>, ()> {
-///     Ok(None)
+///   fn parse<'a>(&self, _ctx: &'a [u8]) -> Option<()> {
+///     None
 ///   }
 /// }
 /// ```

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -1701,7 +1701,16 @@ const _: () = {
       let warning = tm.first_warning();
       let extra = usize::from(warning.is_some());
       let mut map = s.serialize_map(Some(entries.len() + extra))?;
-      for (key, value) in entries {
+      // Build the `"<family1>:<name>"` JSON key ONCE per surviving entry (P1+P4:
+      // the `TagMap` no longer carries a per-insert combined key). A single
+      // reused `String` buffer (cleared each turn) avoids a per-entry alloc.
+      let mut key = std::string::String::new();
+      for (group, name, value) in entries {
+        key.clear();
+        key.reserve(group.len() + 1 + name.len());
+        key.push_str(group);
+        key.push(':');
+        key.push_str(name);
         map.serialize_entry(key.as_str(), value)?;
       }
       if let Some(w) = warning {

--- a/src/formats/aac.rs
+++ b/src/formats/aac.rs
@@ -193,9 +193,8 @@ impl parser_sealed::Sealed for ProcessAac {}
 impl FormatParser for ProcessAac {
   type Meta<'a> = Meta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(data)
   }
 }
@@ -207,7 +206,7 @@ impl FormatParser for ProcessAac {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   parse_inner(data)
 }
 
@@ -215,15 +214,15 @@ pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
 /// [`FormatParser::Meta`] GAT (`type Meta<'a> = Meta<'a>`) returns this
 /// borrowed form directly into the closed [`crate::format_parser::AnyMeta`]
 /// enum — no `'static` upgrade (Codex AF2).
-fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+fn parse_inner(data: &[u8]) -> Option<Meta<'_>> {
   // AAC.pm:99-105 header validation. A reject here returns `Ok(None)` —
   // Perl `return 0` BEFORE `$et->SetFileType()` (AAC.pm:107).
   if data.len() < 7 {
-    return Ok(None); // $raf->Read($buff,7)==7 or return 0  (AAC.pm:99)
+    return None; // $raf->Read($buff,7)==7 or return 0  (AAC.pm:99)
   }
   let buff = &data[..7];
   if buff[0] != 0xff || (buff[1] != 0xf0 && buff[1] != 0xf1) {
-    return Ok(None); // unless $buff =~ /^\xff[\xf0\xf1]/  (AAC.pm:100)
+    return None; // unless $buff =~ /^\xff[\xf0\xf1]/  (AAC.pm:100)
   }
   // my @t = unpack('NnC', $buff)  (AAC.pm:101)
   let t0 = u32::from_be_bytes([buff[0], buff[1], buff[2], buff[3]]); // $t[0] = 'N'
@@ -234,15 +233,15 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
   // ExifTool's own — they intentionally differ from the %AAC::Main bit
   // table's Bit016-017 / Bit018-021 extraction. Do NOT "correct" them.
   if (t0 >> 16) & 0x03 == 3 {
-    return Ok(None); // AAC.pm:102 (reserved profile type)
+    return None; // AAC.pm:102 (reserved profile type)
   }
   if (t0 >> 12) & 0x0f > 12 {
-    return Ok(None); // AAC.pm:103 (validate sampling frequency index)
+    return None; // AAC.pm:103 (validate sampling frequency index)
   }
   // my $len = (($t[0] << 11) & 0x1800) | (($t[1] >> 5) & 0x07ff)  (AAC.pm:104)
   let len = (((t0 << 11) & 0x1800) | ((t1 as u32 >> 5) & 0x07ff)) as usize;
   if len < 7 {
-    return Ok(None); // AAC.pm:105
+    return None; // AAC.pm:105
   }
 
   // Bit-stream walk to extract ProfileType / SampleRate / Channels via
@@ -293,12 +292,12 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
   // with an unconditional `last` (AAC.pm:136).
   let encoder: Option<&str> = encoder_from_filler(data, t0, t2, len);
 
-  Ok(Some(Meta {
+  Some(Meta {
     profile_type,
     sample_rate,
     channels,
     encoder,
-  }))
+  })
 }
 
 /// Extract the Encoder string from the first AAC frame's filler payload
@@ -478,24 +477,6 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for AAC parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers if streaming readers are added.
-///
-/// §5: derived via `thiserror` (`Display` + `core::error::Error` in every
-/// feature tier — `thiserror` v2 with `default-features = false` emits
-/// `core::error::Error`, so `Error` is a real `Error` even on no-std).
-/// `#[non_exhaustive]` lets the first real variant land without a breaking
-/// change. The derive expands `Display` to an empty `match *self {}`, so no
-/// `#[error(…)]` attribute is needed while the enum has no variants.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -506,15 +487,6 @@ pub enum Error {}
 #[cfg(test)]
 mod tests {
   use super::*;
-
-  #[test]
-  fn aac_error_is_core_error() {
-    // §5: thiserror v2 (default-features=false) makes the empty error enum
-    // a real `core::error::Error` in every feature tier.
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   #[test]
   fn table_and_keys_are_faithful() {
     let g = AAC_MAIN.get();
@@ -605,7 +577,7 @@ mod tests {
       std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/AAC.aac"),
     )
     .expect("read AAC.aac fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     // ProfileType = (0x50>>6)&0x03 raw extracted by process_bit_stream
     // ⇒ 1 (low complexity). bit-stream emits I64; typed Meta lifts to u8.
     assert_eq!(meta.profile_type(), 1);
@@ -620,14 +592,14 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short_buffer() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(&[0xff, 0xf1]).unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(&[0xff, 0xf1]).is_none());
   }
 
   #[test]
   fn parse_borrowed_rejects_bad_sync() {
     let data = [0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-    assert!(parse_borrowed(&data).unwrap().is_none());
+    assert!(parse_borrowed(&data).is_none());
   }
 
   #[test]
@@ -636,7 +608,7 @@ mod tests {
     // Construct: ff f1 c0 00 ... ⇒ t0=ff_f1_c0_00; (t0>>16)&0x03 = 0xc0&3 = 0.
     // Try ff f1 ff 00 ⇒ t0 = ff_f1_ff_00; (t0>>16)&0x03 = 0xff&3 = 3 ⇒ reject.
     let data = [0xff, 0xf1, 0xff, 0x00, 0x00, 0x00, 0x00];
-    assert!(parse_borrowed(&data).unwrap().is_none());
+    assert!(parse_borrowed(&data).is_none());
   }
 
   /// Drive the `Meta` through the golden-pattern engine
@@ -735,7 +707,7 @@ mod tests {
       std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/AAC.aac"),
     )
     .expect("read AAC.aac fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let projected = meta.project();
     // The one faithful MediaInfo contribution: a single audio track kind.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Audio]);
@@ -759,9 +731,7 @@ mod tests {
       std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/AAC.aac"),
     )
     .expect("read AAC.aac fixture");
-    let meta = <ProcessAac as FormatParser>::parse(&ProcessAac, &bytes)
-      .expect("ok")
-      .expect("parsed");
+    let meta = <ProcessAac as FormatParser>::parse(&ProcessAac, &bytes).expect("parsed");
     assert_eq!(meta.profile_type(), 1);
     assert_eq!(meta.sample_rate(), 44100);
     assert_eq!(meta.encoder(), Some("Lavc57.107.100"));

--- a/src/formats/aiff.rs
+++ b/src/formats/aiff.rs
@@ -859,12 +859,11 @@ impl FormatParser for ProcessAiff {
   type Context<'a> = &'a [u8];
   /// Rust-level fatal error (none today; AIFF parsing has no I/O modes —
   /// every bad input is `Ok(None)` per Perl `return 0`).
-  type Error = Error;
 
   /// Parse an AIFF/AIFC/DJVU file's bytes into a typed [`Meta`], or
   /// `None` if the buffer is not a recognized FORM container (AIFF.pm:191
   /// short read, :209 magic mismatch, :199 AT&TFORM tail mismatch).
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(data)
   }
 }
@@ -877,14 +876,14 @@ impl FormatParser for ProcessAiff {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   parse_inner(data)
 }
 
-fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+fn parse_inner(data: &[u8]) -> Option<Meta<'_>> {
   // AIFF.pm:191 `return 0 unless $raf->Read($buff, 12) == 12`.
   if data.len() < 12 {
-    return Ok(None);
+    return None;
   }
   // AIFF.pm:194-207 DjVu arm. `AT&TFORM` magic + (`DJVU`|`DJVM`) at
   // bytes 12..16. Bundled reads 4 EXTRA bytes (`return 0 unless
@@ -894,23 +893,23 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
   let mut djvm_multi_page = false;
   let magic: Magic = if data.starts_with(b"AT&TFORM") {
     if data.len() < 16 {
-      return Ok(None);
+      return None;
     }
     match &data[12..16] {
       b"DJVU" => {}
       b"DJVM" => djvm_multi_page = true,
-      _ => return Ok(None),
+      _ => return None,
     }
     Magic::Djvu
   } else {
     // AIFF.pm:209 `return 0 unless $buff =~ /^FORM....(AIF(F|C))/s`.
     if &data[0..4] != b"FORM" {
-      return Ok(None);
+      return None;
     }
     match &data[8..12] {
       b"AIFF" => Magic::Aiff,
       b"AIFC" => Magic::Aifc,
-      _ => return Ok(None),
+      _ => return None,
     }
   };
 
@@ -920,13 +919,13 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
   // loop is skipped. This is identical to AIFF.pm's `fast3` mode
   // (AIFF.pm:203 `return 1 if $fast3`).
   if magic == Magic::Djvu {
-    return Ok(Some(Meta {
+    return Some(Meta {
       magic,
       djvm_multi_page,
       events: Vec::new(),
       composite_duration: None,
       _lifetime: core::marker::PhantomData,
-    }));
+    });
   }
 
   // AIFF.pm:215 `SetByteOrder('MM')` — AIFF is big-endian throughout.
@@ -1078,13 +1077,13 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
   //   `PrintConv => 'ConvertDuration($val)'`
   let composite_duration = compute_composite_duration(&events);
 
-  Ok(Some(Meta {
+  Some(Meta {
     magic,
     djvm_multi_page,
     events,
     composite_duration,
     _lifetime: core::marker::PhantomData,
-  }))
+  })
 }
 
 /// AIFF.pm:136-145 composite Duration. `RawConv = $val[1] / $val[0]`
@@ -1671,21 +1670,6 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for AIFF parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers if streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` are derived via `thiserror`
-/// (v2, `default-features = false` ⇒ `core::error::Error` for no-std);
-/// `#[non_exhaustive]` lets future variants land without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -1972,7 +1956,7 @@ mod tests {
     data.extend_from_slice(&(body.len() as u32).to_be_bytes());
     data.extend_from_slice(&body);
 
-    let meta = parse_borrowed(&data).unwrap().expect("AIFF parsed");
+    let meta = parse_borrowed(&data).expect("AIFF parsed");
     assert_eq!(meta.magic(), Magic::Aiff);
     assert_eq!(meta.name(), Some("Hello"));
     let common = meta.common().expect("COMM extracted");
@@ -2032,14 +2016,6 @@ mod tests {
     assert_eq!(c.raw_text(), b"NONE");
     assert_eq!(c.unwrap_raw_text_ref().as_slice(), b"NONE");
   }
-
-  #[test]
-  fn aiff_error_is_thiserror_uninhabited() {
-    // §5: empty enum derives core::error::Error via thiserror.
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   // ---------- golden-pattern `Taggable` / `Project` surface --------------
 
   /// Drive the `Meta` through the golden-pattern engine
@@ -2063,7 +2039,7 @@ mod tests {
       env!("CARGO_MANIFEST_DIR")
     ))
     .expect("read AIFC.aifc fixture");
-    let meta = parse_borrowed(&data).unwrap().expect("AIFC parsed");
+    let meta = parse_borrowed(&data).expect("AIFC parsed");
 
     // -j (PrintConv).
     let w = emit_into_tagmap(&meta, ConvMode::PrintConv);
@@ -2114,7 +2090,7 @@ mod tests {
       env!("CARGO_MANIFEST_DIR")
     ))
     .expect("read AIFF_duration.aif fixture");
-    let meta = parse_borrowed(&data).unwrap().expect("AIFF parsed");
+    let meta = parse_borrowed(&data).expect("AIFF parsed");
 
     // -j: ConvertDuration string, under the Composite (-G1) group.
     let w = emit_into_tagmap(&meta, ConvMode::PrintConv);
@@ -2140,7 +2116,7 @@ mod tests {
       env!("CARGO_MANIFEST_DIR")
     ))
     .expect("read AIFF_duration.aif fixture");
-    let meta = parse_borrowed(&data).unwrap().expect("AIFF parsed");
+    let meta = parse_borrowed(&data).expect("AIFF parsed");
     let tags: Vec<_> = meta.tags(ConvMode::PrintConv).collect();
 
     let mut saw_aiff = false;
@@ -2176,7 +2152,7 @@ mod tests {
     data.extend_from_slice(b"AT&TFORM");
     data.extend_from_slice(&0u32.to_be_bytes()); // FORM length (unused here)
     data.extend_from_slice(b"DJVU");
-    let meta = parse_borrowed(&data).unwrap().expect("DjVu parsed");
+    let meta = parse_borrowed(&data).expect("DjVu parsed");
     assert_eq!(meta.magic(), Magic::Djvu);
     assert_eq!(meta.tags(ConvMode::PrintConv).count(), 0);
   }
@@ -2192,7 +2168,7 @@ mod tests {
       env!("CARGO_MANIFEST_DIR")
     ))
     .expect("read AIFF_duration.aif fixture");
-    let meta = parse_borrowed(&data).unwrap().expect("AIFF parsed");
+    let meta = parse_borrowed(&data).expect("AIFF parsed");
     let projected = meta.project();
 
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Audio]);
@@ -2225,7 +2201,7 @@ mod tests {
       env!("CARGO_MANIFEST_DIR")
     ))
     .expect("read AIFF.aif fixture");
-    let meta = parse_borrowed(&data).unwrap().expect("AIFF parsed");
+    let meta = parse_borrowed(&data).expect("AIFF parsed");
     let projected = meta.project();
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Audio]);
     assert!(projected.media().duration().is_none());

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -3463,11 +3463,11 @@ mod tests {
     let desc_idx = tm
       .entries()
       .iter()
-      .position(|(k, _)| k == "APE:CoverArtFrontDesc");
+      .position(|(g, n, _)| g == "APE" && n == "CoverArtFrontDesc");
     let cover_idx = tm
       .entries()
       .iter()
-      .position(|(k, _)| k == "APE:CoverArtFront");
+      .position(|(g, n, _)| g == "APE" && n == "CoverArtFront");
     assert!(desc_idx < cover_idx);
   }
 
@@ -3596,7 +3596,7 @@ mod tests {
     let names: Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(k, _)| k.strip_prefix("APE:"))
+      .filter_map(|(g, n, _)| (g == "APE").then_some(n.as_str()))
       .collect();
     assert_eq!(names, &["Title", "Artist"]);
     assert_eq!(

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -1549,24 +1549,6 @@ impl Meta<'_> {
   }
 }
 
-// =============================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// =============================================================================
-
-/// Rust-level fatal modes for APE parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers if streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` are derived via `thiserror`
-/// (v2, `default-features = false` ⇒ `core::error::Error` in every
-/// feature tier); the hand-written impls are gone. `#[non_exhaustive]`
-/// lets a real variant land later without a breaking change. The enum is
-/// currently uninhabited, so it carries no `#[error(...)]` arms and no
-/// variant predicates (nothing to predicate).
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
 impl FormatParser for ProcessApe {
   /// GAT: `Meta<'a>`. APE's typed Meta already owns its resolved
   /// tag-name strings and `TagValue` payloads, so `'a` is phantom; the
@@ -1576,7 +1558,6 @@ impl FormatParser for ProcessApe {
   /// Chained format (spec §6.4): `&'a [u8]` + `&'a mut SharedFlags` for
   /// the `done_id3`/`done_ape` cross-recursion plumbing.
   type Context<'a> = Context<'a>;
-  type Error = Error;
 
   /// Run the APE planner and produce a typed [`Meta`]. Returns:
   ///   * `Ok(Some(meta))` — APE header / trailer was detected and a
@@ -1602,16 +1583,16 @@ impl FormatParser for ProcessApe {
   /// bundled `APE::ProcessAPE` from a `$$et{FileType}`-already-set chain
   /// (ID3.pm:1722-1727) only runs the trailer scan, faithful to that
   /// gate.
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Self::Error> {
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     // Trailer-only: bundled APE.pm:118 (`Just looks for APE trailer if
     // FileType is already set`) — never re-runs the embedded ID3 dispatch
     // (the chaining parent did it). Body-only is the faithful path.
     if ctx.trailer_only {
-      return Ok(parse_body_only(ctx));
+      return parse_body_only(ctx);
     }
     // Full-parse: run the embedded ID3 chain alongside the MAC/APE body.
     // `ape = ["id3"]` per Cargo.toml ⇒ `parse_full_chained` is always present.
-    Ok(parse_full_chained(ctx.data, ctx.shared))
+    parse_full_chained(ctx.data, ctx.shared)
   }
 }
 
@@ -1723,7 +1704,6 @@ pub(crate) fn parse_full_chained<'a>(data: &'a [u8], shared: &mut SharedFlags) -
   // pass sets `DoneID3` (trailer size for APE.pm:169) and returns `$hdrEnd`.
   let (id3, hdr_end) = if shared.done_id3().is_none() {
     crate::formats::id3::process::parse_id3_with_hdr_end(data, Some(&mut *shared), true)
-      .unwrap_or((None, 0))
   } else {
     (None, shared.id3_hdr_end().unwrap_or(0))
   };
@@ -4145,7 +4125,6 @@ mod tests {
     let data = build_minimal_ape_input();
     let mut shared = SharedFlags::new();
     let meta = <ProcessApe as FormatParser>::parse(&ProcessApe, Context::new(&data, &mut shared))
-      .expect("ok")
       .expect("parsed");
     // Header is NewHeader (MAC vers >= 3980 ⇒ NewHeader table).
     assert!(matches!(meta.header_ref(), Some(Header::New(_))));
@@ -4159,8 +4138,7 @@ mod tests {
   fn typed_parse_returns_none_for_short_input() {
     let data = vec![0u8; 5];
     let mut shared = SharedFlags::new();
-    let r = <ProcessApe as FormatParser>::parse(&ProcessApe, Context::new(&data, &mut shared))
-      .expect("ok");
+    let r = <ProcessApe as FormatParser>::parse(&ProcessApe, Context::new(&data, &mut shared));
     assert!(r.is_none());
   }
 
@@ -4205,7 +4183,6 @@ mod tests {
       &ProcessApe,
       Context::new_trailer_only(&data, &mut shared),
     )
-    .expect("ok")
     .expect("trailer-only meta");
     // Trailer-only ⇒ no header.
     assert!(meta.header_ref().is_none());
@@ -4219,7 +4196,6 @@ mod tests {
     let data = build_minimal_ape_input();
     let mut shared = SharedFlags::new();
     let meta = <ProcessApe as FormatParser>::parse(&ProcessApe, Context::new(&data, &mut shared))
-      .expect("ok")
       .expect("parsed");
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::PrintConv, &mut w);
@@ -4236,7 +4212,6 @@ mod tests {
     let data = build_minimal_ape_input();
     let mut shared = SharedFlags::new();
     let meta = <ProcessApe as FormatParser>::parse(&ProcessApe, Context::new(&data, &mut shared))
-      .expect("ok")
       .expect("parsed");
     assert_eq!(meta.artist(), Some("Tester"));
   }
@@ -4258,7 +4233,6 @@ mod tests {
     let data = build_minimal_ape_input();
     let mut shared = SharedFlags::new();
     let meta = <ProcessApe as FormatParser>::parse(&ProcessApe, Context::new(&data, &mut shared))
-      .expect("ok")
       .expect("parsed");
     let mains = meta.main_tags_slice();
     assert!(!mains.is_empty(), "fixture has an Artist tag");
@@ -4274,7 +4248,6 @@ mod tests {
     let data = build_minimal_ape_input();
     let mut shared = SharedFlags::new();
     let meta = <ProcessApe as FormatParser>::parse(&ProcessApe, Context::new(&data, &mut shared))
-      .expect("ok")
       .expect("parsed");
     let header = meta.header_ref().expect("MAC NewHeader present");
     assert!(header.is_new());
@@ -4339,18 +4312,6 @@ mod tests {
       &[1, 2, 3]
     );
   }
-
-  #[test]
-  fn ape_error_is_uninhabited_and_thiserror_derived() {
-    // §5: Error is uninhabited; this only needs to compile to prove the
-    // thiserror-derived `Display`/`Error` impls exist. `Option<Error>`
-    // is always None.
-    fn _assert_error<E: core::error::Error>() {}
-    _assert_error::<Error>();
-    let none: Option<Error> = None;
-    assert!(none.is_none());
-  }
-
   // --- Golden-pattern `Taggable` / `Project` tests ------------------------
 
   use crate::emit::{ConvMode, Taggable};

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -1354,7 +1354,11 @@ impl Header {
 /// D8 — no public fields, accessors only.
 #[derive(Debug, Clone)]
 pub struct MainTag {
-  name: String,
+  /// Resolved tag name. A short identifier (stored, feeds the emitted tag
+  /// name) ⇒ `SmolStr`. `MakeTag` builds the dynamic name in a transient
+  /// `String` (a builder — String per the rule); it is converted to `SmolStr`
+  /// here at the store boundary.
+  name: smol_str::SmolStr,
   value: TagValue,
 }
 
@@ -1750,7 +1754,10 @@ fn meta_from_plan(plan: Plan) -> Meta<'static> {
   let main_tags: Vec<MainTag> = plan
     .pending
     .into_iter()
-    .map(|(_g1, name, value)| MainTag { name, value })
+    .map(|(_g1, name, value)| MainTag {
+      name: name.into(),
+      value,
+    })
     .collect();
   // 3) Intra-APE Composite:Duration. Resolve the 4 Require ingredients
   // against the header + main tags ALONE (not cross-format). Mirrors the
@@ -4290,7 +4297,7 @@ mod tests {
   fn ape_main_tag_value_ref_accessor() {
     // §3: MainTag::value_ref() is the non-Copy `_ref` getter.
     let t = MainTag {
-      name: "Artist".to_string(),
+      name: "Artist".into(),
       value: TagValue::Str("Tester".into()),
     };
     assert_eq!(t.name(), "Artist");

--- a/src/formats/audible.rs
+++ b/src/formats/audible.rs
@@ -783,14 +783,13 @@ impl FormatParser for ProcessAa {
   /// Rust-level fatal error (none today; AA parsing has no I/O modes —
   /// every bad input either returns `Ok(None)` or accumulates warnings/
   /// errors into the typed Meta and returns `Ok(Some)`).
-  type Error = Error;
 
   /// Parse an AA file's bytes into a typed [`Meta`], or `None` if the
   /// buffer is not a valid AA (short read, wrong magic, or embedded
   /// filesize mismatch — Audible.pm:201-205). Returns `Err` only for
   /// Rust-level fatal modes; the current port has none.
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -802,8 +801,8 @@ impl FormatParser for ProcessAa {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
-  Ok(parse_inner(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
+  parse_inner(data)
 }
 
 /// Inner parser — produces a borrow-from-input [`Meta`] (chunk-11 cover
@@ -1373,24 +1372,6 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for AA parsing. Currently empty — every bad
-/// input either produces `Ok(None)` (Perl `return 0`) or surfaces
-/// warnings/errors inside the typed [`Meta`] (Perl `$et->Warn` /
-/// `$et->Error`). Reserved for future I/O wrappers if streaming readers
-/// are added.
-///
-/// §5: derived via `thiserror` (v2, `default-features = false` ⇒
-/// `core::error::Error`), `#[non_exhaustive]` so variants can be added
-/// without a breaking change. Variant names are kept stable for
-/// [`crate::format_parser::AnyError`]'s `From`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -1683,7 +1664,7 @@ mod tests {
   /// Typed parse + TagMap, returning the `Audible:*` entries in order
   /// (key without the prefix, value). Order is preserved by the typed sink.
   fn audible_entries(bytes: &[u8]) -> Vec<(String, TagValue)> {
-    let meta = parse_borrowed(bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(bytes).expect("parsed");
     let tm = emit_into_tagmap(&meta, true);
     tm.entries()
       .iter()
@@ -1766,7 +1747,7 @@ mod tests {
   fn dict_cover_art_uses_binary_placeholder() {
     // Raw bytes preserved via the typed parse + TagMap.
     let bytes = build_aa_with_dict(&[("_cover_art", "ABCDE")]);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let tm = emit_into_tagmap(&meta, true);
     match tm.get("Audible", "CoverArt").expect("CoverArt") {
       TagValue::Bytes(b) => assert_eq!(b.as_slice(), b"ABCDE"),
@@ -1923,7 +1904,7 @@ mod tests {
   #[test]
   fn parse_borrowed_returns_typed_meta() {
     let bytes = build_aa_with_dict(&[("author", "Alice"), ("title", "Book")]);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let names: Vec<&str> = meta.entries().iter().map(|e| e.name()).collect();
     assert_eq!(names, vec!["Author", "Title"]);
     match meta.entries()[0].value_ref() {
@@ -1935,7 +1916,7 @@ mod tests {
   #[test]
   fn parse_borrowed_returns_chapter_count_accessor() {
     let bytes = build_aa_with_two_chap_chunks(1, 42);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     assert_eq!(meta.chapter_count(), Some(42));
   }
 
@@ -1960,16 +1941,14 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short_buffer() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(&[0u8; 8]).unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(&[0u8; 8]).is_none());
   }
 
   #[test]
   fn format_parser_trait_returns_meta_static() {
     let bytes = build_aa_with_dict(&[("author", "Alice")]);
-    let meta = <ProcessAa as FormatParser>::parse(&ProcessAa, &bytes)
-      .expect("ok")
-      .expect("parsed");
+    let meta = <ProcessAa as FormatParser>::parse(&ProcessAa, &bytes).expect("parsed");
     assert_eq!(meta.entries().len(), 1);
     assert_eq!(meta.entries()[0].name(), "Author");
   }
@@ -1977,7 +1956,7 @@ mod tests {
   #[test]
   fn taggable_emits_typed_tags() {
     let bytes = build_aa_with_dict(&[("author", "Alice"), ("title", "Book")]);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let w = emit_into_tagmap(&meta, true);
     assert_eq!(w.get_str("Audible", "Author"), Some("Alice".to_string()));
     assert_eq!(w.get_str("Audible", "Title"), Some("Book".to_string()));
@@ -1986,7 +1965,7 @@ mod tests {
   #[test]
   fn taggable_emits_chapter_count_as_i64() {
     let bytes = build_aa_with_two_chap_chunks(1, 7);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let w = emit_into_tagmap(&meta, true);
     assert_eq!(w.get_str("Audible", "ChapterCount"), Some("7".to_string()));
   }
@@ -1995,7 +1974,7 @@ mod tests {
   fn taggable_group_is_audible_family0_and_family1() {
     use crate::emit::{ConvMode, Taggable};
     let bytes = build_aa_with_dict(&[("author", "Alice"), ("title", "Book")]);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let tags: std::vec::Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     assert_eq!(tags.len(), 2);
     for t in &tags {
@@ -2022,7 +2001,7 @@ mod tests {
     );
 
     // The typed Meta carries the warning on its `warnings()` accessor.
-    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&data).expect("parsed");
     assert!(meta.warnings().iter().any(|s| s == "Invalid TOC"));
   }
 
@@ -2030,7 +2009,7 @@ mod tests {
   fn project_populates_audio_track_only() {
     use crate::metadata::{Project, TrackKind};
     let bytes = build_aa_with_dict(&[("author", "Alice"), ("title", "Book")]);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let projected = meta.project();
     // AA is an audiobook: one audio track kind, nothing else decoded.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Audio]);

--- a/src/formats/audible.rs
+++ b/src/formats/audible.rs
@@ -1668,10 +1668,7 @@ mod tests {
     let tm = emit_into_tagmap(&meta, true);
     tm.entries()
       .iter()
-      .filter_map(|(k, v)| {
-        k.strip_prefix("Audible:")
-          .map(|n| (n.to_string(), v.clone()))
-      })
+      .filter_map(|(g, n, v)| (g == "Audible").then(|| (n.to_string(), v.clone())))
       .collect()
   }
 

--- a/src/formats/crw.rs
+++ b/src/formats/crw.rs
@@ -154,20 +154,6 @@ const FILE_TYPE: &str = "CRW";
 const MAX_NESTING: u32 = 30;
 
 // ===========================================================================
-// Error — uninhabited (Perl `return 0` ⇒ `Ok(None)`)
-// ===========================================================================
-
-/// Rust-level fatal modes for CRW parsing. Currently empty — every bad input
-/// produces `Ok(None)` (Perl `return 0`) or accumulates warnings in the
-/// [`CrwMeta`]. Reserved for future streaming-reader wrappers.
-///
-/// §5: `Display` + `core::error::Error` via `thiserror`; `#[non_exhaustive]`
-/// keeps future variants additive.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // `ProcessCrw` — the lib-first parser
 // ===========================================================================
 
@@ -180,10 +166,9 @@ impl parser_sealed::Sealed for ProcessCrw {}
 impl FormatParser for ProcessCrw {
   type Meta<'a> = CrwMeta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -193,8 +178,8 @@ impl FormatParser for ProcessCrw {
 /// # Errors
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<CrwMeta<'_>>, Error> {
-  Ok(parse_inner(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<CrwMeta<'_>> {
+  parse_inner(data)
 }
 
 /// `ProcessCRW` (`CanonRaw.pm:812-833`): validate the CIFF header, then walk

--- a/src/formats/dsf.rs
+++ b/src/formats/dsf.rs
@@ -412,11 +412,10 @@ impl FormatParser for ProcessDsf {
   /// SharedFlags`.
   type Context<'a> = Context<'a>;
   /// Rust-level fatal error (none today; DSF parsing has no I/O modes).
-  type Error = Error;
 
   /// Parse a DSF file's bytes into a typed [`Meta`] borrowing from
   /// `ctx.data` (`'a`).
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(ctx.data)
   }
 }
@@ -431,7 +430,7 @@ impl FormatParser for ProcessDsf {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   parse_inner(data)
 }
 
@@ -447,10 +446,10 @@ pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
 ///   but the fmt-chunk read failed (DSF.pm:71-72 Warn + return 1).
 /// - `Ok(Some({ fmt: Some(...), id3_trailer: Option<...> }))` — happy
 ///   path; optional ID3v2 trailer carried through.
-fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+fn parse_inner(data: &[u8]) -> Option<Meta<'_>> {
   // DSF.pm:62 `$raf->Read($buff,40)==40 or return 0`.
   if data.len() < 40 {
-    return Ok(None);
+    return None;
   }
   // DSF.pm:63 `$buff =~ /^DSD \x1c\0{7}.{16}fmt /s`. The regex is
   // anchored (^) and the `{16}` middle is "any 16 bytes" (Perl `.` under
@@ -459,16 +458,16 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
   // unconstrained.
   let head = &data[..40];
   if &head[0..4] != b"DSD " {
-    return Ok(None);
+    return None;
   }
   if head[4] != 0x1c {
-    return Ok(None);
+    return None;
   }
   if !head[5..12].iter().all(|&b| b == 0) {
-    return Ok(None);
+    return None;
   }
   if &head[28..32] != b"fmt " {
-    return Ok(None);
+    return None;
   }
   // DSF.pm:66 `SetByteOrder('II')` — every Get* below is little-endian.
   // DSF.pm:67 `my $fmtLen = Get64u(\$buff,32)`.
@@ -505,13 +504,13 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
     // Faithful to the bundled-Perl flow: the trailer's `metaPos`/`metaLen`
     // were already captured from the header.
     let id3_trailer = id3_trailer_slice(data, file_size, meta_pos);
-    return Ok(Some(Meta {
+    return Some(Meta {
       fmt: None,
       fmt_warning: Some("Error reading DSF fmt chunk"),
       id3_trailer,
       #[cfg(feature = "id3")]
       id3: id3_from_trailer(id3_trailer),
-    }));
+    });
   }
   // DSF.pm:76 `$buff = substr($buff,28) . $buf2` — the dirInfo buffer
   // is `'fmt '` + chunkSize (12 bytes from head[28..40]) + payload
@@ -623,13 +622,13 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
     })
   };
   let id3_trailer = id3_trailer_slice(data, file_size, meta_pos);
-  Ok(Some(Meta {
+  Some(Meta {
     fmt,
     fmt_warning: None,
     id3_trailer,
     #[cfg(feature = "id3")]
     id3: id3_from_trailer(id3_trailer),
-  }))
+  })
 }
 
 /// Parse the optional ID3v2 trailer slice (DSF.pm:88-97) into a typed
@@ -643,8 +642,6 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
 fn id3_from_trailer(trailer: Option<&[u8]>) -> Option<crate::formats::id3::Id3Meta<'_>> {
   let slice = trailer?;
   crate::formats::id3::process::parse_id3_borrowed(slice, None, /* print_conv */ true)
-    .ok()
-    .flatten()
 }
 
 /// Computes the present-mask bit per `DSF_KEYS` entry based on whether
@@ -906,26 +903,6 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for DSF parsing. Currently empty — every bad
-/// input produces either `Ok(None)` (`return 0` per DSF.pm:62-63) or
-/// `Ok(Some(Meta { fmt: None, fmt_warning: Some(...) }))` (`Warn +
-/// return 1` per DSF.pm:71-72). Reserved for future I/O wrappers if
-/// streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` are derived via `thiserror`
-/// (v2, `default-features = false` ⇒ `core::error::Error` in every
-/// feature tier, not just `std`); the hand-written impls are gone.
-/// `#[non_exhaustive]` lets a real variant land later without a breaking
-/// change. The enum is currently uninhabited, so it carries no
-/// `#[error(...)]` arms and no variant predicates (nothing to predicate).
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -1113,30 +1090,30 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short_buffer() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(&[0u8; 39]).unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(&[0u8; 39]).is_none());
   }
 
   #[test]
   fn parse_borrowed_rejects_bad_magic() {
     let mut bad = happy_path_dsf();
     bad[0..4].copy_from_slice(b"XXXX");
-    assert!(parse_borrowed(&bad).unwrap().is_none());
+    assert!(parse_borrowed(&bad).is_none());
     let mut bad = happy_path_dsf();
     bad[4] = 0x00; // not 0x1c
-    assert!(parse_borrowed(&bad).unwrap().is_none());
+    assert!(parse_borrowed(&bad).is_none());
     let mut bad = happy_path_dsf();
     bad[5] = 0xff; // not \0
-    assert!(parse_borrowed(&bad).unwrap().is_none());
+    assert!(parse_borrowed(&bad).is_none());
     let mut bad = happy_path_dsf();
     bad[28..32].copy_from_slice(b"FMTA");
-    assert!(parse_borrowed(&bad).unwrap().is_none());
+    assert!(parse_borrowed(&bad).is_none());
   }
 
   #[test]
   fn parse_borrowed_happy_path_populates_fmt_data() {
     let bytes = happy_path_dsf();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     assert!(meta.fmt_warning().is_none());
     assert!(meta.id3_trailer().is_none());
     let fmt = meta.fmt().expect("fmt populated");
@@ -1162,7 +1139,7 @@ mod tests {
     v.extend_from_slice(&0u64.to_le_bytes());
     v.extend_from_slice(b"fmt ");
     v.extend_from_slice(&8u64.to_le_bytes()); // fmtLen = 8 (≤ 12 ⇒ guard fail)
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.fmt().is_none());
     assert_eq!(meta.fmt_warning(), Some("Error reading DSF fmt chunk"));
     assert!(meta.id3_trailer().is_none());
@@ -1182,7 +1159,7 @@ mod tests {
     v.extend_from_slice(&0u64.to_le_bytes());
     v.extend_from_slice(b"fmt ");
     v.extend_from_slice(&12u64.to_le_bytes()); // fmtLen = 12 (NOT > 12)
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.fmt().is_none());
     assert_eq!(meta.fmt_warning(), Some("Error reading DSF fmt chunk"));
   }
@@ -1197,7 +1174,7 @@ mod tests {
       v.extend_from_slice(&0u64.to_le_bytes());
       v.extend_from_slice(b"fmt ");
       v.extend_from_slice(&fmt_len.to_le_bytes());
-      let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+      let meta = parse_borrowed(&v).expect("parsed");
       assert!(meta.fmt().is_none(), "fmt_len={fmt_len}");
       assert_eq!(meta.fmt_warning(), Some("Error reading DSF fmt chunk"));
     }
@@ -1213,7 +1190,7 @@ mod tests {
     v.extend_from_slice(&0u64.to_le_bytes());
     v.extend_from_slice(b"fmt ");
     v.extend_from_slice(&1000u64.to_le_bytes());
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.fmt().is_none());
     assert_eq!(meta.fmt_warning(), Some("Error reading DSF fmt chunk"));
   }
@@ -1241,7 +1218,7 @@ mod tests {
     v.extend_from_slice(&4096u32.to_le_bytes());
     // Pad to total payload of 987 bytes (951 zeros after the 36-byte head).
     v.extend(core::iter::repeat(0u8).take(987 - 36));
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.fmt_warning().is_none());
     let fmt = meta.fmt().expect("populated");
     assert_eq!(fmt.format_version(), 1);
@@ -1258,7 +1235,7 @@ mod tests {
     v.extend_from_slice(&0u64.to_le_bytes());
     v.extend_from_slice(b"fmt ");
     v.extend_from_slice(&48u64.to_le_bytes()); // fmtLen = 48 ⇒ need 36 more
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.fmt().is_none());
     assert_eq!(meta.fmt_warning(), Some("Error reading DSF fmt chunk"));
   }
@@ -1281,14 +1258,14 @@ mod tests {
   fn parse_borrowed_carries_id3_trailer_slice() {
     let id3_bytes = b"ID3\x03\x00\x00\x00\x00\x00\x01\x00";
     let v = dsf_with_trailer(id3_bytes);
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert_eq!(meta.id3_trailer(), Some(&id3_bytes[..]));
   }
 
   #[test]
   fn parse_borrowed_no_id3_trailer_when_meta_pos_zero() {
     let bytes = happy_path_dsf(); // metaPos == 0
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     assert!(meta.id3_trailer().is_none());
   }
 
@@ -1300,7 +1277,7 @@ mod tests {
     let mut v = happy_path_dsf();
     v[12..20].copy_from_slice(&50u64.to_le_bytes()); // fileSize = 50
     v[20..28].copy_from_slice(&100u64.to_le_bytes()); // metaPos = 100
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.id3_trailer().is_none());
   }
 
@@ -1310,7 +1287,7 @@ mod tests {
     let mut v = happy_path_dsf();
     v[12..20].copy_from_slice(&76u64.to_le_bytes()); // fileSize = 76
     v[20..28].copy_from_slice(&76u64.to_le_bytes()); // metaPos = 76
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.id3_trailer().is_none());
   }
 
@@ -1326,7 +1303,7 @@ mod tests {
     // Note: we don't actually append 20MB — the bounds check on
     // `end > data.len()` rejects before the size guard. Equivalent
     // behavior (both guards reject).
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.id3_trailer().is_none());
   }
 
@@ -1337,7 +1314,7 @@ mod tests {
     v[12..20].copy_from_slice(&100u64.to_le_bytes()); // claim fileSize = 100
     v[20..28].copy_from_slice(&76u64.to_le_bytes()); // metaPos = 76
     // But the file is only 76 bytes — `end > data.len()` rejects.
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.id3_trailer().is_none());
   }
 
@@ -1346,7 +1323,7 @@ mod tests {
   #[test]
   fn sink_emits_full_fmt_set_in_key_order_print_conv() {
     let bytes = happy_path_dsf();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let mut w = TagMap::new();
     emit_via_engine(&meta, true, &mut w);
     // Spot-check: PrintConv-resolved names + numeric raw scalars.
@@ -1370,7 +1347,7 @@ mod tests {
   #[test]
   fn sink_emits_full_fmt_set_print_conv_off() {
     let bytes = happy_path_dsf();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let mut w = TagMap::new();
     emit_via_engine(&meta, false, &mut w);
     // -n: raw numeric for FormatID / ChannelType (hash NOT applied).
@@ -1445,7 +1422,7 @@ mod tests {
     v.extend_from_slice(&7u32.to_le_bytes()); // FormatVersion = 7
     v.extend_from_slice(&0u32.to_le_bytes()); // FormatID = 0 ⇒ "DSD Raw"
     assert_eq!(v.len(), 48);
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.fmt_warning().is_none());
     let fmt = meta.fmt().expect("partial fmt");
     assert_eq!(fmt.present_mask, 0b0000_0011); // keys 3,4 only
@@ -1475,7 +1452,7 @@ mod tests {
     v.extend_from_slice(&13u64.to_le_bytes()); // fmtLen = 13
     v.extend_from_slice(&[0u8; 1]); // 1 byte payload
     assert_eq!(v.len(), 41);
-    let meta = parse_borrowed(&v).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&v).expect("parsed");
     assert!(meta.fmt_warning().is_none());
     assert!(
       meta.fmt().is_none(),
@@ -1569,9 +1546,7 @@ mod tests {
     let bytes = happy_path_dsf();
     let mut shared = SharedFlags::new();
     let ctx = Context::new(&bytes, &mut shared);
-    let meta = <ProcessDsf as FormatParser>::parse(&ProcessDsf, ctx)
-      .expect("ok")
-      .expect("parsed");
+    let meta = <ProcessDsf as FormatParser>::parse(&ProcessDsf, ctx).expect("parsed");
     // GAT path borrows from the input; this fixture has metaPos=0 (no ID3
     // trailer), so the trailer slice is absent here.
     assert!(meta.id3_trailer().is_none());
@@ -1735,7 +1710,7 @@ mod tests {
     // §3: `FmtData` is Copy ⇒ `Meta::fmt()` returns `Option<T>` by
     // value (not `Option<&T>`), and the field getters are by-value too.
     let buf = happy_path_dsf();
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     let fmt: Option<FmtData> = meta.fmt();
     let fmt = fmt.expect("fmt present on happy path");
     assert_eq!(fmt.channel_count(), 2);
@@ -1753,20 +1728,9 @@ mod tests {
   fn dsf_id3_ref_accessor_absent_without_trailer() {
     // §3: the non-Copy nested-Meta getter is `id3_ref()`.
     let buf = happy_path_dsf();
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     assert!(meta.id3_ref().is_none(), "metaPos=0 ⇒ no ID3 trailer");
   }
-
-  #[test]
-  fn dsf_error_is_uninhabited_and_thiserror_derived() {
-    // §5: Error is uninhabited; this proves the thiserror-derived
-    // `Display`/`Error` impls exist (must compile).
-    fn _assert_error<E: core::error::Error>() {}
-    _assert_error::<Error>();
-    let none: Option<Error> = None;
-    assert!(none.is_none());
-  }
-
   // --- Golden-pattern `Taggable` / `Project` ------------------------------
 
   /// `Taggable::tags(-j)` yields the full fmt-chunk set in DSF_KEYS order
@@ -1775,7 +1739,7 @@ mod tests {
   #[test]
   fn taggable_emits_full_fmt_set_print_conv() {
     let bytes = happy_path_dsf();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::PrintConv, &mut w);
     assert_eq!(w.get_str("File", "FormatVersion"), Some("1".to_string()));
@@ -1796,7 +1760,7 @@ mod tests {
   #[test]
   fn taggable_emits_raw_scalars_value_conv() {
     let bytes = happy_path_dsf();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::ValueConv, &mut w);
     assert_eq!(w.get_str("File", "FormatID"), Some("0".to_string()));
@@ -1810,7 +1774,7 @@ mod tests {
   #[test]
   fn taggable_group_is_file_family0_and_family1() {
     let bytes = happy_path_dsf();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let tags: std::vec::Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     assert!(!tags.is_empty());
     for t in &tags {
@@ -1834,7 +1798,7 @@ mod tests {
         .join("tests/fixtures/dsf_with_id3v2_trailer.dsf"),
     )
     .expect("read dsf_with_id3v2_trailer.dsf fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     assert!(meta.id3_ref().is_some(), "fixture carries an ID3v2 trailer");
 
     // The tag stream: fmt-chunk `File:*` tags, THEN the ID3 trailer tags.
@@ -1874,7 +1838,7 @@ mod tests {
   fn project_is_audio_only_no_duration() {
     use crate::metadata::{Project, TrackKind};
     let bytes = happy_path_dsf();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let md = Project::project(&meta);
     assert_eq!(md.media().track_kinds(), &[TrackKind::Audio]);
     assert!(

--- a/src/formats/dsf.rs
+++ b/src/formats/dsf.rs
@@ -1827,7 +1827,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(k, _)| k.starts_with("ID3v2") || k == "File:ID3Size"),
+        .any(|(g, n, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 trailer tags present in the engine output"
     );
   }

--- a/src/formats/dv.rs
+++ b/src/formats/dv.rs
@@ -905,16 +905,15 @@ impl FormatParser for ProcessDv {
   /// Spec §8: leaf format Context is `&'a [u8]`.
   type Context<'a> = &'a [u8];
   /// Rust-level fatal error (none today; DV parsing has no I/O modes).
-  type Error = Error;
 
   /// Parse a DV file's bytes into a typed [`ParseOutcome`], or `None`
   /// if the buffer is not a valid DV file (short read, no DIF header,
   /// fewer than 6 blocks). Returns `Err` only for Rust-level fatal
   /// modes; the current port has none.
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     // `parse_outcome` yields a `ParseOutcome<'static>`; covariance widens
     // it to the caller's `'a`.
-    Ok(parse_outcome(data))
+    parse_outcome(data)
   }
 }
 
@@ -927,8 +926,8 @@ impl FormatParser for ProcessDv {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<ParseOutcome<'static>>, Error> {
-  Ok(parse_outcome(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<ParseOutcome<'static>> {
+  parse_outcome(data)
 }
 
 fn parse_outcome(data: &[u8]) -> Option<ParseOutcome<'static>> {
@@ -1149,39 +1148,12 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for DV parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers if streaming readers are added.
-///
-/// §5: derived via `thiserror` (`Display` + `core::error::Error` in every
-/// feature tier — `thiserror` v2 with `default-features = false` emits
-/// `core::error::Error`, so `Error` is a real `Error` even on no-std).
-/// `#[non_exhaustive]` lets the first real variant land without a breaking
-/// change. The derive expands `Display` to an empty `match *self {}`, so no
-/// `#[error(…)]` attribute is needed while the enum has no variants.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
 #[cfg(test)]
 mod tests {
   use super::*;
-
-  #[test]
-  fn dv_error_is_core_error() {
-    // §5: thiserror v2 (default-features=false) makes the empty error enum
-    // a real `core::error::Error` in every feature tier.
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   #[test]
   fn profiles_and_tag_order_are_faithful() {
     // DV.pm:21-113 → 10 entries; DV.pm:116-121 → 13 tags.
@@ -1444,7 +1416,7 @@ mod tests {
     let mut data = vec![0u8; 8000];
     data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0xbf]); // dsf=1
     data[451] = 0x00; // stype = 0 ⇒ profile[1] (PAL)
-    let outcome = parse_borrowed(&data).expect("ok").expect("parsed");
+    let outcome = parse_borrowed(&data).expect("parsed");
     match outcome {
       ParseOutcome::Meta(m) => {
         assert_eq!(m.image_width(), 720);
@@ -1462,13 +1434,13 @@ mod tests {
     let mut data = vec![0u8; 480];
     data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0x3f]);
     data[451] = 0x1f;
-    let outcome = parse_borrowed(&data).expect("ok").expect("parsed");
+    let outcome = parse_borrowed(&data).expect("parsed");
     assert!(matches!(outcome, ParseOutcome::UnrecognizedProfile));
   }
 
   #[test]
   fn parse_borrowed_rejects_empty() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
   }
 
   #[test]
@@ -1603,9 +1575,7 @@ mod tests {
     let mut data = vec![0u8; 8000];
     data[0..4].copy_from_slice(&[0x1f, 0x07, 0x00, 0xbf]);
     data[451] = 0x00;
-    let outcome = <ProcessDv as FormatParser>::parse(&ProcessDv, &data)
-      .expect("ok")
-      .expect("parsed");
+    let outcome = <ProcessDv as FormatParser>::parse(&ProcessDv, &data).expect("parsed");
     assert!(matches!(outcome, ParseOutcome::Meta(_)));
   }
 }

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -829,14 +829,13 @@ impl FormatParser for ProcessFlac {
   type Context<'a> = Context<'a>;
   /// Rust-level fatal error type (no variants today; reserved for future
   /// I/O wrappers).
-  type Error = Error;
 
   /// Run the typed parser. Returns:
   /// - `Ok(Some(meta))` — FLAC magic accepted; tags extracted (FLAC.pm:279
   ///   `return 1`).
   /// - `Ok(None)` — magic rejected (FLAC.pm:254 `or return 0`).
   /// - `Err(_)` — unreachable today.
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(ctx.data, ctx.shared)
   }
 }
@@ -857,7 +856,7 @@ impl FormatParser for ProcessFlac {
 pub fn parse_borrowed<'a>(
   data: &'a [u8],
   shared: &mut crate::format_parser::SharedFlags,
-) -> Result<Option<Meta<'a>>, Error> {
+) -> Option<Meta<'a>> {
   parse_inner(data, shared)
 }
 
@@ -865,7 +864,7 @@ pub fn parse_borrowed<'a>(
 fn parse_inner<'a>(
   data: &'a [u8],
   shared: &mut crate::format_parser::SharedFlags,
-) -> Result<Option<Meta<'a>>, Error> {
+) -> Option<Meta<'a>> {
   // -- FLAC.pm:243-247 — embedded ID3 (`ProcessID3`) ----------------------
   //
   //    unless ($$et{DoneID3}) {
@@ -890,7 +889,6 @@ fn parse_inner<'a>(
       Some(&mut *shared),
       /* print_conv */ true,
     )
-    .unwrap_or((None, 0))
   } else {
     (None, shared.id3_hdr_end().unwrap_or(0))
   };
@@ -898,7 +896,7 @@ fn parse_inner<'a>(
   // -- FLAC.pm:254 — `fLaC` magic check -----------------------------------
   // `$raf->Read($buff, 4) == 4 and $buff eq 'fLaC' or return 0`
   if data.len() < offset + 4 || &data[offset..offset + 4] != b"fLaC" {
-    return Ok(None);
+    return None;
   }
 
   // -- FLAC.pm:256-280 — block chain walk ---------------------------------
@@ -964,7 +962,7 @@ fn parse_inner<'a>(
       break;
     }
   }
-  Ok(Some(meta))
+  Some(meta)
 }
 
 /// Compute the byte offset where the FLAC body starts after an optional
@@ -1847,21 +1845,6 @@ pub fn write_convert_duration<W: core::fmt::Write + ?Sized>(
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for FLAC parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`) or a tagged warning
-/// (Perl `Warn`). Reserved for future I/O wrappers.
-///
-/// §5: `Display` + `core::error::Error` are derived via `thiserror`
-/// (v2, `default-features = false` ⇒ `core::error::Error` for no-std);
-/// `#[non_exhaustive]` lets future variants land without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -2151,9 +2134,7 @@ mod tests {
   fn process_flac_typed_parser_extracts_real_fixture() {
     let data = fixture("FLAC.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared)
-      .expect("ok")
-      .expect("flac");
+    let meta = parse_borrowed(&data, &mut shared).expect("flac");
     assert_eq!(meta.block_size_min(), Some(4608));
     assert_eq!(meta.sample_rate(), Some(8000));
     assert_eq!(meta.channels(), Some(2));
@@ -2186,11 +2167,7 @@ mod tests {
   #[test]
   fn process_flac_typed_rejects_missing_magic() {
     let mut shared = crate::format_parser::SharedFlags::new();
-    assert!(
-      parse_borrowed(b"not-flac-data-here", &mut shared)
-        .unwrap()
-        .is_none()
-    );
+    assert!(parse_borrowed(b"not-flac-data-here", &mut shared).is_none());
   }
 
   #[test]
@@ -2200,9 +2177,7 @@ mod tests {
     data.extend_from_slice(&[b'I', b'D', b'3', 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
     data.extend_from_slice(&body);
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared)
-      .expect("ok")
-      .expect("flac");
+    let meta = parse_borrowed(&data, &mut shared).expect("flac");
     assert_eq!(meta.sample_rate(), Some(8000));
   }
 
@@ -2211,9 +2186,7 @@ mod tests {
     // Just `fLaC` — magic OK, no blocks. format_error stays false (silent
     // exit on pos+4 > len, faithful).
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(b"fLaC", &mut shared)
-      .expect("ok")
-      .expect("flac");
+    let meta = parse_borrowed(b"fLaC", &mut shared).expect("flac");
     assert!(meta.stream_info.block_size_min.is_none());
     assert!(!meta.has_format_error());
   }
@@ -2222,9 +2195,7 @@ mod tests {
   fn process_flac_typed_oversized_block_sets_format_error() {
     let data: &[u8] = &[b'f', b'L', b'a', b'C', 0x80, 0xff, 0xff, 0xff];
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(data, &mut shared)
-      .expect("ok")
-      .expect("flac");
+    let meta = parse_borrowed(data, &mut shared).expect("flac");
     assert!(meta.has_format_error());
   }
 
@@ -2318,7 +2289,7 @@ mod tests {
     // object loses key order).
     let data = fixture("FLAC_picture.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     let mut tm = TagMap::new();
     emit_via_engine(&meta, true, &mut tm);
     let names: Vec<&str> = tm
@@ -2400,7 +2371,7 @@ mod tests {
   fn sink_into_map_writer_emits_streaminfo_tags() {
     let data = fixture("FLAC.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     let mut w = TagMap::new();
     emit_via_engine(&meta, true, &mut w);
     let g = |n: &str| w.get("FLAC", n).cloned();
@@ -2553,15 +2524,6 @@ mod tests {
     assert!(cover.is_cover_art());
     assert!(named.try_unwrap_cover_art_ref().is_err());
   }
-
-  #[test]
-  fn flac_error_is_thiserror_uninhabited() {
-    // §5: empty enum derives core::error::Error via thiserror — assert the
-    // trait bound holds without needing to construct a value.
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   // ---------- Golden-pattern `Taggable` / `Project` ----------------------
 
   /// `Taggable::tags(-j)` yields the StreamInfo set (no PrintConv) through
@@ -2571,7 +2533,7 @@ mod tests {
   fn taggable_emits_streaminfo_print_conv() {
     let data = fixture("FLAC.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::PrintConv, &mut w);
     assert_eq!(w.get_str("FLAC", "SampleRate"), Some("8000".to_string()));
@@ -2601,7 +2563,7 @@ mod tests {
   fn taggable_emits_vorbis_multi_artist_list() {
     let data = fixture("FLAC_multi_artist.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     for mode in [ConvMode::PrintConv, ConvMode::ValueConv] {
       let mut w = TagMap::new();
       crate::emit::run_emission(&meta, mode, &mut w);
@@ -2623,7 +2585,7 @@ mod tests {
   fn taggable_emits_picture_tags() {
     let data = fixture("FLAC_picture.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     // -j: PrintConv name + binary bytes.
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::PrintConv, &mut w);
@@ -2645,7 +2607,7 @@ mod tests {
   fn taggable_group_family0_and_family1_per_subtable() {
     let data = fixture("FLAC_duration.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     let tags: Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     assert!(!tags.is_empty());
     let mut saw_flac = false;
@@ -2674,7 +2636,7 @@ mod tests {
   fn taggable_emits_composite_duration() {
     let data = fixture("FLAC_duration.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::PrintConv, &mut w);
     assert_eq!(
@@ -2695,7 +2657,7 @@ mod tests {
   fn taggable_chains_id3_before_flac_body() {
     let data = fixture("FLAC_id3_prefix.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     assert!(meta.id3_ref().is_some(), "fixture carries an ID3v2 prefix");
     let names: Vec<String> = meta
       .tags(ConvMode::PrintConv)
@@ -2733,7 +2695,7 @@ mod tests {
     use crate::metadata::{Project, TrackKind};
     let data = fixture("FLAC_duration.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     let md = Project::project(&meta);
     assert_eq!(md.media().track_kinds(), &[TrackKind::Audio]);
     assert_eq!(md.media().duration(), Some(Duration::from_secs(30)));
@@ -2753,7 +2715,7 @@ mod tests {
     // FLAC.flac has TotalSamples == 0 ⇒ duration() is None.
     let data = fixture("FLAC.flac");
     let mut shared = crate::format_parser::SharedFlags::new();
-    let meta = parse_borrowed(&data, &mut shared).unwrap().unwrap();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
     assert!(meta.duration().is_none());
     let md = Project::project(&meta);
     assert_eq!(md.media().track_kinds(), &[TrackKind::Audio]);

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -481,8 +481,11 @@ impl<'a> VorbisNamed<'a> {
 /// fields, accessors only.
 #[derive(Debug, Clone)]
 pub struct VorbisAuto<'a> {
-  /// Auto-derived name (owned; synthesized, cannot borrow from input).
-  name: String,
+  /// Auto-derived name (owned; synthesized via the Vorbis.pm regex transform,
+  /// cannot borrow from input). A short tag identifier (stored, feeds the
+  /// emitted tag name) ⇒ `SmolStr`; the regex transform builds it in a
+  /// transient `String` (a builder — String per the rule), converted here.
+  name: smol_str::SmolStr,
   /// raw UTF-8 value.
   value: Cow<'a, str>,
 }
@@ -491,14 +494,14 @@ impl<'a> VorbisAuto<'a> {
   /// Construct an auto-named Vorbis comment payload.
   #[must_use]
   #[inline(always)]
-  pub const fn new(name: String, value: Cow<'a, str>) -> Self {
+  pub const fn new(name: smol_str::SmolStr, value: Cow<'a, str>) -> Self {
     Self { name, value }
   }
-  /// Auto-derived name (§3: `String` projected to `&str`).
+  /// Auto-derived name (§3: `SmolStr` projected to `&str`).
   #[must_use]
   #[inline(always)]
   pub fn name(&self) -> &str {
-    &self.name
+    self.name.as_str()
   }
   /// Raw UTF-8 value (§3: `Cow` projected to `&str`).
   #[must_use]
@@ -1186,7 +1189,7 @@ fn process_vorbis_comments<'a>(payload: &'a [u8], out: &mut Vec<VorbisItem<'a>>)
           )));
         } else {
           out.push(VorbisItem::Auto(VorbisAuto::new(
-            vorbis_derive_name(&tag_upper),
+            vorbis_derive_name(&tag_upper).into(),
             val,
           )));
         }
@@ -2514,7 +2517,7 @@ mod tests {
     assert_eq!(n.value(), "Alice");
     assert!(n.is_listable());
 
-    let auto = VorbisItem::Auto(VorbisAuto::new("FooBar".to_string(), Cow::Borrowed("42")));
+    let auto = VorbisItem::Auto(VorbisAuto::new("FooBar".into(), Cow::Borrowed("42")));
     assert!(auto.is_auto());
     let a = auto.unwrap_auto_ref();
     assert_eq!(a.name(), "FooBar");

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -2295,7 +2295,7 @@ mod tests {
     let names: Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(k, _)| k.strip_prefix("FLAC:"))
+      .filter_map(|(g, n, _)| (g == "FLAC").then_some(n.as_str()))
       .filter(|n| n.starts_with("Picture"))
       .collect();
     assert_eq!(
@@ -2682,7 +2682,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(k, _)| k.starts_with("ID3v2") || k == "File:ID3Size"),
+        .any(|(g, n, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 tags present in the engine output"
     );
   }

--- a/src/formats/flash.rs
+++ b/src/formats/flash.rs
@@ -559,10 +559,9 @@ impl parser_sealed::Sealed for ProcessFlv {}
 impl FormatParser for ProcessFlv {
   type Meta<'a> = Meta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -573,8 +572,8 @@ impl FormatParser for ProcessFlv {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
-  Ok(parse_inner(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
+  parse_inner(data)
 }
 
 /// Inner parser. Faithful to `ProcessFLV` (Flash.pm:467-525):
@@ -3378,17 +3377,6 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for FLV parsing. Currently empty — every bad
-/// input either produces `Ok(None)` (Perl `return 0` at Flash.pm:474/475)
-/// or surfaces warnings inside the typed [`Meta`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-pub enum Error {}
-
-// ===========================================================================
 // Tests
 // ===========================================================================
 
@@ -3398,14 +3386,14 @@ mod tests {
 
   #[test]
   fn flv_short_buffer_returns_none() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(b"FLV").unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(b"FLV").is_none());
   }
 
   #[test]
   fn flv_bad_magic_returns_none() {
     let bytes = [b'X', b'L', b'V', 0x01, 0x05, 0, 0, 0, 9];
-    assert!(parse_borrowed(&bytes).unwrap().is_none());
+    assert!(parse_borrowed(&bytes).is_none());
   }
 
   #[test]
@@ -4202,7 +4190,7 @@ mod tests {
       "/tests/fixtures/Flash.flv"
     ))
     .expect("read Flash.flv fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("FLV accepted");
+    let meta = parse_borrowed(&bytes).expect("FLV accepted");
     // -j: PrintConv strings + the per-tag conversions.
     let tm = emit_into_tagmap(&meta, true);
     assert_eq!(tm.get_str("Flash", "AudioEncoding"), Some("MP3".into()));
@@ -4227,7 +4215,7 @@ mod tests {
       "/tests/fixtures/Flash.flv"
     ))
     .expect("read Flash.flv fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tags: Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     assert!(!tags.is_empty(), "the onMetaData packet must yield tags");
     for t in &tags {
@@ -4246,7 +4234,7 @@ mod tests {
       "/tests/fixtures/Flash.flv"
     ))
     .expect("read Flash.flv fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let projected = meta.project();
     // FLV projects to a video container; the rest of MediaInfo is empty.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Video]);

--- a/src/formats/flash.rs
+++ b/src/formats/flash.rs
@@ -107,6 +107,18 @@ const fn is_struct(code: u8) -> bool {
   matches!(code, 0x03 | 0x08 | 0x10)
 }
 
+/// Max recursion depth for the AMF (`onMetaData`/`onXMPData`) script-data
+/// walker (Golden-v2 Contract 3a). Bundled `ProcessMeta` recurses without a
+/// hard cap (it relies on the finite `$dirLen`), but a hostile FLV can nest
+/// AMF strict-arrays (`0x0a`) or objects (`0x03`/`0x08`/`0x10`) arbitrarily
+/// deep, recursing the mutually-recursive `walk_pairs`/`walk_array`/
+/// `collect_array_items` cluster until the stack overflows — a DoS. Real FLV
+/// `onMetaData` nests a couple of levels (the `keyframes` object holds two
+/// flat arrays), so this cap is a large superset that never trips on a real
+/// file; the output stays byte-identical. Exceeding it stops recursion,
+/// faithful to a truncated subtree contributing no further tags.
+const MAX_AMF_DEPTH: u32 = 100;
+
 /// `%processMetaPacket` (Flash.pm:34) — top-level script-data packet names
 /// that drive the meta walker. The first string of a top-level meta tag is
 /// the packet name; only `onMetaData` and `onXMPData` are walked
@@ -1366,6 +1378,7 @@ fn process_meta(
       // collapsed Perl's undef (top-level) vs defined-empty (empty-key
       // parent) — see R8/F1 fixture.
       let outcome = walk_pairs(
+        0, // top-level packet walk — depth 0
         data,
         &mut pos,
         r#type,
@@ -1418,6 +1431,7 @@ fn process_meta(
       // (`Flash:Name` last-wins for the
       // `flash_toplevel_array_objects.flv` fixture, R8/F2).
       match collect_array_items(
+        0, // top-level lone array — depth 0
         data,
         &mut pos,
         SubTable::Meta,
@@ -1533,6 +1547,7 @@ fn process_meta(
 ///   * Top-level strict-array struct children received spurious
 ///     `0Name`-style prefixes that bundled never appends (R8/F2).
 fn walk_pairs(
+  depth: u32,
   data: &[u8],
   pos: &mut usize,
   struct_type: u8,
@@ -1541,6 +1556,13 @@ fn walk_pairs(
   entries: &mut std::vec::Vec<Entry>,
   warnings: &mut std::vec::Vec<SmolStr>,
 ) -> WalkOutcome {
+  // Golden-v2 3a — recursion-depth guard for the AMF object/array cluster.
+  // Real `onMetaData` nests a couple of levels, far below `MAX_AMF_DEPTH`, so
+  // this never trips on a real file (byte-identical); it bounds stack growth
+  // on a maliciously deep AMF tree. Stop as a bundled `last Record`.
+  if depth >= MAX_AMF_DEPTH {
+    return WalkOutcome::Abort;
+  }
   loop {
     // Read key (u16-prefixed). Bundled Flash.pm:350 `last Record if $pos
     // + 2 > $dirLen` — no warning at this point ($val=''). Bundled DOES
@@ -1745,7 +1767,9 @@ fn walk_pairs(
           // continues (see the block comment above). Any warnings the
           // child pushed are preserved (shared `warnings` vec) and the
           // advanced cursor is preserved (shared `pos`).
+          // A nested object is one level deeper (Golden-v2 3a).
           let _ = walk_pairs(
+            depth + 1,
             data,
             pos,
             vtype,
@@ -1786,7 +1810,9 @@ fn walk_pairs(
       // $structName . $i if defined $structName` fires per element.
       // (Top-level strict-arrays don't reach this path — `process_meta`
       // dispatches them directly with `None` carrier.)
+      // A child array is one level deeper (Golden-v2 3a).
       if walk_array(
+        depth + 1,
         data,
         pos,
         sub_table_for_value,
@@ -1891,6 +1917,7 @@ fn walk_pairs(
 ///   element type, AND the half-collected list is DROPPED (faithful: Perl
 ///   never reaches the `\@vals` assignment).
 fn walk_array(
+  depth: u32,
   data: &[u8],
   pos: &mut usize,
   table: SubTable,
@@ -1899,6 +1926,10 @@ fn walk_array(
   entries: &mut std::vec::Vec<Entry>,
   warnings: &mut std::vec::Vec<SmolStr>,
 ) -> WalkOutcome {
+  // Golden-v2 3a — recursion-depth guard (same cluster as `walk_pairs`).
+  if depth >= MAX_AMF_DEPTH {
+    return WalkOutcome::Abort;
+  }
   // Delegate to `collect_array_items` so nested strict-arrays can reuse
   // the same body (Codex R2/F2 — the prior shape called `read_value` on
   // a nested 0x0a element, which returned `AmfValue::StrictArray`
@@ -1908,7 +1939,11 @@ fn walk_array(
   // top-level element of THIS strict array gets the bundled element-wise
   // conversion. R14/F1 (mul_1000) and R15/F1 (trim_trailing_ws) share this
   // carry; the nested-array recursion inside the helper resets to NEUTRAL.
+  //
+  // `walk_array` is a thin delegator over the SAME array frame, so it passes
+  // its own `depth` (not `depth + 1`) to `collect_array_items`.
   match collect_array_items(
+    depth,
     data,
     pos,
     table,
@@ -2028,6 +2063,7 @@ impl ArrayValueConv {
 /// producing bundled's `[[a,b,...],...]` JSON shape).
 #[allow(clippy::too_many_arguments)]
 fn collect_array_items(
+  depth: u32,
   data: &[u8],
   pos: &mut usize,
   table: SubTable,
@@ -2036,6 +2072,13 @@ fn collect_array_items(
   entries: &mut std::vec::Vec<Entry>,
   warnings: &mut std::vec::Vec<SmolStr>,
 ) -> ArrayOutcome {
+  // Golden-v2 3a — recursion-depth guard (same cluster as `walk_pairs`).
+  // Return an empty list (the "no further items" outcome) so the walk stops
+  // without pushing a spurious truncation warning; a real file never reaches
+  // this depth, so the output is unchanged.
+  if depth >= MAX_AMF_DEPTH {
+    return ArrayOutcome::Ok(std::vec::Vec::new());
+  }
   if *pos + 4 > data.len() {
     // Bundled Flash.pm:411 `last if $pos + 4 > $dirLen` — no warning at
     // this point. The post-loop line 455 (`not defined $val and defined
@@ -2208,7 +2251,9 @@ fn collect_array_items(
       // `collect_array_items` returning `None` on `Unsupported` /
       // `Truncated` leaf reads (the `ReadResult::Truncated` /
       // `Unsupported` arms below in this fn's scalar branch).
+      // A struct element nests one level deeper (Golden-v2 3a).
       let _ = walk_pairs(
+        depth + 1,
         data,
         pos,
         vtype,
@@ -2267,7 +2312,9 @@ fn collect_array_items(
       // Recursing `mul_1000` here produced the bogus `[[1500,61000]]` for a
       // `totaldatarate` nested array; recursing `trim_trailing_ws` would
       // wrongly trim inner-array strings. Bundled does neither.
+      // A nested strict-array is one level deeper (Golden-v2 3a).
       match collect_array_items(
+        depth + 1,
         data,
         pos,
         table,
@@ -3668,6 +3715,7 @@ mod tests {
     let mut entries = std::vec::Vec::new();
     let mut warnings = std::vec::Vec::new();
     let result = collect_array_items(
+      0,
       &bytes,
       &mut pos,
       SubTable::Meta,
@@ -3734,6 +3782,7 @@ mod tests {
     let mut entries = std::vec::Vec::new();
     let mut warnings = std::vec::Vec::new();
     let result = collect_array_items(
+      0,
       &bytes,
       &mut pos,
       SubTable::Meta,
@@ -3816,6 +3865,7 @@ mod tests {
     let mut entries = std::vec::Vec::new();
     let mut warnings = std::vec::Vec::new();
     let result = collect_array_items(
+      0,
       &bytes,
       &mut pos,
       SubTable::Meta,
@@ -3887,6 +3937,7 @@ mod tests {
     let mut entries = std::vec::Vec::new();
     let mut warnings = std::vec::Vec::new();
     let result = collect_array_items(
+      0,
       &bytes,
       &mut pos,
       SubTable::Meta,
@@ -3982,6 +4033,7 @@ mod tests {
     let mut entries = std::vec::Vec::new();
     let mut warnings = std::vec::Vec::new();
     let result = collect_array_items(
+      0,
       &bytes,
       &mut pos,
       SubTable::Meta,
@@ -4025,6 +4077,7 @@ mod tests {
     let mut entries = std::vec::Vec::new();
     let mut warnings = std::vec::Vec::new();
     let result = collect_array_items(
+      0,
       &bytes,
       &mut pos,
       SubTable::Meta,
@@ -4206,5 +4259,40 @@ mod tests {
     assert!(projected.lens().is_none());
     assert!(projected.gps().is_none());
     assert!(projected.capture().is_none());
+  }
+
+  #[test]
+  fn deeply_nested_amf_arrays_do_not_overflow_the_stack() {
+    // Golden-v2 Contract 3a — a hostile FLV can nest AMF strict-arrays
+    // arbitrarily deep, recursing `collect_array_items` until the stack
+    // overflows (a DoS). With `MAX_AMF_DEPTH` the walk stops at the cap and
+    // returns. 100_000 is a superset of any real `onMetaData` nesting
+    // (single-digit), so the cap never trips on a real file (byte-identical
+    // output). Mirrors the well-formed `collect_array_items_handles_nested_
+    // strict_array` fixture, just nested far past the budget.
+    const N: usize = 100_000;
+    // Body for `collect_array_items` (the leading 0x0a marker already
+    // consumed by the caller): N nested strict-arrays, each `count=1` + a
+    // `0x0a` element marker, innermost `count=0`.
+    let mut bytes = std::vec::Vec::new();
+    for _ in 0..N {
+      bytes.extend_from_slice(&1u32.to_be_bytes()); // count = 1
+      bytes.push(0x0a); // element[0] is a nested strict-array
+    }
+    bytes.extend_from_slice(&0u32.to_be_bytes()); // innermost count = 0
+    let mut pos = 0;
+    let mut entries = std::vec::Vec::new();
+    let mut warnings = std::vec::Vec::new();
+    // The depth budget bounds the recursion; this returns without overflowing.
+    let _ = collect_array_items(
+      0,
+      &bytes,
+      &mut pos,
+      SubTable::Meta,
+      Some("a"),
+      ArrayValueConv::NEUTRAL,
+      &mut entries,
+      &mut warnings,
+    );
   }
 }

--- a/src/formats/h264.rs
+++ b/src/formats/h264.rs
@@ -3256,7 +3256,7 @@ mod tests {
     let wb_keys = j
       .entries()
       .iter()
-      .filter(|(k, _)| k.as_str().contains("WhiteBalance"))
+      .filter(|(_, n, _)| n.contains("WhiteBalance"))
       .count();
     assert_eq!(wb_keys, 1, "only the priority winner is emitted");
   }

--- a/src/formats/h264.rs
+++ b/src/formats/h264.rs
@@ -1179,10 +1179,9 @@ impl parser_sealed::Sealed for ProcessH264 {}
 impl FormatParser for ProcessH264 {
   type Meta<'a> = H264Meta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = H264Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, H264Error> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -1190,17 +1189,12 @@ impl FormatParser for ProcessH264 {
 /// PES payload an M2TS demuxer would hand us) and returns a typed
 /// [`H264Meta`].
 ///
-/// Returns `Ok(None)` when the buffer contains no NAL start code at all
-/// (not an H.264 stream); `Ok(Some(meta))` otherwise — `meta` may be
+/// Returns `None` when the buffer contains no NAL start code at all
+/// (not an H.264 stream); `Some(meta)` otherwise — `meta` may be
 /// [`H264Meta::is_empty`] when the stream had no SPS size and no MDPM block.
-///
-/// # Errors
-///
-/// Returns `Err` only for Rust-level fatal modes — there are none today
-/// ([`H264Error`] is uninhabited), so this is always `Ok`. The signature
-/// matches the other format ports for a uniform call shape.
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<H264Meta<'_>>, H264Error> {
-  Ok(parse_inner(data))
+#[must_use]
+pub fn parse_borrowed(data: &[u8]) -> Option<H264Meta<'_>> {
+  parse_inner(data)
 }
 
 /// Inner parser body. `None` ⇒ no NAL start code anywhere (reject); else
@@ -2994,18 +2988,6 @@ impl crate::metadata::Project for H264Meta<'_> {
   }
 }
 
-// ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for H.264 parsing. Currently uninhabited — every
-/// bad input produces `Ok(None)` (no NAL start code) or `Ok(Some(empty))`
-/// (no SPS / no MDPM), faithful to `ParseH264Video`, which never dies.
-/// Reserved for a future I/O-fallible demuxer wrapper.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum H264Error {}
-
 // NOTE on serde (rust-type-conventions §8): the typed `H264Meta` does NOT
 // implement `Serialize` directly — like every other format port in this
 // crate, the `-j`/`-n` JSON view is produced by the shared
@@ -3094,30 +3076,17 @@ mod tests {
     stream.extend_from_slice(&[0x00, 0x00, 0x00, 0x01, 0x09, 0x10]);
     stream
   }
-
-  #[test]
-  fn h264_error_is_core_error() {
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<H264Error>();
-  }
-
   #[test]
   fn parse_borrowed_rejects_non_h264() {
     // No NAL start code anywhere ⇒ `Ok(None)`.
-    assert!(
-      parse_borrowed(b"not an h264 stream at all")
-        .unwrap()
-        .is_none()
-    );
-    assert!(parse_borrowed(&[]).unwrap().is_none());
+    assert!(parse_borrowed(b"not an h264 stream at all").is_none());
+    assert!(parse_borrowed(&[]).is_none());
   }
 
   #[test]
   fn parse_borrowed_accepts_avchd_fixture() {
     let data = avchd_fixture();
-    let meta = parse_borrowed(&data)
-      .expect("ok")
-      .expect("has a NAL start code");
+    let meta = parse_borrowed(&data).expect("has a NAL start code");
     assert!(!meta.is_empty(), "the MDPM block must yield tags");
     assert_eq!(meta.make(), Some("Canon"));
   }
@@ -3125,7 +3094,7 @@ mod tests {
   #[test]
   fn avchd_fixture_print_conv_tags() {
     let data = avchd_fixture();
-    let meta = parse_borrowed(&data).unwrap().unwrap();
+    let meta = parse_borrowed(&data).unwrap();
     let tm = emit_into_tagmap(&meta, true);
     // -j mode — PrintConv labels.
     assert_eq!(
@@ -3152,7 +3121,7 @@ mod tests {
   #[test]
   fn avchd_fixture_numeric_tags() {
     let data = avchd_fixture();
-    let meta = parse_borrowed(&data).unwrap().unwrap();
+    let meta = parse_borrowed(&data).unwrap();
     let tm = emit_into_tagmap(&meta, false);
     // -n mode — raw post-ValueConv scalars.
     assert_eq!(
@@ -3189,7 +3158,7 @@ mod tests {
     stream.extend_from_slice(&escape_rbsp(&sei));
     stream.extend_from_slice(&[0x00, 0x00, 0x00, 0x01, 0x09, 0x10]);
 
-    let meta = parse_borrowed(&stream).unwrap().unwrap();
+    let meta = parse_borrowed(&stream).unwrap();
     let names: Vec<&str> = meta.entries().iter().map(super::H264Entry::name).collect();
     assert_eq!(names, ["WhiteBalance"], "must stop before the 0xa2 record");
 
@@ -3243,7 +3212,7 @@ mod tests {
       0x70, 0xff, 0x00, 0x20, 0x00, // Camera1 ⇒ WhiteBalance "Hold"
       0xa8, 0x00, 0x00, 0x00, 0x00, // top-level WhiteBalance "Auto" (Priority=>0)
     ]);
-    let meta = parse_borrowed(&stream).unwrap().unwrap();
+    let meta = parse_borrowed(&stream).unwrap();
 
     // Both WhiteBalance entries are parsed (the Camera1 one and the 0xa8 one),
     // each carrying its `FoundTag` priority — the relegation happens at
@@ -3338,7 +3307,7 @@ mod tests {
     // `ParseH264Video` reports them under `GPS:`, not `H264:` (Codex R5 F1).
     // 0xb1 GPSLatitudeRef="N" is a simple single-record GPS tag.
     let s1 = mdpm_stream(&[0xb1, b'N', 0x00, 0x00, 0x00]);
-    let meta = parse_borrowed(&s1).unwrap().unwrap();
+    let meta = parse_borrowed(&s1).unwrap();
     let e = meta
       .entries()
       .iter()
@@ -3347,7 +3316,7 @@ mod tests {
     assert!(e.group().is_gps(), "GPS block ⇒ family-1 GPS");
     // Non-GPS MDPM tag stays in H264 (0xa8 WhiteBalance).
     let s2 = mdpm_stream(&[0xa8, 0x00, 0x00, 0x00, 0x01]);
-    let meta2 = parse_borrowed(&s2).unwrap().unwrap();
+    let meta2 = parse_borrowed(&s2).unwrap();
     let wb = meta2
       .entries()
       .iter()
@@ -3375,7 +3344,7 @@ mod tests {
       0xa6, 0x00, 0x00, 0x00, 0x99, // Flash=0x99
       0xbe, b'Z', 0x00, 0x00, 0x00, // GPSStatus="Z" (string-enum miss)
     ]);
-    let meta = parse_borrowed(&stream).unwrap().unwrap();
+    let meta = parse_borrowed(&stream).unwrap();
     let j = emit_into_tagmap(&meta, true);
     assert_eq!(
       j.get_str("H264", "ExposureProgram").as_deref(),
@@ -3401,7 +3370,7 @@ mod tests {
     // with `PrintHex => 1` (H264.pm:529) ⇒ `Unknown (0x9999)` in -j, raw
     // `39321` in -n — NOT the `RawConv` "Unknown" string (Codex R5 F2).
     let stream = mdpm_stream(&[0xe0, 0x99, 0x99, 0x00, 0x00]);
-    let meta = parse_borrowed(&stream).unwrap().unwrap();
+    let meta = parse_borrowed(&stream).unwrap();
     let j = emit_into_tagmap(&meta, true);
     assert_eq!(
       j.get_str("H264", "Make").as_deref(),
@@ -3417,7 +3386,7 @@ mod tests {
     // WhiteBalance (mask 0xe0 ⇒ 5, off-map) ⇒ `Unknown (5)` in -j, `5` in -n
     // (Codex R5 F2). b1=0x50 ⇒ ep=5; b2=0xa0 ⇒ wb=5; b3=0xff ⇒ no Focus.
     let stream = mdpm_stream(&[0x70, 0x00, 0x50, 0xa0, 0xff]);
-    let meta = parse_borrowed(&stream).unwrap().unwrap();
+    let meta = parse_borrowed(&stream).unwrap();
     let j = emit_into_tagmap(&meta, true);
     assert_eq!(
       j.get_str("H264", "ExposureProgram").as_deref(),
@@ -3489,7 +3458,7 @@ mod tests {
     let mut stream: Vec<u8> = vec![0x00, 0x00, 0x00, 0x01, 0x67];
     stream.extend_from_slice(sps_rbsp);
     stream.extend_from_slice(&[0x00, 0x00, 0x00, 0x01, 0x09, 0x10]);
-    let meta = parse_borrowed(&stream).unwrap().unwrap();
+    let meta = parse_borrowed(&stream).unwrap();
     let tm = emit_into_tagmap(&meta, true);
     assert_eq!(tm.get_str("H264", "ImageWidth").as_deref(), Some("1280"));
     assert_eq!(tm.get_str("H264", "ImageHeight").as_deref(), Some("720"));
@@ -3498,10 +3467,8 @@ mod tests {
   #[test]
   fn format_parser_trait_matches_parse_borrowed() {
     let data = avchd_fixture();
-    let via_trait = <ProcessH264 as FormatParser>::parse(&ProcessH264, &data)
-      .expect("ok")
-      .expect("some");
-    let via_direct = parse_borrowed(&data).unwrap().unwrap();
+    let via_trait = <ProcessH264 as FormatParser>::parse(&ProcessH264, &data).expect("some");
+    let via_direct = parse_borrowed(&data).unwrap();
     assert_eq!(via_trait.entries().len(), via_direct.entries().len());
     assert_eq!(via_trait.make(), via_direct.make());
   }
@@ -3684,7 +3651,7 @@ mod tests {
     let mut stream: Vec<u8> = vec![0x00, 0x00, 0x00, 0x01, 0x67];
     stream.extend_from_slice(&[0x42, 0xc0, 0x1f]);
     stream.extend_from_slice(&[0x00, 0x00, 0x00, 0x01, 0x09, 0x10]);
-    let meta = parse_borrowed(&stream).unwrap().unwrap();
+    let meta = parse_borrowed(&stream).unwrap();
     assert!(
       meta
         .entries()
@@ -3701,9 +3668,7 @@ mod tests {
     // (`0b1000_0110`) sets the forbidden_zero_bit; the warning must be pushed
     // into `H264Meta.warnings` BEFORE the scan stops.
     let stream: [u8; 5] = [0x00, 0x00, 0x00, 0x01, 0x86];
-    let meta = parse_borrowed(&stream)
-      .unwrap()
-      .expect("start code present");
+    let meta = parse_borrowed(&stream).expect("start code present");
     assert!(
       meta.entries().is_empty(),
       "a forbidden-bit NAL parses no tags",
@@ -3917,9 +3882,7 @@ mod tests {
 
     // Must not panic (overflow-checked builds) and must emit no tags: the
     // huge real type is not 5, so the MDPM payload is never decoded.
-    let meta = parse_borrowed(&stream)
-      .expect("parse must succeed")
-      .expect("stream has a NAL start code");
+    let meta = parse_borrowed(&stream).expect("stream has a NAL start code");
     assert!(
       meta.is_empty(),
       "an overflowing SEI payload type must not fabricate MDPM tags, got {:?}",
@@ -3936,7 +3899,7 @@ mod tests {
     let mut ok_stream: Vec<u8> = vec![0x00, 0x00, 0x00, 0x01, 0x06];
     ok_stream.extend_from_slice(&escape_rbsp(&ok_sei));
     ok_stream.extend_from_slice(&[0x00, 0x00, 0x00, 0x01, 0x09, 0x10]);
-    let ok = parse_borrowed(&ok_stream).unwrap().unwrap();
+    let ok = parse_borrowed(&ok_stream).unwrap();
     assert_eq!(
       ok.entries()
         .iter()
@@ -3992,9 +3955,7 @@ mod tests {
 
     // Must not panic on any build and must not emit the out-of-sequence
     // warning (the ids are strictly ascending).
-    let meta = parse_borrowed(&stream)
-      .expect("parse must succeed")
-      .expect("has a NAL start code");
+    let meta = parse_borrowed(&stream).expect("has a NAL start code");
     assert!(
       meta.warnings().is_empty(),
       "strictly-ascending records ⇒ no out-of-sequence warning",
@@ -4013,7 +3974,7 @@ mod tests {
   fn taggable_group_is_h264_family0_and_entry_family1() {
     use crate::emit::{ConvMode, Taggable};
     let data = avchd_fixture();
-    let meta = parse_borrowed(&data).unwrap().unwrap();
+    let meta = parse_borrowed(&data).unwrap();
     let tags: Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     assert!(!tags.is_empty(), "the MDPM block must yield tags");
     // No H264 table row is `Unknown => 1`.
@@ -4037,7 +3998,7 @@ mod tests {
     // avchd fixture (single WhiteBalance) and assert the filter yields exactly
     // one WhiteBalance — the engine's one-per-`group:name` default render.
     let data = avchd_fixture();
-    let meta = parse_borrowed(&data).unwrap().unwrap();
+    let meta = parse_borrowed(&data).unwrap();
     let wb_count = meta
       .tags(ConvMode::PrintConv)
       .filter(|t| t.tag().name() == "WhiteBalance")
@@ -4049,7 +4010,7 @@ mod tests {
   fn project_populates_video_track() {
     use crate::metadata::{Project, TrackKind};
     let data = avchd_fixture();
-    let meta = parse_borrowed(&data).unwrap().unwrap();
+    let meta = parse_borrowed(&data).unwrap();
     let projected = meta.project();
     // H.264 is a video elementary stream ⇒ a single video track kind.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Video]);

--- a/src/formats/id3/mod.rs
+++ b/src/formats/id3/mod.rs
@@ -78,7 +78,7 @@ pub mod v2_common;
 pub mod v2_process;
 
 pub use process::{
-  Id3Context, Id3Error, Id3Meta, Id3Picture, Id3v1Meta, Id3v2Frame, Id3v2Version, ProcessId3,
+  Id3Context, Id3Meta, Id3Picture, Id3v1Meta, Id3v2Frame, Id3v2Version, ProcessId3,
   parse_id3_borrowed, parse_id3v1_from_block,
 };
 
@@ -86,4 +86,4 @@ pub use process::{
 // `mpeg-audio` + `ape`. The plain `id3` feature (pulled by flac/aiff/dsf/ape
 // for the ID3-prefix chain) does NOT compile these.
 #[cfg(feature = "mp3")]
-pub use process::{Mp3Context, Mp3Error, Mp3Meta, ProcessMp3, parse_mp3_borrowed};
+pub use process::{Mp3Context, Mp3Meta, ProcessMp3, parse_mp3_borrowed};

--- a/src/formats/id3/process.rs
+++ b/src/formats/id3/process.rs
@@ -2875,7 +2875,7 @@ mod tests {
   fn emit_entries<T: crate::emit::Taggable>(
     meta: &T,
     mode: crate::emit::ConvMode,
-  ) -> Vec<(SmolStr, TagValue)> {
+  ) -> Vec<(SmolStr, SmolStr, TagValue)> {
     let mut tm = crate::tagmap::TagMap::new();
     crate::emit::run_emission(meta, mode, &mut tm);
     tm.entries().to_vec()
@@ -2891,7 +2891,7 @@ mod tests {
   #[test]
   fn id3v1_taggable_matches_reference_emission() {
     // Faithful transcription of `crate::formats::real::emit_id3v1`.
-    fn reference(id3: &Id3v1Meta<'_>, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+    fn reference(id3: &Id3v1Meta<'_>, print_conv: bool) -> Vec<(SmolStr, SmolStr, TagValue)> {
       let mut out = crate::tagmap::TagMap::new();
       let group = "ID3v1";
       if let Some(s) = id3.title() {

--- a/src/formats/id3/process.rs
+++ b/src/formats/id3/process.rs
@@ -983,7 +983,6 @@ impl FormatParser for ProcessId3 {
   /// `SmolStr`, so `'a` is phantom; Codex AF2).
   type Meta<'a> = Id3Meta<'a>;
   type Context<'a> = Id3Context<'a>;
-  type Error = Id3Error;
 
   /// Parse the ID3 directory at the start of `ctx.data()`. Returns
   /// `Ok(Some(meta))` when an ID3v1 OR ID3v2 was detected, `Ok(None)`
@@ -993,8 +992,9 @@ impl FormatParser for ProcessId3 {
   /// Stages in `-j` PrintConv mode (the closed-dispatch convention; the
   /// Meta is mode-locked, Codex BF2 — sink with `sink(true, ...)`). For
   /// `-n` access use [`parse_id3_borrowed`] with `print_conv = false`.
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Self::Error> {
-    parse_id3_inner(ctx.data, Some(ctx.shared), /* print_conv */ true).map(|(meta, _hdr_end)| meta)
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    let (meta, _hdr_end) = parse_id3_inner(ctx.data, Some(ctx.shared), /* print_conv */ true);
+    meta
   }
 }
 
@@ -1061,7 +1061,6 @@ impl FormatParser for ProcessMp3 {
   /// sub-Meta borrows its `encoder` field; Codex AF2).
   type Meta<'a> = Mp3Meta<'a>;
   type Context<'a> = Mp3Context<'a>;
-  type Error = Mp3Error;
 
   /// Parse a candidate MP3 file. Returns `Ok(Some(meta))` if ID3 OR
   /// MPEG audio sync was detected, `Ok(None)` otherwise. Faithful to
@@ -1072,8 +1071,8 @@ impl FormatParser for ProcessMp3 {
   /// already run. The typed sub-Metas are populated so the `serialize_tags`
   /// emits ID3 + MPEG + APE tags without the legacy bridge (Codex
   /// BF1/CF1).
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Self::Error> {
-    parse_mp3_typed(ctx.data, ctx.ext, ctx.shared).map_err(Mp3Error::Id3)
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_mp3_typed(ctx.data, ctx.ext, ctx.shared)
   }
 }
 
@@ -1111,7 +1110,7 @@ fn parse_mp3_typed<'a>(
   data: &'a [u8],
   ext: Option<&str>,
   shared: &mut SharedFlags,
-) -> Result<Option<Mp3Meta<'a>>, Id3Error> {
+) -> Option<Mp3Meta<'a>> {
   // -- 1. ID3 (ID3.pm:1691-1693) ------------------------------------------
   // `unless ($$et{DoneID3}) { $rtnVal = ProcessID3(...) }` (ID3.pm:1691-1693).
   // When a prior parser in the chain (e.g. APE/DSF/FLAC) already ran
@@ -1126,7 +1125,7 @@ fn parse_mp3_typed<'a>(
     // `$hdrEnd`) on `shared` so a subsequent chained parser / recursive MP3
     // dispatch observes them (Codex B-R3-1/B-R3-2). No manual marker patch
     // is needed here.
-    parse_id3_inner(data, Some(&mut *shared), /* print_conv */ true)?
+    parse_id3_inner(data, Some(&mut *shared), /* print_conv */ true)
   } else {
     // DoneID3 already set ⇒ bundled `ProcessID3` returns 0 and the `unless`
     // skips it (ID3.pm:1691-1693). No ID3 sub-Meta. The bundled flow only
@@ -1150,16 +1149,14 @@ fn parse_mp3_typed<'a>(
   let post_id3 = data.get(hdr_end..).unwrap_or(&[]);
   let bounded = &post_id3[..scan_len.min(post_id3.len())];
   // `mpeg::AudioError` is uninhabited; the `Ok(None)` path covers "no sync".
-  let mpeg = crate::formats::mpeg::parse_borrowed(bounded, mp3_flag, ext_str)
-    .ok()
-    .flatten();
+  let mpeg = crate::formats::mpeg::parse_borrowed(bounded, mp3_flag, ext_str);
 
   // -- rtnVal (ID3.pm:1722 `if ($rtnVal ...)`) ----------------------------
   let rtn_val = id3.is_some() || mpeg.is_some();
   if !rtn_val {
     // Perl returns 0 ⇒ no File:* promotion; the engine emits the
     // file-format error. The typed entry returns `Ok(None)`.
-    return Ok(None);
+    return None;
   }
 
   // -- 3. APE trailer fallback (ID3.pm:1722-1727) -------------------------
@@ -1175,12 +1172,12 @@ fn parse_mp3_typed<'a>(
     crate::formats::ape::parse_trailer_only_owned(data, shared)
   };
 
-  Ok(Some(Mp3Meta {
+  Some(Mp3Meta {
     id3,
     mpeg,
     ape,
     found: rtn_val,
-  }))
+  })
 }
 
 /// Lib-first direct entry for the MP3 wrapper with **decoupled `shared`
@@ -1192,43 +1189,14 @@ fn parse_mp3_typed<'a>(
 ///
 /// The ID3 sub-Meta is staged in `-j` PrintConv mode (sink with
 /// `sink(true, ...)`); MPEG / APE sub-Metas apply PrintConv at sink time.
-///
-/// # Errors
-///
-/// Returns the per-format [`Mp3Error`].
 #[cfg(feature = "mp3")]
+#[must_use]
 pub fn parse_mp3_borrowed<'a>(
   data: &'a [u8],
   ext: Option<&str>,
   shared: &mut SharedFlags,
-) -> Result<Option<Mp3Meta<'a>>, Mp3Error> {
-  parse_mp3_typed(data, ext, shared).map_err(Mp3Error::Id3)
-}
-
-/// Rust-level fatal modes for ID3 parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`) or a non-fatal Warn that
-/// lands as an [`Id3Meta::warnings_slice`] entry. Reserved for future I/O
-/// wrappers.
-///
-/// §5: `Display` + `core::error::Error` are derived via `thiserror` (v2,
-/// `default-features = false`) so the trait is present in every feature tier.
-/// `#[non_exhaustive]` lets variants land later without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Id3Error {}
-
-/// Rust-level fatal modes for MP3 parsing. Wraps [`Id3Error`] for the
-/// nested ID3 dispatch.
-///
-/// §5: derived via `thiserror`; `#[from]` on the wrapped [`Id3Error`] gives a
-/// free `From<Id3Error>` + `source()`. `#[non_exhaustive]` for additive growth.
-#[cfg(feature = "mp3")]
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Mp3Error {
-  /// An ID3 parsing error bubbled up from the nested directory parser.
-  #[error("MP3: ID3 parsing failed: {0}")]
-  Id3(#[from] Id3Error),
+) -> Option<Mp3Meta<'a>> {
+  parse_mp3_typed(data, ext, shared)
 }
 
 // ===========================================================================
@@ -1280,7 +1248,7 @@ fn parse_id3_inner<'a>(
   data: &'a [u8],
   shared: Option<&mut SharedFlags>,
   print_conv: bool,
-) -> Result<(Option<Id3Meta<'a>>, usize), Id3Error> {
+) -> (Option<Id3Meta<'a>>, usize) {
   let _ = print_conv; // no longer mode-locks (Codex B-R2-1); see fn docs.
 
   // ID3.pm:1435 `return 0 if $$et{DoneID3}` — the `ProcessID3` recursion
@@ -1293,7 +1261,7 @@ fn parse_id3_inner<'a>(
   // has no cross-format state to guard on — the legacy scratch `Metadata`
   // owns its own `DoneID3` for internal recursion.
   if shared.as_ref().is_some_and(|sf| sf.done_id3().is_some()) {
-    return Ok((None, 0));
+    return (None, 0);
   }
 
   // PrintConv (`-j`) pass — the accessor + `sink(true)` source.
@@ -1319,7 +1287,7 @@ fn parse_id3_inner<'a>(
   }
 
   if !found {
-    return Ok((None, hdr_end));
+    return (None, hdr_end);
   }
   // Raw (`-n`) pass — the `sink(false)` source. Same input, same engine,
   // PrintConv disabled (ID3v1 Genre %genre ID3.pm:371-375; TLEN
@@ -1352,7 +1320,7 @@ fn parse_id3_inner<'a>(
   }
   let warnings: Vec<SmolStr> = staging.warnings_slice().iter().map(SmolStr::new).collect();
   let errors: Vec<SmolStr> = staging.errors_slice().iter().map(SmolStr::new).collect();
-  Ok((
+  (
     Some(Id3Meta {
       v2_version,
       id3v1,
@@ -1364,7 +1332,7 @@ fn parse_id3_inner<'a>(
       _phantom: core::marker::PhantomData,
     }),
     hdr_end,
-  ))
+  )
 }
 
 /// Lift a single ID3v1-group tag into the typed [`Id3v1Meta`] subframe.
@@ -1890,17 +1858,14 @@ fn reverse_unsync_inplace(v: &[u8]) -> Vec<u8> {
 /// Genre `"Hip-Hop"`); `print_conv = false` stages in `-n` post-ValueConv
 /// raw mode (e.g. Genre `7`). The returned Meta must be sinked in the same
 /// mode (see `serialize_tags` for [`Id3Meta`]; Codex BF2).
-///
-/// # Errors
-///
-/// Returns `Err` for Rust-level fatal modes (none today; reserved for
-/// future I/O wrappers).
+#[must_use]
 pub fn parse_id3_borrowed<'a>(
   data: &'a [u8],
   shared: Option<&mut SharedFlags>,
   print_conv: bool,
-) -> Result<Option<Id3Meta<'a>>, Id3Error> {
-  parse_id3_inner(data, shared, print_conv).map(|(meta, _hdr_end)| meta)
+) -> Option<Id3Meta<'a>> {
+  let (meta, _hdr_end) = parse_id3_inner(data, shared, print_conv);
+  meta
 }
 
 /// As [`parse_id3_borrowed`], but ALSO returns the bundled `$hdrEnd`
@@ -1912,15 +1877,12 @@ pub fn parse_id3_borrowed<'a>(
 /// 0). The `DoneID3` "ran" marker + trailer size are recorded on `shared`
 /// exactly as [`parse_id3_borrowed`] does (so APE.pm:169's footer shift sees
 /// the v1-trailer size).
-///
-/// # Errors
-///
-/// Returns `Err` for Rust-level fatal modes (none today).
+#[must_use]
 pub(crate) fn parse_id3_with_hdr_end<'a>(
   data: &'a [u8],
   shared: Option<&mut SharedFlags>,
   print_conv: bool,
-) -> Result<(Option<Id3Meta<'a>>, usize), Id3Error> {
+) -> (Option<Id3Meta<'a>>, usize) {
   parse_id3_inner(data, shared, print_conv)
 }
 
@@ -2044,7 +2006,6 @@ mod tests {
     .expect("read MP3.mp3 fixture");
     let mut shared = SharedFlags::new();
     let meta = parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared)
-      .expect("ok")
       .expect("MPEG-only MP3 must be Some(Mp3Meta), not None (Codex BF1/CF1)");
     assert!(meta.found());
     assert!(meta.id3().is_none(), "MP3.mp3 has no ID3");
@@ -2072,7 +2033,6 @@ mod tests {
     )
     .expect("read MP3.mp3 fixture");
     let meta = crate::parse_mp3(&bytes, Some("MP3"))
-      .expect("ok")
       .expect("public parse_mp3 must be Some for MPEG-only MP3");
     assert!(meta.mpeg().is_some());
   }
@@ -2086,9 +2046,7 @@ mod tests {
       std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/MP3.mp3"),
     )
     .expect("read MP3.mp3 fixture");
-    let meta = crate::parse_bytes(&bytes)
-      .expect("ok")
-      .expect("parse_bytes must accept MPEG-only MP3");
+    let meta = crate::parse_bytes(&bytes).expect("parse_bytes must accept MPEG-only MP3");
     match meta {
       crate::AnyMeta::Mp3(m) => {
         assert!(
@@ -2112,9 +2070,7 @@ mod tests {
     )
     .expect("read ID3v2_with_mpeg_audio.mp3 fixture");
     let mut shared = SharedFlags::new();
-    let meta = parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared)
-      .expect("ok")
-      .expect("found");
+    let meta = parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared).expect("found");
     let id3 = meta.id3().expect("ID3 sub-Meta present");
     assert_eq!(id3.title(), Some("Test"));
     assert!(
@@ -2146,9 +2102,7 @@ mod tests {
         .join("tests/fixtures/ID3v2_with_mpeg_audio.mp3"),
     )
     .expect("read ID3v2_with_mpeg_audio.mp3 fixture");
-    let meta = crate::parse_bytes(&bytes)
-      .expect("ok")
-      .expect("parse_bytes must accept ID3v2+MPEG MP3");
+    let meta = crate::parse_bytes(&bytes).expect("parse_bytes must accept ID3v2+MPEG MP3");
     match meta {
       crate::AnyMeta::Mp3(m) => {
         assert_eq!(
@@ -2183,7 +2137,6 @@ mod tests {
     // Simulate a prior parser having already processed ID3 (ID3.pm:1436).
     shared.set_done_id3(0);
     let meta = parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared)
-      .expect("ok")
       .expect("MPEG sync alone still accepts the file");
     assert!(
       meta.id3().is_none(),
@@ -2216,7 +2169,6 @@ mod tests {
     // both `DoneID3` and the carried `id3_hdr_end` (the post-ID3v2 offset).
     let mut shared = SharedFlags::new();
     let id3 = parse_id3_borrowed(&bytes, Some(&mut shared), /* print_conv */ true)
-      .expect("ok")
       .expect("large-ID3 artwork file has an ID3v2 directory");
     assert!(id3.v2_version().is_some(), "ID3v2 directory parsed");
     assert!(shared.done_id3().is_some(), "DoneID3 set by typed ID3 pass");
@@ -2232,7 +2184,6 @@ mod tests {
     // bundled recursion-after-Seek path). It must scan from the carried
     // hdr_end and STILL emit MPEG tags.
     let meta = parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared)
-      .expect("ok")
       .expect("MPEG frame after the large ID3v2 body still accepts the file");
     assert!(
       meta.id3().is_none(),
@@ -2261,7 +2212,6 @@ mod tests {
     shared.set_done_id3(0); // injected; no typed ID3 pass ran.
     assert_eq!(shared.id3_hdr_end(), None, "no carried hdr_end");
     let meta = parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared)
-      .expect("ok")
       .expect("MPEG sync within first 8192 bytes still accepts via offset-0 fallback");
     assert!(
       meta.mpeg().is_some(),
@@ -2283,9 +2233,8 @@ mod tests {
     .expect("read MP3.mp3 fixture");
     let mut shared = SharedFlags::new();
     assert_eq!(shared.done_id3(), None, "precondition: DoneID3 unset");
-    let meta = parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared)
-      .expect("ok")
-      .expect("MPEG-only MP3 accepted");
+    let meta =
+      parse_mp3_borrowed(&bytes, Some("MP3"), &mut shared).expect("MPEG-only MP3 accepted");
     assert!(meta.id3().is_none(), "MP3.mp3 has no ID3");
     assert_eq!(
       shared.done_id3(),
@@ -2540,9 +2489,7 @@ mod tests {
   fn parse_id3_borrowed_returns_some_for_id3v1_trailer() {
     let mut data: Vec<u8> = vec![0; 256];
     data.extend_from_slice(&build_id3v1_block());
-    let meta = parse_id3_borrowed(&data, None, true)
-      .expect("ok")
-      .expect("found");
+    let meta = parse_id3_borrowed(&data, None, true).expect("found");
     assert_eq!(meta.id3_size(), 128);
     assert_eq!(meta.title(), Some("Hello"));
     assert_eq!(meta.artist(), Some("Phil"));
@@ -2556,9 +2503,7 @@ mod tests {
   fn parse_id3_borrowed_id3v1_subframe_populated() {
     let mut data: Vec<u8> = vec![0; 256];
     data.extend_from_slice(&build_id3v1_block());
-    let meta = parse_id3_borrowed(&data, None, true)
-      .expect("ok")
-      .expect("found");
+    let meta = parse_id3_borrowed(&data, None, true).expect("found");
     let v1 = meta.id3v1().expect("v1 present");
     assert_eq!(v1.title(), Some("Hello"));
     assert_eq!(v1.artist(), Some("Phil"));
@@ -2571,7 +2516,7 @@ mod tests {
   #[test]
   fn parse_id3_borrowed_returns_none_when_no_id3() {
     let data = vec![0u8; 64];
-    assert!(parse_id3_borrowed(&data, None, true).expect("ok").is_none());
+    assert!(parse_id3_borrowed(&data, None, true).is_none());
   }
 
   #[test]
@@ -2595,9 +2540,7 @@ mod tests {
     data.push(0x00);
     data.extend_from_slice(&(title_frame.len() as u32).to_be_bytes());
     data.extend_from_slice(&title_frame);
-    let meta = parse_id3_borrowed(&data, None, true)
-      .expect("ok")
-      .expect("found");
+    let meta = parse_id3_borrowed(&data, None, true).expect("found");
     assert_eq!(meta.v2_version(), Some(Id3v2Version::V2_2));
     assert_eq!(meta.title(), Some("Hello"));
     // The ID3v2.2 frame iterator should contain Title.
@@ -2627,7 +2570,7 @@ mod tests {
     let mut shared = SharedFlags::new();
     // A prior parser already ran ID3 and consumed a 128-byte v1 trailer.
     shared.set_done_id3(128);
-    let meta = parse_id3_borrowed(&data, Some(&mut shared), true).expect("ok");
+    let meta = parse_id3_borrowed(&data, Some(&mut shared), true);
     assert!(
       meta.is_none(),
       "guard returns Ok(None) without re-running (ID3.pm:1435)"
@@ -2654,7 +2597,7 @@ mod tests {
     .expect("read MP3.mp3 fixture");
     let mut shared = SharedFlags::new();
     assert_eq!(shared.done_id3(), None, "precondition: DoneID3 unset");
-    let meta = parse_id3_borrowed(&bytes, Some(&mut shared), true).expect("ok");
+    let meta = parse_id3_borrowed(&bytes, Some(&mut shared), true);
     assert!(meta.is_none(), "MP3.mp3 has no ID3 directory");
     assert_eq!(
       shared.done_id3(),
@@ -2669,9 +2612,7 @@ mod tests {
     data.extend_from_slice(&build_id3v1_block());
     let mut shared = SharedFlags::new();
     let ctx = Id3Context::new(&data, &mut shared);
-    let meta = <ProcessId3 as FormatParser>::parse(&ProcessId3, ctx)
-      .expect("ok")
-      .expect("found");
+    let meta = <ProcessId3 as FormatParser>::parse(&ProcessId3, ctx).expect("found");
     assert_eq!(meta.title(), Some("Hello"));
     assert_eq!(meta.id3_size(), 128);
   }
@@ -2683,9 +2624,7 @@ mod tests {
     data.extend_from_slice(&build_id3v1_block());
     let mut shared = SharedFlags::new();
     let ctx = Mp3Context::new(&data, &mut shared, Some("MP3"));
-    let meta = <ProcessMp3 as FormatParser>::parse(&ProcessMp3, ctx)
-      .expect("ok")
-      .expect("found");
+    let meta = <ProcessMp3 as FormatParser>::parse(&ProcessMp3, ctx).expect("found");
     let id3 = meta.id3().expect("id3 sub-meta present");
     assert_eq!(id3.title(), Some("Hello"));
     assert!(meta.found());
@@ -2695,9 +2634,7 @@ mod tests {
   fn id3_meta_sinker_replays_into_writer() {
     let mut data: Vec<u8> = vec![0; 256];
     data.extend_from_slice(&build_id3v1_block());
-    let meta = parse_id3_borrowed(&data, None, true)
-      .expect("ok")
-      .expect("found");
+    let meta = parse_id3_borrowed(&data, None, true).expect("found");
     let mut w = crate::tagmap::TagMap::new();
     crate::emit::run_emission(&meta, crate::emit::ConvMode::PrintConv, &mut w);
     assert_eq!(w.get_str("ID3v1", "Title"), Some("Hello".into()));
@@ -2722,18 +2659,14 @@ mod tests {
     data.extend_from_slice(&build_id3v1_block()); // genre byte = 7 (Hip-Hop)
 
     // -j mode: parse + sink in PrintConv mode → "Hip-Hop".
-    let meta_j = parse_id3_borrowed(&data, None, true)
-      .expect("ok")
-      .expect("found");
+    let meta_j = parse_id3_borrowed(&data, None, true).expect("found");
     let mut wj = crate::tagmap::TagMap::new();
     crate::emit::run_emission(&meta_j, crate::emit::ConvMode::PrintConv, &mut wj);
     assert_eq!(wj.get_str("ID3v1", "Genre"), Some("Hip-Hop".into()));
 
     // -n mode: parse + sink in raw mode → "7" (the raw genre byte),
     // matching bundled `exiftool -j -n`.
-    let meta_n = parse_id3_borrowed(&data, None, false)
-      .expect("ok")
-      .expect("found");
+    let meta_n = parse_id3_borrowed(&data, None, false).expect("found");
     let mut wn = crate::tagmap::TagMap::new();
     crate::emit::run_emission(&meta_n, crate::emit::ConvMode::ValueConv, &mut wn);
     assert_eq!(
@@ -2769,17 +2702,13 @@ mod tests {
     data.extend_from_slice(&frame);
 
     // -j: "7 s" (PrintConv).
-    let meta_j = parse_id3_borrowed(&data, None, true)
-      .expect("ok")
-      .expect("found");
+    let meta_j = parse_id3_borrowed(&data, None, true).expect("found");
     let mut wj = crate::tagmap::TagMap::new();
     crate::emit::run_emission(&meta_j, crate::emit::ConvMode::PrintConv, &mut wj);
     assert_eq!(wj.get_str("ID3v2_3", "Length"), Some("7 s".into()));
 
     // -n: 7 (raw ValueConv seconds), matching bundled `exiftool -j -n`.
-    let meta_n = parse_id3_borrowed(&data, None, false)
-      .expect("ok")
-      .expect("found");
+    let meta_n = parse_id3_borrowed(&data, None, false).expect("found");
     let mut wn = crate::tagmap::TagMap::new();
     crate::emit::run_emission(&meta_n, crate::emit::ConvMode::ValueConv, &mut wn);
     assert_eq!(
@@ -2823,9 +2752,7 @@ mod tests {
     // ONE parse via the typed `FormatParser` entry (stages BOTH lists).
     let mut shared = SharedFlags::new();
     let ctx = Id3Context::new(&data, &mut shared);
-    let meta = <ProcessId3 as FormatParser>::parse(&ProcessId3, ctx)
-      .expect("ok")
-      .expect("ID3 found");
+    let meta = <ProcessId3 as FormatParser>::parse(&ProcessId3, ctx).expect("ID3 found");
 
     // sink(true) — PrintConv `-j`.
     let mut wj = crate::tagmap::TagMap::new();
@@ -2882,9 +2809,7 @@ mod tests {
     data.push(0x00);
     data.extend_from_slice(&size.to_be_bytes());
     data.extend_from_slice(&body);
-    let meta = parse_id3_borrowed(&data, None, true)
-      .expect("ok")
-      .expect("found");
+    let meta = parse_id3_borrowed(&data, None, true).expect("found");
     let pic = meta.picture().expect("picture present");
     assert_eq!(pic.mime(), "image/jpeg");
     assert_eq!(pic.picture_type(), 3);

--- a/src/formats/matroska.rs
+++ b/src/formats/matroska.rs
@@ -2238,9 +2238,8 @@ impl parser_sealed::Sealed for ProcessMatroska {}
 impl FormatParser for ProcessMatroska {
   type Meta<'a> = Meta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(data)
   }
 }
@@ -2252,7 +2251,7 @@ impl FormatParser for ProcessMatroska {
 ///
 /// Returns `Err` only for Rust-level fatal modes (none today — every bad
 /// input is `Ok(None)` per Matroska.pm `return 0`).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   parse_inner(data)
 }
 
@@ -2384,9 +2383,9 @@ const DEFAULT_GROUP: &str = "Matroska";
 /// pre-validation. We walk from offset 0; the walker re-reads the
 /// (already-validated) magic-as-ID and the EBMLHeader body size, then
 /// descends into the EBML header sub-elements.
-fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+fn parse_inner(data: &[u8]) -> Option<Meta<'_>> {
   if data.len() < 4 || data[..4] != EBML_MAGIC {
-    return Ok(None); // Matroska.pm:996 — magic gate
+    return None; // Matroska.pm:996 — magic gate
   }
   let mut w = Walker {
     data,
@@ -2404,11 +2403,11 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
     track_uid_to_group: std::collections::HashMap::new(),
   };
   walk(&mut w);
-  Ok(Some(Meta {
+  Some(Meta {
     entries: w.entries,
     doc_type: w.doc_type,
     timecode_scale_ns: w.timecode_scale_ns,
-  }))
+  })
 }
 
 /// Main EBML walk. Faithful loop port of Matroska.pm:1022-1236. Stops on
@@ -3622,17 +3621,6 @@ fn maybe_handle_conditional<'a>(w: &mut Walker<'a>, id: i64, body: &'a [u8]) -> 
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for Matroska parsing. Currently empty — every
-/// bad input produces `Ok(None)` (Perl `return 0`) or walks past silently
-/// (unknown EBML IDs). Reserved for future I/O wrappers.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Unit tests
 // ===========================================================================
 
@@ -3654,13 +3642,6 @@ mod tests {
     );
     w
   }
-
-  #[test]
-  fn matroska_error_is_core_error() {
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   #[test]
   fn get_vint_single_byte_id() {
     // 0x82 ⇒ length-marker bit at 0x80, value = 0x02 (the DocType ID's
@@ -3839,13 +3820,13 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short_buffer() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(&[0x1a, 0x45, 0xdf]).unwrap().is_none()); // 3-byte
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(&[0x1a, 0x45, 0xdf]).is_none()); // 3-byte
   }
 
   #[test]
   fn parse_borrowed_rejects_bad_magic() {
-    assert!(parse_borrowed(&[0x00, 0x00, 0x00, 0x00]).unwrap().is_none());
+    assert!(parse_borrowed(&[0x00, 0x00, 0x00, 0x00]).is_none());
   }
 
   #[test]
@@ -3855,9 +3836,7 @@ mod tests {
       "/tests/fixtures/Matroska.mkv"
     ))
     .expect("read Matroska.mkv fixture");
-    let meta = parse_borrowed(&bytes)
-      .expect("ok")
-      .expect("matroska accepted");
+    let meta = parse_borrowed(&bytes).expect("matroska accepted");
     assert_eq!(meta.doc_type(), Some("matroska"));
     assert!(!meta.is_webm());
     assert_eq!(meta.timecode_scale_ns(), Some(1_000_000));
@@ -3880,7 +3859,7 @@ mod tests {
       "/tests/fixtures/Matroska_unknown_segment.mkv"
     ))
     .expect("read F4 fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tm = emit_into_tagmap(&meta, true);
     // Info emitted under `Info:`
     assert_eq!(tm.get_str("Info", "TimecodeScale"), Some("1 ms".into()));
@@ -3902,7 +3881,7 @@ mod tests {
       "/tests/fixtures/Matroska_cluster_skip.mkv"
     ))
     .expect("read F3 fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tm = emit_into_tagmap(&meta, true);
     // Info BEFORE cluster: emitted
     assert_eq!(tm.get_str("Info", "TimecodeScale"), Some("1 ms".into()));
@@ -3925,7 +3904,7 @@ mod tests {
       "/tests/fixtures/Matroska_attachment.mkv"
     ))
     .expect("read F5 fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     for print_conv in [true, false] {
       let tm = emit_into_tagmap(&meta, print_conv);
       // The raw `TagValue::Bytes` storage stringifies as lower-hex via
@@ -3952,7 +3931,7 @@ mod tests {
       "/tests/fixtures/Matroska_simpletag.mkv"
     ))
     .expect("read F1 fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tm = emit_into_tagmap(&meta, true);
     // TITLE → Title, ARTIST → Artist (Matroska.pm:764, 777).
     assert_eq!(tm.get_str("Matroska", "Title"), Some("Hello World".into()));
@@ -4034,7 +4013,7 @@ mod tests {
       "/tests/fixtures/Matroska_duration_zero_scale.mkv"
     ))
     .expect("read R3 zero-scale fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     // Sanity: TimecodeScale captured as 0.
     assert_eq!(meta.timecode_scale_ns(), Some(0));
     // -j mode: both Duration and TimecodeScale render as bare numeric
@@ -4064,7 +4043,7 @@ mod tests {
       "/tests/fixtures/Matroska_duration_before_scale.mkv"
     ))
     .expect("read R3 order-skewed fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     assert_eq!(meta.timecode_scale_ns(), Some(1_000_000));
     let tm_j = emit_into_tagmap(&meta, true);
     assert_eq!(tm_j.get_str("Info", "Duration"), Some("0:01:00".into()));
@@ -4079,7 +4058,7 @@ mod tests {
       "/tests/fixtures/Matroska_unknown_segment.mkv"
     ))
     .expect("read F2 fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     // Pre-F2: walker breaks on the unknown-size VINT → Info/Tracks lost.
     // Post-F2: Info+Tracks descended.
     let tm = emit_into_tagmap(&meta, true);
@@ -4095,7 +4074,7 @@ mod tests {
       "/tests/fixtures/Matroska.mkv"
     ))
     .expect("read fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tm = emit_into_tagmap(&meta, true);
     assert_eq!(tm.get_str("Matroska", "DocType"), Some("matroska".into()));
     assert_eq!(tm.get_str("Info", "TimecodeScale"), Some("1 ms".into()));
@@ -4130,7 +4109,7 @@ mod tests {
       "/tests/fixtures/Matroska.mkv"
     ))
     .expect("read fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tags: Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     // No Matroska tag carries `Unknown => 1`.
     assert!(tags.iter().all(|t| !t.unknown()));
@@ -4166,7 +4145,7 @@ mod tests {
       "/tests/fixtures/Matroska.mkv"
     ))
     .expect("read fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let projected = meta.project();
     // Matroska projects to a video container; the rest of MediaInfo is empty.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Video]);

--- a/src/formats/moi.rs
+++ b/src/formats/moi.rs
@@ -453,7 +453,6 @@ impl FormatParser for ProcessMoi {
   /// Spec §8: leaf format Context is `&'a [u8]`.
   type Context<'a> = &'a [u8];
   /// Rust-level fatal error (none today; MOI parsing has no I/O modes).
-  type Error = Error;
 
   /// Parse a MOI file's bytes into a typed [`Meta`], or `None` if the
   /// buffer is not a valid MOI sidecar (short read, wrong magic, or
@@ -461,7 +460,7 @@ impl FormatParser for ProcessMoi {
   ///
   /// Returns `Err` only for Rust-level fatal modes; the current port
   /// has none (every bad input is `Ok(None)` per Perl's `return 0`).
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(data)
   }
 }
@@ -471,23 +470,23 @@ impl FormatParser for ProcessMoi {
 /// method returns this borrowed form directly — no `'static` upgrade. Both
 /// the trait `parse` and the lib-first direct call ([`parse_borrowed`])
 /// share this body (Codex AF2).
-fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+fn parse_inner(data: &[u8]) -> Option<Meta<'_>> {
   // MOI.pm:110 — `$raf->Read($buff,256) == 256 and $buff =~ /^V6/ or
   // return 0`. The 256-byte read AND the `V6` prefix are BOTH required.
   let total_len = data.len();
   if total_len < 256 {
-    return Ok(None);
+    return None;
   }
   let head: &[u8; 256] = data[..256]
     .try_into()
     .expect("256-byte head is exactly 256 bytes");
   if &head[..2] != b"V6" {
-    return Ok(None);
+    return None;
   }
   // MOI.pm:111-114 — embedded BE u32 filesize at offset 0x02 must match.
   let embedded_size = u32::from_be_bytes([head[2], head[3], head[4], head[5]]) as u64;
   if embedded_size != total_len as u64 {
-    return Ok(None);
+    return None;
   }
   // MOI.pm:116 `SetByteOrder('MM')` — every subsequent int16u / int32u
   // read uses `from_be_bytes`.
@@ -498,7 +497,7 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
   let audio_codec = Some(u16::from_be_bytes([head[0x84], head[0x85]]));
   let audio_bitrate = Some(audio_bitrate_value_conv(head[0x86]));
   let video_bitrate = Some(parse_video_bitrate(&head[0xda..0xdc]));
-  Ok(Some(Meta {
+  Some(Meta {
     version,
     datetime_original,
     duration,
@@ -506,7 +505,7 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
     audio_codec,
     audio_bitrate,
     video_bitrate,
-  }))
+  })
 }
 
 /// Lib-first direct entry. Identical to [`FormatParser::parse`] now that
@@ -518,7 +517,7 @@ fn parse_inner(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   parse_inner(data)
 }
 
@@ -855,24 +854,6 @@ fn aspect_ratio_raw(ar: AspectRatio) -> u8 {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for MOI parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers if streaming readers are added.
-///
-/// §5: derived via `thiserror` (`Display` + `core::error::Error` in every
-/// feature tier — `thiserror` v2 with `default-features = false` emits
-/// `core::error::Error`, so `Error` is a real `Error` even on no-std).
-/// `#[non_exhaustive]` lets the first real variant land without a breaking
-/// change. The derive expands `Display` to an empty `match *self {}`, so no
-/// `#[error(…)]` attribute is needed while the enum has no variants.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -884,15 +865,6 @@ pub enum Error {}
 mod tests {
   use super::*;
   use crate::tagmap::TagMap;
-
-  #[test]
-  fn moi_error_is_core_error() {
-    // §5: thiserror v2 (default-features=false) makes the empty error enum
-    // a real `core::error::Error` in every feature tier.
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   // ---------- ValueConv helpers ------------------------------------------
 
   #[test]
@@ -1099,7 +1071,7 @@ mod tests {
   #[test]
   fn parse_borrowed_extracts_every_field() {
     let buf = fixture_buffer();
-    let meta = parse_borrowed(&buf).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&buf).expect("parsed");
     assert_eq!(meta.version(), "V6");
     let dt = meta.datetime_original().expect("dt");
     assert_eq!((dt.year(), dt.month(), dt.day()), (2011, 5, 15));
@@ -1117,22 +1089,22 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short_buffer() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(&[0u8; 100]).unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(&[0u8; 100]).is_none());
   }
 
   #[test]
   fn parse_borrowed_rejects_bad_magic() {
     let mut buf = fixture_buffer();
     buf[0] = b'X';
-    assert!(parse_borrowed(&buf).unwrap().is_none());
+    assert!(parse_borrowed(&buf).is_none());
   }
 
   #[test]
   fn parse_borrowed_rejects_filesize_mismatch() {
     let mut buf = fixture_buffer();
     buf[2..6].copy_from_slice(&999u32.to_be_bytes()); // claims 999 ≠ 320
-    assert!(parse_borrowed(&buf).unwrap().is_none());
+    assert!(parse_borrowed(&buf).is_none());
   }
 
   // ---------- Taggable emission (print_conv on / off) ------------------------
@@ -1151,7 +1123,7 @@ mod tests {
   }
 
   fn collect(buf: &[u8], print_conv: bool) -> TagMap {
-    let meta = parse_borrowed(buf).expect("ok").expect("parsed");
+    let meta = parse_borrowed(buf).expect("parsed");
     emit_into_tagmap(&meta, print_conv)
   }
 
@@ -1308,7 +1280,7 @@ mod tests {
     // Faithful to ExifTool.pm:9907 sorted-key walk. Order is preserved by the
     // `Taggable` emission order -> `TagMap` entry order (the JSON object loses it).
     let buf = fixture_buffer();
-    let meta = parse_borrowed(&buf).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&buf).expect("parsed");
     let tm = emit_into_tagmap(&meta, true);
     let format_names: std::vec::Vec<&str> = tm
       .entries()
@@ -1333,7 +1305,7 @@ mod tests {
   fn taggable_group_is_moi_family0_and_family1() {
     use crate::emit::{ConvMode, Taggable};
     let buf = fixture_buffer();
-    let meta = parse_borrowed(&buf).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&buf).expect("parsed");
     let tags: std::vec::Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     // MOIVersion, DateTimeOriginal, Duration, AspectRatio, AudioCodec,
     // AudioBitrate, VideoBitrate — 7 tags, none Unknown.
@@ -1353,7 +1325,7 @@ mod tests {
   fn project_populates_video_track_duration_and_created() {
     use crate::metadata::{Project, TrackKind};
     let buf = fixture_buffer();
-    let meta = parse_borrowed(&buf).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&buf).expect("parsed");
     let projected = meta.project();
     // MOI is a camcorder video sidecar: one video track kind.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Video]);
@@ -1383,9 +1355,7 @@ mod tests {
     // returns `Meta<'static>`) produces the same fields as the
     // borrow-from-input `parse_borrowed`.
     let buf = fixture_buffer();
-    let meta = <ProcessMoi as FormatParser>::parse(&ProcessMoi, &buf)
-      .expect("ok")
-      .expect("parsed");
+    let meta = <ProcessMoi as FormatParser>::parse(&ProcessMoi, &buf).expect("parsed");
     assert_eq!(meta.version(), "V6");
     assert_eq!(meta.aspect_ratio(), Some(AspectRatio::R4x3Pal));
     assert_eq!(meta.video_bitrate(), Some(VideoBitrate::Known(8_500_000)));

--- a/src/formats/moi.rs
+++ b/src/formats/moi.rs
@@ -1285,7 +1285,7 @@ mod tests {
     let format_names: std::vec::Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(k, _)| k.strip_prefix("MOI:"))
+      .filter_map(|(g, n, _)| (g == "MOI").then_some(n.as_str()))
       .collect();
     assert_eq!(
       format_names,

--- a/src/formats/mpc.rs
+++ b/src/formats/mpc.rs
@@ -595,7 +595,6 @@ impl FormatParser for ProcessMpc {
   /// Chained-format Context: `data + SharedFlags`. See [`Context`].
   type Context<'a> = Context<'a>;
   /// Rust-level fatal error (currently none — every bad input is `Ok(None)`).
-  type Error = Error;
 
   /// Parse an MPC file's bytes into a typed [`Meta`], or `None` if the
   /// buffer is not a valid MP+ stream (short read or wrong magic; MPC.pm:92).
@@ -614,10 +613,10 @@ impl FormatParser for ProcessMpc {
   /// `parse_mpc` was fixed in R4 — R5 propagates the chain down to ALL
   /// public surfaces). The Context's `shared` reference threads the
   /// `DoneID3`/`DoneAPE` cross-recursion state through the chain.
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     // `mpc = ["id3", "ape"]` per Cargo.toml ⇒ `parse_full_chained` is always
     // present here.
-    Ok(parse_full_chained(ctx.data, ctx.shared))
+    parse_full_chained(ctx.data, ctx.shared)
   }
 }
 
@@ -638,11 +637,11 @@ impl FormatParser for ProcessMpc {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   // `mpc = ["id3", "ape"]` per Cargo.toml ⇒ `parse_full_chained` is always
   // present here.
   let mut shared = crate::format_parser::SharedFlags::default();
-  Ok(parse_full_chained(data, &mut shared))
+  parse_full_chained(data, &mut shared)
 }
 
 /// Inner parser — produces a borrow-from-input [`Meta`] from the MPC
@@ -657,15 +656,15 @@ pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
 /// Takes an `offset` (the post-ID3-prefix offset, or 0) so a typed
 /// caller that already ran ID3 (e.g. `parse_full_chained`) can pass the
 /// body offset and avoid re-detecting the prefix.
-fn parse_inner_at(data: &[u8], offset: usize) -> Result<Option<Meta<'_>>, Error> {
+fn parse_inner_at(data: &[u8], offset: usize) -> Option<Meta<'_>> {
   let body = data.get(offset..).unwrap_or(&[]);
   // MPC.pm:92 `$raf->Read($buff,32) == 32 and $buff =~ /^MP\+(.)/s or return 0`.
   if body.len() < 32 {
-    return Ok(None); // short read ⇒ Perl `$raf->Read != 32` ⇒ return 0
+    return None; // short read ⇒ Perl `$raf->Read != 32` ⇒ return 0
   }
   let hdr = &body[..32];
   if &hdr[..3] != b"MP+" {
-    return Ok(None); // magic mismatch ⇒ Perl regex no-match ⇒ return 0
+    return None; // magic mismatch ⇒ Perl regex no-match ⇒ return 0
   }
   // MPC.pm:93 `my $vers = ord($1) & 0x0f` — low nibble of byte 3.
   let version = hdr[3] & 0x0f;
@@ -681,7 +680,7 @@ fn parse_inner_at(data: &[u8], offset: usize) -> Result<Option<Meta<'_>>, Error>
     (None, true)
   };
 
-  Ok(Some(Meta {
+  Some(Meta {
     version,
     sv7_header,
     warn_unsupported_version,
@@ -689,7 +688,7 @@ fn parse_inner_at(data: &[u8], offset: usize) -> Result<Option<Meta<'_>>, Error>
     id3: None,
     #[cfg(feature = "ape")]
     ape: None,
-  }))
+  })
 }
 
 /// Full MPC parse with the embedded ID3 prefix (MPC.pm:84-87) and APE
@@ -727,7 +726,6 @@ pub(crate) fn parse_full_chained<'a>(
   // recursion guard (ID3.pm:1435).
   let (id3, hdr_end) = if shared.done_id3().is_none() {
     crate::formats::id3::process::parse_id3_with_hdr_end(data, Some(&mut *shared), true)
-      .unwrap_or((None, 0))
   } else {
     (None, shared.id3_hdr_end().unwrap_or(0))
   };
@@ -736,7 +734,7 @@ pub(crate) fn parse_full_chained<'a>(
   // magic-miss (MPC.pm:92), drop everything (including the ID3 prefix) so
   // the `parse_any` candidate loop tries the next type. Same semantics as
   // APE's body-magic gate.
-  let mut meta = parse_inner_at(data, hdr_end).ok()??;
+  let mut meta = parse_inner_at(data, hdr_end)?;
   meta.id3 = id3;
 
   // 3. APE trailer (MPC.pm:111-113 `require Image::ExifTool::APE;
@@ -1066,22 +1064,6 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for MPC parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers if streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` derived via `thiserror` (v2,
-/// `default-features = false` ⇒ `core::error::Error` in every feature
-/// tier, not just `std`). `#[non_exhaustive]` lets I/O variants land
-/// without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -1275,14 +1257,14 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short_buffer() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(b"MP+\x07").unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(b"MP+\x07").is_none());
   }
 
   #[test]
   fn parse_borrowed_rejects_non_mpc_magic() {
     let data = [0u8; 32];
-    assert!(parse_borrowed(&data).unwrap().is_none());
+    assert!(parse_borrowed(&data).is_none());
   }
 
   #[test]
@@ -1296,7 +1278,7 @@ mod tests {
       std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/MPC.mpc"),
     )
     .expect("read MPC.mpc fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     assert_eq!(meta.version(), 0x07);
     let h = meta.sv7_header().expect("SV7 header present");
     assert_eq!(h.total_frames(), 102);
@@ -1341,7 +1323,7 @@ mod tests {
       std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/sv8.mpc"),
     )
     .expect("read sv8.mpc fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     assert_eq!(meta.version(), 0x08);
     assert!(meta.sv7_header().is_none());
     assert!(meta.warn_unsupported_version());
@@ -1356,9 +1338,7 @@ mod tests {
     .expect("read MPC.mpc fixture");
     let mut shared = SharedFlags::new();
     let ctx = Context::new(&bytes, &mut shared);
-    let meta = <ProcessMpc as FormatParser>::parse(&ProcessMpc, ctx)
-      .expect("ok")
-      .expect("parsed");
+    let meta = <ProcessMpc as FormatParser>::parse(&ProcessMpc, ctx).expect("parsed");
     let h = meta.sv7_header().expect("SV7 header");
     assert_eq!(h.total_frames(), 102);
     assert_eq!(h.encoder_version(), 115);
@@ -1565,7 +1545,7 @@ mod tests {
   #[test]
   fn taggable_emits_sv7_print_conv() {
     let bytes = fixture("MPC.mpc");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::PrintConv, &mut w);
     assert_eq!(w.get_str("MPC", "TotalFrames"), Some("102".to_string()));
@@ -1586,7 +1566,7 @@ mod tests {
   #[test]
   fn taggable_emits_raw_scalars_value_conv() {
     let bytes = fixture("MPC.mpc");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::ValueConv, &mut w);
     assert_eq!(w.get_str("MPC", "SampleRate"), Some("0".to_string()));
@@ -1600,7 +1580,7 @@ mod tests {
   #[test]
   fn taggable_group_is_mpc_family0_and_family1() {
     let bytes = fixture("MPC.mpc");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let tags: std::vec::Vec<_> = meta
       .tags(ConvMode::PrintConv)
       .filter(|t| t.tag().group_ref().family1() == "MPC")
@@ -1624,7 +1604,7 @@ mod tests {
   #[cfg(feature = "id3")]
   fn taggable_chains_id3_prefix_before_mpc_body() {
     let bytes = fixture("mpc_with_id3v2_prefix.mpc");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     assert!(meta.id3_ref().is_some(), "fixture carries an ID3v2 prefix");
 
     let names: std::vec::Vec<String> = meta
@@ -1652,7 +1632,7 @@ mod tests {
   #[cfg(feature = "ape")]
   fn taggable_arm_chains_ape_trailer_after_mpc_body() {
     let bytes = fixture("mpc_with_apev2_trailer.mpc");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     // The `tags()` stream now carries the APE:* tags (ape::Meta is Taggable);
     // they follow the MPC:* body in the same stream.
     let names: std::vec::Vec<String> = meta
@@ -1697,7 +1677,7 @@ mod tests {
   fn project_is_audio_only_no_duration() {
     use crate::metadata::{Project, TrackKind};
     let bytes = fixture("MPC.mpc");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&bytes).expect("parsed");
     let md = Project::project(&meta);
     assert_eq!(md.media().track_kinds(), &[TrackKind::Audio]);
     assert!(

--- a/src/formats/mpc.rs
+++ b/src/formats/mpc.rs
@@ -1449,7 +1449,7 @@ mod tests {
     // No MPC:* tags emitted (sv7_header is None). The format-tag entries
     // carry the `"<Group1>:<Name>"` keys; warnings live in their own
     // accumulator (`TagMap::warnings`).
-    assert!(w.entries().iter().all(|(k, _)| !k.starts_with("MPC:")));
+    assert!(w.entries().iter().all(|(g, _, _)| g != "MPC"));
     // The warning is pushed through write_warning ⇒ TagMap::warnings.
     assert_eq!(
       w.warnings(),
@@ -1653,9 +1653,9 @@ mod tests {
     // TagMap entries (which preserve first-occurrence position).
     let mut w = TagMap::new();
     emit_via_engine(&meta, true, &mut w);
-    let keys: std::vec::Vec<&str> = w.entries().iter().map(|(k, _)| k.as_str()).collect();
-    let mpc_pos = keys.iter().position(|k| k.starts_with("MPC:"));
-    let ape_pos = keys.iter().position(|k| k.starts_with("APE:"));
+    let keys: std::vec::Vec<&str> = w.entries().iter().map(|(g, _, _)| g.as_str()).collect();
+    let mpc_pos = keys.iter().position(|g| *g == "MPC");
+    let ape_pos = keys.iter().position(|g| *g == "APE");
     if let (Some(mp), Some(ap)) = (mpc_pos, ape_pos) {
       assert!(
         mp < ap,

--- a/src/formats/mpeg.rs
+++ b/src/formats/mpeg.rs
@@ -1711,9 +1711,8 @@ impl FormatParser for ProcessMpegAudio {
   /// AF2).
   type Meta<'a> = AudioMeta<'a>;
   type Context<'a> = AudioContext<'a>;
-  type Error = AudioError;
 
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, AudioError> {
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(ctx.data, ctx.mp3, ctx.ext)
   }
 }
@@ -1725,11 +1724,7 @@ impl FormatParser for ProcessMpegAudio {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed<'a>(
-  data: &'a [u8],
-  mp3: bool,
-  ext: &str,
-) -> Result<Option<AudioMeta<'a>>, AudioError> {
+pub fn parse_borrowed<'a>(data: &'a [u8], mp3: bool, ext: &str) -> Option<AudioMeta<'a>> {
   parse_inner(data, mp3, ext)
 }
 
@@ -1737,16 +1732,12 @@ pub fn parse_borrowed<'a>(
 /// `encoder` field borrows from `data`). The [`FormatParser::Meta`] GAT
 /// (`type Meta<'a> = AudioMeta<'a>`) returns this borrowed form
 /// directly into the closed [`crate::format_parser::AnyMeta`] enum (Codex AF2).
-fn parse_inner<'a>(
-  data: &'a [u8],
-  mp3: bool,
-  ext: &str,
-) -> Result<Option<AudioMeta<'a>>, AudioError> {
+fn parse_inner<'a>(data: &'a [u8], mp3: bool, ext: &str) -> Option<AudioMeta<'a>> {
   // MPEG.pm:472 — `$$buffPt =~ m{(\xff.{3})}sg`. Returns `None` ⇒ Ok(None)
   // (Perl `return 0` BEFORE `$et->SetFileType()` at MPEG.pm:496).
   let (word, pos_after_header) = match scan_for_header(data, mp3, ext) {
     Some(pair) => pair,
-    None => return Ok(None),
+    None => return None,
   };
   // MPEG.pm:498-499 — `ProcessFrameHeader($et, $tagTablePtr, $word)`. The
   // validated header word is bit-extracted into typed fields.
@@ -1755,14 +1746,14 @@ fn parse_inner<'a>(
     // Defensive: `extract_header_fields` returns None only when the
     // version/layer raw values are reserved. `check_header` already
     // rejected those; treat as unreachable but defensive.
-    None => return Ok(None),
+    None => return None,
   };
   // MPEG.pm:501-578 — Xing/Info VBR + LAME tail. Reads relative to
   // `pos_after_header`. The tail's `last` exits leave whatever was already
   // emitted in `meta` in place; the call always returns to the caller
   // (no fatal modes).
   parse_xing_lame_into(data, pos_after_header, &mut meta);
-  Ok(Some(meta))
+  Some(meta)
 }
 
 // ===========================================================================
@@ -2035,22 +2026,6 @@ impl crate::metadata::Project for AudioMeta<'_> {
 }
 
 // ===========================================================================
-// `AudioError` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for MPEG audio parsing. Currently empty — every
-/// bad input produces `Ok(None)` (Perl `return 0`). Reserved for future
-/// I/O wrappers if streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` are derived via `thiserror` (v2,
-/// `default-features = false`), so the trait is implemented in every feature
-/// tier. `#[non_exhaustive]` lets variants land later without a breaking
-/// change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum AudioError {}
-
-// ===========================================================================
 // `ProcessMp3` — raw MPEG-audio entry preserving R5 fix API
 // ===========================================================================
 
@@ -2188,9 +2163,7 @@ mod tests {
       std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/MP3.mp3"),
     )
     .expect("read MP3.mp3 fixture");
-    let meta = parse_borrowed(&bytes, true, "MP3")
-      .expect("ok")
-      .expect("parsed");
+    let meta = parse_borrowed(&bytes, true, "MP3").expect("parsed");
     assert_eq!(meta.mpeg_audio_version(), AudioVersion::V1);
     assert_eq!(meta.audio_layer(), AudioLayer::L3);
     assert_eq!(meta.audio_bitrate(), AudioBitrate::Known(128_000));
@@ -2201,18 +2174,14 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short_buffer() {
-    assert!(parse_borrowed(&[], true, "MP3").unwrap().is_none());
-    assert!(
-      parse_borrowed(&[0xff, 0xfb], true, "MP3")
-        .unwrap()
-        .is_none()
-    );
+    assert!(parse_borrowed(&[], true, "MP3").is_none());
+    assert!(parse_borrowed(&[0xff, 0xfb], true, "MP3").is_none());
   }
 
   #[test]
   fn parse_borrowed_rejects_bad_sync() {
     let data = [0x00; 32];
-    assert!(parse_borrowed(&data, true, "MP3").unwrap().is_none());
+    assert!(parse_borrowed(&data, true, "MP3").is_none());
   }
 
   // ───────────────────────── ConvertBitrate ─────────────────────────
@@ -2253,9 +2222,7 @@ mod tests {
 
   fn collect(buf: &[u8], print_conv: bool) -> TagMap {
     let mut w = TagMap::new();
-    let meta = parse_borrowed(buf, true, "MP3")
-      .expect("ok")
-      .expect("parsed");
+    let meta = parse_borrowed(buf, true, "MP3").expect("parsed");
     crate::emit::run_emission(
       &meta,
       crate::emit::ConvMode::from_print_conv(print_conv),
@@ -2590,9 +2557,7 @@ mod tests {
     .expect("read MP3.mp3 fixture");
     let mut shared = SharedFlags::new();
     let ctx = AudioContext::new(&bytes, "MP3", true, &mut shared);
-    let meta = <ProcessMpegAudio as FormatParser>::parse(&ProcessMpegAudio, ctx)
-      .expect("ok")
-      .expect("parsed");
+    let meta = <ProcessMpegAudio as FormatParser>::parse(&ProcessMpegAudio, ctx).expect("parsed");
     assert_eq!(meta.mpeg_audio_version(), AudioVersion::V1);
     assert_eq!(meta.audio_layer(), AudioLayer::L3);
     assert_eq!(meta.audio_bitrate(), AudioBitrate::Known(128_000));

--- a/src/formats/mxf.rs
+++ b/src/formats/mxf.rs
@@ -2287,6 +2287,13 @@ fn process_primer(w: &mut Walker, buf: &[u8]) {
 /// `(int16u local-tag, int16u length, value)` triplets; each local-tag is
 /// resolved to a global UL through the Primer, the UL looked up in
 /// [`TAG_TABLE`], and the value decoded + emitted.
+///
+/// Golden-v2 3a — this walk is **structurally bounded, not recursive**: it is
+/// a flat `while pos + 4 < end` loop over the triplets in one KLV value, with
+/// no self-call. A nested object is NOT walked inline; it is referenced by an
+/// InstanceUID (a `strong_refs` string) and resolved later by the SEPARATE
+/// recursive [`set_groups`] tree walk, which carries the recursion budget.
+/// So no depth cap is needed here.
 fn process_local_set(w: &mut Walker, dir_name: &'static str, buf: &[u8]) {
   let end = buf.len();
   // Per-set book-keeping (MXF.pm:2612).
@@ -2559,6 +2566,21 @@ fn duration_or_drop(raw: i64) -> Option<MxfValue> {
 // §14. SetGroups tree walk (MXF.pm:2731-2778)
 // ===========================================================================
 
+/// Max recursion depth for the `SetGroups` strong-reference object-tree walk
+/// (Golden-v2 Contract 3a). Bundled `SetGroups` (MXF.pm:2731-2778) recurses
+/// the file-declared strong-reference graph with only a `DidGroups` cycle
+/// guard (mirrored by [`set_groups`]'s `visited` set). The cycle guard stops a
+/// *cyclic* graph, but a hostile file can declare a long ACYCLIC chain of
+/// distinct objects (`Preface`→A→B→C→…), one per top-level KLV local set, so
+/// the recursion would grow to the chain length and overflow the stack — a
+/// DoS reachable from a crafted (large) real file. Real MXF object trees are
+/// shallow (`Preface`→`ContentStorage`→`Package`→`Track`→`Sequence`→
+/// `Component`, ≈6-8 deep), so this cap is a large superset that never trips
+/// on a real file (byte-identical output). Exceeding it stops descending that
+/// branch (the deeper objects keep their default `MXF` family-1 group — they
+/// are unreachable garbage in any real file).
+const MAX_OBJECT_TREE_DEPTH: u32 = 1000;
+
 /// Walk the MXF object tree from each `Preface` root to assign `Track<N>`
 /// family-1 groups (MXF.pm:2731-2778 `SetGroups`). When an object carries a
 /// `TrackID`, that ID's `Track<N>` group is propagated down its entire
@@ -2570,7 +2592,8 @@ fn fix_groups(w: &mut Walker) {
   let prefaces: Vec<SmolStr> = w.prefaces.clone();
   let mut visited: std::collections::HashSet<SmolStr> = std::collections::HashSet::new();
   for root in prefaces {
-    set_groups(w, &root, None, false, &mut visited);
+    // Each `Preface` root starts the tree walk at depth 0.
+    set_groups(w, 0, &root, None, false, &mut visited);
   }
 }
 
@@ -2579,11 +2602,19 @@ fn fix_groups(w: &mut Walker) {
 /// inside a `SourcePackage` sub-tree.
 fn set_groups(
   w: &mut Walker,
+  depth: u32,
   instance: &SmolStr,
   inherited_track_id: Option<i64>,
   in_source: bool,
   visited: &mut std::collections::HashSet<SmolStr>,
 ) {
+  // Golden-v2 3a — recursion-depth guard for the strong-reference tree. Real
+  // object trees are ≈6-8 deep, far below `MAX_OBJECT_TREE_DEPTH`, so this
+  // never trips on a real file (byte-identical); it bounds stack growth on a
+  // maliciously long strong-ref chain.
+  if depth >= MAX_OBJECT_TREE_DEPTH {
+    return;
+  }
   // MXF.pm:2735-2736 — `return unless $objInfo and not $$objInfo{DidGroups}`.
   if !visited.insert(instance.clone()) {
     return;
@@ -2635,9 +2666,10 @@ fn set_groups(
     }
   }
 
-  // MXF.pm:2770-2772 — recurse into the strong-reference children.
+  // MXF.pm:2770-2772 — recurse into the strong-reference children (one level
+  // deeper, Golden-v2 3a).
   for child in &strong_refs {
-    set_groups(w, child, track_id, child_in_source, visited);
+    set_groups(w, depth + 1, child, track_id, child_in_source, visited);
   }
 }
 
@@ -3368,5 +3400,36 @@ mod tests {
     assert!(projected.lens().is_none());
     assert!(projected.gps().is_none());
     assert!(projected.capture().is_none());
+  }
+
+  #[test]
+  fn deeply_chained_strong_refs_do_not_overflow_the_stack() {
+    // Golden-v2 Contract 3a — `set_groups` recurses the file-declared
+    // strong-reference graph. The `visited` cycle guard stops a cyclic graph,
+    // but a hostile MXF can declare a long ACYCLIC chain of distinct objects
+    // (`Preface`→obj1→obj2→…), one per top-level KLV local set, which would
+    // recurse to the chain length and overflow the stack (a DoS reachable
+    // from a crafted large file: the KLV walk populates `objects`/`prefaces`
+    // then `fix_groups` runs). With `MAX_OBJECT_TREE_DEPTH` the descent stops
+    // at the cap. 200_000 is far past any real tree (≈6-8 deep), so the cap
+    // never trips on a real file (byte-identical output).
+    const N: usize = 200_000;
+    let mut w = Walker::new();
+    for i in 0..N {
+      let inst = SmolStr::new(std::format!("obj{i}"));
+      let mut obj = ObjInfo {
+        name: SmolStr::new("Preface"),
+        ..ObjInfo::default()
+      };
+      if i + 1 < N {
+        obj
+          .strong_refs
+          .push(SmolStr::new(std::format!("obj{}", i + 1)));
+      }
+      w.objects.insert(inst, obj);
+    }
+    w.prefaces.push(SmolStr::new("obj0"));
+    // The depth budget bounds the recursion; this returns without overflowing.
+    fix_groups(&mut w);
   }
 }

--- a/src/formats/mxf.rs
+++ b/src/formats/mxf.rs
@@ -1924,10 +1924,9 @@ impl FormatParser for ProcessMxf {
   type Meta<'a> = MxfMeta<'a>;
   /// Leaf-format Context — `&'a [u8]` (Engine-only, no chained state).
   type Context<'a> = &'a [u8];
-  type Error = MxfError;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, MxfError> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -1938,8 +1937,8 @@ impl FormatParser for ProcessMxf {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today — every bad input is
 /// `Ok(None)`, faithful to MXF.pm:2816-2817 `return 0`).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<MxfMeta<'_>>, MxfError> {
-  Ok(parse_inner(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<MxfMeta<'_>> {
+  parse_inner(data)
 }
 
 // ===========================================================================
@@ -2937,34 +2936,12 @@ impl crate::metadata::Project for MxfMeta<'_> {
 }
 
 // ===========================================================================
-// §19. `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for MXF parsing. Currently empty — every bad input
-/// produces `Ok(None)` (faithful to MXF.pm:2816-2817 `return 0`).
-///
-/// §5: derived via `thiserror` (v2, `default-features = false` ⇒
-/// `core::error::Error`), `#[non_exhaustive]` so variants can be added
-/// without a breaking change. Variant names are kept stable for
-/// [`crate::format_parser::AnyError`]'s `From`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-pub enum MxfError {}
-
-// ===========================================================================
 // §20. Tests
 // ===========================================================================
 
 #[cfg(test)]
 mod tests {
   use super::*;
-
-  #[test]
-  fn mxf_error_is_core_error() {
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<MxfError>();
-  }
-
   #[test]
   fn ul_notation_renders_dotted_groups() {
     let key = [
@@ -3213,8 +3190,8 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_non_mxf() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(b"not an mxf file at all").unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(b"not an mxf file at all").is_none());
   }
 
   #[test]
@@ -3224,7 +3201,7 @@ mod tests {
       "/tests/fixtures/MXF.mxf"
     ))
     .expect("read MXF.mxf fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("MXF accepted");
+    let meta = parse_borrowed(&bytes).expect("MXF accepted");
     assert_eq!(meta.header_type(), Some("OpenHeader"));
     // MXFVersion is the first emitted tag (from the header subtable).
     let names: Vec<&str> = meta.entries().iter().map(MxfEntry::name).collect();
@@ -3250,7 +3227,7 @@ mod tests {
       "/tests/fixtures/MXF.mxf"
     ))
     .expect("read fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tm = emit_into_tagmap(&meta, ConvMode::PrintConv);
     assert_eq!(tm.get_str("MXF", "MXFVersion"), Some("1.2".into()));
     assert_eq!(
@@ -3294,7 +3271,7 @@ mod tests {
       "/tests/fixtures/MXF.mxf"
     ))
     .expect("read fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tm = emit_into_tagmap(&meta, ConvMode::ValueConv);
     // -n: ComponentDataDefinition is the raw UL string.
     assert_eq!(
@@ -3311,7 +3288,7 @@ mod tests {
       "/tests/fixtures/MXF.mxf"
     ))
     .expect("read fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let tags: Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     // Every production entry is visible (the walk pre-filters Unknown rows).
     assert!(tags.iter().all(|t| !t.unknown()));
@@ -3387,7 +3364,7 @@ mod tests {
       "/tests/fixtures/MXF.mxf"
     ))
     .expect("read fixture");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("accepted");
+    let meta = parse_borrowed(&bytes).expect("accepted");
     let projected = meta.project();
     // MXF projects to a single video track; the rest of MediaInfo is empty.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Video]);

--- a/src/formats/ogg.rs
+++ b/src/formats/ogg.rs
@@ -1805,7 +1805,6 @@ impl FormatParser for ProcessOgg {
   /// GAT: the Meta borrows from the input `'a` directly (Codex AF2).
   type Meta<'a> = Meta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
   /// Parse an Ogg file's bytes into a typed [`Meta`].
   ///
@@ -1830,7 +1829,7 @@ impl FormatParser for ProcessOgg {
   ///
   /// A fresh [`crate::format_parser::SharedFlags`] is constructed per
   /// call (the trait's `&[u8]` Context has no chain state to thread).
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     // `ogg = ["flac", "id3"]` per Cargo.toml ⇒ `parse_full_chained` is
     // always present here.
     let mut shared = crate::format_parser::SharedFlags::default();
@@ -1863,7 +1862,7 @@ impl FormatParser for ProcessOgg {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8], print_conv_enabled: bool) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8], print_conv_enabled: bool) -> Option<Meta<'_>> {
   // `ogg = ["id3", "flac"]` per Cargo.toml ⇒ `id3` is always present here.
   let mut shared = crate::format_parser::SharedFlags::default();
   parse_full_chained(data, &mut shared, print_conv_enabled)
@@ -1901,14 +1900,13 @@ pub(crate) fn parse_full_chained<'a>(
   data: &'a [u8],
   shared: &mut crate::format_parser::SharedFlags,
   print_conv: bool,
-) -> Result<Option<Meta<'a>>, Error> {
+) -> Option<Meta<'a>> {
   // 1. Embedded ID3 (Ogg.pm:79-83). The recursion guard (ID3.pm:1435 `return
   //    0 if $$et{DoneID3}`) is honoured here via `shared.done_id3().is_none()`:
   //    only call when ID3 has not already run on this chain (a standalone
   //    OGG file-type entry always gets a fresh `SharedFlags`).
   let (id3, hdr_end) = if shared.done_id3().is_none() {
     crate::formats::id3::process::parse_id3_with_hdr_end(data, Some(&mut *shared), true)
-      .unwrap_or((None, 0))
   } else {
     (None, shared.id3_hdr_end().unwrap_or(0))
   };
@@ -1918,16 +1916,16 @@ pub(crate) fn parse_full_chained<'a>(
   //    `ape::parse_full_chained` (the body parser sees the bytes starting at
   //    the post-ID3-header offset).
   let body_slice = data.get(hdr_end..).unwrap_or(&[]);
-  match parse_inner(body_slice, print_conv)? {
+  match parse_inner(body_slice, print_conv) {
     Some(mut meta) => {
       meta.id3 = id3;
-      Ok(Some(meta))
+      Some(meta)
     }
     // `parse_inner` always returns `Some` today (the typed Meta carries
     // `success` even for non-OGG input). The `None` arm is reachable only
     // if a future revision starts rejecting on Rust-level errors; treat as
     // "no Meta" so the candidate loop continues.
-    None => Ok(None),
+    None => None,
   }
 }
 
@@ -1936,7 +1934,7 @@ pub(crate) fn parse_full_chained<'a>(
 /// re: zero-alloc revisit). The [`FormatParser::Meta`] GAT (`type
 /// Meta<'a> = Meta<'a>`) returns this borrowed form directly into the
 /// closed [`crate::format_parser::AnyMeta`] enum (Codex AF2).
-fn parse_inner(data: &[u8], print_conv_enabled: bool) -> Result<Option<Meta<'_>>, Error> {
+fn parse_inner(data: &[u8], print_conv_enabled: bool) -> Option<Meta<'_>> {
   // Stage the legacy push-style emissions into a side `Metadata` so the
   // bundled-faithful list-coalesce + name-synthesis paths stay byte-exact
   // (faithful to Vorbis.pm:154-210 + ExifTool.pm:9505-9520). The side
@@ -2147,7 +2145,7 @@ fn parse_inner(data: &[u8], print_conv_enabled: bool) -> Result<Option<Meta<'_>>
     .map(|w| staged_warning_to_owned(w.as_str()))
     .collect();
   let comments: Vec<Comment> = staging.tags_slice().iter().map(tag_to_comment).collect();
-  Ok(Some(Meta {
+  Some(Meta {
     #[cfg(feature = "id3")]
     id3: None,
     file_type_override,
@@ -2158,7 +2156,7 @@ fn parse_inner(data: &[u8], print_conv_enabled: bool) -> Result<Option<Meta<'_>>
     warnings,
     success,
     _marker: core::marker::PhantomData,
-  }))
+  })
 }
 
 /// First-wins outcome reducer. Bundled `OverrideFileType`
@@ -2252,24 +2250,6 @@ fn tag_to_comment(tag: &crate::value::Tag) -> Comment {
     )),
   }
 }
-
-// ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for OGG parsing. Currently empty — every parse
-/// failure surfaces as `success == false` on the returned [`Meta`]
-/// (Perl `return 0`) so the bridge can emit the engine-level `ExifTool:
-/// Error => "File format error"`. Reserved for future I/O wrappers if
-/// streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` derived via `thiserror` (v2,
-/// `default-features = false` ⇒ `core::error::Error` in every feature
-/// tier, not just `std`). `#[non_exhaustive]` lets I/O variants land
-/// without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
 
 // ===========================================================================
 // `Taggable` — the golden-pattern emission path
@@ -3014,7 +2994,7 @@ mod tests {
   fn parse_borrowed_rejects_short_buffer() {
     // 4-byte OggS magic only — ProcessOGG never accepts a page, so success
     // is false but the typed Meta still exists with empty comments/warnings.
-    let meta = parse_borrowed(b"OggS", true).expect("ok").expect("meta");
+    let meta = parse_borrowed(b"OggS", true).expect("meta");
     assert!(!meta.success());
     assert!(meta.comments().is_empty());
     assert!(meta.warnings().is_empty());
@@ -3124,9 +3104,7 @@ mod tests {
   fn format_parser_trait_returns_borrowed_meta() {
     // GAT path: `Meta<'a> = Meta<'a>` (phantom `'a`). Drive the trait
     // API with empty bytes and confirm the shape.
-    let meta: Meta<'_> = <ProcessOgg as FormatParser>::parse(&ProcessOgg, b"")
-      .expect("ok")
-      .expect("meta");
+    let meta: Meta<'_> = <ProcessOgg as FormatParser>::parse(&ProcessOgg, b"").expect("meta");
     assert!(!meta.success());
   }
 
@@ -3573,7 +3551,7 @@ mod tests {
   #[test]
   fn taggable_emits_vorbis_comments() {
     let data = fixture("Vorbis.ogg");
-    let meta = parse_borrowed(&data, true).unwrap().unwrap();
+    let meta = parse_borrowed(&data, true).unwrap();
     let mut w = TagMap::new();
     crate::emit::run_emission(&meta, ConvMode::PrintConv, &mut w);
     // Vendor is always emitted (Vorbis.pm:181-187).
@@ -3597,7 +3575,7 @@ mod tests {
   #[test]
   fn taggable_emits_vorbis_interleaved_list() {
     let data = fixture("ogg_vorbis_interleaved_list.ogg");
-    let meta = parse_borrowed(&data, true).unwrap().unwrap();
+    let meta = parse_borrowed(&data, true).unwrap();
     // Find the coalesced list comment (ARTIST/PERFORMER/CONTACT) in the
     // typed Meta to learn its name + expected values.
     let list = meta
@@ -3636,7 +3614,7 @@ mod tests {
   #[test]
   fn taggable_emits_opus_header() {
     let data = fixture("synthetic_opus_minimal.opus");
-    let meta = parse_borrowed(&data, true).unwrap().unwrap();
+    let meta = parse_borrowed(&data, true).unwrap();
     assert!(
       meta.opus_header().is_some(),
       "fixture carries an OpusHead packet"
@@ -3660,7 +3638,7 @@ mod tests {
   #[test]
   fn taggable_emits_metadata_block_picture() {
     let data = fixture("Opus.opus");
-    let meta = parse_borrowed(&data, true).unwrap().unwrap();
+    let meta = parse_borrowed(&data, true).unwrap();
     assert!(
       !meta.pictures().is_empty(),
       "Opus.opus carries a METADATA_BLOCK_PICTURE"
@@ -3691,7 +3669,7 @@ mod tests {
     // Opus.opus exercises Opus:* header tags + FLAC:* Picture sub-fields +
     // Vorbis:* comments in one stream.
     let data = fixture("Opus.opus");
-    let meta = parse_borrowed(&data, true).unwrap().unwrap();
+    let meta = parse_borrowed(&data, true).unwrap();
     let tags: Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     assert!(!tags.is_empty());
     let mut saw_opus = false;
@@ -3729,7 +3707,7 @@ mod tests {
   #[cfg(feature = "id3")]
   fn taggable_chains_id3_before_ogg_body() {
     let data = fixture("ogg_id3_prefixed.ogg");
-    let meta = parse_borrowed(&data, true).unwrap().unwrap();
+    let meta = parse_borrowed(&data, true).unwrap();
     assert!(meta.id3_ref().is_some(), "fixture carries an ID3v2 prefix");
     let names: Vec<String> = meta
       .tags(ConvMode::PrintConv)
@@ -3806,7 +3784,7 @@ mod tests {
   fn project_is_audio_only_no_duration() {
     use crate::metadata::{Project, TrackKind};
     let data = fixture("Vorbis.ogg");
-    let meta = parse_borrowed(&data, true).unwrap().unwrap();
+    let meta = parse_borrowed(&data, true).unwrap();
     let md = Project::project(&meta);
     assert_eq!(md.media().track_kinds(), &[TrackKind::Audio]);
     assert!(md.media().duration().is_none());

--- a/src/formats/ogg.rs
+++ b/src/formats/ogg.rs
@@ -3341,7 +3341,11 @@ mod tests {
     emit_via_engine(&meta, true, &mut tm);
     // The insertion order is exactly the declared-offset order: every key
     // present in the map appears, NOT including the dropped bitrate fields.
-    let keys: Vec<String> = tm.entries().iter().map(|(k, _)| k.to_string()).collect();
+    let keys: Vec<String> = tm
+      .entries()
+      .iter()
+      .map(|(g, n, _)| std::format!("{g}:{n}"))
+      .collect();
     assert_eq!(
       keys,
       vec![
@@ -3421,7 +3425,11 @@ mod tests {
     };
     let mut tm = TagMap::new();
     emit_via_engine(&meta, true, &mut tm);
-    let keys: Vec<String> = tm.entries().iter().map(|(k, _)| k.to_string()).collect();
+    let keys: Vec<String> = tm
+      .entries()
+      .iter()
+      .map(|(g, n, _)| std::format!("{g}:{n}"))
+      .collect();
     assert_eq!(
       keys,
       vec![
@@ -3456,7 +3464,11 @@ mod tests {
     };
     let mut tm = TagMap::new();
     emit_via_engine(&meta, true, &mut tm);
-    let keys: Vec<String> = tm.entries().iter().map(|(k, _)| k.to_string()).collect();
+    let keys: Vec<String> = tm
+      .entries()
+      .iter()
+      .map(|(g, n, _)| std::format!("{g}:{n}"))
+      .collect();
     assert_eq!(
       keys,
       vec![
@@ -3493,7 +3505,11 @@ mod tests {
     };
     let mut tm = TagMap::new();
     emit_via_engine(&meta, true, &mut tm);
-    let keys: Vec<String> = tm.entries().iter().map(|(k, _)| k.to_string()).collect();
+    let keys: Vec<String> = tm
+      .entries()
+      .iter()
+      .map(|(g, n, _)| std::format!("{g}:{n}"))
+      .collect();
     assert_eq!(
       keys,
       vec!["Opus:OpusVersion", "Opus:AudioChannels"],
@@ -3561,7 +3577,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(k, _)| k.starts_with("Vorbis:") && k != "Vorbis:Vendor"),
+        .any(|(g, n, _)| g == "Vorbis" && n != "Vendor"),
       "at least one Vorbis comment beyond vendor: {:?}",
       w.entries()
     );
@@ -3731,11 +3747,11 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(k, _)| k.starts_with("ID3v2") || k == "File:ID3Size"),
+        .any(|(g, n, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 tags present in the engine output"
     );
     assert!(
-      w.entries().iter().any(|(k, _)| k.starts_with("Vorbis:")),
+      w.entries().iter().any(|(g, _, _)| g == "Vorbis"),
       "OGG body tags present in the engine output"
     );
   }

--- a/src/formats/plist.rs
+++ b/src/formats/plist.rs
@@ -704,8 +704,11 @@ impl PlistContentOverride {
 /// D8: no public fields; accessors only.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlistTag {
-  /// Generated tag name (e.g. `"TestDictAuthor"`, `"TestReal"`).
-  name: String,
+  /// Generated tag name (e.g. `"TestDictAuthor"`, `"TestReal"`). A short tag
+  /// identifier (stored, feeds the emitted tag name) ⇒ `SmolStr`; the static
+  /// hit is a `&'static str` and the dynamic name is built in a transient
+  /// `String` (a builder — String per the rule), both converted here.
+  name: smol_str::SmolStr,
   /// The typed leaf value (already `ValueConv`-converted).
   value: PlistLeaf,
   /// The `%PLIST::Main` `PrintConv` to apply at serialize time, in print
@@ -2040,7 +2043,7 @@ fn decode_xml_leaf(name: &str, inner: &str, self_closing: bool) -> PlistValue {
 fn last_wins_by_name_xml_only(scratch: Vec<PlistTag>) -> Vec<PlistTag> {
   // Only XML-group tags actually engage the dedup. A PLIST-group sub-walk
   // tag (from `CompressedPLIST`) is always kept.
-  let mut seen_xml: Vec<String> = Vec::new();
+  let mut seen_xml: Vec<smol_str::SmolStr> = Vec::new();
   let mut keep: Vec<PlistTag> = Vec::new();
   for tag in scratch.iter().rev() {
     if tag.group_override.is_some() {
@@ -2694,16 +2697,17 @@ fn emit_tag(id: &str, format: PlistFormat, leaf: PlistLeaf) -> PlistTag {
       other => other,
     };
     PlistTag {
-      name: info.name.to_string(),
+      name: info.name.into(),
       value,
       print_conv,
       group_override: None,
     }
   } else {
-    let name = match format {
+    let name: smol_str::SmolStr = match format {
       PlistFormat::Binary => generate_binary_tag_name(id),
       PlistFormat::Xml => generate_xml_tag_name(id),
-    };
+    }
+    .into();
     PlistTag {
       name,
       value: leaf,

--- a/src/formats/plist.rs
+++ b/src/formats/plist.rs
@@ -927,9 +927,8 @@ impl FormatParser for ProcessPlist {
   /// Leaf format: reads a single byte slice.
   type Context<'a> = &'a [u8];
   /// Rust-level fatal error — none today (every bad input is `Ok(None)`).
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(data)
   }
 }
@@ -941,7 +940,7 @@ impl FormatParser for ProcessPlist {
 ///
 /// Returns `Err` only for Rust-level fatal modes (none today — every bad
 /// input is `Ok(None)`, faithful to bundled `ProcessPLIST` `return 0`).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<PlistMeta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<PlistMeta<'_>> {
   parse_inner(data)
 }
 
@@ -1022,7 +1021,7 @@ fn plist_element_present(head: &[u8]) -> bool {
 /// (PLIST.pm:453-502): an XML plist (leading `<`, after optional whitespace)
 /// goes to the XML decoder; a `bplist0`-prefixed file to the binary decoder;
 /// anything else is `None` (not a plist).
-fn parse_inner(data: &[u8]) -> Result<Option<PlistMeta<'_>>, Error> {
+fn parse_inner(data: &[u8]) -> Option<PlistMeta<'_>> {
   // PLIST.pm:461-463 — `$$dataPt =~ /\G</` decides XML vs not. The `\G`
   // anchor is at `$start` (0 here); a plist XML file begins with `<?xml`
   // possibly after leading whitespace (the XMP entry tolerates leading
@@ -1047,7 +1046,7 @@ fn parse_inner(data: &[u8]) -> Result<Option<PlistMeta<'_>>, Error> {
   let first_non_ws = xml_view.iter().position(|b| !b.is_ascii_whitespace());
   if first_non_ws.is_some_and(|idx| xml_view[idx] == b'<') {
     // XML plist (PLIST.pm:464-469 — the XMP-machinery branch).
-    return Ok(parse_xml(data));
+    return parse_xml(data);
   }
   // PLIST.pm:480 — `$$dataPt =~ /\Gbplist0/` ⇒ binary PLIST. Once the magic
   // matches, the file is RECOGNIZED as PLIST (PLIST.pm:483 `SetFileType` +
@@ -1055,7 +1054,7 @@ fn parse_inner(data: &[u8]) -> Result<Option<PlistMeta<'_>>, Error> {
   // a decode failure carries `PLIST:Error` rather than dropping the file
   // (Codex R14 F1). So this is `Ok(Some(...))`, never `Ok(None)`.
   if data.starts_with(BPLIST_MAGIC) {
-    return Ok(Some(parse_binary(data)));
+    return Some(parse_binary(data));
   }
   // Not an XML plist, not a binary plist. PLIST.pm:490-493 covers JSON-plist
   // (`{"`-prefixed, out of scope per module docs). PLIST.pm:494-499 covers the
@@ -1063,7 +1062,7 @@ fn parse_inner(data: &[u8]) -> Result<Option<PlistMeta<'_>>, Error> {
   // port routes that at the [`crate::parser::finalization_error`] seam — `Ok(
   // None)` here lets the engine candidate loop exhaust, then the finalization
   // path returns bundled's exact `ExifTool:Error` text (Codex R20 F2).
-  Ok(None)
+  None
 }
 
 // ===========================================================================
@@ -3567,21 +3566,6 @@ const _: () = {
 };
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for PLIST parsing. Currently empty — every bad
-/// input produces `Ok(None)` (faithful to bundled `ProcessPLIST` `return 0`).
-/// `#[non_exhaustive]` lets the first real variant land without a breaking
-/// change.
-///
-/// §5: derived via `thiserror` (`Display` + `core::error::Error` in every
-/// feature tier).
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Tests
 // ===========================================================================
 
@@ -3632,27 +3616,16 @@ mod tests {
       && b[22] == b':'
       && b[23..25].iter().all(u8::is_ascii_digit)
   }
-
-  #[test]
-  fn plist_error_is_core_error() {
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   #[test]
   fn detects_binary_plist() {
-    let meta = parse_borrowed(BIN_FIXTURE)
-      .expect("no fatal")
-      .expect("binary plist recognized");
+    let meta = parse_borrowed(BIN_FIXTURE).expect("binary plist recognized");
     assert!(meta.format().is_binary());
     assert_eq!(meta.format().group(), "PLIST");
   }
 
   #[test]
   fn detects_xml_plist() {
-    let meta = parse_borrowed(XML_FIXTURE)
-      .expect("no fatal")
-      .expect("xml plist recognized");
+    let meta = parse_borrowed(XML_FIXTURE).expect("xml plist recognized");
     assert!(meta.format().is_xml());
     assert_eq!(meta.format().group(), "XML");
   }
@@ -3660,13 +3633,9 @@ mod tests {
   #[test]
   fn rejects_non_plist() {
     // Neither a `bplist0` prefix nor a leading `<` ⇒ not a plist (`Ok(None)`).
-    assert!(
-      parse_borrowed(b"not a plist at all")
-        .expect("no fatal")
-        .is_none()
-    );
+    assert!(parse_borrowed(b"not a plist at all").is_none());
     // Empty buffer ⇒ not a plist.
-    assert!(parse_borrowed(b"").expect("no fatal").is_none());
+    assert!(parse_borrowed(b"").is_none());
     // NOTE: a `bplist00` magic with no trailer is NOT rejected — once the magic
     // matches it is a RECOGNIZED PLIST carrying the error (PLIST.pm:483-489);
     // see `truncated_binary_is_recognized_with_error` (Codex R14 F1).
@@ -3681,9 +3650,7 @@ mod tests {
   #[test]
   fn truncated_binary_is_recognized_with_error() {
     // The 8-byte magic only (no 32-byte trailer ⇒ PLIST.pm:419 `return 0`).
-    let meta = parse_borrowed(b"bplist00")
-      .expect("no fatal")
-      .expect("truncated bplist00 is RECOGNIZED, not Ok(None)");
+    let meta = parse_borrowed(b"bplist00").expect("truncated bplist00 is RECOGNIZED, not Ok(None)");
     assert!(meta.format().is_binary());
     assert_eq!(meta.error(), Some("Error reading binary PLIST file"));
     assert!(
@@ -3729,7 +3696,6 @@ mod tests {
     ];
     for (label, data) in cases {
       let meta = parse_borrowed(&data)
-        .expect("no fatal")
         .unwrap_or_else(|| panic!("{label}: must be RECOGNIZED, not Ok(None)"));
       assert!(meta.format().is_binary(), "{label}: binary");
       assert_eq!(
@@ -3744,7 +3710,7 @@ mod tests {
   /// binary fixture still decodes to its tags with NO error.
   #[test]
   fn binary_success_has_no_error() {
-    let meta = parse_borrowed(BIN_FIXTURE).unwrap().unwrap();
+    let meta = parse_borrowed(BIN_FIXTURE).unwrap();
     assert!(meta.format().is_binary());
     assert_eq!(meta.error(), None);
     assert!(!meta.tags_slice().is_empty());
@@ -3754,7 +3720,7 @@ mod tests {
   /// bundled-oracle values.
   #[test]
   fn binary_fixture_tag_values() {
-    let meta = parse_borrowed(BIN_FIXTURE).unwrap().unwrap();
+    let meta = parse_borrowed(BIN_FIXTURE).unwrap();
     let tm = emit_into_tagmap(&meta, crate::emit::ConvMode::PrintConv);
     assert_eq!(
       tm.get_str("PLIST", "TestString").as_deref(),
@@ -3848,9 +3814,7 @@ mod tests {
   fn binary_oversized_data_is_length_only_placeholder() {
     for size in [1_000_000_u32, 2_000_000, u32::MAX] {
       let bytes = truncated_data_bplist(size);
-      let meta = parse_borrowed(&bytes)
-        .expect("no fatal")
-        .expect("recognized binary plist");
+      let meta = parse_borrowed(&bytes).expect("recognized binary plist");
       let tag = meta
         .tags_slice()
         .iter()
@@ -3900,9 +3864,7 @@ mod tests {
     trailer[31] = table_off;
     out.extend_from_slice(&trailer);
 
-    let meta = parse_borrowed(&out)
-      .expect("no fatal")
-      .expect("recognized binary plist");
+    let meta = parse_borrowed(&out).expect("recognized binary plist");
     let tag = meta
       .tags_slice()
       .iter()
@@ -3918,7 +3880,7 @@ mod tests {
   /// The XML fixture decodes to the same value set under the `"XML"` group.
   #[test]
   fn xml_fixture_tag_values() {
-    let meta = parse_borrowed(XML_FIXTURE).unwrap().unwrap();
+    let meta = parse_borrowed(XML_FIXTURE).unwrap();
     let tm = emit_into_tagmap(&meta, crate::emit::ConvMode::PrintConv);
     assert_eq!(
       tm.get_str("XML", "TestString").as_deref(),
@@ -4325,7 +4287,7 @@ mod tests {
     body.extend_from_slice(&0u64.to_be_bytes()); // topObj
     body.extend_from_slice(&table_off.to_be_bytes());
 
-    let meta = parse_borrowed(&body).unwrap().unwrap();
+    let meta = parse_borrowed(&body).unwrap();
     let tm = emit_into_tagmap(&meta, crate::emit::ConvMode::PrintConv);
     // Bundled emits the unsigned scalar `9223372036854775808`.
     assert_eq!(

--- a/src/formats/png.rs
+++ b/src/formats/png.rs
@@ -208,20 +208,6 @@ fn std_case(chunk: &[u8; 4]) -> Option<&'static [u8; 4]> {
 }
 
 // ===========================================================================
-// Error — uninhabited (Perl `return 0` ⇒ `Ok(None)`)
-// ===========================================================================
-
-/// Rust-level fatal modes for PNG parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers if streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` are derived via `thiserror`;
-/// `#[non_exhaustive]` keeps future variants additive.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // `ProcessPng` — the lib-first parser
 // ===========================================================================
 
@@ -234,10 +220,9 @@ impl parser_sealed::Sealed for ProcessPng {}
 impl FormatParser for ProcessPng {
   type Meta<'a> = PngMeta<'a>;
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -247,8 +232,8 @@ impl FormatParser for ProcessPng {
 /// # Errors
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<PngMeta<'_>>, Error> {
-  Ok(parse_inner(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<PngMeta<'_>> {
+  parse_inner(data)
 }
 
 /// The chunk walker proper. `PNG.pm:1424` `return 0 unless $raf->Read($sig,8)
@@ -2923,15 +2908,15 @@ mod tests {
 
   #[test]
   fn signature_rejects_non_png() {
-    assert!(parse_borrowed(b"NOTAPNG\0").unwrap().is_none());
-    assert!(parse_borrowed(b"\x89PNG\r\n\x1a").unwrap().is_none()); // 7 bytes
-    assert!(parse_borrowed(&[]).unwrap().is_none());
+    assert!(parse_borrowed(b"NOTAPNG\0").is_none());
+    assert!(parse_borrowed(b"\x89PNG\r\n\x1a").is_none()); // 7 bytes
+    assert!(parse_borrowed(&[]).is_none());
   }
 
   #[test]
   fn signature_accepts_canonical_png() {
     let bytes = minimal_png_bytes();
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.dimensions(), Some((16, 16)));
     assert_eq!(meta.bit_depth(), Some(1));
     assert!(meta.color_type().expect("ihdr").is_grayscale());
@@ -2947,7 +2932,7 @@ mod tests {
     bytes.extend_from_slice(PNG_SIGNATURE);
     bytes.extend_from_slice(&0x80000000u32.to_be_bytes());
     bytes.extend_from_slice(b"IHDR");
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(meta.warnings().iter().any(|w| w.contains("chunk size")));
   }
 
@@ -2955,7 +2940,7 @@ mod tests {
   fn truncated_after_signature_yields_warning() {
     // Only the signature.
     let bytes = PNG_SIGNATURE.to_vec();
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     // No IHDR seen; the walker tries to read the next 8-byte header,
     // sees zero remaining bytes, warns and exits.
     assert!(meta.warnings().iter().any(|w| w.contains("Truncated")));
@@ -2977,7 +2962,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"pHYs", &phys));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.pixels_per_unit_x(), Some(2834));
     assert_eq!(meta.pixels_per_unit_y(), Some(2834));
     assert_eq!(meta.pixel_units(), Some(1));
@@ -3001,7 +2986,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"tEXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.text_records().len(), 1);
     let r = &meta.text_records()[0];
     assert!(r.kind().is_text());
@@ -3029,7 +3014,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"iTXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.text_records().len(), 1);
     let r = &meta.text_records()[0];
     assert!(r.kind().is_itxt());
@@ -3085,7 +3070,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"iTXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     let r = &meta.text_records()[0];
     // After inflate the record is no longer flagged compressed and carries the
     // decoded UTF-8 value — emission is identical to a plain iTXt.
@@ -3113,7 +3098,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"iTXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     let r = &meta.text_records()[0];
     assert!(r.is_compressed());
     assert_eq!(r.value(), "");
@@ -3147,7 +3132,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"zTXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.text_records().len(), 1);
     let r = &meta.text_records()[0];
     // Stored through the tEXt path: kind = tEXt, value decoded, NOT compressed.
@@ -3173,7 +3158,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"zTXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     let r = &meta.text_records()[0];
     assert!(r.kind().is_ztxt());
     assert!(r.is_compressed());
@@ -3202,7 +3187,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"zTXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(
       meta
         .warnings()
@@ -3229,7 +3214,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"iCCP", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.icc_profile_name(), Some("sRGB IEC61966-2.1"));
     // No warning on clean inflate; the ICC-tag decode is deferred silently.
     assert!(meta.warnings().is_empty(), "got {:?}", meta.warnings());
@@ -3250,7 +3235,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"iCCP", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.icc_profile_name(), Some("sRGB"));
     assert!(meta.warnings().iter().any(|w| w == "Error inflating iCCP"));
   }
@@ -3277,7 +3262,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"eXIf", &body));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     // The captured block is the INFLATED TIFF, ready for parse_exif_block —
     // a single native (non-profile) source.
     assert_single_exif_event(&meta, false, &tiff);
@@ -3299,7 +3284,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"eXIf", &body));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(meta.exif_events().is_empty());
     assert!(meta.warnings().iter().any(|w| w == "Error inflating eXIf"));
   }
@@ -3322,7 +3307,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"eXIf", &tiff));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_single_exif_event(&meta, false, &tiff);
   }
 
@@ -3346,7 +3331,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"eXIf", &tiff));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_single_exif_event(&meta, false, &tiff[inner_start..]);
     assert!(meta.warnings().iter().any(|w| w.contains("Exif00")),);
   }
@@ -3363,7 +3348,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"eXIf", b"XX\0bad"));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(meta.exif_events().is_empty());
     assert!(meta.warnings().iter().any(|w| w == "Invalid eXIf chunk"));
   }
@@ -3379,7 +3364,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"bKGD", &[0]));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.background_color(), Some("0"));
   }
 
@@ -3398,7 +3383,7 @@ mod tests {
     bkgd.extend_from_slice(&3u16.to_be_bytes());
     bytes.extend_from_slice(&chunk(b"bKGD", &bkgd));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.background_color(), Some("1 2 3"));
   }
 
@@ -3416,7 +3401,7 @@ mod tests {
     t.extend_from_slice(&[5, 22, 9, 30, 15]); // month, day, hour, min, sec
     bytes.extend_from_slice(&chunk(b"tIME", &t));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert_eq!(meta.modify_date(), Some("2025:05:22 09:30:15"));
   }
 
@@ -3434,7 +3419,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IDAT", b"\x00")); // minimal IDAT
     bytes.extend_from_slice(&chunk(b"tEXt", b"Comment\0Hi"));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(
       meta
         .warnings()
@@ -3450,7 +3435,7 @@ mod tests {
     bytes.extend_from_slice(PNG_SIGNATURE);
     bytes.extend_from_slice(&chunk(b"bKGD", &[0]));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(
       meta
         .warnings()
@@ -3471,7 +3456,7 @@ mod tests {
     ihdr_data.extend_from_slice(&[8, 2, 0, 0, 0]);
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr_data));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(
       meta
         .warnings()
@@ -3882,7 +3867,7 @@ mod tests {
     bytes.extend_from_slice(&chunk(b"IHDR", &ihdr));
     bytes.extend_from_slice(&chunk(b"tEXt", &payload));
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     // The decoded TIFF lands as a single ExifProfile event (walk order),
     // surfaced by `exif_events` for the chained walk.
     assert_single_exif_event(&meta, true, &tiff);
@@ -3902,7 +3887,7 @@ mod tests {
     bytes.extend_from_slice(&100u32.to_be_bytes());
     bytes.extend_from_slice(b"IHDR");
     bytes.extend_from_slice(b"\x00\x00\x00\x00\x00");
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     assert!(meta.warnings().iter().any(|w| w == "Corrupted PNG image"),);
   }
 
@@ -3923,7 +3908,7 @@ mod tests {
     bytes.extend_from_slice(&ihdr_data);
     bytes.extend_from_slice(&0xdead_beef_u32.to_be_bytes()); // intentional bad CRC
     bytes.extend_from_slice(&chunk(b"IEND", &[]));
-    let meta = parse_borrowed(&bytes).unwrap().expect("png parses");
+    let meta = parse_borrowed(&bytes).expect("png parses");
     // The IHDR data should still have decoded; default mode does NOT warn
     // about bad CRC.
     assert_eq!(meta.dimensions(), Some((1, 1)));

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -1574,9 +1574,8 @@ impl FormatParser for ProcessMov {
   /// Leaf format Context is `&'a [u8]`.
   type Context<'a> = &'a [u8];
   /// Rust-level fatal error (none today; QuickTime parsing has no I/O modes).
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     // The leaf `FormatParser::parse` carries no extension channel; the
     // closed dispatch in `format_parser.rs` routes the `%useExt` rule
     // through the extension-aware [`parse_with_ext`] entry instead.
@@ -1592,7 +1591,7 @@ impl FormatParser for ProcessMov {
 /// # Errors
 ///
 /// Returns `Err` for Rust-level fatal modes (none today).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   parse_inner(data, None)
 }
 
@@ -1608,7 +1607,7 @@ pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
 /// # Errors
 ///
 /// Returns `Err` for Rust-level fatal modes (none today).
-pub fn parse_with_ext<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>, Error> {
+pub fn parse_with_ext<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   parse_inner(data, ext)
 }
 
@@ -1618,7 +1617,7 @@ pub fn parse_with_ext<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Me
 ///
 /// `ext` is the uppercased `$$et{FILE_EXT}` (ExifTool.pm:2966), used only for
 /// the `%useExt` rule (QuickTime.pm:10006-10007).
-fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>, Error> {
+fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // QuickTime.pm:9966 `$raf->Read($buff,8) == 8 or return 0` — the FIRST step
   // is a plain 8-byte read; QuickTime.pm:9973 `($size, $tag) = unpack('Na4',
   // $buff)` then yields the RAW 32-bit `$size` and the 4-byte `$tag`.
@@ -1634,7 +1633,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
   // then does the size check set `$warnStr` and `last`. So such a file is
   // accepted as QuickTime with the bundled warning, never `Ok(None)`.
   if data.len() < 8 {
-    return Ok(None); // QuickTime.pm:9966 `$raf->Read($buff,8) == 8 or return 0`.
+    return None; // QuickTime.pm:9966 `$raf->Read($buff,8) == 8 or return 0`.
   }
   let raw_size32 = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
   let mut first = [0u8; 4];
@@ -1645,7 +1644,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
   // ALONE, never on `$size` (so an invalid/size-0/truncated size still
   // passes if the type is recognized).
   if !is_known_top_level(&first) {
-    return Ok(None);
+    return None;
   }
 
   // QuickTime.pm:9986-10012: resolve the file type from the RAW first
@@ -1941,7 +1940,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
   // DEFERRED: wire exif::parse_exif_block once #36 (Exif+GPS) merges.
   let embedded_exif_deferred = detect_embedded_exif(data);
 
-  Ok(Some(Meta {
+  Some(Meta {
     qt,
     stream,
     embedded_exif_deferred,
@@ -1949,7 +1948,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<Meta<'a>>
     mime,
     warning,
     _marker: core::marker::PhantomData,
-  }))
+  })
 }
 
 /// Recover the FIRST `moov`/`mvhd` CreateDate as the RAW 1904-epoch second
@@ -2788,21 +2787,6 @@ fn alloc_track_group(n: usize) -> String {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for QuickTime parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`). Reserved for future I/O
-/// wrappers.
-///
-/// §5: derived via `thiserror` (`Display` + `core::error::Error` in every
-/// feature tier). `#[non_exhaustive]` lets the first real variant land
-/// without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Tests
 // ===========================================================================
 
@@ -2840,13 +2824,6 @@ mod tests {
       HeaderOutcome::Malformed { .. } => panic!("unexpected malformed header"),
     }
   }
-
-  #[test]
-  fn quicktime_error_is_core_error() {
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<Error>();
-  }
-
   #[test]
   fn reads_simple_atom_header() {
     let data = atom(b"ftyp", b"qt  \0\0\0\0");
@@ -2972,7 +2949,7 @@ mod tests {
     data.extend_from_slice(&mdat);
     data.extend_from_slice(&moov);
 
-    let meta = parse_inner(&data, None).expect("parse ok").expect("meta");
+    let meta = parse_inner(&data, None).expect("meta");
     // Walker reached the trailing moov ⇒ mvhd state present.
     assert_eq!(meta.qt.time_scale(), Some(1000));
     assert_eq!(meta.qt.movie_header_version(), Some(0));
@@ -2994,7 +2971,7 @@ mod tests {
     let mut data = ftyp;
     data.extend_from_slice(&mdat);
 
-    let meta = parse_inner(&data, None).expect("parse ok").expect("meta");
+    let meta = parse_inner(&data, None).expect("meta");
     assert_eq!(meta.qt.media_data_size(), Some(2_147_483_648));
     assert_eq!(meta.qt.media_data_offset(), Some((mdat_offset + 16) as u64));
     assert_eq!(meta.file_type, "MOV");
@@ -3047,7 +3024,7 @@ mod tests {
     let mut data = ftyp;
     data.extend_from_slice(&moov_zero);
 
-    let meta = parse_inner(&data, None).expect("parse ok").expect("meta");
+    let meta = parse_inner(&data, None).expect("meta");
     // ftyp tags ARE present.
     assert_eq!(meta.qt.major_brand(), Some("qt  "));
     // The size-0 moov payload was NOT decoded: no mvhd-derived state.
@@ -3073,7 +3050,7 @@ mod tests {
     let payload_start = data.len() + 8; // after ftyp + the mdat 8-byte header
     data.extend_from_slice(&mdat_zero);
 
-    let meta = parse_inner(&data, None).expect("parse ok").expect("meta");
+    let meta = parse_inner(&data, None).expect("meta");
     assert_eq!(meta.qt.media_data_offset(), Some(payload_start as u64));
     assert_eq!(
       meta.qt.media_data_size(),
@@ -3313,13 +3290,13 @@ mod tests {
   #[test]
   fn parse_inner_rejects_unknown_first_atom() {
     let data = atom(b"XXXX", b"\0\0\0\0");
-    assert!(parse_inner(&data, None).expect("ok").is_none());
+    assert!(parse_inner(&data, None).is_none());
   }
 
   #[test]
   fn parse_inner_accepts_ftyp_and_resolves_type() {
     let data = atom(b"ftyp", b"M4A \0\0\0\0M4A mp42");
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     assert_eq!(meta.file_type(), "M4A");
     // MajorBrand keeps the trailing space (the %ftypLookup PrintConv key).
     assert_eq!(meta.quicktime().major_brand(), Some("M4A "));
@@ -3423,7 +3400,7 @@ mod tests {
     data.extend_from_slice(&mdat);
     data.extend_from_slice(&moov);
 
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     // The `gps `-handler track contributed nothing; the `mdat` scan decoded the
     // buried block. Exactly one sample, from the scan.
     assert_eq!(
@@ -3481,7 +3458,7 @@ mod tests {
     data.extend_from_slice(&mdat);
     data.extend_from_slice(&moov);
 
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     // The box decoded the block once; the scan is suppressed — NOT doubled.
     assert_eq!(
       meta.stream().gps_samples().len(),
@@ -3551,7 +3528,7 @@ mod tests {
     data.extend_from_slice(&gps0);
     data.extend_from_slice(&moov);
 
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     let samples = meta.stream().gps_samples();
     // BOTH sources extracted: the `gps0` record AND the scanned freeGPS block.
     // (Pre-fix: only the `gps0` sample — the scan was wrongly suppressed.)
@@ -3601,7 +3578,7 @@ mod tests {
     };
     let ft = |major: &[u8; 4], handlers: &[&[u8; 4]]| {
       let data = build(major, handlers);
-      let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+      let meta = parse_inner(&data, None).expect("accepted");
       (meta.file_type(), meta.mime())
     };
 
@@ -3672,16 +3649,14 @@ mod tests {
     let data = [ftyp, moov].concat();
 
     // `.glv` extension ⇒ `%useExt` promotes MP4→GLV (override skipped).
-    let glv = parse_inner(&data, Some("GLV"))
-      .expect("ok")
-      .expect("accepted");
+    let glv = parse_inner(&data, Some("GLV")).expect("accepted");
     assert_eq!(glv.file_type(), "GLV");
     // `%mimeLookup{GLV}` is undef ⇒ the `'video/mp4'` fallback (QuickTime.pm:10008).
     assert_eq!(glv.mime(), "video/mp4");
 
     // Same bytes, NO `.glv` ext ⇒ MP4 not promoted ⇒ the audio-only MP4→M4A
     // override fires (QuickTime.pm:10619-10624).
-    let m4a = parse_inner(&data, None).expect("ok").expect("accepted");
+    let m4a = parse_inner(&data, None).expect("accepted");
     assert_eq!(m4a.file_type(), "M4A");
     assert_eq!(m4a.mime(), "audio/mp4");
 
@@ -3703,9 +3678,7 @@ mod tests {
       ),
     ]
     .concat();
-    let qt = parse_inner(&qt_data, Some("GLV"))
-      .expect("ok")
-      .expect("accepted");
+    let qt = parse_inner(&qt_data, Some("GLV")).expect("accepted");
     assert_eq!(qt.file_type(), "MOV");
     assert_eq!(qt.mime(), "video/quicktime");
   }
@@ -3746,7 +3719,7 @@ mod tests {
     let data = atom(b"ftyp", b"qt  \0\0\0\0qt  ");
     let mut full = data;
     full.extend_from_slice(&atom(b"moov", &moov_body));
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     let track = &meta.quicktime().tracks()[0];
     // 1200 / 600 = 2.0 — the final movie TimeScale is used regardless of the
     // trak-before-mvhd file order (faithful durationInfo ValueConv).
@@ -3788,7 +3761,7 @@ mod tests {
     full.extend_from_slice(&moov1);
     full.extend_from_slice(&moov2);
 
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     // Final global TimeScale is the SECOND moov's (last-wins).
     assert_eq!(meta.quicktime().time_scale(), Some(300));
     let track = &meta.quicktime().tracks()[0];
@@ -3822,7 +3795,7 @@ mod tests {
     full.extend_from_slice(&moov1);
     full.extend_from_slice(&moov2);
 
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     let qt = meta.quicktime();
     // The raw Duration COUNT survives moov2's short mvhd (absent ⇒ no erase).
     assert_eq!(qt.duration_count(), Some(3000));
@@ -3845,7 +3818,7 @@ mod tests {
     let mut data = 100u32.to_be_bytes().to_vec();
     data.extend_from_slice(b"ftyp");
     data.extend_from_slice(b"mp42"); // 12 bytes total
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     assert_eq!(meta.file_type(), "MP4");
     assert_eq!(meta.mime(), "video/mp4");
     // Truncated payload ⇒ no ftyp tags decoded.
@@ -3867,7 +3840,7 @@ mod tests {
     let mut data = 100u32.to_be_bytes().to_vec();
     data.extend_from_slice(b"mdat");
     data.extend_from_slice(b"XXXX"); // 12 bytes total
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
     // mdat-size/offset from the DECLARED size (100 - 8 = 92), offset = 8.
     assert_eq!(meta.quicktime().media_data_size(), Some(92));
@@ -3887,7 +3860,7 @@ mod tests {
     let mut data = 10u32.to_be_bytes().to_vec(); // declared size 10 (< 12)
     data.extend_from_slice(b"ftyp");
     data.push(b'm'); // 9 bytes total, declared 2-byte payload overruns
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
   }
 
@@ -3903,7 +3876,7 @@ mod tests {
     for size in 2u32..=7 {
       let mut data = size.to_be_bytes().to_vec();
       data.extend_from_slice(b"ftyp");
-      let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+      let meta = parse_inner(&data, None).expect("accepted");
       assert_eq!(meta.file_type(), "MOV", "size {size}: file type");
       assert_eq!(
         meta.warning.as_deref(),
@@ -3914,7 +3887,7 @@ mod tests {
     // The same for a `moov`/`mdat` first atom — any magic type is accepted.
     let mut moov4 = 4u32.to_be_bytes().to_vec();
     moov4.extend_from_slice(b"moov");
-    let meta = parse_inner(&moov4, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&moov4, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
     assert_eq!(meta.warning.as_deref(), Some("Invalid atom size"));
   }
@@ -3930,7 +3903,7 @@ mod tests {
     let mut data = 1u32.to_be_bytes().to_vec();
     data.extend_from_slice(b"ftyp");
     data.extend_from_slice(&[0u8; 4]); // only 4 of the 8 ext-size bytes
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
     assert_eq!(meta.warning.as_deref(), Some("Truncated atom header"));
 
@@ -3938,7 +3911,7 @@ mod tests {
     let mut mdat = 1u32.to_be_bytes().to_vec();
     mdat.extend_from_slice(b"mdat");
     mdat.extend_from_slice(&[0u8; 3]);
-    let meta = parse_inner(&mdat, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&mdat, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
     assert_eq!(meta.warning.as_deref(), Some("Truncated atom header"));
   }
@@ -3956,7 +3929,7 @@ mod tests {
       .chain(b"ftyp")
       .copied()
       .collect::<Vec<u8>>();
-    let meta = parse_inner(&size8, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&size8, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
     assert_eq!(meta.mime(), "video/quicktime");
 
@@ -3964,7 +3937,7 @@ mod tests {
     let mut size11 = 11u32.to_be_bytes().to_vec();
     size11.extend_from_slice(b"ftyp");
     size11.extend_from_slice(b"qt ");
-    let meta = parse_inner(&size11, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&size11, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
   }
 
@@ -3981,7 +3954,7 @@ mod tests {
     data.extend_from_slice(&24u64.to_be_bytes()); // 64-bit size = 24
     data.extend_from_slice(b"isom"); // major brand
     data.extend_from_slice(&[0u8; 4]); // minor version
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     // MOV via SetFileType(), NOT MP4 from the `isom` brand.
     assert_eq!(meta.file_type(), "MOV");
     // The brand is still decoded from the (valid) extended-size atom walk.
@@ -3998,7 +3971,7 @@ mod tests {
     let mut data = 16u32.to_be_bytes().to_vec();
     data.extend_from_slice(b"pict");
     data.extend_from_slice(&[0u8; 8]);
-    let meta = parse_inner(&data, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&data, None).expect("accepted");
     assert_eq!(meta.file_type(), "MOV");
   }
 
@@ -4012,7 +3985,7 @@ mod tests {
     data.extend_from_slice(b"meta");
     data.extend_from_slice(&[0u8; 8]);
     assert!(
-      parse_inner(&data, None).expect("ok").is_none(),
+      parse_inner(&data, None).is_none(),
       "`meta` is not a magic-regex first atom — must be rejected"
     );
     // `moof` / `udta` likewise: Main keys but not magic atoms.
@@ -4020,7 +3993,7 @@ mod tests {
       let mut d = 16u32.to_be_bytes().to_vec();
       d.extend_from_slice(tag);
       d.extend_from_slice(&[0u8; 8]);
-      assert!(parse_inner(&d, None).expect("ok").is_none());
+      assert!(parse_inner(&d, None).is_none());
     }
   }
 
@@ -4056,7 +4029,7 @@ mod tests {
     let mut full = atom(b"ftyp", b"qt  \0\0\0\0qt  ");
     full.extend_from_slice(&moov);
 
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     let track = &meta.quicktime().tracks()[0];
     // MediaTimeScale is last-wins (the field IS present in the short mdhd).
     assert_eq!(track.media_time_scale(), Some(300));
@@ -4080,7 +4053,7 @@ mod tests {
     let mut full = atom(b"ftyp", b"qt  \0\0\0\0qt  ");
     full.extend_from_slice(&moov);
 
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     assert_eq!(
       meta.warning.as_deref(),
       Some("Truncated 'mvhd' data (missing 88 bytes)")
@@ -4101,9 +4074,7 @@ mod tests {
     let moov_tkhd = atom(b"moov", &atom(b"trak", &trak_body));
     let mut full_tkhd = atom(b"ftyp", b"qt  \0\0\0\0qt  ");
     full_tkhd.extend_from_slice(&moov_tkhd);
-    let meta = parse_inner(&full_tkhd, None)
-      .expect("ok")
-      .expect("accepted");
+    let meta = parse_inner(&full_tkhd, None).expect("accepted");
     // The truncation is per-track, NOT a document-level warning.
     assert_eq!(meta.warning, None);
     let track = &meta.quicktime().tracks()[0];
@@ -4120,9 +4091,7 @@ mod tests {
     let moov_mdhd = atom(b"moov", &atom(b"trak", &atom(b"mdia", &mdia_body)));
     let mut full_mdhd = atom(b"ftyp", b"qt  \0\0\0\0qt  ");
     full_mdhd.extend_from_slice(&moov_mdhd);
-    let meta = parse_inner(&full_mdhd, None)
-      .expect("ok")
-      .expect("accepted");
+    let meta = parse_inner(&full_mdhd, None).expect("accepted");
     assert_eq!(meta.warning, None);
     let track = &meta.quicktime().tracks()[0];
     assert_eq!(
@@ -4145,7 +4114,7 @@ mod tests {
     moov_body.extend_from_slice(b"mvhd");
     let mut full = atom(b"ftyp", b"qt  \0\0\0\0");
     full.extend_from_slice(&atom(b"moov", &moov_body));
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     assert_eq!(meta.warning.as_deref(), Some("Invalid atom size"));
     // The invalid-size mvhd is never decoded.
     assert_eq!(meta.quicktime().time_scale(), None);
@@ -4162,7 +4131,7 @@ mod tests {
     trak_body.extend_from_slice(b"tkhd");
     let mut full = atom(b"ftyp", b"qt  \0\0\0\0");
     full.extend_from_slice(&atom(b"moov", &atom(b"trak", &trak_body)));
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     // Per-track, NOT a document-level warning.
     assert_eq!(meta.warning, None);
     let track = &meta.quicktime().tracks()[0];
@@ -4198,7 +4167,7 @@ mod tests {
     full.extend_from_slice(&mk_moov(600, &mk_trak(1, 600))); // Track1 (first)
     full.extend_from_slice(&mk_moov(600, &mk_trak(2, 1200))); // Track1 again
 
-    let meta = parse_inner(&full, None).expect("ok").expect("accepted");
+    let meta = parse_inner(&full, None).expect("accepted");
     let tracks = meta.quicktime().tracks();
     assert_eq!(tracks.len(), 2, "both traks are decoded into the list");
     // BOTH tracks carry family-1 group Track1 (per-moov reset).
@@ -4286,7 +4255,7 @@ mod tests {
     // `Meta` owns its data (phantom `'a`); leak the buffer so the returned
     // `Meta` is `'static` for the test helper (the process exits after tests).
     let leaked: &'static [u8] = std::boxed::Box::leak(bytes.into_boxed_slice());
-    parse_borrowed(leaked).expect("ok").expect("parsed")
+    parse_borrowed(leaked).expect("parsed")
   }
 
   #[test]

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -63,6 +63,17 @@ use crate::{
 /// `(66 * 365 + 17) * 24 * 3600` — QuickTime.pm:1361.
 const QT_EPOCH_OFFSET: i64 = (66 * 365 + 17) * 24 * 3600;
 
+/// Max container-atom recursion depth for the box/atom walk (Golden-v2
+/// Contract 3a). ExifTool's `ProcessMOV` has no hard cap (it relies on the
+/// finite atom sizes + EOF), but a maliciously deep box tree would recurse
+/// `walk_atoms`→`walk_trak`→`walk_atoms` (or the freeGPS/embedded-Exif
+/// `udta`/`meta` scans) until the stack overflows — a DoS. Real media nests
+/// single-digit deep (`moov`→`trak`→`mdia`→`minf`→`stbl`→…), so this cap is a
+/// large superset that never trips on a real file; the output stays
+/// byte-identical. Exceeding the cap simply stops recursion (no warning),
+/// faithful to a truncated/garbage subtree contributing no tags.
+const MAX_ATOM_DEPTH: u32 = 100;
+
 // ===========================================================================
 // Atom header reading (QuickTime.pm:9966-10078)
 // ===========================================================================
@@ -348,13 +359,28 @@ fn truncated_atom_warning(
 /// extended size ⇒ `Invalid atom size` etc.) inside moov/trak/mdia still set
 /// `$warnStr` and emit the warning before the `last`. The first such warning
 /// is recorded into `warning` (first-wins, threaded through nested walks).
+///
+/// `depth` is the recursion budget (Golden-v2 Contract 3a): a `walk_atoms`
+/// re-entered from inside another `walk_atoms`/`walk_trak` closure passes the
+/// enclosing `depth + 1`; the top-level/entry walks pass `0`. When `depth`
+/// reaches [`MAX_ATOM_DEPTH`] the walk stops, bounding stack use on a hostile
+/// file with no effect on real media (whose nesting is single-digit, far below
+/// the cap — so the output is byte-identical).
 fn walk_atoms(
+  depth: u32,
   data: &[u8],
   start: usize,
   end: usize,
   warning: &mut Option<String>,
   mut f: impl FnMut(&AtomHeader, &[u8], &mut Option<String>),
 ) {
+  // Golden-v2 3a — recursion-depth guard. Real QuickTime nesting is
+  // single-digit (`moov`→`trak`→`mdia`→`minf`→…); `MAX_ATOM_DEPTH` is a
+  // superset, so this never trips on a real file (byte-identical output) but
+  // caps stack growth on a maliciously deep box tree (a stack-overflow DoS).
+  if depth >= MAX_ATOM_DEPTH {
+    return;
+  }
   let mut pos = start;
   while pos < end {
     match read_atom_header(data, pos, false) {
@@ -1265,7 +1291,8 @@ fn decode_hdlr(payload: &[u8]) -> Option<String> {
 /// `$$self{MediaTS}` set by the SAME mdhd table — that one IS parse-order
 /// and is handled inside [`decode_mdhd`].)
 fn decode_moov_mvhd(payload: &[u8], qt: &mut QuickTimeMeta, warning: &mut Option<String>) {
-  walk_atoms(payload, 0, payload.len(), warning, |inner, ibody, _w| {
+  // Top-level entry (the `parse_inner` file loop) — depth 0.
+  walk_atoms(0, payload, 0, payload.len(), warning, |inner, ibody, _w| {
     if &inner.atom_type == b"mvhd" {
       decode_mvhd(ibody, qt);
     }
@@ -1290,7 +1317,8 @@ fn decode_moov_mvhd(payload: &[u8], qt: &mut QuickTimeMeta, warning: &mut Option
 /// global is THIS [`KodakFrea::version`](crate::metadata::KodakFrea::version),
 /// threaded into the `mdat` freeGPS scan via [`parse_inner`].
 fn decode_frea(payload: &[u8], qt: &mut QuickTimeMeta, warning: &mut Option<String>) {
-  walk_atoms(payload, 0, payload.len(), warning, |inner, ibody, _w| {
+  // Top-level entry (the `parse_inner` file loop) — depth 0.
+  walk_atoms(0, payload, 0, payload.len(), warning, |inner, ibody, _w| {
     let frea = qt.kodak_frea_mut();
     match &inner.atom_type {
       // `tima` Duration — `int32u` (Kodak.pm:2980-2985). ExifTool's `int32u`
@@ -1344,10 +1372,12 @@ fn decode_moov_trak(
   // later same-group track (first-wins) so default JSON keeps the FIRST moov's
   // `Track1`.
   let mut track_num: u32 = 0;
-  walk_atoms(payload, 0, payload.len(), warning, |inner, ibody, _w| {
+  // Top-level entry (the `parse_inner` file loop) — this `moov` walk is depth
+  // 0; `walk_trak` re-enters `walk_atoms` so it starts one level deeper (1).
+  walk_atoms(0, payload, 0, payload.len(), warning, |inner, ibody, _w| {
     if &inner.atom_type == b"trak" {
       track_num += 1; // QuickTime.pm:10354 `++$track`
-      let mut track = walk_trak(ibody, movie_ts);
+      let mut track = walk_trak(1, ibody, movie_ts);
       track.set_track_group(track_num);
       qt.push_track(track);
     }
@@ -1362,10 +1392,11 @@ fn decode_moov_trak(
 /// attaches the `Truncated '...' data` / `Invalid atom size` warning to the
 /// *current* family-1 group, so the warning is recorded ON THE TRACK (surfaced
 /// as `Track#:Warning`), not the document-level `ExifTool:Warning`.
-fn walk_trak(payload: &[u8], movie_timescale: Option<u32>) -> MediaTrack {
+fn walk_trak(depth: u32, payload: &[u8], movie_timescale: Option<u32>) -> MediaTrack {
   let mut track = MediaTrack::new();
   let mut track_warning: Option<String> = None;
   walk_atoms(
+    depth,
     payload,
     0,
     payload.len(),
@@ -1377,9 +1408,16 @@ fn walk_trak(payload: &[u8], movie_timescale: Option<u32>) -> MediaTrack {
           track.merge_track_header(decoded);
         }
         b"mdia" => {
-          // mdia contains mdhd + hdlr + minf (QuickTime.pm:7218-7237).
-          walk_atoms(body, 0, body.len(), w, |inner, ibody, _w| {
-            match &inner.atom_type {
+          // mdia contains mdhd + hdlr + minf (QuickTime.pm:7218-7237). This
+          // re-enters `walk_atoms` from inside the trak walk, so it runs one
+          // level deeper than the enclosing `walk_trak` (Golden-v2 3a).
+          walk_atoms(
+            depth + 1,
+            body,
+            0,
+            body.len(),
+            w,
+            |inner, ibody, _w| match &inner.atom_type {
               b"mdhd" => decode_mdhd(ibody, &mut track),
               b"hdlr" => {
                 if let Some(code) = decode_hdlr(ibody) {
@@ -1387,8 +1425,8 @@ fn walk_trak(payload: &[u8], movie_timescale: Option<u32>) -> MediaTrack {
                 }
               }
               _ => {}
-            }
-          });
+            },
+          );
         }
         _ => {}
       }
@@ -1931,7 +1969,8 @@ fn first_moov_create_date_raw(data: &[u8]) -> Option<u64> {
     };
     if &header.atom_type == b"moov" {
       let body = &data[header.payload_start..header.payload_end.min(data.len())];
-      walk_atoms(body, 0, body.len(), &mut None, |inner, ibody, _w| {
+      // Top-level scan (the file loop above) — depth 0.
+      walk_atoms(0, body, 0, body.len(), &mut None, |inner, ibody, _w| {
         if &inner.atom_type == b"mvhd"
           && let Some(&version) = ibody.first()
         {
@@ -1981,7 +2020,8 @@ fn detect_embedded_exif(data: &[u8]) -> bool {
     };
     let body = &data[header.payload_start..header.payload_end.min(data.len())];
     detected |= match &header.atom_type {
-      b"moov" => detect_embedded_exif_in_dir(body),
+      // Top-level entry into the directory scan — depth 0.
+      b"moov" => detect_embedded_exif_in_dir(0, body),
       // A top-level `uuid` carrying an `Exif` TIFF block.
       b"uuid" => is_uuid_exif_payload(body),
       _ => false,
@@ -1997,16 +2037,25 @@ fn detect_embedded_exif(data: &[u8]) -> bool {
 /// Recursively scan a `moov`/`udta`/`meta` directory for an embedded-Exif
 /// atom (`QVMI` / `MVTG` / `Exif` / `uuid`-Exif). QuickTime.pm nests these
 /// under `moov`→`udta` (QuickTime.pm:2058, 2070).
-fn detect_embedded_exif_in_dir(body: &[u8]) -> bool {
+///
+/// `depth` is the recursion budget (Golden-v2 3a): the `udta`/`meta`/`trak`
+/// self-recursion passes `depth + 1`, and the `walk_atoms` walk runs at the
+/// same `depth` — so a hostile deeply-nested `udta` chain is bounded by
+/// [`MAX_ATOM_DEPTH`] on both the self-recursion and the box walk.
+fn detect_embedded_exif_in_dir(depth: u32, body: &[u8]) -> bool {
+  if depth >= MAX_ATOM_DEPTH {
+    return false;
+  }
   let mut found = false;
-  walk_atoms(body, 0, body.len(), &mut None, |inner, ibody, _w| {
+  walk_atoms(depth, body, 0, body.len(), &mut None, |inner, ibody, _w| {
     found |= match &inner.atom_type {
       // Casio `QVMI` / FujiFilm `MVTG` — standard Exif IFD blocks
       // (QuickTime.pm:2056-2080) — and a bare `Exif`-type atom (TIFF block).
       b"QVMI" | b"MVTG" | b"Exif" => true,
       b"uuid" => is_uuid_exif_payload(ibody),
-      // Recurse into nested containers (`udta`, `meta`, `trak`).
-      b"udta" | b"meta" | b"trak" => detect_embedded_exif_in_dir(ibody),
+      // Recurse into nested containers (`udta`, `meta`, `trak`) — one level
+      // deeper than the enclosing directory scan.
+      b"udta" | b"meta" | b"trak" => detect_embedded_exif_in_dir(depth + 1, ibody),
       _ => false,
     };
   });
@@ -3060,7 +3109,7 @@ mod tests {
     moov_body.extend_from_slice(&mvhd);
     let mut decoded_mvhd = false;
     let mut warn = None;
-    walk_atoms(&moov_body, 0, moov_body.len(), &mut warn, |a, _, _| {
+    walk_atoms(0, &moov_body, 0, moov_body.len(), &mut warn, |a, _, _| {
       if &a.atom_type == b"mvhd" {
         decoded_mvhd = true;
       }
@@ -3144,7 +3193,7 @@ mod tests {
     moov_body.extend_from_slice(b"mvhd");
     let mut warn: Option<String> = None;
     let mut decoded = false;
-    walk_atoms(&moov_body, 0, moov_body.len(), &mut warn, |a, _, _| {
+    walk_atoms(0, &moov_body, 0, moov_body.len(), &mut warn, |a, _, _| {
       if &a.atom_type == b"mvhd" {
         decoded = true;
       }
@@ -4416,5 +4465,45 @@ mod tests {
     assert!(projected.lens().is_none());
     assert!(projected.gps().is_none());
     assert!(projected.capture().is_none());
+  }
+
+  #[test]
+  fn deeply_nested_atoms_do_not_overflow_the_stack() {
+    // Golden-v2 Contract 3a — a hostile file can nest container atoms
+    // arbitrarily deep. The production walk recurses on `trak`/`mdia` (and
+    // the freeGPS / embedded-Exif scans recurse on `udta`/`meta`); a
+    // closure that re-enters `walk_atoms` per nested container is exactly
+    // that pattern. Without a recursion budget this blows the stack
+    // (a DoS); with `MAX_ATOM_DEPTH` the walk simply stops at the cap and
+    // returns. The nesting here (100_000) is a superset of any real file's
+    // single-digit nesting, so the cap never triggers on a real input.
+    const N: usize = 100_000;
+    // Build N nested `moov` containers: innermost is an 8-byte empty `moov`,
+    // each outer frame wraps the previous one's bytes.
+    let mut buf = atom(b"moov", &[]);
+    for _ in 1..N {
+      buf = atom(b"moov", &buf);
+    }
+
+    // A recursive walker mirroring the production `walk_trak`/`mdia` shape:
+    // each nested `moov` re-enters `walk_atoms` at `depth + 1`.
+    fn recurse(depth: u32, body: &[u8], count: &mut u64) {
+      walk_atoms(depth, body, 0, body.len(), &mut None, |inner, ibody, _w| {
+        if &inner.atom_type == b"moov" {
+          *count += 1;
+          recurse(depth + 1, ibody, count);
+        }
+      });
+    }
+
+    let mut count = 0u64;
+    recurse(0, &buf, &mut count);
+    // The budget bounds the walk; at least one container was visited and we
+    // returned without overflowing.
+    assert!(count >= 1, "expected to visit at least one nested moov");
+    assert!(
+      count <= u64::from(MAX_ATOM_DEPTH),
+      "the recursion budget must cap the walk at MAX_ATOM_DEPTH containers"
+    );
   }
 }

--- a/src/formats/quicktime_stream.rs
+++ b/src/formats/quicktime_stream.rs
@@ -1303,7 +1303,7 @@ fn process_mebx_subdir(tag_id: &str, value: &[u8], out: &mut QuickTimeStreamMeta
   // (Duration / GPSLatitude / GPSLongitude are keyed on full reverse-DNS
   // paths), so the `PrintConv` render equals the `-n` render — collect once in
   // the default print mode (the `-ee`/`-j` golden mode).
-  if let Ok(Some(meta)) = crate::formats::plist::parse_borrowed(value) {
+  if let Some(meta) = crate::formats::plist::parse_borrowed(value) {
     for emitted in crate::emit::Taggable::tags(&meta, crate::emit::ConvMode::PrintConv) {
       // `Unknown => 1` tags are dropped from default output (every PLIST tag is
       // always-emitted, so this is a no-op in practice — kept for parity with

--- a/src/formats/real.rs
+++ b/src/formats/real.rs
@@ -246,7 +246,8 @@ struct MdprStream {
 #[derive(Debug, Clone)]
 struct FileInfoProp {
   /// `Real-MDPR{N}:<Name>` — the dynamic-name as derived by Real.pm:196-220.
-  name: String,
+  /// A short tag identifier (stored, feeds the emitted tag name) ⇒ `SmolStr`.
+  name: smol_str::SmolStr,
   /// PrintConv form (`-j`); identical to `value_raw` for identity converters.
   value_print: String,
   /// Post-ValueConv form (`-n`); typically a bare integer string for the
@@ -273,8 +274,8 @@ struct ContTags {
 struct RjmdTag {
   /// Final tag name after `tr/A-Za-z0-9//dc` + `ucfirst` then the Perl
   /// `%Real::Metadata` static-rename table (`Album/Name → AlbumName`,
-  /// `Track/Category → TrackCategory`, …).
-  name: String,
+  /// `Track/Category → TrackCategory`, …). A short tag identifier ⇒ `SmolStr`.
+  name: smol_str::SmolStr,
   /// The post-ValueConv string (used for both `-j` and `-n`; the Real
   /// metadata table has no PrintConv toggles).
   value: String,
@@ -291,7 +292,8 @@ struct RjmdTag {
 /// — `value` is the single source of truth for both modes.
 #[derive(Debug, Clone)]
 struct RaCodecField {
-  name: String,
+  /// A static codec-field identifier (`"Channels"`, `"Title"`, …) ⇒ `SmolStr`.
+  name: smol_str::SmolStr,
   value: String,
   /// `true` when the bundled `-n`/`-j` output is a bare JSON number.
   emit_as_int: bool,
@@ -926,7 +928,7 @@ fn parse_real_properties(body: &[u8]) -> Vec<FileInfoProp> {
         if info_name == "ContentRating" {
           let print = content_rating_print(val_u32);
           out.push(FileInfoProp {
-            name: info_name.to_string(),
+            name: info_name.as_str().into(),
             value_print: print.to_string(),
             value_raw: val_u32.to_string(),
             emit_raw_as_int: true,
@@ -938,7 +940,7 @@ fn parse_real_properties(body: &[u8]) -> Vec<FileInfoProp> {
             _ => "",
           };
           out.push(FileInfoProp {
-            name: info_name.to_string(),
+            name: info_name.as_str().into(),
             value_print: print.to_string(),
             value_raw: val_u32.to_string(),
             emit_raw_as_int: true,
@@ -946,7 +948,7 @@ fn parse_real_properties(body: &[u8]) -> Vec<FileInfoProp> {
         } else {
           let v = val_u32.to_string();
           out.push(FileInfoProp {
-            name: info_name.to_string(),
+            name: info_name.as_str().into(),
             value_print: v.clone(),
             value_raw: v,
             emit_raw_as_int: true,
@@ -958,7 +960,7 @@ fn parse_real_properties(body: &[u8]) -> Vec<FileInfoProp> {
         let s = raw_bytes_to_json_string(null_truncate(raw_val));
         let (vc_print, _was_dated) = apply_file_info_value_conv(&info_name, &s, found_in_table);
         out.push(FileInfoProp {
-          name: info_name.to_string(),
+          name: info_name.as_str().into(),
           value_print: vc_print.clone(),
           value_raw: vc_print,
           emit_raw_as_int: false,
@@ -971,7 +973,7 @@ fn parse_real_properties(body: &[u8]) -> Vec<FileInfoProp> {
         // future-proofness.
         let s = raw_bytes_to_json_string(raw_val);
         out.push(FileInfoProp {
-          name: info_name.to_string(),
+          name: info_name.as_str().into(),
           value_print: s.clone(),
           value_raw: s,
           emit_raw_as_int: false,
@@ -1260,8 +1262,10 @@ fn parse_real_meta(body: &[u8], prefix: &str, out: &mut Vec<RjmdTag>) {
     //   5 => 'undef', 6 => 'string', 7 => 'string' (date), 8 => 'string',
     //   9 => undef (grouping), 10 => undef (reference).
     // Real.pm:457-466 — `GetTagInfo`/dynamic-name synthesis. Apply the
-    // RJMD-name remap (Real.pm:264-268).
-    let resolved_name = resolve_rjmd_tag(&full_tag);
+    // RJMD-name remap (Real.pm:264-268). `resolve_rjmd_tag` builds the name in
+    // a transient `String` (a builder — String per the project rule); the
+    // STORED field is a short tag identifier ⇒ `SmolStr`.
+    let resolved_name = smol_str::SmolStr::from(resolve_rjmd_tag(&full_tag));
     // Real.pm:468-490 — emit if `$valueLen && $format`.
     if value_len > 0 {
       let raw_value = &body[value_data_pos..value_data_pos + value_len];
@@ -1634,7 +1638,7 @@ fn parse_ra3(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 0 Channels (int16u).
   if let Some(v) = read_u16(cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "Channels".to_string(),
+      name: "Channels".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1645,7 +1649,7 @@ fn parse_ra3(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 2 BytesPerMinute (int16u).
   if let Some(v) = read_u16(cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "BytesPerMinute".to_string(),
+      name: "BytesPerMinute".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1654,7 +1658,7 @@ fn parse_ra3(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 3 AudioBytes (int32u).
   if let Some(v) = read_u32(cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "AudioBytes".to_string(),
+      name: "AudioBytes".into(),
       value: fmt_u32(v),
       emit_as_int: true,
     });
@@ -1714,7 +1718,7 @@ fn parse_ra4(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 6 AudioBytes int32u — EMIT.
   if let Some(v) = read_u32(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "AudioBytes".to_string(),
+      name: "AudioBytes".into(),
       value: fmt_u32(v),
       emit_as_int: true,
     });
@@ -1723,7 +1727,7 @@ fn parse_ra4(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 7 BytesPerMinute int32u — EMIT.
   if let Some(v) = read_u32(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "BytesPerMinute".to_string(),
+      name: "BytesPerMinute".into(),
       value: fmt_u32(v),
       emit_as_int: true,
     });
@@ -1736,7 +1740,7 @@ fn parse_ra4(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 10 AudioFrameSize int16u (default) — EMIT (no Unknown tag).
   if let Some(v) = read_u16(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "AudioFrameSize".to_string(),
+      name: "AudioFrameSize".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1749,7 +1753,7 @@ fn parse_ra4(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 13 SampleRate int16u — EMIT.
   if let Some(v) = read_u16(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "SampleRate".to_string(),
+      name: "SampleRate".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1760,7 +1764,7 @@ fn parse_ra4(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 15 BitsPerSample int16u — EMIT.
   if let Some(v) = read_u16(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "BitsPerSample".to_string(),
+      name: "BitsPerSample".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1769,7 +1773,7 @@ fn parse_ra4(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 16 Channels int16u — EMIT.
   if let Some(v) = read_u16(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "Channels".to_string(),
+      name: "Channels".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1841,7 +1845,7 @@ fn parse_ra5(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 6 AudioBytes int32u — EMIT.
   if let Some(v) = read_u32(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "AudioBytes".to_string(),
+      name: "AudioBytes".into(),
       value: fmt_u32(v),
       emit_as_int: true,
     });
@@ -1850,7 +1854,7 @@ fn parse_ra5(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 7 BytesPerMinute int32u — EMIT.
   if let Some(v) = read_u32(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "BytesPerMinute".to_string(),
+      name: "BytesPerMinute".into(),
       value: fmt_u32(v),
       emit_as_int: true,
     });
@@ -1867,7 +1871,7 @@ fn parse_ra5(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 12 SampleRate int16u — EMIT.
   if let Some(v) = read_u16(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "SampleRate".to_string(),
+      name: "SampleRate".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1878,7 +1882,7 @@ fn parse_ra5(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 14 BitsPerSample int32u — EMIT.
   if let Some(v) = read_u32(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "BitsPerSample".to_string(),
+      name: "BitsPerSample".into(),
       value: fmt_u32(v),
       emit_as_int: true,
     });
@@ -1887,7 +1891,7 @@ fn parse_ra5(header: &[u8], meta: &mut RealMeta<'_>) {
   // Field 15 Channels int16u — EMIT.
   if let Some(v) = read_u16(header, cursor) {
     meta.ra_fields.push(RaCodecField {
-      name: "Channels".to_string(),
+      name: "Channels".into(),
       value: u32::from(v).to_string(),
       emit_as_int: true,
     });
@@ -1911,8 +1915,8 @@ fn ra_text_field(header: &[u8], cursor: usize, name: &str, meta: &mut RealMeta<'
   let s = raw_bytes_to_json_string(null_truncate(raw));
   if !s.is_empty() {
     meta.ra_fields.push(RaCodecField {
-      name: name.to_string(),
-      value: s.clone(),
+      name: name.into(),
+      value: s,
       emit_as_int: false,
     });
   }

--- a/src/formats/real.rs
+++ b/src/formats/real.rs
@@ -501,7 +501,6 @@ impl FormatParser for ProcessReal {
   /// Leaf format Context is `&'a [u8]`.
   type Context<'a> = &'a [u8];
   /// Rust-level fatal error.
-  type Error = RealError;
 
   /// Parse a Real file's bytes into a typed [`RealMeta`], or `None` if the
   /// buffer is not a Real file (no magic match — Real.pm:523).
@@ -511,7 +510,7 @@ impl FormatParser for ProcessReal {
   /// (Real.pm:536 `($ext and $ext eq 'RPM')` is false). Callers that
   /// need the RAM-vs-RPM distinction use [`parse_with_ext`] (the engine
   /// dispatch in `AnyParser::parse_any` does).
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, RealError> {
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     parse_inner(data, None)
   }
 }
@@ -525,7 +524,7 @@ impl FormatParser for ProcessReal {
 ///
 /// Returns `Err` for Rust-level fatal modes (currently none — every bad
 /// input is `Ok(None)` per Perl `return 0`).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<RealMeta<'_>>, RealError> {
+pub fn parse_borrowed(data: &[u8]) -> Option<RealMeta<'_>> {
   parse_inner(data, None)
 }
 
@@ -542,32 +541,29 @@ pub fn parse_borrowed(data: &[u8]) -> Result<Option<RealMeta<'_>>, RealError> {
 ///
 /// Returns `Err` for Rust-level fatal modes (currently none — every bad
 /// input is `Ok(None)` per Perl `return 0`).
-pub fn parse_with_ext<'a>(
-  data: &'a [u8],
-  ext: Option<&str>,
-) -> Result<Option<RealMeta<'a>>, RealError> {
+pub fn parse_with_ext<'a>(data: &'a [u8], ext: Option<&str>) -> Option<RealMeta<'a>> {
   parse_inner(data, ext)
 }
 
-fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Result<Option<RealMeta<'a>>, RealError> {
+fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<RealMeta<'a>> {
   // Real.pm:522 — `$raf->Read($buff,8) == 8`.
   if data.len() < 8 {
-    return Ok(None);
+    return None;
   }
   // Real.pm:523 — magic dispatch.
   if data.starts_with(b".RMF") {
-    return Ok(Some(parse_rm(data)));
+    return Some(parse_rm(data));
   }
   if data.starts_with(b".ra\xfd") {
-    return Ok(Some(parse_ra(data)));
+    return Some(parse_ra(data));
   }
   if data.starts_with(b"pnm://") || data.starts_with(b"rtsp://") || data.starts_with(b"http://") {
     // Real.pm:533-555 — Metafile branch. `parse_metafile` itself decides
     // acceptance (Real.pm:546 http-URL gate); a rejected buffer returns
     // `Ok(None)` ⇒ `return 0` ⇒ the engine candidate loop continues.
-    return Ok(parse_metafile(data, ext));
+    return parse_metafile(data, ext);
   }
-  Ok(None)
+  None
 }
 
 // ===========================================================================
@@ -2479,21 +2475,6 @@ impl crate::metadata::Project for RealMeta<'_> {
 }
 
 // ===========================================================================
-// `RealError` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for Real parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`).
-///
-/// §5: derived via `thiserror` (`Display` + `core::error::Error` in every
-/// feature tier — `thiserror` v2 with `default-features = false` emits
-/// `core::error::Error`). `#[non_exhaustive]` lets the first real variant
-/// land without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum RealError {}
-
-// ===========================================================================
 // Optional serde `Serialize` impl for `Rendered<'_, '_, RealMeta<'_>>`
 // ===========================================================================
 //
@@ -2508,13 +2489,6 @@ pub enum RealError {}
 #[cfg(test)]
 mod tests {
   use super::*;
-
-  #[test]
-  fn real_error_is_core_error() {
-    fn assert_error<E: core::error::Error>() {}
-    assert_error::<RealError>();
-  }
-
   #[test]
   fn real_audio_version_from_raw_round_trip() {
     assert_eq!(RealAudioVersion::from_raw(3), RealAudioVersion::Ra3);
@@ -2598,20 +2572,20 @@ mod tests {
 
   #[test]
   fn parse_inner_rejects_short_buffer() {
-    assert!(parse_inner(&[], None).unwrap().is_none());
-    assert!(parse_inner(&[0u8; 4], None).unwrap().is_none());
+    assert!(parse_inner(&[], None).is_none());
+    assert!(parse_inner(&[0u8; 4], None).is_none());
   }
 
   #[test]
   fn parse_inner_rejects_bad_magic() {
-    assert!(parse_inner(b"NOMAGIC1", None).unwrap().is_none());
+    assert!(parse_inner(b"NOMAGIC1", None).is_none());
   }
 
   #[test]
   fn parse_inner_accepts_rm_magic() {
     let mut buf = b".RMF\x00\x00\x00\x12".to_vec();
     buf.resize(64, 0);
-    let m = parse_inner(&buf, None).unwrap().expect("RM accepted");
+    let m = parse_inner(&buf, None).expect("RM accepted");
     assert_eq!(m.kind(), RealKind::Rm);
   }
 
@@ -2619,7 +2593,7 @@ mod tests {
   fn parse_inner_accepts_ra_magic() {
     let mut buf = b".ra\xfd\x00\x04\x00\x00".to_vec();
     buf.resize(520, 0);
-    let m = parse_inner(&buf, None).unwrap().expect("RA accepted");
+    let m = parse_inner(&buf, None).expect("RA accepted");
     assert_eq!(m.kind(), RealKind::Ra);
     assert_eq!(m.ra_version(), Some(RealAudioVersion::Ra4));
   }
@@ -2627,9 +2601,7 @@ mod tests {
   #[test]
   fn parse_inner_accepts_pnm_uri_metafile() {
     // RAM URL line.
-    let m = parse_inner(b"pnm://host/file.ra\n", None)
-      .unwrap()
-      .expect("metafile accepted");
+    let m = parse_inner(b"pnm://host/file.ra\n", None).expect("metafile accepted");
     assert_eq!(m.kind(), RealKind::Ram);
   }
 
@@ -2676,11 +2648,7 @@ mod tests {
     assert!(parse_metafile(b"http://host/page.html\nhttp://host/ok.rm\n", None).is_none());
     // `parse_inner` propagates the `None` (the magic prefix matched, but
     // the Metafile branch declined).
-    assert!(
-      parse_inner(b"http://host/page.html\n", None)
-        .unwrap()
-        .is_none()
-    );
+    assert!(parse_inner(b"http://host/page.html\n", None).is_none());
   }
 
   #[test]
@@ -2994,7 +2962,7 @@ mod tests {
   #[test]
   fn taggable_emits_rm_prop_mdpr_print_and_raw() {
     let data = fixture("Real.rm");
-    let m = parse_borrowed(&data).unwrap().expect("RM parses");
+    let m = parse_borrowed(&data).expect("RM parses");
 
     // -j (PrintConv): bitrate/duration/Flags render as strings.
     let pj = emit(&m, true);
@@ -3066,7 +3034,7 @@ mod tests {
   #[test]
   fn taggable_emits_ra_header_under_versioned_group() {
     let data = fixture("Real.ra");
-    let m = parse_borrowed(&data).unwrap().expect("RA parses");
+    let m = parse_borrowed(&data).expect("RA parses");
     assert_eq!(m.ra_version(), Some(RealAudioVersion::Ra4));
     // The RA fixture decodes as RA4 ⇒ codec fields live under `Real-RA4`.
     // (Identity table: -j and -n agree on the value.)
@@ -3095,7 +3063,7 @@ mod tests {
     // family-1), which the `TagMap` sink collapses to family-1 only.
     use crate::emit::{ConvMode, Taggable};
     let rm = fixture("Real.rm");
-    let m = parse_borrowed(&rm).unwrap().expect("RM parses");
+    let m = parse_borrowed(&rm).expect("RM parses");
     let tags: Vec<_> = m.tags(ConvMode::PrintConv).collect();
     // Every Real-* subgroup carries family-0 = the module name "Real"; the
     // chained ID3v1 carries family-0/1 both "ID3v1".
@@ -3141,7 +3109,7 @@ mod tests {
 
     // RA header subgroup: family-0 "Real", family-1 "Real-RA4".
     let ra = fixture("Real.ra");
-    let mra = parse_borrowed(&ra).unwrap().expect("RA parses");
+    let mra = parse_borrowed(&ra).expect("RA parses");
     let ra_tags: Vec<_> = mra.tags(ConvMode::PrintConv).collect();
     assert!(!ra_tags.is_empty());
     for t in &ra_tags {
@@ -3151,9 +3119,7 @@ mod tests {
 
     // Metafile subgroup: family-0/1 both "Real".
     let ram = fixture("real_synth_ram_pnm.ram");
-    let mram = parse_with_ext(&ram, Some("RAM"))
-      .unwrap()
-      .expect("RAM parses");
+    let mram = parse_with_ext(&ram, Some("RAM")).expect("RAM parses");
     let ram_tags: Vec<_> = mram.tags(ConvMode::PrintConv).collect();
     assert!(!ram_tags.is_empty());
     for t in &ram_tags {
@@ -3170,7 +3136,7 @@ mod tests {
     // tags follow ALL the Real-* tags (PROP→MDPR→CONT→RJMD), at the position
     // the retired `emit_id3v1` ran.
     let data = fixture("Real.rm");
-    let m = parse_borrowed(&data).unwrap().expect("RM parses");
+    let m = parse_borrowed(&data).expect("RM parses");
 
     let pj = emit(&m, true);
     assert_eq!(
@@ -3215,7 +3181,7 @@ mod tests {
     // edge branches: present-but-empty Title (`Some("")`) and a sparse genre
     // byte (no %genre entry ⇒ `Unknown (n)` in -j, raw byte in -n).
     let empty = fixture("real_synth_id3v1_empty_title.rm");
-    let me = parse_borrowed(&empty).unwrap().expect("RM parses");
+    let me = parse_borrowed(&empty).expect("RM parses");
     let ej = emit(&me, true);
     // Present-but-empty Title is emitted as the empty string (faithful).
     assert_eq!(
@@ -3224,7 +3190,7 @@ mod tests {
     );
 
     let sparse = fixture("real_synth_id3v1_sparse_genre.rm");
-    let ms = parse_borrowed(&sparse).unwrap().expect("RM parses");
+    let ms = parse_borrowed(&sparse).expect("RM parses");
     let sj = emit(&ms, true);
     // Sparse genre ⇒ `Unknown (n)` PrintConv string.
     let g = sj.get_str("ID3v1", "Genre").expect("Genre present");
@@ -3265,7 +3231,7 @@ mod tests {
   fn project_rm_audio_track_and_duration() {
     use crate::metadata::{Project, TrackKind};
     let data = fixture("Real.rm");
-    let m = parse_borrowed(&data).unwrap().expect("RM parses");
+    let m = parse_borrowed(&data).expect("RM parses");
     let md = m.project();
     // Real.rm: stream 0 is audio/x-pn-realaudio ⇒ one Audio track; stream 1
     // is logical-fileinfo ⇒ no track.
@@ -3285,7 +3251,7 @@ mod tests {
   fn project_ra_is_single_audio_track() {
     use crate::metadata::{Project, TrackKind};
     let data = fixture("Real.ra");
-    let m = parse_borrowed(&data).unwrap().expect("RA parses");
+    let m = parse_borrowed(&data).expect("RA parses");
     let md = m.project();
     // RA is a single RealAudio stream ⇒ one Audio track, no duration accessor.
     assert_eq!(md.media().track_kinds(), &[TrackKind::Audio]);

--- a/src/formats/real.rs
+++ b/src/formats/real.rs
@@ -2955,7 +2955,10 @@ mod tests {
   /// emission order; `entries()` is first-occurrence order).
   #[cfg(feature = "alloc")]
   fn keys(tm: &crate::tagmap::TagMap) -> Vec<String> {
-    tm.entries().iter().map(|(k, _)| k.to_string()).collect()
+    tm.entries()
+      .iter()
+      .map(|(g, n, _)| std::format!("{g}:{n}"))
+      .collect()
   }
 
   #[cfg(feature = "alloc")]

--- a/src/formats/red.rs
+++ b/src/formats/red.rs
@@ -1037,10 +1037,9 @@ impl FormatParser for ProcessR3D {
   type Meta<'a> = Meta<'a>;
   /// Spec §8: leaf format Context is `&'a [u8]`.
   type Context<'a> = &'a [u8];
-  type Error = Error;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -1050,8 +1049,8 @@ impl FormatParser for ProcessR3D {
 /// # Errors
 ///
 /// Returns `Err` for Rust-level fatal modes (none today).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
-  Ok(parse_inner(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
+  parse_inner(data)
 }
 
 fn parse_inner<'a>(data: &'a [u8]) -> Option<Meta<'a>> {
@@ -1964,21 +1963,6 @@ fn push_r3d_value(tags: &mut std::vec::Vec<crate::emit::EmittedTag>, name: &str,
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for R3D parsing. Currently empty — every bad
-/// input produces `Ok(None)` (Perl `return 0`).
-///
-/// §5: derived via `thiserror` (v2, `default-features = false` ⇒
-/// `core::error::Error`), `#[non_exhaustive]` so variants can be added
-/// without a breaking change. Variant names are kept stable for
-/// [`crate::format_parser::AnyError`]'s `From`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -2372,9 +2356,7 @@ mod tests {
   fn parse_borrowed_returns_meta_for_real_fixture() {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
     let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
-    let meta = parse_borrowed(&bytes)
-      .expect("ok")
-      .expect("real Red.r3d parses");
+    let meta = parse_borrowed(&bytes).expect("real Red.r3d parses");
     assert_eq!(meta.redcode_version(), Some(b'2'));
     assert_eq!(meta.image_width(), Some(5120));
     assert_eq!(meta.image_height(), Some(2560));
@@ -2397,9 +2379,8 @@ mod tests {
   fn format_parser_trait_returns_meta_static() {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
     let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
-    let meta = <ProcessR3D as FormatParser>::parse(&ProcessR3D, &bytes)
-      .expect("ok")
-      .expect("real Red.r3d parses");
+    let meta =
+      <ProcessR3D as FormatParser>::parse(&ProcessR3D, &bytes).expect("real Red.r3d parses");
     assert_eq!(meta.image_width(), Some(5120));
     assert_eq!(meta.start_edge_code(), Some("01:49:54:11"));
   }
@@ -2420,9 +2401,7 @@ mod tests {
   fn taggable_emits_typed_tags() {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
     let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
-    let meta = parse_borrowed(&bytes)
-      .expect("ok")
-      .expect("real Red.r3d parses");
+    let meta = parse_borrowed(&bytes).expect("real Red.r3d parses");
     // PrintConv ON.
     let w = emit_into_tagmap(&meta, true);
     assert_eq!(w.get_str("Red", "RedcodeVersion"), Some("2".to_string()));
@@ -2453,9 +2432,7 @@ mod tests {
     use crate::emit::{ConvMode, Taggable};
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
     let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
-    let meta = parse_borrowed(&bytes)
-      .expect("ok")
-      .expect("real Red.r3d parses");
+    let meta = parse_borrowed(&bytes).expect("real Red.r3d parses");
     let tags: std::vec::Vec<_> = meta.tags(ConvMode::PrintConv).collect();
     assert!(!tags.is_empty());
     for t in &tags {
@@ -2474,9 +2451,7 @@ mod tests {
     use crate::metadata::{Project, TrackKind};
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/Red.r3d");
     let bytes = std::fs::read(&path).expect("read Red.r3d fixture");
-    let meta = parse_borrowed(&bytes)
-      .expect("ok")
-      .expect("real Red.r3d parses");
+    let meta = parse_borrowed(&bytes).expect("real Red.r3d parses");
     let projected = meta.project();
     // R3D is Redcode video: one video track kind + header pixel dimensions.
     assert_eq!(projected.media().track_kinds(), &[TrackKind::Video]);

--- a/src/formats/riff.rs
+++ b/src/formats/riff.rs
@@ -406,10 +406,9 @@ impl FormatParser for ProcessRiff {
   type Meta<'a> = RiffMeta<'a>;
   /// Leaf-format Context — `&'a [u8]` (no chained state).
   type Context<'a> = &'a [u8];
-  type Error = RiffError;
 
-  fn parse<'a>(&self, data: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, RiffError> {
-    Ok(parse_inner(data))
+  fn parse<'a>(&self, data: Self::Context<'a>) -> Option<Self::Meta<'a>> {
+    parse_inner(data)
   }
 }
 
@@ -419,8 +418,8 @@ impl FormatParser for ProcessRiff {
 ///
 /// Returns `Err` only for Rust-level fatal modes (none today — every bad
 /// input is `Ok(None)`, faithful to RIFF.pm:2039 `return 0`).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<RiffMeta<'_>>, RiffError> {
-  Ok(parse_inner(data))
+pub fn parse_borrowed(data: &[u8]) -> Option<RiffMeta<'_>> {
+  parse_inner(data)
 }
 
 // ===========================================================================
@@ -2538,17 +2537,6 @@ fn bmp_compression_label(val: u32) -> &'static str {
 }
 
 // ===========================================================================
-// §8. `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for RIFF parsing. Currently empty — every bad
-/// input produces `Ok(None)`, faithful to RIFF.pm:2039 / 2045 / 2096
-/// (`return 0` / soft-fail on truncation).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-pub enum RiffError {}
-
-// ===========================================================================
 // §9. Tests
 // ===========================================================================
 
@@ -2684,7 +2672,7 @@ mod tests {
   #[test]
   fn synth_avi_round_trip() {
     let bytes = synth_avi();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     assert_eq!(meta.file_type(), "AVI");
     assert_eq!(meta.mime(), "video/x-msvideo");
     assert!(!meta.is_rf64());
@@ -2785,9 +2773,9 @@ mod tests {
 
   #[test]
   fn rejects_non_riff() {
-    assert!(parse_borrowed(b"NOPE\0\0\0\0WAVE").expect("ok").is_none());
-    assert!(parse_borrowed(b"").expect("ok").is_none());
-    assert!(parse_borrowed(b"RIFF").expect("ok").is_none()); // < 12 bytes
+    assert!(parse_borrowed(b"NOPE\0\0\0\0WAVE").is_none());
+    assert!(parse_borrowed(b"").is_none());
+    assert!(parse_borrowed(b"RIFF").is_none()); // < 12 bytes
   }
 
   #[test]
@@ -2796,7 +2784,7 @@ mod tests {
     bytes.extend_from_slice(b"RF64");
     bytes.extend_from_slice(&8u32.to_le_bytes());
     bytes.extend_from_slice(b"WAVE");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     assert_eq!(meta.file_type(), "WAV");
     assert!(meta.is_rf64());
   }
@@ -2876,7 +2864,7 @@ mod tests {
     bytes.extend_from_slice(b"avih");
     bytes.extend_from_slice(&0xffff_ffffu32.to_le_bytes());
     // No payload — read_chunk should detect EOF on the next iteration.
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     assert_eq!(meta.file_type(), "AVI");
     // No entries — the avih's payload was unreachable.
     assert!(meta.entries().is_empty());
@@ -2895,7 +2883,7 @@ mod tests {
     let idit = b"Mon Mar 10 15:04:43 2003";
     bytes.extend_from_slice(&(idit.len() as u32).to_le_bytes());
     bytes.extend_from_slice(idit);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     // No IDIT emission.
     assert!(
       meta
@@ -2931,7 +2919,7 @@ mod tests {
     let outer = (bytes.len() - 8) as u32;
     bytes[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     let names: Vec<_> = meta
       .entries()
       .iter()
@@ -2993,7 +2981,7 @@ mod tests {
     let outer = (buf.len() - 8) as u32;
     buf[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     let artist = meta
       .entries()
       .iter()
@@ -3036,7 +3024,7 @@ mod tests {
     let outer = (buf.len() - 8) as u32;
     buf[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     let find = |name: &str| -> Option<&RiffValue> {
       meta
         .entries()
@@ -3082,7 +3070,7 @@ mod tests {
     let outer = (buf.len() - 8) as u32;
     buf[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     // Only CodePage emitted (2-byte CSET); empty IART → Artist == "".
     assert_eq!(
       meta
@@ -3130,7 +3118,7 @@ mod tests {
     let outer = (buf.len() - 8) as u32;
     buf[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     let find = |name: &str| -> Option<&RiffValue> {
       meta
         .entries()
@@ -3217,7 +3205,7 @@ mod tests {
 
     // End-to-end: the INFO IART decodes through cp1252 (Latin), and there is
     // NO unsupported-charset warning (the Raw(1252) was reset).
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     let find = |name: &str| -> Option<&RiffValue> {
       meta
         .entries()
@@ -3265,7 +3253,7 @@ mod tests {
     let outer = (buf.len() - 8) as u32;
     buf[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     match meta
       .entries()
       .iter()
@@ -3342,7 +3330,7 @@ mod tests {
     let outer = (buf.len() - 8) as u32;
     buf[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     assert!(meta.is_corrupted(), "truncated fmt must mark corrupted");
     assert!(
       meta.entries().iter().all(|e| e.name() != "Encoding"),
@@ -3369,7 +3357,7 @@ mod tests {
     let outer = (buf.len() - 8) as u32;
     buf[4..8].copy_from_slice(&outer.to_le_bytes());
 
-    let meta = parse_borrowed(&buf).expect("ok").expect("some");
+    let meta = parse_borrowed(&buf).expect("some");
     assert!(!meta.is_corrupted());
     assert!(meta.entries().iter().any(|e| e.name() == "Encoding"));
   }

--- a/src/formats/wavpack.rs
+++ b/src/formats/wavpack.rs
@@ -634,7 +634,6 @@ impl FormatParser for ProcessWv {
   /// `&mut SharedFlags`.
   type Context<'a> = Context<'a>;
   /// Rust-level fatal error (none today; WavPack parsing has no I/O modes).
-  type Error = Error;
 
   /// Parse a WavPack file's bytes into a typed [`Meta`], or `None` if
   /// the buffer is not a valid WavPack file (short read, bad magic, or
@@ -652,10 +651,10 @@ impl FormatParser for ProcessWv {
   ///
   /// Returns `Err` only for Rust-level fatal modes; the current port
   /// has none (every bad input is `Ok(None)` per Perl's `return 0`).
-  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Result<Option<Self::Meta<'a>>, Error> {
+  fn parse<'a>(&self, ctx: Self::Context<'a>) -> Option<Self::Meta<'a>> {
     // `wavpack = ["id3", "ape"]` per Cargo.toml ⇒ `parse_full_chained` is
     // always present here.
-    Ok(parse_full_chained(ctx.data, ctx.shared))
+    parse_full_chained(ctx.data, ctx.shared)
   }
 }
 
@@ -674,11 +673,11 @@ impl FormatParser for ProcessWv {
 ///
 /// Returns `Err` for Rust-level fatal modes (none today; reserved for
 /// future I/O wrappers).
-pub fn parse_borrowed(data: &[u8]) -> Result<Option<Meta<'_>>, Error> {
+pub fn parse_borrowed(data: &[u8]) -> Option<Meta<'_>> {
   // `wavpack = ["id3", "ape"]` per Cargo.toml ⇒ `parse_full_chained` is always
   // present here.
   let mut shared = crate::format_parser::SharedFlags::default();
-  Ok(parse_full_chained(data, &mut shared))
+  parse_full_chained(data, &mut shared)
 }
 
 /// Inner parser — produces a borrow-from-input [`Meta`]. The
@@ -810,9 +809,8 @@ pub(crate) fn parse_full_chained<'a>(
   // recursion guard. Only the v1-trailer scan is meaningful for WV (the
   // wvpk magic must be at offset 0, so the v2-prefix branch can't fire).
   if shared.done_id3().is_none() {
-    meta.id3 = crate::formats::id3::process::parse_id3_with_hdr_end(data, Some(&mut *shared), true)
-      .ok()
-      .and_then(|(m, _hdr_end)| m);
+    meta.id3 =
+      crate::formats::id3::process::parse_id3_with_hdr_end(data, Some(&mut *shared), true).0;
   }
 
   // 3. APE trailer (WavPack.pm:101-103). `parse_trailer_only_owned`
@@ -994,22 +992,6 @@ impl crate::metadata::Project for Meta<'_> {
 }
 
 // ===========================================================================
-// `Error` — Rust-level fatal modes (currently none)
-// ===========================================================================
-
-/// Rust-level fatal modes for WavPack parsing. Currently empty — every
-/// bad input produces `Ok(None)` (Perl `return 0`). Reserved for future
-/// I/O wrappers if streaming readers are added.
-///
-/// §5: `Display` + `core::error::Error` derived via `thiserror` (v2,
-/// `default-features = false` ⇒ `core::error::Error` in every feature
-/// tier, not just `std`). `#[non_exhaustive]` lets I/O variants land
-/// without a breaking change.
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum Error {}
-
-// ===========================================================================
 // Engine entry — typed parse + File:* + sink into `Metadata`
 // ===========================================================================
 
@@ -1147,7 +1129,7 @@ mod tests {
     //   DataFormat raw=0 → Integer
     //   SampleRate raw=10 → Hz(48000)
     let data = header_with_flags(0x0480_008d);
-    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&data).expect("parsed");
     assert_eq!(meta.bytes_per_sample(), 1);
     assert_eq!(meta.audio_type(), AudioType::Mono);
     assert_eq!(meta.compression(), Compression::Lossless);
@@ -1168,7 +1150,7 @@ mod tests {
     //   DataFormat raw=1 → FloatingPoint
     //   SampleRate raw=15 → Custom
     let data = header_with_flags(0xFFFF_FFFF);
-    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&data).expect("parsed");
     assert_eq!(meta.bytes_per_sample(), 4);
     assert_eq!(meta.audio_type(), AudioType::Mono);
     assert_eq!(meta.compression(), Compression::Hybrid);
@@ -1180,16 +1162,16 @@ mod tests {
 
   #[test]
   fn parse_borrowed_rejects_short() {
-    assert!(parse_borrowed(&[]).unwrap().is_none());
-    assert!(parse_borrowed(&[0u8; 16]).unwrap().is_none());
-    assert!(parse_borrowed(&[0u8; 31]).unwrap().is_none());
+    assert!(parse_borrowed(&[]).is_none());
+    assert!(parse_borrowed(&[0u8; 16]).is_none());
+    assert!(parse_borrowed(&[0u8; 31]).is_none());
   }
 
   #[test]
   fn parse_borrowed_rejects_bad_magic() {
     let mut data = vec![0u8; 32];
     data[..4].copy_from_slice(b"WVPK");
-    assert!(parse_borrowed(&data).unwrap().is_none());
+    assert!(parse_borrowed(&data).is_none());
   }
 
   #[test]
@@ -1198,7 +1180,7 @@ mod tests {
     data[..4].copy_from_slice(b"wvpk");
     data[8] = 0x05; // out of {0x02, 0x10}
     data[9] = 0x04;
-    assert!(parse_borrowed(&data).unwrap().is_none());
+    assert!(parse_borrowed(&data).is_none());
   }
 
   #[test]
@@ -1207,7 +1189,7 @@ mod tests {
     data[..4].copy_from_slice(b"wvpk");
     data[8] = 0x10;
     data[9] = 0x05; // not 0x04
-    assert!(parse_borrowed(&data).unwrap().is_none());
+    assert!(parse_borrowed(&data).is_none());
   }
 
   #[test]
@@ -1215,7 +1197,7 @@ mod tests {
     // Byte 8 == 0x02 is the other allowed version (WavPack.pm:88).
     let mut data = header_with_flags(0);
     data[8] = 0x02; // 0x0402
-    let meta = parse_borrowed(&data).expect("ok").expect("parsed");
+    let meta = parse_borrowed(&data).expect("parsed");
     assert_eq!(meta.bytes_per_sample(), 1); // raw=0 +1
   }
 
@@ -1228,9 +1210,7 @@ mod tests {
     let data = header_with_flags(0x0480_008d);
     let mut shared = SharedFlags::new();
     let ctx = Context::new(&data, &mut shared);
-    let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx)
-      .expect("ok")
-      .expect("parsed");
+    let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx).expect("parsed");
     // Identical extraction to `parse_borrowed`: the GAT path now threads
     // the input borrow through, so the chained-trailer scan range survives
     // (previously dropped by the removed `into_static`; Codex AF2).
@@ -1248,7 +1228,7 @@ mod tests {
     data[..4].copy_from_slice(b"WVPK");
     let mut shared = SharedFlags::new();
     let ctx = Context::new(&data, &mut shared);
-    let result = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx).unwrap();
+    let result = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx);
     assert!(result.is_none());
   }
 
@@ -1276,9 +1256,7 @@ mod tests {
     let data = header_with_flags(flags_le);
     let mut shared = SharedFlags::new();
     let ctx = Context::new(&data, &mut shared);
-    let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx)
-      .unwrap()
-      .unwrap();
+    let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx).unwrap();
     let mut w = TagMap::new();
     crate::emit::run_emission(
       &meta,
@@ -1436,7 +1414,7 @@ mod tests {
     // ExifTool.pm:9907 numeric sort ⇒ 6.1..6.5. Order is preserved by the
     // golden `run_emission` -> `TagMap` entries (the JSON object loses it).
     let data = header_with_flags(0x0480_008d);
-    let meta = parse_borrowed(&data).unwrap().unwrap();
+    let meta = parse_borrowed(&data).unwrap();
     let mut tm = TagMap::new();
     crate::emit::run_emission(&meta, crate::emit::ConvMode::PrintConv, &mut tm);
     // WavPack tags use family-1 group "File" (WavPack.pm GROUPS{1}); the

--- a/src/formats/wavpack.rs
+++ b/src/formats/wavpack.rs
@@ -1422,7 +1422,7 @@ mod tests {
     let names: std::vec::Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(k, _)| k.strip_prefix("File:"))
+      .filter_map(|(g, n, _)| (g == "File").then_some(n.as_str()))
       .collect();
     assert_eq!(
       names,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,26 @@ pub use formats::wavpack::ProcessWv;
 /// ```
 #[cfg(feature = "std")]
 pub fn parse_bytes(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, AnyError> {
+  // Golden-v2 Contract 3d — a `catch_unwind` BACKSTOP at the public boundary.
+  // The primary no-panic guarantee is 3a (the recursion budgets) + 3b (the
+  // `tests/no_panic.rs` proptest gate); this only converts an UNANTICIPATED
+  // panic (a future bug, a slice-index regression, an arithmetic overflow in a
+  // debug build) into the same empty result a clean rejection yields, so an
+  // untrusted byte stream can never crash the host process. `AssertUnwindSafe`
+  // is sound here: the closure only READS `bytes` (a shared `&[u8]`) and
+  // returns an owned/borrowed result — no `&mut` state is left half-updated
+  // across the boundary.
+  match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse_bytes_inner(bytes))) {
+    Ok(result) => result,
+    Err(_) => Ok(None),
+  }
+}
+
+/// Inner body of [`parse_bytes`] (see that fn's doc + Golden-v2 3d note). The
+/// public wrapper adds the `catch_unwind` backstop. `parse_bytes` is itself
+/// `std`-only, so its inner shares that gate.
+#[cfg(feature = "std")]
+fn parse_bytes_inner(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, AnyError> {
   // Empty filename ⇒ magic-only detection (ExifTool.pm:2965-3045 with
   // `$ext = undef`). Each candidate is tried in turn; the first parser to
   // return `Ok(Some(meta))` wins. Faithful to the legacy
@@ -388,6 +408,17 @@ pub fn parse_bytes(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, An
 #[cfg(feature = "std")]
 #[must_use]
 pub fn media_metadata(bytes: &[u8]) -> Option<MediaMetadata> {
+  // Golden-v2 Contract 3d — `catch_unwind` backstop (see [`parse_bytes`]).
+  // Backstop only; 3a (recursion budgets) + 3b (proptest) are the primary
+  // guarantee. `AssertUnwindSafe` is sound: the closure only reads `bytes`.
+  // A caught panic ⇒ `None` (the `Option` default), same as a clean miss.
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| media_metadata_inner(bytes)))
+    .unwrap_or_default()
+}
+
+/// Inner body of [`media_metadata`] (see that fn's doc + Golden-v2 3d note).
+#[cfg(feature = "std")]
+fn media_metadata_inner(bytes: &[u8]) -> Option<MediaMetadata> {
   // `parse_bytes` errors are convenience-swallowed to `None` (see the doc
   // contract); `Ok(None)` (no format matched) is likewise `None`.
   match parse_bytes(bytes) {
@@ -514,8 +545,26 @@ pub fn parse_dv(
 ///
 /// Returns the per-format [`exif::Error`] (currently uninhabited — every bad
 /// input is `Ok(None)`).
-#[cfg(feature = "exif")]
+#[cfg(all(feature = "exif", feature = "std"))]
 pub fn parse_exif(bytes: &[u8]) -> core::result::Result<Option<exif::ExifMeta<'_>>, exif::Error> {
+  // Golden-v2 Contract 3d — `catch_unwind` backstop (see [`parse_bytes`]).
+  // Backstop only; 3a/3b are the primary guarantee. `AssertUnwindSafe` is
+  // sound: the closure only reads `bytes`.
+  match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse_exif_inner(bytes))) {
+    Ok(result) => result,
+    Err(_) => Ok(None),
+  }
+}
+
+/// `parse_exif` on a no_std (no `catch_unwind`) build — direct passthrough.
+#[cfg(all(feature = "exif", not(feature = "std")))]
+pub fn parse_exif(bytes: &[u8]) -> core::result::Result<Option<exif::ExifMeta<'_>>, exif::Error> {
+  parse_exif_inner(bytes)
+}
+
+/// Inner body of [`parse_exif`] (see that fn's doc + Golden-v2 3d note).
+#[cfg(feature = "exif")]
+fn parse_exif_inner(bytes: &[u8]) -> core::result::Result<Option<exif::ExifMeta<'_>>, exif::Error> {
   exif::parse_borrowed(bytes)
 }
 
@@ -526,9 +575,28 @@ pub fn parse_exif(bytes: &[u8]) -> core::result::Result<Option<exif::ExifMeta<'_
 /// the `gps` feature is enabled (reached through the IFD0 `GPSInfo` tag).
 ///
 /// Returns `None` when `block` is not a valid TIFF header.
-#[cfg(feature = "exif")]
+#[cfg(all(feature = "exif", feature = "std"))]
 #[must_use]
 pub fn parse_exif_block(block: &[u8]) -> Option<exif::ExifMeta<'_>> {
+  // Golden-v2 Contract 3d — `catch_unwind` backstop (see [`parse_bytes`]).
+  // Backstop only; 3a/3b are the primary guarantee. `AssertUnwindSafe` is
+  // sound: the closure only reads `block`. A caught panic ⇒ `None`.
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    parse_exif_block_inner(block)
+  }))
+  .unwrap_or_default()
+}
+
+/// `parse_exif_block` on a no_std (no `catch_unwind`) build — direct passthrough.
+#[cfg(all(feature = "exif", not(feature = "std")))]
+#[must_use]
+pub fn parse_exif_block(block: &[u8]) -> Option<exif::ExifMeta<'_>> {
+  parse_exif_block_inner(block)
+}
+
+/// Inner body of [`parse_exif_block`] (see that fn's doc + Golden-v2 3d note).
+#[cfg(feature = "exif")]
+fn parse_exif_block_inner(block: &[u8]) -> Option<exif::ExifMeta<'_>> {
   exif::parse_exif_block(block)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! use exifast::{parse_bytes, AnyMeta};
 //!
 //! let bytes = std::fs::read("file.moi").unwrap();
-//! if let Some(meta) = parse_bytes(&bytes).unwrap() {
+//! if let Some(meta) = parse_bytes(&bytes) {
 //!   match meta {
 //!     AnyMeta::Moi(moi) => {
 //!       println!("MOI version: {}", moi.version());
@@ -46,7 +46,7 @@
 //!
 //! let bytes = std::fs::read("song.flac").unwrap();
 //! let mut shared = SharedFlags::new();
-//! if let Some(flac) = exifast::parse_flac(&bytes, &mut shared).unwrap() {
+//! if let Some(flac) = exifast::parse_flac(&bytes, &mut shared) {
 //!   if let Some(rate) = flac.sample_rate() {
 //!     println!("Sample rate: {} Hz", rate);
 //!   }
@@ -159,31 +159,28 @@ pub use emit::{ConvMode, EmittedTag, Taggable};
 // The public top-level `parse_bytes` + per-format `parse_<fmt>` entry points
 // land here so callers don't need to traverse into `formats::<fmt>` for the
 // happy path. Per skill §6 (no module-name stutter), each format's typed
-// `Meta`/`Error`/`Context` types now use the bare names — so they CANNOT all
+// `Meta`/`Context` types now use the bare names — so they CANNOT all
 // be re-exported at the crate root unaliased (`formats::moi::Meta` and
 // `formats::aac::Meta` would collide). The per-format typed surface is
 // therefore reached through the public [`formats`] module
 // (`exifast::formats::<fmt>::Meta`); only the parser-handle unit-structs
 // (`ProcessXxx`) are re-exported here (their names are unique). The universal
-// [`parse_bytes`] / [`AnyMeta`] / [`AnyError`] surface and every
-// `parse_<fmt>` fn stay at the crate root.
+// [`parse_bytes`] / [`AnyMeta`] surface and every `parse_<fmt>` fn stay at the
+// crate root.
 
 /// The optional serde [`Serialize`](serde::Serialize) view of a typed
 /// [`AnyMeta`] (`-j`/`-n` mode wrapper) — available with `--features serde`.
 #[cfg(all(feature = "serde", feature = "alloc"))]
 pub use format_parser::Rendered;
-pub use format_parser::{
-  AnyError, AnyMeta, AnyParser, ExplicitThenLiteral, FileTypeFinalize, SharedFlags,
-};
+pub use format_parser::{AnyMeta, AnyParser, ExplicitThenLiteral, FileTypeFinalize, SharedFlags};
 
 // Per-format parser-handle re-exports. The `ProcessXxx` unit-struct is the
 // parser handle (carried in `AnyParser`). The typed `Meta<'a>` (+ accessor
-// methods) and the fatal-error `Error` (carried in `AnyError`) are reached via
-// `exifast::formats::<fmt>::{Meta, Error}` — they are NOT re-exported at the
-// crate root because their bare §6 names would collide across formats.
-// (id3 keeps its `Id3*`/`Mp3*` axis prefixes and mpeg uses `Audio*`, but for a
-// uniform surface those per-format Meta/Error/Context types are also reached
-// only via the `formats` module, not the crate root.)
+// methods) are reached via `exifast::formats::<fmt>::Meta` — they are NOT
+// re-exported at the crate root because their bare §6 names would collide
+// across formats. (id3 keeps its `Id3*`/`Mp3*` axis prefixes and mpeg uses
+// `Audio*`, but for a uniform surface those per-format Meta/Context types are
+// also reached only via the `formats` module, not the crate root.)
 #[cfg(feature = "aac")]
 pub use formats::aac::ProcessAac;
 #[cfg(feature = "aiff")]
@@ -246,13 +243,12 @@ pub use formats::wavpack::ProcessWv;
 /// and route through the closed [`AnyParser`] / [`AnyMeta`] enums.
 ///
 /// Returns:
-/// - `Ok(Some(meta))` — the first parser to accept the data, wrapped in
+/// - `Some(meta)` — the first parser to accept the data, wrapped in
 ///   the appropriate [`AnyMeta`] variant.
-/// - `Ok(None)` — no parser accepted the data (no detected format in the
-///   compiled feature set matched).
-/// - `Err(AnyError)` — a per-format parser surfaced a Rust-level fatal
-///   error. Most format ports today have no fatal modes (uninhabited
-///   `XxxError` enums), so the `Err` branch is unreachable in practice.
+/// - `None` — no parser accepted the data (no detected format in the
+///   compiled feature set matched). No ported format has a Rust-level fatal
+///   mode, so a malformed input is either a rejected candidate (`None`) or an
+///   accepted `AnyMeta` carrying a `Warn`/`Error` tag — never an error here.
 ///
 /// The returned [`AnyMeta`] borrows from the input `bytes` for zero
 /// allocation on the happy path. To store a Meta beyond the lifetime of
@@ -268,25 +264,9 @@ pub use formats::wavpack::ProcessWv;
 /// can fall back to the legacy [`parser::extract_info`] for byte-exact CLI
 /// JSON output, or build their own `AnyParser` resolution via
 /// [`format_parser::any_parser_for`].
-///
-/// # Errors
-///
-/// See [`AnyError`].
-///
-/// # Examples
-///
-/// ```no_run
-/// # #[cfg(feature = "moi")] {
-/// use exifast::{parse_bytes, AnyMeta};
-///
-/// let bytes = std::fs::read("file.moi").unwrap();
-/// if let Some(AnyMeta::Moi(moi)) = parse_bytes(&bytes).unwrap() {
-///   println!("MOI version: {}", moi.version());
-/// }
-/// # }
-/// ```
 #[cfg(feature = "std")]
-pub fn parse_bytes(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, AnyError> {
+#[must_use]
+pub fn parse_bytes(bytes: &[u8]) -> Option<AnyMeta<'_>> {
   // Golden-v2 Contract 3d — a `catch_unwind` BACKSTOP at the public boundary.
   // The primary no-panic guarantee is 3a (the recursion budgets) + 3b (the
   // `tests/no_panic.rs` proptest gate); this only converts an UNANTICIPATED
@@ -296,20 +276,18 @@ pub fn parse_bytes(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, An
   // is sound here: the closure only READS `bytes` (a shared `&[u8]`) and
   // returns an owned/borrowed result — no `&mut` state is left half-updated
   // across the boundary.
-  match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse_bytes_inner(bytes))) {
-    Ok(result) => result,
-    Err(_) => Ok(None),
-  }
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse_bytes_inner(bytes)))
+    .unwrap_or(None)
 }
 
 /// Inner body of [`parse_bytes`] (see that fn's doc + Golden-v2 3d note). The
 /// public wrapper adds the `catch_unwind` backstop. `parse_bytes` is itself
 /// `std`-only, so its inner shares that gate.
 #[cfg(feature = "std")]
-fn parse_bytes_inner(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, AnyError> {
+fn parse_bytes_inner(bytes: &[u8]) -> Option<AnyMeta<'_>> {
   // Empty filename ⇒ magic-only detection (ExifTool.pm:2965-3045 with
   // `$ext = undef`). Each candidate is tried in turn; the first parser to
-  // return `Ok(Some(meta))` wins. Faithful to the legacy
+  // return `Some(meta)` wins. Faithful to the legacy
   // `parser::extract_info` loop, minus the candidate-rejection side
   // effects on `Metadata` (the typed `AnyMeta` carries everything).
   //
@@ -329,7 +307,7 @@ fn parse_bytes_inner(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, 
     // `SetFileType('PLIST', 'application/xml')` and hands the body to
     // `PLIST::FoundTag`. This port has no standalone XMP parser, so replicate that
     // hop here — exactly as `parser::extract_info_typed` does — and dispatch as
-    // `PLIST` so the typed API yields `AnyMeta::Plist` (not silently `Ok(None)`).
+    // `PLIST` so the typed API yields `AnyMeta::Plist` (not silently `None`).
     // `magic()` stays a faithful 1:1 of `%magicNumber` (the PLIST gate is
     // unchanged); the BOM tolerance lives only in this XMP→PLIST route, and
     // `ProcessPlist` itself skips a leading UTF-8 BOM at its XML gate.
@@ -355,14 +333,14 @@ fn parse_bytes_inner(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, 
       None,
       cand.header_skip(),
       Some(cand.parent_type()),
-    )? {
-      return Ok(Some(m));
+    ) {
+      return Some(m);
     }
     // Reset shared flags between rejected candidates so partial
     // side-effects (e.g. a probe that touched `done_id3`) don't leak.
     shared = SharedFlags::new();
   }
-  Ok(None)
+  None
 }
 
 // ===========================================================================
@@ -386,12 +364,10 @@ fn parse_bytes_inner(bytes: &[u8]) -> core::result::Result<Option<AnyMeta<'_>>, 
 ///   until its Phase-2 projection lands. So a recognized non-EXIF file yields
 ///   `Some(MediaMetadata)` whose [`camera`](MediaMetadata::camera) etc. are
 ///   `None`.
-/// - `None` — no parser accepted the bytes (unknown/empty input), OR a
-///   per-format parser raised a Rust-level fatal. **Parse errors are
-///   intentionally swallowed as `None`** for this convenience entry; a caller
-///   that needs to distinguish "unrecognized" from "fatal parser error"
-///   should use [`parse_bytes`] (which returns `Result<Option<_>, AnyError>`)
-///   and call [`AnyMeta::project`](crate::AnyMeta::project) itself.
+/// - `None` — no parser accepted the bytes (unknown/empty input). A caller
+///   that wants the typed `AnyMeta` (e.g. to inspect a non-EXIF format's tags
+///   directly) should use [`parse_bytes`] and call
+///   [`AnyMeta::project`](crate::AnyMeta::project) itself.
 ///
 /// # Examples
 ///
@@ -419,12 +395,8 @@ pub fn media_metadata(bytes: &[u8]) -> Option<MediaMetadata> {
 /// Inner body of [`media_metadata`] (see that fn's doc + Golden-v2 3d note).
 #[cfg(feature = "std")]
 fn media_metadata_inner(bytes: &[u8]) -> Option<MediaMetadata> {
-  // `parse_bytes` errors are convenience-swallowed to `None` (see the doc
-  // contract); `Ok(None)` (no format matched) is likewise `None`.
-  match parse_bytes(bytes) {
-    Ok(Some(any)) => Some(any.project()),
-    Ok(None) | Err(_) => None,
-  }
+  // `None` from `parse_bytes` (no format matched) maps straight through.
+  parse_bytes(bytes).map(|any| any.project())
 }
 
 // ===========================================================================
@@ -442,94 +414,57 @@ fn media_metadata_inner(bytes: &[u8]) -> Option<MediaMetadata> {
 // MP3 / MPEG-audio entries also take an extension string.
 
 /// Parse a MOI buffer directly. See [`formats::moi::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::moi::Error`] (currently uninhabited).
 #[cfg(feature = "moi")]
-pub fn parse_moi(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::moi::Meta<'_>>, formats::moi::Error> {
+#[must_use]
+pub fn parse_moi(bytes: &[u8]) -> Option<formats::moi::Meta<'_>> {
   formats::moi::parse_borrowed(bytes)
 }
 
 /// Parse a Matroska/MKV/MKA/MKS/WebM buffer directly. See
 /// [`formats::matroska::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::matroska::Error`] (currently
-/// uninhabited).
 #[cfg(feature = "matroska")]
-pub fn parse_matroska(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::matroska::Meta<'_>>, formats::matroska::Error> {
+#[must_use]
+pub fn parse_matroska(bytes: &[u8]) -> Option<formats::matroska::Meta<'_>> {
   formats::matroska::parse_borrowed(bytes)
 }
 
 /// Parse a QuickTime / MP4 / MOV / M4A / M4V / 3GP / 3G2 buffer directly.
 /// See [`formats::quicktime::parse_borrowed`]. **SP1**: the box/atom walker
 /// plus the core structural atoms only (see the module docs).
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::quicktime::Error`] (currently
-/// uninhabited).
 #[cfg(feature = "quicktime")]
-pub fn parse_quicktime(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::quicktime::Meta<'_>>, formats::quicktime::Error> {
+#[must_use]
+pub fn parse_quicktime(bytes: &[u8]) -> Option<formats::quicktime::Meta<'_>> {
   formats::quicktime::parse_borrowed(bytes)
 }
 
 /// Parse an MXF (Material Exchange Format) buffer directly. See
 /// [`formats::mxf::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::mxf::MxfError`] (currently uninhabited).
 #[cfg(feature = "mxf")]
-pub fn parse_mxf(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::mxf::MxfMeta<'_>>, formats::mxf::MxfError> {
+#[must_use]
+pub fn parse_mxf(bytes: &[u8]) -> Option<formats::mxf::MxfMeta<'_>> {
   formats::mxf::parse_borrowed(bytes)
 }
 
 /// Parse an Apple Property List buffer directly — decodes both the binary
 /// (`bplist0…`) and XML (`<?xml …?>`) encodings. See
 /// [`formats::plist::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::plist::Error`] (currently uninhabited).
 #[cfg(feature = "plist")]
-pub fn parse_plist(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::plist::PlistMeta<'_>>, formats::plist::Error> {
+#[must_use]
+pub fn parse_plist(bytes: &[u8]) -> Option<formats::plist::PlistMeta<'_>> {
   formats::plist::parse_borrowed(bytes)
 }
 
 /// Parse an AAC (ADTS) buffer directly. See [`formats::aac::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::aac::Error`] (currently uninhabited).
 #[cfg(feature = "aac")]
-pub fn parse_aac(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::aac::Meta<'_>>, formats::aac::Error> {
+#[must_use]
+pub fn parse_aac(bytes: &[u8]) -> Option<formats::aac::Meta<'_>> {
   formats::aac::parse_borrowed(bytes)
 }
 
 /// Parse a DV stream buffer directly. See [`formats::dv::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::dv::Error`] (currently uninhabited).
 #[cfg(feature = "dv")]
-pub fn parse_dv(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::dv::ParseOutcome<'static>>, formats::dv::Error> {
+#[must_use]
+pub fn parse_dv(bytes: &[u8]) -> Option<formats::dv::ParseOutcome<'static>> {
   formats::dv::parse_borrowed(bytes)
 }
 
@@ -541,30 +476,28 @@ pub fn parse_dv(
 /// SubDirectory — those container ports call [`exif::parse_exif_block`]
 /// directly on the embedded block.
 ///
-/// # Errors
-///
-/// Returns the per-format [`exif::Error`] (currently uninhabited — every bad
-/// input is `Ok(None)`).
+/// Returns `None` when `bytes` is not a valid TIFF header (a malformed
+/// standalone TIFF surfaces its diagnostics as `Warn`/`Error` tags on the
+/// returned [`exif::ExifMeta`], never as a fatal error).
 #[cfg(all(feature = "exif", feature = "std"))]
-pub fn parse_exif(bytes: &[u8]) -> core::result::Result<Option<exif::ExifMeta<'_>>, exif::Error> {
+#[must_use]
+pub fn parse_exif(bytes: &[u8]) -> Option<exif::ExifMeta<'_>> {
   // Golden-v2 Contract 3d — `catch_unwind` backstop (see [`parse_bytes`]).
   // Backstop only; 3a/3b are the primary guarantee. `AssertUnwindSafe` is
   // sound: the closure only reads `bytes`.
-  match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse_exif_inner(bytes))) {
-    Ok(result) => result,
-    Err(_) => Ok(None),
-  }
+  std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| parse_exif_inner(bytes))).unwrap_or(None)
 }
 
 /// `parse_exif` on a no_std (no `catch_unwind`) build — direct passthrough.
 #[cfg(all(feature = "exif", not(feature = "std")))]
-pub fn parse_exif(bytes: &[u8]) -> core::result::Result<Option<exif::ExifMeta<'_>>, exif::Error> {
+#[must_use]
+pub fn parse_exif(bytes: &[u8]) -> Option<exif::ExifMeta<'_>> {
   parse_exif_inner(bytes)
 }
 
 /// Inner body of [`parse_exif`] (see that fn's doc + Golden-v2 3d note).
 #[cfg(feature = "exif")]
-fn parse_exif_inner(bytes: &[u8]) -> core::result::Result<Option<exif::ExifMeta<'_>>, exif::Error> {
+fn parse_exif_inner(bytes: &[u8]) -> Option<exif::ExifMeta<'_>> {
   exif::parse_borrowed(bytes)
 }
 
@@ -601,26 +534,16 @@ fn parse_exif_block_inner(block: &[u8]) -> Option<exif::ExifMeta<'_>> {
 }
 
 /// Parse an Audible (AA) buffer directly. See [`formats::audible::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::audible::Error`] (currently uninhabited).
 #[cfg(feature = "audible")]
-pub fn parse_audible(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::audible::Meta<'_>>, formats::audible::Error> {
+#[must_use]
+pub fn parse_audible(bytes: &[u8]) -> Option<formats::audible::Meta<'_>> {
   formats::audible::parse_borrowed(bytes)
 }
 
 /// Parse a Red R3D buffer directly. See [`formats::red::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::red::Error`] (currently uninhabited).
 #[cfg(feature = "red")]
-pub fn parse_r3d(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::red::Meta<'_>>, formats::red::Error> {
+#[must_use]
+pub fn parse_r3d(bytes: &[u8]) -> Option<formats::red::Meta<'_>> {
   formats::red::parse_borrowed(bytes)
 }
 
@@ -634,16 +557,13 @@ pub fn parse_r3d(
 /// `print_conv = true` stages the tags in `-j` PrintConv mode (e.g. ID3v1
 /// Genre `"Hip-Hop"`); `false` stages in `-n` post-ValueConv raw mode
 /// (e.g. Genre `7`). One parse stages BOTH lists; the renderer picks by mode.
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::id3::Id3Error`] (currently uninhabited).
 #[cfg(feature = "id3")]
+#[must_use]
 pub fn parse_id3<'a>(
   bytes: &'a [u8],
   shared: Option<&mut SharedFlags>,
   print_conv: bool,
-) -> core::result::Result<Option<formats::id3::Id3Meta<'a>>, formats::id3::Id3Error> {
+) -> Option<formats::id3::Id3Meta<'a>> {
   formats::id3::parse_id3_borrowed(bytes, shared, print_conv)
 }
 
@@ -661,15 +581,9 @@ pub fn parse_id3<'a>(
 ///
 /// The ID3 sub-Meta is staged in `-j` (PrintConv) mode; sink the result
 /// with `sink(true, ...)`.
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::id3::Mp3Error`].
 #[cfg(feature = "mp3")]
-pub fn parse_mp3<'a>(
-  bytes: &'a [u8],
-  ext: Option<&str>,
-) -> core::result::Result<Option<formats::id3::Mp3Meta<'a>>, formats::id3::Mp3Error> {
+#[must_use]
+pub fn parse_mp3<'a>(bytes: &'a [u8], ext: Option<&str>) -> Option<formats::id3::Mp3Meta<'a>> {
   // `parse_mp3_borrowed` decouples the transient `shared` AND `ext` borrows
   // from the returned `id3::Mp3Meta<'a>` (which borrows only from `bytes`), so a
   // local `SharedFlags` and a transient `ext` are both valid here.
@@ -679,14 +593,9 @@ pub fn parse_mp3<'a>(
 
 /// Parse an AIFF (or AIFC) buffer directly. See
 /// [`formats::aiff::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::aiff::Error`] (currently uninhabited).
 #[cfg(feature = "aiff")]
-pub fn parse_aiff(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::aiff::Meta<'_>>, formats::aiff::Error> {
+#[must_use]
+pub fn parse_aiff(bytes: &[u8]) -> Option<formats::aiff::Meta<'_>> {
   formats::aiff::parse_borrowed(bytes)
 }
 
@@ -707,59 +616,40 @@ pub fn parse_aiff(
 /// (`parse_full_owned`) skipped the ID3 chain — silent metadata loss on
 /// `ape_id3_prefixed.ape` / `ape_with_id3v1_trailer.ape` / etc. through
 /// this path.
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::ape::Error`] (currently uninhabited).
 #[cfg(feature = "ape")]
-pub fn parse_ape<'a>(
-  bytes: &'a [u8],
-  shared: &mut SharedFlags,
-) -> core::result::Result<Option<formats::ape::Meta<'a>>, formats::ape::Error> {
+#[must_use]
+pub fn parse_ape<'a>(bytes: &'a [u8], shared: &mut SharedFlags) -> Option<formats::ape::Meta<'a>> {
   // `ape = ["id3"]` per Cargo.toml ⇒ `parse_full_chained` is always present
   // here. Returns `Option<Meta<'a>>` where `'a` is tied to `bytes` (the
   // nested `Id3Meta` borrows from `bytes`); `shared` is transient.
-  Ok(formats::ape::parse_full_chained(bytes, shared))
+  formats::ape::parse_full_chained(bytes, shared)
 }
 
 /// Parse a DSF (DSD Stream File) buffer directly. See
 /// [`formats::dsf::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::dsf::Error`] (currently uninhabited).
 #[cfg(feature = "dsf")]
-pub fn parse_dsf(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::dsf::Meta<'_>>, formats::dsf::Error> {
+#[must_use]
+pub fn parse_dsf(bytes: &[u8]) -> Option<formats::dsf::Meta<'_>> {
   formats::dsf::parse_borrowed(bytes)
 }
 
 /// Parse a FLAC buffer directly. See [`formats::flac::parse_borrowed`].
 ///
 /// `shared` carries cross-format state (`DoneID3` flag, etc.).
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::flac::Error`] (currently uninhabited).
 #[cfg(feature = "flac")]
+#[must_use]
 pub fn parse_flac<'a>(
   bytes: &'a [u8],
   shared: &mut SharedFlags,
-) -> core::result::Result<Option<formats::flac::Meta<'a>>, formats::flac::Error> {
+) -> Option<formats::flac::Meta<'a>> {
   formats::flac::parse_borrowed(bytes, shared)
 }
 
 /// Parse a Real (RM / RA / RAM / RPM) buffer directly. See
 /// [`formats::real::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::real::RealError`] (currently uninhabited).
 #[cfg(feature = "real")]
-pub fn parse_real(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::real::RealMeta<'_>>, formats::real::RealError> {
+#[must_use]
+pub fn parse_real(bytes: &[u8]) -> Option<formats::real::RealMeta<'_>> {
   formats::real::parse_borrowed(bytes)
 }
 
@@ -771,27 +661,17 @@ pub fn parse_real(
 /// that extracted the PES payload) and want the typed [`formats::h264::H264Meta`].
 ///
 /// Returns `Ok(None)` when `bytes` contains no NAL start code at all.
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::h264::H264Error`] (currently uninhabited).
 #[cfg(feature = "h264")]
-pub fn parse_h264(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::h264::H264Meta<'_>>, formats::h264::H264Error> {
+#[must_use]
+pub fn parse_h264(bytes: &[u8]) -> Option<formats::h264::H264Meta<'_>> {
   formats::h264::parse_borrowed(bytes)
 }
 
 /// Parse a Flash Video (FLV) buffer directly. See
 /// [`formats::flash::parse_borrowed`].
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::flash::Error`] (currently uninhabited).
 #[cfg(feature = "flash")]
-pub fn parse_flv(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::flash::Meta<'_>>, formats::flash::Error> {
+#[must_use]
+pub fn parse_flv(bytes: &[u8]) -> Option<formats::flash::Meta<'_>> {
   formats::flash::parse_borrowed(bytes)
 }
 
@@ -800,15 +680,9 @@ pub fn parse_flv(
 ///
 /// `print_conv_enabled = true` matches bundled `perl exiftool -j`;
 /// `false` matches `-j -n`.
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::ogg::Error`] (currently uninhabited).
 #[cfg(feature = "ogg")]
-pub fn parse_ogg(
-  bytes: &[u8],
-  print_conv_enabled: bool,
-) -> core::result::Result<Option<formats::ogg::Meta<'_>>, formats::ogg::Error> {
+#[must_use]
+pub fn parse_ogg(bytes: &[u8], print_conv_enabled: bool) -> Option<formats::ogg::Meta<'_>> {
   formats::ogg::parse_borrowed(bytes, print_conv_enabled)
 }
 
@@ -818,16 +692,13 @@ pub fn parse_ogg(
 /// `mp3 = true` enforces Layer III (MPEG.pm:466). `ext` is the file
 /// extension (uppercased, no leading dot — e.g. `"MP3"`, `"MUS"`); the
 /// empty string disables the validation-reject retry (MPEG.pm:488).
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::mpeg::AudioError`] (currently uninhabited).
 #[cfg(feature = "mpeg-audio")]
+#[must_use]
 pub fn parse_mpeg_audio<'a>(
   bytes: &'a [u8],
   mp3: bool,
   ext: &str,
-) -> core::result::Result<Option<formats::mpeg::AudioMeta<'a>>, formats::mpeg::AudioError> {
+) -> Option<formats::mpeg::AudioMeta<'a>> {
   formats::mpeg::parse_borrowed(bytes, mp3, ext)
 }
 
@@ -843,18 +714,13 @@ pub fn parse_mpeg_audio<'a>(
 /// A fresh [`SharedFlags`] is constructed per call (the public entry has
 /// no chain state to thread). The returned `Meta<'a>` is tied to `bytes`
 /// (the nested ID3 / APE sub-Metas borrow from `bytes`).
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::mpc::Error`] (currently uninhabited).
 #[cfg(feature = "mpc")]
-pub fn parse_mpc(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::mpc::Meta<'_>>, formats::mpc::Error> {
+#[must_use]
+pub fn parse_mpc(bytes: &[u8]) -> Option<formats::mpc::Meta<'_>> {
   // `mpc = ["id3", "ape"]` per Cargo.toml ⇒ `parse_full_chained` is always
   // present here.
   let mut shared = SharedFlags::default();
-  Ok(formats::mpc::parse_full_chained(bytes, &mut shared))
+  formats::mpc::parse_full_chained(bytes, &mut shared)
 }
 
 /// Parse a WavPack `.wv` buffer directly, including the embedded ID3
@@ -869,18 +735,13 @@ pub fn parse_mpc(
 /// A fresh [`SharedFlags`] is constructed per call. The returned
 /// `Meta<'a>` is tied to `bytes` (the nested ID3 / APE sub-Metas borrow
 /// from `bytes`).
-///
-/// # Errors
-///
-/// Returns the per-format [`formats::wavpack::Error`] (currently uninhabited).
 #[cfg(feature = "wavpack")]
-pub fn parse_wavpack(
-  bytes: &[u8],
-) -> core::result::Result<Option<formats::wavpack::Meta<'_>>, formats::wavpack::Error> {
+#[must_use]
+pub fn parse_wavpack(bytes: &[u8]) -> Option<formats::wavpack::Meta<'_>> {
   // `wavpack = ["id3", "ape"]` per Cargo.toml ⇒ `parse_full_chained` is
   // always present here.
   let mut shared = SharedFlags::default();
-  Ok(formats::wavpack::parse_full_chained(bytes, &mut shared))
+  formats::wavpack::parse_full_chained(bytes, &mut shared)
 }
 
 // ===========================================================================
@@ -891,13 +752,13 @@ pub fn parse_wavpack(
 mod tests {
   use super::*;
 
-  /// `parse_bytes` returns `Ok(None)` for an empty input — no parser
+  /// `parse_bytes` returns `None` for an empty input — no parser
   /// accepts an empty buffer, which matches ExifTool's
-  /// `File is empty` Error-only path (here surfaced as `Ok(None)`).
+  /// `File is empty` Error-only path (here surfaced as `None`).
   #[test]
   #[cfg(feature = "std")]
   fn parse_bytes_empty_input_returns_none() {
-    let result = parse_bytes(b"").unwrap();
+    let result = parse_bytes(b"");
     assert!(result.is_none());
   }
 
@@ -921,8 +782,7 @@ mod tests {
   }
 
   /// `media_metadata` returns `None` for empty input (no parser accepts an
-  /// empty buffer) — the convenience entry's `Ok(None) | Err(_) => None`
-  /// contract.
+  /// empty buffer) — `parse_bytes(..) == None` maps straight through.
   #[test]
   #[cfg(feature = "std")]
   fn media_metadata_empty_input_is_none() {
@@ -930,12 +790,12 @@ mod tests {
     assert!(media_metadata(b"\x00\x00\x00\x00not-a-format").is_none());
   }
 
-  /// `parse_bytes` returns `Ok(None)` for a buffer that no parser
+  /// `parse_bytes` returns `None` for a buffer that no parser
   /// accepts (random bytes with no magic-number match).
   #[test]
   #[cfg(feature = "std")]
   fn parse_bytes_unknown_format_returns_none() {
-    let result = parse_bytes(b"\x00\x00\x00\x00not-a-format").unwrap();
+    let result = parse_bytes(b"\x00\x00\x00\x00not-a-format");
     assert!(result.is_none());
   }
 
@@ -955,10 +815,10 @@ mod tests {
     // Pad to 64 bytes so the MOI parser doesn't reject on too-short.
     let mut padded = bytes.to_vec();
     padded.resize(64, 0);
-    let result = parse_bytes(&padded).unwrap();
+    let result = parse_bytes(&padded);
     // The MOI parser may accept or reject this minimal buffer depending on
     // its internal validation; we don't pin the exact outcome here, just
-    // that the dispatch produces an `Ok(_)` (no panic, no `Err`).
+    // that the dispatch doesn't panic.
     let _ = result;
   }
 
@@ -982,9 +842,7 @@ mod tests {
     .expect("read ogg_id3_prefixed.ogg fixture");
     // Sanity: the fixture really does start with an ID3v2 prefix (NOT OggS).
     assert!(data.starts_with(b"ID3"), "fixture must be ID3-prefixed");
-    let meta = parse_bytes(&data)
-      .expect("parse_bytes must not error")
-      .expect("ID3-prefixed Ogg must be recognized");
+    let meta = parse_bytes(&data).expect("ID3-prefixed Ogg must be recognized");
     // Core C-R4-1 assertion: dispatch to Ogg, NOT the mis-routed Mp3.
     assert!(
       matches!(meta, AnyMeta::Ogg(_)),
@@ -1010,7 +868,7 @@ mod tests {
 
   /// Codex R13/F1 [REAL-INPUT]: a UTF-8-BOM XML plist with NO filename must
   /// dispatch to [`AnyMeta::Plist`] through the public typed `parse_bytes` API —
-  /// NOT silently return `Ok(None)`. With an empty filename, magic-only detection
+  /// NOT silently return `None`. With an empty filename, magic-only detection
   /// yields `XMP` first (XMP `%magicNumber` accepts the `\xef\xbb\xbf` BOM,
   /// ExifTool.pm:1045) while the PLIST `%magicNumber` (ExifTool.pm:1015) does NOT,
   /// so the later PLIST candidate never matches. Bundled ExifTool reaches this
@@ -1034,9 +892,8 @@ mod tests {
       data.starts_with(&[0xEF, 0xBB, 0xBF]),
       "fixture must be UTF-8-BOM-prefixed"
     );
-    let meta = parse_bytes(&data)
-      .expect("parse_bytes must not error")
-      .expect("BOM XML plist must be recognized via XMP→PLIST relabel, not Ok(None)");
+    let meta =
+      parse_bytes(&data).expect("BOM XML plist must be recognized via XMP→PLIST relabel, not None");
     // Core R13/F1 assertion: the typed API dispatches to the PLIST arm.
     assert!(
       matches!(meta, AnyMeta::Plist(_)),
@@ -1121,7 +978,7 @@ mod tests {
     let meta = {
       // `ext` is a short-lived String dropped at the end of this block.
       let ext: String = String::from("MP3");
-      let m = parse_mp3(&bytes, Some(ext.as_str())).expect("ok");
+      let m = parse_mp3(&bytes, Some(ext.as_str()));
       // `ext` drops here; `m` must remain valid (borrows only `bytes`).
       m
     };
@@ -1139,7 +996,7 @@ mod tests {
     let bytes: Vec<u8> = vec![0u8; 64];
     let meta = {
       let mut shared = SharedFlags::new();
-      let m = parse_ape(&bytes, &mut shared).expect("ok");
+      let m = parse_ape(&bytes, &mut shared);
       // `shared` drops here; `m` must remain valid (ape::Meta is owned).
       m
     };
@@ -1147,6 +1004,6 @@ mod tests {
     // `shared` can also be reused for a second parse without aliasing the
     // first meta — exercise that path too.
     let mut shared2 = SharedFlags::new();
-    let _ = parse_ape(&bytes, &mut shared2).expect("ok");
+    let _ = parse_ape(&bytes, &mut shared2);
   }
 }

--- a/src/metadata/riff.rs
+++ b/src/metadata/riff.rs
@@ -221,7 +221,7 @@ mod tests {
   #[test]
   fn from_riff_fills_media_info() {
     let bytes = minimal_avi_bytes();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     let projected = MediaMetadata::from_riff(&meta);
     assert_eq!(projected.media().width(), Some(320));
     assert_eq!(projected.media().height(), Some(240));
@@ -235,7 +235,7 @@ mod tests {
   #[test]
   fn from_riff_fills_camera_software() {
     let bytes = minimal_avi_bytes();
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     let projected = MediaMetadata::from_riff(&meta);
     let cam = projected.camera().expect("camera");
     assert_eq!(cam.software(), Some("Acme"));
@@ -299,7 +299,7 @@ mod tests {
     // vids stream is 100 @25fps = 4s; ratio 3.0 ∈ (1.9, 3.1) ⇒ use the video
     // stream (RIFF.pm:1660-1663). Oracle: bundled Composite:Duration = 4.
     let bytes = avi_with_video_stream(40_000, 300, 25, 100);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     let dur = MediaMetadata::from_riff(&meta)
       .media()
       .duration()
@@ -316,7 +316,7 @@ mod tests {
     // Ratio 1.0 (header == video): NOT in (1.9, 3.1) ⇒ keep the avih
     // FrameCount/FrameRate duration. 100 @25fps = 4s.
     let bytes = avi_with_video_stream(40_000, 100, 25, 100);
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     let dur = MediaMetadata::from_riff(&meta)
       .media()
       .duration()
@@ -335,7 +335,7 @@ mod tests {
     bytes.extend_from_slice(b"RIFF");
     bytes.extend_from_slice(&4u32.to_le_bytes());
     bytes.extend_from_slice(b"AVI ");
-    let meta = parse_borrowed(&bytes).expect("ok").expect("some");
+    let meta = parse_borrowed(&bytes).expect("some");
     let projected = MediaMetadata::from_riff(&meta);
     assert!(projected.camera().is_none());
     assert!(projected.media().width().is_none());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -484,6 +484,11 @@ fn extract_info_typed(name: &str, data: &[u8], print_conv_enabled: bool) -> Stri
   // Diagnostics: the FIRST warning + FIRST error reach the document.
   let mut warning: Option<String> = None;
   let mut error: Option<String> = None;
+  // The format-tag sink, filled by the accepted candidate's `serialize_tags`
+  // and serialized DIRECTLY into the document (P4). Declared here (outliving the
+  // candidate loop) so the post-loop `Document` can borrow it; empty until a
+  // candidate is accepted (an unfinalized parse renders just `obj`).
+  let mut tm = crate::tagmap::TagMap::new();
   // `$$self{FILE_TYPE}` bookkeeping (ExifTool.pm:3080): set once finalized.
   let mut finalized = false;
   // Fresh per-candidate cross-format state (mirrors `parse_bytes`).
@@ -752,17 +757,11 @@ fn extract_info_typed(name: &str, data: &[u8], print_conv_enabled: bool) -> Stri
 
     // ----- Format tags + diagnostics via the typed tag emission ----------
     // Drive the typed Meta's inherent `serialize_tags` into a `TagMap` (the
-    // inline first-wins sink), then merge its entries into the document and
-    // lift its FIRST warning/error.
-    let mut tm = crate::tagmap::TagMap::new();
+    // inline first-wins sink). The FIRST warning/error is lifted into the
+    // document's diagnostics; the format tags are serialized DIRECTLY at the
+    // final step (P4 — no `serde_json::to_value` round-trip + no second key
+    // alloc), see the `Document` serializer below.
     let _ = meta.serialize_tags(print_conv_enabled, &mut tm);
-    for (key, value) in tm.entries() {
-      insert(
-        &mut obj,
-        key.to_string(),
-        serde_json::to_value(value).unwrap_or(Value::Null),
-      );
-    }
     if let Some(w) = tm.first_warning() {
       warning.get_or_insert_with(|| w.to_string());
     }
@@ -782,7 +781,9 @@ fn extract_info_typed(name: &str, data: &[u8], print_conv_enabled: bool) -> Stri
   }
 
   // Generated `ExifTool:Warning` / `ExifTool:Error` join the same dedup set
-  // (ExifTool.pm:2951; only the FIRST of each under default `-j`).
+  // (ExifTool.pm:2951; only the FIRST of each under default `-j`). These are
+  // orchestration keys (`ExifTool:*`), disjoint from the format-tag keyspace,
+  // so they go into `obj` like the `File:*` triplet.
   if let Some(w) = warning {
     insert(&mut obj, "ExifTool:Warning".into(), Value::String(w));
   }
@@ -790,7 +791,83 @@ fn extract_info_typed(name: &str, data: &[u8], print_conv_enabled: bool) -> Stri
     insert(&mut obj, "ExifTool:Error".into(), Value::String(e));
   }
 
-  Value::Array(vec![Value::Object(obj)]).to_string()
+  // Render the single-element `[{ … }]` document. P4: the FORMAT tags serialize
+  // straight through `TagValue`'s own `Serialize` (the `Document` impl below),
+  // dropping the per-tag `serde_json::to_value` intermediate `Value` + the
+  // second `"g:n"` key allocation the old `Map`-merge paid. The orchestration
+  // keys (`SourceFile`, the `File:*` triplet, `ExifTool:ExifToolVersion`,
+  // `ExifTool:Warning`/`Error`) stay in `obj` (a handful of entries; their
+  // `Value`s are already built). `%noDups` first-wins is preserved EXACTLY: a
+  // format tag whose `"<family1>:<name>"` key already exists in `obj` is
+  // skipped (the orchestration value wins), reproducing the old `or_insert`.
+  serde_json::to_string(&Document { obj: &obj, tags: &tm })
+    .unwrap_or_else(|_| Value::Array(vec![Value::Object(obj)]).to_string())
+}
+
+/// The `extract_info` document as a direct `serde::Serialize` (P4): a one-element
+/// array wrapping a flat object of `"<group>:<name>": value` entries. The
+/// orchestration keys (already `serde_json::Value`) come first, then the FORMAT
+/// tags rendered directly through [`TagValue`]'s `Serialize` — no intermediate
+/// `serde_json::Value` per tag. A format tag whose key already appears in `obj`
+/// is skipped, reproducing the old `Map::or_insert` first-wins against the
+/// orchestration keys (the two keyspaces are disjoint in practice, so this only
+/// guards against a future collision; it never fires today).
+#[cfg(feature = "json")]
+struct Document<'a> {
+  obj: &'a serde_json::Map<String, serde_json::Value>,
+  tags: &'a crate::tagmap::TagMap,
+}
+
+#[cfg(feature = "json")]
+impl serde::Serialize for Document<'_> {
+  fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeSeq;
+    let mut seq = s.serialize_seq(Some(1))?;
+    seq.serialize_element(&DocObject {
+      obj: self.obj,
+      entries: self.tags.entries(),
+    })?;
+    seq.end()
+  }
+}
+
+/// The single per-file object inside the `extract_info` array — its own
+/// `Serialize` so [`Document`] can hand it to `serialize_element`. Emits the
+/// orchestration `obj` entries (already `Value`) then the format tags rendered
+/// directly through [`TagValue`]'s `Serialize` (P4 — no per-tag intermediate
+/// `Value`), with a first-wins skip against `obj`.
+#[cfg(feature = "json")]
+struct DocObject<'a> {
+  obj: &'a serde_json::Map<String, serde_json::Value>,
+  entries: &'a [(smol_str::SmolStr, smol_str::SmolStr, crate::value::TagValue)],
+}
+
+#[cfg(feature = "json")]
+impl serde::Serialize for DocObject<'_> {
+  fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeMap;
+    let mut map = s.serialize_map(Some(self.obj.len() + self.entries.len()))?;
+    // Orchestration keys first (already `Value`).
+    for (k, v) in self.obj {
+      map.serialize_entry(k, v)?;
+    }
+    // Format tags: build the `"g:n"` key once per surviving entry (reusing a
+    // single buffer), skip any key already emitted by `obj` (first-wins), and
+    // serialize the value straight through `TagValue::Serialize`.
+    let mut key = String::new();
+    for (group, name, value) in self.entries {
+      key.clear();
+      key.reserve(group.len() + 1 + name.len());
+      key.push_str(group);
+      key.push(':');
+      key.push_str(name);
+      if self.obj.contains_key(key.as_str()) {
+        continue;
+      }
+      map.serialize_entry(key.as_str(), value)?;
+    }
+    map.end()
+  }
 }
 
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -549,8 +549,8 @@ fn extract_info_typed(name: &str, data: &[u8], print_conv_enabled: bool) -> Stri
     let Some(parser) = any_parser_for(ft) else {
       continue;
     };
-    // Faithful closed-dispatch parse. A Rust-level fatal (unreachable for the
-    // ported formats — uninhabited error enums) maps to "not this candidate".
+    // Faithful closed-dispatch parse. The contract is `Option`: `Some(meta)`
+    // is an accepted candidate, `None` is a rejection ("not this candidate").
     // `cand.header_skip()` is the unknown-leading-header byte count (Perl
     // `$skip`, `ExifTool.pm:3029`) for the terminal JPEG/TIFF candidate — `0`
     // for every ordinary candidate; the JPEG/TIFF arm slices `data` at it.
@@ -561,13 +561,9 @@ fn extract_info_typed(name: &str, data: &[u8], print_conv_enabled: bool) -> Stri
       cand.header_skip(),
       Some(cand.parent_type()),
     ) {
-      Ok(Some(meta)) => meta,
-      Ok(None) => {
+      Some(meta) => meta,
+      None => {
         // Rejected candidate: reset shared so partial side effects don't leak.
-        shared = crate::format_parser::SharedFlags::new();
-        continue;
-      }
-      Err(_) => {
         shared = crate::format_parser::SharedFlags::new();
         continue;
       }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -800,8 +800,11 @@ fn extract_info_typed(name: &str, data: &[u8], print_conv_enabled: bool) -> Stri
   // `Value`s are already built). `%noDups` first-wins is preserved EXACTLY: a
   // format tag whose `"<family1>:<name>"` key already exists in `obj` is
   // skipped (the orchestration value wins), reproducing the old `or_insert`.
-  serde_json::to_string(&Document { obj: &obj, tags: &tm })
-    .unwrap_or_else(|_| Value::Array(vec![Value::Object(obj)]).to_string())
+  serde_json::to_string(&Document {
+    obj: &obj,
+    tags: &tm,
+  })
+  .unwrap_or_else(|_| Value::Array(vec![Value::Object(obj)]).to_string())
 }
 
 /// The `extract_info` document as a direct `serde::Serialize` (P4): a one-element

--- a/src/tagmap.rs
+++ b/src/tagmap.rs
@@ -97,7 +97,6 @@ impl TagMap {
     }
   }
 
-
   /// Insert `value` under the `"<group>:<name>"` key with faithful `FoundTag`
   /// LAST-wins (a later emission of the same key REPLACES the earlier value in
   /// place, preserving first-occurrence POSITION — ExifTool.pm:9437-9519). This
@@ -245,7 +244,6 @@ impl TagMap {
   pub(crate) const fn entries(&self) -> &[(SmolStr, SmolStr, TagValue)] {
     self.entries.as_slice()
   }
-
 
   /// The FIRST recorded warning, if any (`ExifTool:Warning` under default `-j`).
   #[inline(always)]

--- a/src/tagmap.rs
+++ b/src/tagmap.rs
@@ -45,6 +45,7 @@ use crate::value::TagValue;
 use core::convert::Infallible;
 use smol_str::SmolStr;
 use std::{
+  collections::HashMap,
   string::{String, ToString},
   vec::Vec,
 };
@@ -57,9 +58,30 @@ use std::{
 ///
 /// Private to the crate (constructed by [`crate::Rendered`]'s `Serialize` and
 /// [`crate::parser::extract_info`]). NOT a public API surface.
+///
+/// ## Storage (Golden-v2 P1 — O(1) dedup, key built once at serialize)
+///
+/// Entries are stored as the `(family1, name, value)` TRIPLE in
+/// first-occurrence order, with a side index `HashMap<(family1, name) → idx>`
+/// for O(1) last-wins dedup. The previous design keyed dedup on a per-insert
+/// `format!("{group}:{name}")` `SmolStr` and resolved duplicates via an O(n)
+/// linear scan (O(n²) over a walk); this builds NO `"g:n"` string at insert
+/// time — the two short `SmolStr`s (`family1`, `name`, both usually inline so
+/// the clone is a memcpy, not a heap alloc) ARE the key. The combined
+/// `"<family1>:<name>"` JSON key is materialized ONCE per surviving entry at
+/// serialization (the two consumers — [`crate::parser::extract_info`] and
+/// [`crate::Rendered`] — build it from [`entries`](Self::entries)), not per
+/// emission. Net per-insert: one `HashMap` probe + (on a new key) two inline
+/// `SmolStr` clones, vs the old heap `format!` + a growing linear scan.
 pub(crate) struct TagMap {
-  /// `("<Group1>:<Name>", value)` in first-occurrence order, first-wins.
-  entries: Vec<(SmolStr, TagValue)>,
+  /// `(family1, name, value)` in first-occurrence order; the latest value for a
+  /// repeated `(family1, name)` replaces in place (faithful `FoundTag`
+  /// last-wins, keeping first-occurrence POSITION — `ExifTool.pm:9437-9519`).
+  entries: Vec<(SmolStr, SmolStr, TagValue)>,
+  /// `(family1, name) → index into `entries`` for O(1) dedup. The key clones
+  /// the two short `SmolStr`s (inline for ≤23 bytes — no heap), so the dedup
+  /// probe never builds the `"g:n"` string the old design allocated per insert.
+  index: HashMap<(SmolStr, SmolStr), usize>,
   warnings: Vec<String>,
   errors: Vec<String>,
 }
@@ -69,10 +91,12 @@ impl TagMap {
   pub(crate) fn new() -> Self {
     Self {
       entries: Vec::new(),
+      index: HashMap::new(),
       warnings: Vec::new(),
       errors: Vec::new(),
     }
   }
+
 
   /// Insert `value` under the `"<group>:<name>"` key with faithful `FoundTag`
   /// LAST-wins (a later emission of the same key REPLACES the earlier value in
@@ -87,12 +111,22 @@ impl TagMap {
   /// last COMM). No typed sink emits two DIFFERENT family-0 under one
   /// `family1:name`, so the render-stage first-wins never applies here.
   fn insert(&mut self, group: &str, name: &str, value: TagValue) {
-    let key = SmolStr::new(std::format!("{group}:{name}"));
-    if let Some(slot) = self.entries.iter_mut().find(|(k, _)| *k == key) {
-      slot.1 = value; // last-wins, in place (keeps first-occurrence position)
+    // O(1) dedup on the `(family1, name)` PAIR — no `"g:n"` string is built here
+    // (it is materialized once per surviving entry at serialization). The probe
+    // key clones the two `SmolStr`s; tag groups + names are short identifiers
+    // (`"EXIF"`/`"IFD0"`/`"Canon"`, `"MakerNoteVersion"` — all ≤23 bytes), so
+    // `SmolStr::new` stores them INLINE (a memcpy, NO heap allocation). On a
+    // MISS the freshly-built key is moved straight into the index + entries (no
+    // re-clone); on a HIT the latest value replaces in place, keeping
+    // first-occurrence POSITION (faithful `FoundTag` last-wins).
+    let key = (SmolStr::new(group), SmolStr::new(name));
+    if let Some(&idx) = self.index.get(&key) {
+      self.entries[idx].2 = value;
       return;
     }
-    self.entries.push((key, value));
+    let idx = self.entries.len();
+    self.entries.push((key.0.clone(), key.1.clone(), value));
+    self.index.insert(key, idx);
   }
 
   // The `write_*` surface returns `Result<(), Infallible>` so the typed
@@ -203,13 +237,15 @@ impl TagMap {
     Ok(())
   }
 
-  /// The collected format-tag entries (`"<Group1>:<Name>"`, value) in
-  /// first-occurrence order (first-wins already applied). Slice view of the
-  /// backing `Vec` (§3: never expose `&Vec<T>`).
+  /// The collected format-tag entries `(family1, name, value)` in
+  /// first-occurrence order (last-wins dedup already applied). The consumer
+  /// builds the `"<family1>:<name>"` JSON key ONCE per entry here (not per
+  /// emission). Slice view of the backing `Vec` (§3: never expose `&Vec<T>`).
   #[inline(always)]
-  pub(crate) const fn entries(&self) -> &[(SmolStr, TagValue)] {
+  pub(crate) const fn entries(&self) -> &[(SmolStr, SmolStr, TagValue)] {
     self.entries.as_slice()
   }
+
 
   /// The FIRST recorded warning, if any (`ExifTool:Warning` under default `-j`).
   #[inline(always)]
@@ -229,17 +265,13 @@ impl TagMap {
     &self.warnings
   }
 
-  /// Look up an emitted tag's [`TagValue`] by `(group, name)` — the
-  /// `"<group>:<name>"` key (test-only read-back, mirrors the retired
-  /// `MapTagWriter::get`). `None` if never emitted.
+  /// Look up an emitted tag's [`TagValue`] by `(family1, name)` (test-only
+  /// read-back, mirrors the retired `MapTagWriter::get`). `None` if never
+  /// emitted. Uses the O(1) dedup index.
   #[cfg(test)]
   pub(crate) fn get(&self, group: &str, name: &str) -> Option<&TagValue> {
-    let key = std::format!("{group}:{name}");
-    self
-      .entries
-      .iter()
-      .find(|(k, _)| k.as_str() == key)
-      .map(|(_, v)| v)
+    let key = (SmolStr::new(group), SmolStr::new(name));
+    self.index.get(&key).map(|&idx| &self.entries[idx].2)
   }
 
   /// `true` if no tags / warnings / errors were emitted (test-only).

--- a/src/value.rs
+++ b/src/value.rs
@@ -332,6 +332,17 @@ impl Tag {
     &self.group
   }
 
+  /// Consume `self`, yielding its `(group, name, value)` parts — lets a consumer
+  /// MOVE the owned [`TagValue`] (and group/name) out instead of cloning
+  /// `value_ref()`. Used by [`crate::emit::run_emission`] to hand the value to
+  /// the sink without a clone (Golden-v2 P3). Crate-internal: the public read
+  /// path is the borrowing accessors.
+  #[must_use]
+  #[inline(always)]
+  pub(crate) fn into_parts(self) -> (Group, SmolStr, TagValue) {
+    (self.group, self.name, self.value)
+  }
+
   /// The tag's name (e.g. `"Duration"`).
   #[must_use]
   #[inline(always)]

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -112,20 +112,37 @@ const FIXTURES: &[&str] = &[
   "Real.ra",
 ];
 
-/// Measure + report (and, once pinned, assert) the allocation count of a full
-/// `media_metadata` extraction per fixture. `media_metadata` runs the full
-/// detect → parse → project pipeline (the `-j`/`-n`-independent typed path), so
-/// it exercises the MakerNote single-mode decode + the `collect_emitted` /
-/// `run_emission` move-not-clone path. The `parse_bytes` count is reported too
-/// (project() adds the domain fold on top).
+/// Measure + report + assert the per-fixture allocation counts for both the
+/// `media_metadata`/`parse_bytes` typed path AND the `extract_info` `-j`/`-n`
+/// JSON render path.
+///
+/// **One** `#[test]` (not two) ON PURPOSE: the allocation counter is a
+/// PROCESS-GLOBAL `AtomicUsize`, and libtest runs a binary's tests on multiple
+/// threads, so a SECOND measuring test would increment the shared counter
+/// DURING this one's measurement window (cross-contamination — observed as
+/// inflated, non-deterministic counts when both ran in parallel). With a single
+/// test the measured regions are strictly sequential on one thread, so the
+/// counts are deterministic regardless of `--test-threads`. (This binary has no
+/// other test, and the criterion bench is a separate binary with its own
+/// allocator/counter.)
+///
+/// `media_metadata` runs detect → parse → project (the mode-independent typed
+/// path: P0 single-mode MakerNote decode + P2/P3 move-not-clone). `extract_info`
+/// runs the JSON render path (P1 O(1) dedup + P4 direct-serialize + P0). Each
+/// `extract_info` call renders in exactly ONE mode, so a MakerNote fixture's
+/// `-j` run decodes ONLY the PrintConv vendor body (and `-n` only ValueConv).
 #[test]
-fn alloc_budget_media_metadata() {
-  // Warm-up: trigger any one-time lazy static init OUTSIDE the measured region
+fn alloc_budget() {
+  use exifast::parser::extract_info;
+
+  // Warm-up: trigger any one-time lazy static init OUTSIDE the measured regions
   // so it isn't attributed to the first fixture.
   for name in FIXTURES {
     let bytes = fixture_bytes(name);
     let _ = exifast::media_metadata(&bytes);
     let _ = exifast::parse_bytes(&bytes);
+    let _ = extract_info(name, &bytes, true);
+    let _ = extract_info(name, &bytes, false);
   }
 
   println!("\n=== alloc_budget: media_metadata / parse_bytes ===");
@@ -139,9 +156,9 @@ fn alloc_budget_media_metadata() {
     assert!(mm, "{name}: media_metadata accepted the fixture");
     println!("  {name:34}  parse_bytes={pb_allocs:>6}  media_metadata={mm_allocs:>6}");
 
-    // PINNED REGRESSION BUDGETS (Golden-v2 C4). Set at the IMPROVED Phase-A.3
-    // counts with headroom — see the per-fixture comments. A future change that
-    // reintroduces a redundant decode / clone / O(n²) key build trips these.
+    // PINNED REGRESSION BUDGET (Golden-v2 C4) — the IMPROVED Phase-A.3 count
+    // plus headroom. A regression past it means a redundant decode / clone /
+    // per-tag key build crept back in.
     let budget = media_metadata_budget(name);
     assert!(
       mm_allocs <= budget,
@@ -150,24 +167,6 @@ fn alloc_budget_media_metadata() {
        per-tag key build crept back in). If this is an intentional new \
        allocation, re-baseline the budget with a justifying comment."
     );
-  }
-}
-
-/// Also exercise the `-j` (PrintConv) and `-n` (ValueConv) JSON render paths via
-/// `extract_info`, since the MakerNote single-mode decode + the `TagMap` O(1)
-/// dedup + the direct-serialize P4 win all live on the JSON path. Each
-/// `extract_info` call renders in exactly ONE mode, so a MakerNote fixture's
-/// `-j` run should decode ONLY the PrintConv vendor body (and `-n` only the
-/// ValueConv body), not both.
-#[test]
-fn alloc_budget_extract_info() {
-  use exifast::parser::extract_info;
-
-  // Warm-up.
-  for name in FIXTURES {
-    let bytes = fixture_bytes(name);
-    let _ = extract_info(name, &bytes, true);
-    let _ = extract_info(name, &bytes, false);
   }
 
   println!("\n=== alloc_budget: extract_info (-j / -n) ===");
@@ -197,19 +196,38 @@ fn alloc_budget_extract_info() {
 // (a reintroduced clone / double decode / O(n²) key build) does.
 // ---------------------------------------------------------------------------
 
-/// `media_metadata` per-fixture allocation budget.
+/// `media_metadata` per-fixture allocation budget. PINNED at the improved
+/// Phase-A.3 count + ~6-10% headroom (the comment shows the measured count). A
+/// regression past these means a redundant decode / clone / per-tag key build
+/// crept back in; an intentional new allocation should re-baseline WITH a
+/// justifying comment, not just bump the number.
 fn media_metadata_budget(name: &str) -> usize {
   match name {
-    // PLACEHOLDER budgets (Item 0 baseline run): set generously so the harness
-    // PRINTS without asserting-failing on the pre-optimization baseline. These
-    // are TIGHTENED to the improved counts in the final "pin" commit.
+    // Canon dominates (the MakerNote vendor decode). P0 (single-mode decode)
+    // took its `media_metadata` from 1391 → 756.
+    "MakerNotes_Canon.jpg" => 800, // measured 756
+    "MakerNotes_Apple.jpg" => 145, // measured 133 (P0: 176 → 133)
+    "ID3v2_4_big.mp3" => 210,      // measured 194
+    "QuickTime_frea_rexing17b.mov" => 40, // measured 31
+    "Real.ra" => 30,               // measured 21 (P8: 31 → 21)
+    // An unlisted fixture: no pinned budget (the harness still prints + checks
+    // parse acceptance, just no ceiling).
     _ => usize::MAX,
   }
 }
 
-/// `extract_info` `(-j, -n)` per-fixture allocation budget.
+/// `extract_info` `(-j, -n)` per-fixture allocation budget — the JSON render
+/// path that carries the P1 O(1) dedup + P4 direct-serialize + P0 single-mode
+/// MakerNote wins. PINNED at the improved Phase-A.3 counts + headroom.
 fn extract_info_budget(name: &str) -> (usize, usize) {
   match name {
+    // P1+P4 took -j 2085 → 1547; P0 then took it 1547 → 907. -n stays ~1632
+    // (one value-conv decode, now on demand).
+    "MakerNotes_Canon.jpg" => (960, 1720), // measured (907, 1632)
+    "MakerNotes_Apple.jpg" => (370, 490),  // measured (339, 456)
+    "ID3v2_4_big.mp3" => (125, 125),       // measured (110, 109)
+    "QuickTime_frea_rexing17b.mov" => (150, 150), // measured (135, 137); P1: 266/259 → 135/137
+    "Real.ra" => (100, 100),               // measured (88, 87)
     _ => (usize::MAX, usize::MAX),
   }
 }

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -205,11 +205,11 @@ fn media_metadata_budget(name: &str) -> usize {
   match name {
     // Canon dominates (the MakerNote vendor decode). P0 (single-mode decode)
     // took its `media_metadata` from 1391 → 756.
-    "MakerNotes_Canon.jpg" => 800, // measured 756
-    "MakerNotes_Apple.jpg" => 145, // measured 133 (P0: 176 → 133)
-    "ID3v2_4_big.mp3" => 210,      // measured 194
+    "MakerNotes_Canon.jpg" => 800,        // measured 756
+    "MakerNotes_Apple.jpg" => 145,        // measured 133 (P0: 176 → 133)
+    "ID3v2_4_big.mp3" => 210,             // measured 194
     "QuickTime_frea_rexing17b.mov" => 40, // measured 31
-    "Real.ra" => 30,               // measured 21 (P8: 31 → 21)
+    "Real.ra" => 30,                      // measured 21 (P8: 31 → 21)
     // An unlisted fixture: no pinned budget (the harness still prints + checks
     // parse acceptance, just no ceiling).
     _ => usize::MAX,

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -1,0 +1,205 @@
+//! Golden-v2 C4 — allocation-count guard harness.
+//!
+//! A counting `#[global_allocator]` (a thin wrapper over [`std::alloc::System`]
+//! that bumps an [`AtomicUsize`] on every `alloc`) lets us MEASURE the heap
+//! allocation count of a full `media_metadata` / `parse_bytes` extraction over
+//! a handful of representative fixtures. The Phase-A.3 perf items are pure
+//! speedups — byte-identical output, fewer allocations — so this harness is the
+//! deliverable proof: it records the per-fixture alloc count and (after the
+//! perf work lands) PINS an upper bound so a future regression that
+//! reintroduces an O(n²) scan / a redundant clone / a double decode trips the
+//! gate.
+//!
+//! ## How the counter is isolated
+//!
+//! The global allocator counts EVERY allocation in this test binary, including
+//! `std::fs::read`, the test harness, and `format!`/panic machinery. To attribute
+//! allocations to the parse alone we (1) read the fixture bytes FIRST, OUTSIDE the
+//! measured region, (2) warm the detection/parse once (so any lazily-initialized
+//! statics are already allocated), (3) snapshot the counter, run the entry point,
+//! snapshot again, and report the delta. The measured closure's owned result is
+//! moved OUT of the measured region (returned) so its eventual drop — a
+//! deallocation, not an allocation — is irrelevant to the alloc count anyway.
+//!
+//! Run with `cargo test --test alloc_budget -- --nocapture` to see the printed
+//! counts.
+
+#![cfg(all(feature = "std", feature = "exif", feature = "id3", feature = "quicktime"))]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Process-wide allocation counter. Bumped on every successful `alloc`/`realloc`
+/// through the [`Counting`] global allocator. `Relaxed` is sufficient: we only
+/// ever read it from the single thread that runs the measured closure, with the
+/// allocations happening on that same thread (the parse is synchronous).
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// A `System`-delegating allocator that counts allocations. `dealloc` is NOT
+/// counted (we measure allocation pressure, the KPI for a streaming indexer);
+/// `realloc` counts as one allocation (a growth event).
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+  unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+    let p = unsafe { System.alloc(layout) };
+    if !p.is_null() {
+      ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+    p
+  }
+
+  unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    unsafe { System.dealloc(ptr, layout) };
+  }
+
+  unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+    let p = unsafe { System.alloc_zeroed(layout) };
+    if !p.is_null() {
+      ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+    p
+  }
+
+  unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+    let p = unsafe { System.realloc(ptr, layout, new_size) };
+    if !p.is_null() {
+      ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+    p
+  }
+}
+
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+/// Read a fixture's bytes (OUTSIDE the measured region).
+fn fixture_bytes(name: &str) -> Vec<u8> {
+  let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+    .join("tests")
+    .join("fixtures")
+    .join(name);
+  std::fs::read(&path).unwrap_or_else(|e| panic!("read fixture {name}: {e}"))
+}
+
+/// Count allocations performed by `f` (a single synchronous call), returning the
+/// closure's result alongside the delta so the result can be moved out of the
+/// measured region by the caller.
+fn count_allocs<T>(f: impl FnOnce() -> T) -> (T, usize) {
+  let before = ALLOC_COUNT.load(Ordering::Relaxed);
+  let out = f();
+  let after = ALLOC_COUNT.load(Ordering::Relaxed);
+  (out, after - before)
+}
+
+/// The representative fixtures: a camera JPEG with an Apple MakerNote, a camera
+/// JPEG with a Canon MakerNote (out-of-line offset resolution + many typed
+/// fields), a multi-frame ID3v2.4 MP3, and a tag-dense QuickTime MOV.
+const FIXTURES: &[&str] = &[
+  "MakerNotes_Apple.jpg",
+  "MakerNotes_Canon.jpg",
+  "ID3v2_4_big.mp3",
+  "QuickTime_frea_rexing17b.mov",
+];
+
+/// Measure + report (and, once pinned, assert) the allocation count of a full
+/// `media_metadata` extraction per fixture. `media_metadata` runs the full
+/// detect → parse → project pipeline (the `-j`/`-n`-independent typed path), so
+/// it exercises the MakerNote single-mode decode + the `collect_emitted` /
+/// `run_emission` move-not-clone path. The `parse_bytes` count is reported too
+/// (project() adds the domain fold on top).
+#[test]
+fn alloc_budget_media_metadata() {
+  // Warm-up: trigger any one-time lazy static init OUTSIDE the measured region
+  // so it isn't attributed to the first fixture.
+  for name in FIXTURES {
+    let bytes = fixture_bytes(name);
+    let _ = exifast::media_metadata(&bytes);
+    let _ = exifast::parse_bytes(&bytes);
+  }
+
+  println!("\n=== alloc_budget: media_metadata / parse_bytes ===");
+  for &name in FIXTURES {
+    let bytes = fixture_bytes(name);
+    // `parse_bytes` (detect + typed parse, no projection).
+    let (parsed, pb_allocs) = count_allocs(|| exifast::parse_bytes(&bytes).is_some());
+    assert!(parsed, "{name}: parse_bytes accepted the fixture");
+    // `media_metadata` (detect + parse + domain projection).
+    let (mm, mm_allocs) = count_allocs(|| exifast::media_metadata(&bytes).is_some());
+    assert!(mm, "{name}: media_metadata accepted the fixture");
+    println!("  {name:34}  parse_bytes={pb_allocs:>6}  media_metadata={mm_allocs:>6}");
+
+    // PINNED REGRESSION BUDGETS (Golden-v2 C4). Set at the IMPROVED Phase-A.3
+    // counts with headroom — see the per-fixture comments. A future change that
+    // reintroduces a redundant decode / clone / O(n²) key build trips these.
+    let budget = media_metadata_budget(name);
+    assert!(
+      mm_allocs <= budget,
+      "{name}: media_metadata allocated {mm_allocs} > budget {budget} — \
+       a Golden-v2 C4 perf regression (a redundant clone / double decode / \
+       per-tag key build crept back in). If this is an intentional new \
+       allocation, re-baseline the budget with a justifying comment."
+    );
+  }
+}
+
+/// Also exercise the `-j` (PrintConv) and `-n` (ValueConv) JSON render paths via
+/// `extract_info`, since the MakerNote single-mode decode + the `TagMap` O(1)
+/// dedup + the direct-serialize P4 win all live on the JSON path. Each
+/// `extract_info` call renders in exactly ONE mode, so a MakerNote fixture's
+/// `-j` run should decode ONLY the PrintConv vendor body (and `-n` only the
+/// ValueConv body), not both.
+#[test]
+fn alloc_budget_extract_info() {
+  use exifast::parser::extract_info;
+
+  // Warm-up.
+  for name in FIXTURES {
+    let bytes = fixture_bytes(name);
+    let _ = extract_info(name, &bytes, true);
+    let _ = extract_info(name, &bytes, false);
+  }
+
+  println!("\n=== alloc_budget: extract_info (-j / -n) ===");
+  for &name in FIXTURES {
+    let bytes = fixture_bytes(name);
+    let (j, j_allocs) = count_allocs(|| extract_info(name, &bytes, true).len());
+    let (n, n_allocs) = count_allocs(|| extract_info(name, &bytes, false).len());
+    assert!(j > 2 && n > 2, "{name}: extract_info produced a document");
+    println!("  {name:34}  -j={j_allocs:>6}  -n={n_allocs:>6}");
+
+    let (jb, nb) = extract_info_budget(name);
+    assert!(
+      j_allocs <= jb,
+      "{name}: extract_info -j allocated {j_allocs} > budget {jb} (Golden-v2 C4 regression)"
+    );
+    assert!(
+      n_allocs <= nb,
+      "{name}: extract_info -n allocated {n_allocs} > budget {nb} (Golden-v2 C4 regression)"
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PINNED BUDGETS — set after the Phase-A.3 perf items landed (see report).
+// Each is the measured improved count plus a small headroom margin so trivial,
+// allocation-neutral refactors don't trip the gate, while a real regression
+// (a reintroduced clone / double decode / O(n²) key build) does.
+// ---------------------------------------------------------------------------
+
+/// `media_metadata` per-fixture allocation budget.
+fn media_metadata_budget(name: &str) -> usize {
+  match name {
+    // PLACEHOLDER budgets (Item 0 baseline run): set generously so the harness
+    // PRINTS without asserting-failing on the pre-optimization baseline. These
+    // are TIGHTENED to the improved counts in the final "pin" commit.
+    _ => usize::MAX,
+  }
+}
+
+/// `extract_info` `(-j, -n)` per-fixture allocation budget.
+fn extract_info_budget(name: &str) -> (usize, usize) {
+  match name {
+    _ => (usize::MAX, usize::MAX),
+  }
+}

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -24,7 +24,13 @@
 //! Run with `cargo test --test alloc_budget -- --nocapture` to see the printed
 //! counts.
 
-#![cfg(all(feature = "std", feature = "exif", feature = "id3", feature = "quicktime"))]
+#![cfg(all(
+  feature = "std",
+  feature = "exif",
+  feature = "id3",
+  feature = "quicktime",
+  feature = "real"
+))]
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -94,12 +100,16 @@ fn count_allocs<T>(f: impl FnOnce() -> T) -> (T, usize) {
 
 /// The representative fixtures: a camera JPEG with an Apple MakerNote, a camera
 /// JPEG with a Canon MakerNote (out-of-line offset resolution + many typed
-/// fields), a multi-frame ID3v2.4 MP3, and a tag-dense QuickTime MOV.
+/// fields — the heaviest decode, exercises P0 single-mode), a multi-frame
+/// ID3v2.4 MP3, a tag-dense QuickTime MOV (exercises P1's O(1) dedup), and a
+/// RealAudio file (its AudioV* codec fields exercise the P8 static-literal-name
+/// SmolStr sweep).
 const FIXTURES: &[&str] = &[
   "MakerNotes_Apple.jpg",
   "MakerNotes_Canon.jpg",
   "ID3v2_4_big.mp3",
   "QuickTime_frea_rexing17b.mov",
+  "Real.ra",
 ];
 
 /// Measure + report (and, once pinned, assert) the allocation count of a full

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1589,9 +1589,8 @@ fn plist_trunc_bin_conformance() {
 fn plist_trunc_bin_parse_bytes_recognized() {
   let trunc: &[u8] = b"bplist00";
   // Typed public dispatch must recognize it (not `Ok(None)`).
-  let meta = exifast::parse_bytes(trunc)
-    .expect("parse_bytes is infallible for PLIST")
-    .expect("truncated bplist00 is a RECOGNIZED PLIST, not Ok(None)");
+  let meta =
+    exifast::parse_bytes(trunc).expect("truncated bplist00 is a RECOGNIZED PLIST, not Ok(None)");
   match meta {
     exifast::format_parser::AnyMeta::Plist(p) => {
       assert!(p.format().is_binary(), "binary plist");
@@ -5677,9 +5676,7 @@ fn h264_conformance() {
       let golden_name = format!("{fixture}.h264.{suffix}");
       let want = std::fs::read_to_string(format!("{root}/tests/golden/h264/{golden_name}"))
         .unwrap_or_else(|e| panic!("read golden {golden_name}: {e}"));
-      let meta = exifast::parse_h264(&data)
-        .expect("parse_h264 must not error")
-        .expect("synthetic H264 stream must be accepted");
+      let meta = exifast::parse_h264(&data).expect("synthetic H264 stream must be accepted");
       let any = AnyMeta::H264(meta);
       let got = serde_json::to_string(&Rendered::new(&any, print_on)).expect("render H264 meta");
       if let Err(e) = json_equivalent(&got, &want) {
@@ -5707,9 +5704,7 @@ fn h264_oos_mdpm_n_emits_json_number() {
   let root = env!("CARGO_MANIFEST_DIR");
   let data = std::fs::read(format!("{root}/tests/golden/h264/h264_oos_mdpm.h264"))
     .expect("read h264_oos_mdpm fixture");
-  let meta = exifast::parse_h264(&data)
-    .expect("parse_h264 must not error")
-    .expect("h264_oos_mdpm must be accepted");
+  let meta = exifast::parse_h264(&data).expect("h264_oos_mdpm must be accepted");
   let any = AnyMeta::H264(meta);
 
   // `-n` (print_conv = false): WhiteBalance must be a bare JSON NUMBER.
@@ -5747,9 +5742,7 @@ fn h264_forbidden_bit_surfaces_warning() {
   use exifast::{AnyMeta, Rendered};
 
   let data: [u8; 5] = [0x00, 0x00, 0x00, 0x01, 0x86];
-  let meta = exifast::parse_h264(&data)
-    .expect("parse_h264 must not error")
-    .expect("a stream with a start code must be accepted");
+  let meta = exifast::parse_h264(&data).expect("a stream with a start code must be accepted");
   let any = AnyMeta::H264(meta);
 
   for print_on in [true, false] {

--- a/tests/direct_api_chain_routing.rs
+++ b/tests/direct_api_chain_routing.rs
@@ -35,9 +35,7 @@ fn fixture(name: &str) -> Vec<u8> {
 #[cfg(all(feature = "ogg", feature = "id3"))]
 fn parse_ogg_direct_routes_through_full_chained_for_id3_prefix() {
   let bytes = fixture("ogg_id3_prefixed.ogg");
-  let meta = exifast::parse_ogg(&bytes, /* print_conv */ true)
-    .expect("parse_ogg returns Ok")
-    .expect("parse_ogg returns Some");
+  let meta = exifast::parse_ogg(&bytes, /* print_conv */ true).expect("parse_ogg returns Some");
 
   // ID3 prefix detected and nested. The golden carries `File:ID3Size: 34`
   // and `ID3v2_3:Title: "IDPrefixTitle"`.
@@ -81,9 +79,7 @@ fn parse_ogg_direct_routes_through_full_chained_for_id3_prefix() {
 fn parse_ape_direct_routes_through_full_chained_for_id3_prefix() {
   let bytes = fixture("ape_id3_prefixed.ape");
   let mut shared = exifast::SharedFlags::new();
-  let meta = exifast::parse_ape(&bytes, &mut shared)
-    .expect("parse_ape returns Ok")
-    .expect("parse_ape returns Some");
+  let meta = exifast::parse_ape(&bytes, &mut shared).expect("parse_ape returns Some");
 
   // Golden: `File:ID3Size: 30`, `ID3v2_3:Title: "TestTitle"`.
   let id3 = meta.id3_ref().expect("id3 sub-Meta present");
@@ -110,9 +106,7 @@ fn parse_ape_direct_routes_through_full_chained_for_id3_prefix() {
 #[cfg(all(feature = "mpc", feature = "id3"))]
 fn parse_mpc_direct_routes_through_full_chained_for_id3_prefix() {
   let bytes = fixture("mpc_with_id3v2_prefix.mpc");
-  let meta = exifast::parse_mpc(&bytes)
-    .expect("parse_mpc returns Ok")
-    .expect("parse_mpc returns Some");
+  let meta = exifast::parse_mpc(&bytes).expect("parse_mpc returns Some");
 
   // Golden: `File:ID3Size: 34`, `ID3v2_3:Title: "MpcId3v2Title"`.
   let id3 = meta.id3_ref().expect("id3 sub-Meta present");
@@ -134,9 +128,7 @@ fn parse_mpc_direct_routes_through_full_chained_for_id3_prefix() {
 #[cfg(all(feature = "mpc", feature = "ape"))]
 fn parse_mpc_direct_routes_through_full_chained_for_ape_trailer() {
   let bytes = fixture("mpc_with_apev2_trailer.mpc");
-  let meta = exifast::parse_mpc(&bytes)
-    .expect("parse_mpc returns Ok")
-    .expect("parse_mpc returns Some");
+  let meta = exifast::parse_mpc(&bytes).expect("parse_mpc returns Some");
 
   // Golden: `APE:Artist: "MpcApeArtist"`.
   let ape = meta.ape_ref().expect("ape sub-Meta present");
@@ -156,9 +148,7 @@ fn parse_mpc_direct_routes_through_full_chained_for_ape_trailer() {
 #[cfg(all(feature = "wavpack", feature = "ape"))]
 fn parse_wavpack_direct_routes_through_full_chained_for_ape_trailer() {
   let bytes = fixture("wavpack_with_apev2_trailer.wv");
-  let meta = exifast::parse_wavpack(&bytes)
-    .expect("parse_wavpack returns Ok")
-    .expect("parse_wavpack returns Some");
+  let meta = exifast::parse_wavpack(&bytes).expect("parse_wavpack returns Some");
 
   // Golden: `APE:Artist: "WvApeArtist"`.
   let ape = meta.ape_ref().expect("ape sub-Meta present");
@@ -190,9 +180,7 @@ fn parse_wavpack_direct_routes_through_full_chained_for_ape_trailer() {
 #[cfg(all(feature = "mpc", feature = "id3"))]
 fn module_parse_borrowed_mpc_routes_chain_for_id3_prefix() {
   let bytes = fixture("mpc_with_id3v2_prefix.mpc");
-  let meta = exifast::formats::mpc::parse_borrowed(&bytes)
-    .expect("parse_borrowed returns Ok")
-    .expect("parse_borrowed returns Some");
+  let meta = exifast::formats::mpc::parse_borrowed(&bytes).expect("parse_borrowed returns Some");
   let id3 = meta
     .id3_ref()
     .expect("id3 sub-Meta present via module-level entry");
@@ -211,9 +199,7 @@ fn module_parse_borrowed_mpc_routes_chain_for_id3_prefix() {
 #[cfg(all(feature = "mpc", feature = "ape"))]
 fn module_parse_borrowed_mpc_routes_chain_for_ape_trailer() {
   let bytes = fixture("mpc_with_apev2_trailer.mpc");
-  let meta = exifast::formats::mpc::parse_borrowed(&bytes)
-    .expect("parse_borrowed returns Ok")
-    .expect("parse_borrowed returns Some");
+  let meta = exifast::formats::mpc::parse_borrowed(&bytes).expect("parse_borrowed returns Some");
   let ape = meta
     .ape_ref()
     .expect("ape sub-Meta present via module-level entry");
@@ -231,9 +217,8 @@ fn module_parse_borrowed_mpc_routes_chain_for_ape_trailer() {
 #[cfg(all(feature = "wavpack", feature = "ape"))]
 fn module_parse_borrowed_wavpack_routes_chain_for_ape_trailer() {
   let bytes = fixture("wavpack_with_apev2_trailer.wv");
-  let meta = exifast::formats::wavpack::parse_borrowed(&bytes)
-    .expect("parse_borrowed returns Ok")
-    .expect("parse_borrowed returns Some");
+  let meta =
+    exifast::formats::wavpack::parse_borrowed(&bytes).expect("parse_borrowed returns Some");
   let ape = meta
     .ape_ref()
     .expect("ape sub-Meta present via module-level entry");
@@ -258,7 +243,6 @@ fn module_parse_borrowed_wavpack_routes_chain_for_ape_trailer() {
 fn module_parse_borrowed_ogg_routes_chain_for_id3_prefix() {
   let bytes = fixture("ogg_id3_prefixed.ogg");
   let meta = exifast::formats::ogg::parse_borrowed(&bytes, /* print_conv */ true)
-    .expect("parse_borrowed returns Ok")
     .expect("parse_borrowed returns Some");
   let id3 = meta
     .id3_ref()
@@ -291,9 +275,8 @@ fn trait_parse_ape_routes_chain_for_id3_prefix() {
   let bytes = fixture("ape_id3_prefixed.ape");
   let mut shared = exifast::SharedFlags::new();
   let ctx = Context::new(&bytes, &mut shared);
-  let meta = <ProcessApe as FormatParser>::parse(&ProcessApe, ctx)
-    .expect("trait parse returns Ok")
-    .expect("trait parse returns Some");
+  let meta =
+    <ProcessApe as FormatParser>::parse(&ProcessApe, ctx).expect("trait parse returns Some");
   let id3 = meta
     .id3_ref()
     .expect("id3 sub-Meta present via trait surface");
@@ -322,8 +305,7 @@ fn trait_parse_ape_trailer_only_skips_id3_chain() {
   let bytes = fixture("ape_id3_prefixed.ape");
   let mut shared = exifast::SharedFlags::new();
   let ctx = Context::new_trailer_only(&bytes, &mut shared);
-  let result =
-    <ProcessApe as FormatParser>::parse(&ProcessApe, ctx).expect("trait parse returns Ok");
+  let result = <ProcessApe as FormatParser>::parse(&ProcessApe, ctx);
   // Trailer-only: no full-buffer ID3 detection — the chain MUST stay
   // skipped (the bundled gate at APE.pm:118 is honored).
   if let Some(meta) = result {
@@ -343,9 +325,8 @@ fn trait_parse_mpc_routes_chain_for_id3_prefix() {
   let bytes = fixture("mpc_with_id3v2_prefix.mpc");
   let mut shared = exifast::SharedFlags::new();
   let ctx = Context::new(&bytes, &mut shared);
-  let meta = <ProcessMpc as FormatParser>::parse(&ProcessMpc, ctx)
-    .expect("trait parse returns Ok")
-    .expect("trait parse returns Some");
+  let meta =
+    <ProcessMpc as FormatParser>::parse(&ProcessMpc, ctx).expect("trait parse returns Some");
   let id3 = meta
     .id3_ref()
     .expect("id3 sub-Meta present via trait surface");
@@ -367,9 +348,8 @@ fn trait_parse_mpc_routes_chain_for_ape_trailer() {
   let bytes = fixture("mpc_with_apev2_trailer.mpc");
   let mut shared = exifast::SharedFlags::new();
   let ctx = Context::new(&bytes, &mut shared);
-  let meta = <ProcessMpc as FormatParser>::parse(&ProcessMpc, ctx)
-    .expect("trait parse returns Ok")
-    .expect("trait parse returns Some");
+  let meta =
+    <ProcessMpc as FormatParser>::parse(&ProcessMpc, ctx).expect("trait parse returns Some");
   let ape = meta
     .ape_ref()
     .expect("ape sub-Meta present via trait surface");
@@ -390,9 +370,7 @@ fn trait_parse_wavpack_routes_chain_for_ape_trailer() {
   let bytes = fixture("wavpack_with_apev2_trailer.wv");
   let mut shared = exifast::SharedFlags::new();
   let ctx = Context::new(&bytes, &mut shared);
-  let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx)
-    .expect("trait parse returns Ok")
-    .expect("trait parse returns Some");
+  let meta = <ProcessWv as FormatParser>::parse(&ProcessWv, ctx).expect("trait parse returns Some");
   let ape = meta
     .ape_ref()
     .expect("ape sub-Meta present via trait surface");
@@ -418,9 +396,8 @@ fn trait_parse_wavpack_routes_chain_for_ape_trailer() {
 fn trait_parse_ogg_routes_chain_for_id3_prefix() {
   use exifast::formats::ogg::ProcessOgg;
   let bytes = fixture("ogg_id3_prefixed.ogg");
-  let meta = <ProcessOgg as FormatParser>::parse(&ProcessOgg, &bytes)
-    .expect("trait parse returns Ok")
-    .expect("trait parse returns Some");
+  let meta =
+    <ProcessOgg as FormatParser>::parse(&ProcessOgg, &bytes).expect("trait parse returns Some");
   let id3 = meta
     .id3_ref()
     .expect("id3 sub-Meta present via trait surface");

--- a/tests/exif_direct_api.rs
+++ b/tests/exif_direct_api.rs
@@ -14,14 +14,12 @@ fn standalone_tiff_dispatches_to_exif_arm() {
     "/tests/fixtures/Exif.tif"
   ))
   .unwrap();
-  let meta = exifast::parse_bytes(&data)
-    .unwrap()
-    .expect("TIFF recognized");
+  let meta = exifast::parse_bytes(&data).expect("TIFF recognized");
   assert!(matches!(meta, AnyMeta::Exif(_)), "got {meta:?}");
   // The reusable entry returns the same typed ExifMeta.
   let block = exifast::parse_exif_block(&data).expect("parse_exif_block");
   assert_eq!(block.entry("Make").map(|e| e.name()), Some("Make"));
   // The direct `parse_exif` accessor too.
-  let direct = exifast::parse_exif(&data).unwrap().expect("parse_exif");
+  let direct = exifast::parse_exif(&data).expect("parse_exif");
   assert!(direct.entry("LensModel").is_some());
 }

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -34,9 +34,7 @@ fn exif_makernote_fixture_dispatches_to_pentax() {
     "/tests/fixtures/Exif_makernote.tif"
   ))
   .unwrap();
-  let meta = exifast::parse_exif(&data)
-    .expect("Exif parse returns Ok")
-    .expect("TIFF recognized");
+  let meta = exifast::parse_exif(&data).expect("TIFF recognized");
 
   // The Make tag was emitted into the entry list (the walker passes it
   // through to the dispatcher AND surfaces it as a leaf tag).
@@ -688,9 +686,7 @@ fn panasonic3_dcft7_base12_out_of_line_lenstype() {
   use exifast::exif::makernotes::BaseRule;
   use exifast::value::TagValue;
 
-  let meta = exifast::parse_exif(DCFT7_BASE12_TIFF)
-    .expect("parse ok")
-    .expect("TIFF recognized");
+  let meta = exifast::parse_exif(DCFT7_BASE12_TIFF).expect("TIFF recognized");
 
   // Model selected the Panasonic3 (DC-FT7) variant: the dispatcher gave it
   // `Base => 12` (`MakerNotes.pm:758`) and the 12-byte header.
@@ -725,9 +721,7 @@ fn panasonic3_dcft7_base12_out_of_line_lenstype() {
 #[test]
 fn panasonic3_dcft7_base0_offset_is_corrupted() {
   use exifast::value::TagValue;
-  let meta = exifast::parse_exif(DCFT7_BASE0_TIFF)
-    .expect("parse ok")
-    .expect("TIFF recognized");
+  let meta = exifast::parse_exif(DCFT7_BASE0_TIFF).expect("TIFF recognized");
   let mn = meta.maker_note().expect("MakerNote captured");
   let lens = mn
     .emissions_print_conv()
@@ -847,7 +841,7 @@ fn panasonic2_mke_type2_does_not_run_main_parser() {
   assert_eq!(t.len(), 86);
   t.extend_from_slice(b"Panasonic\x00");
 
-  let meta = exifast::parse_exif(&t).expect("parse ok").expect("TIFF");
+  let meta = exifast::parse_exif(&t).expect("TIFF");
   let mn = meta.maker_note().expect("MakerNote captured");
   // Dispatched to Panasonic (MakerNotePanasonic2 — make=Panasonic + "MKE").
   assert!(
@@ -923,7 +917,7 @@ fn sony_ericsson_does_not_run_main_parser() {
   assert_eq!(t.len(), 94);
   t.extend_from_slice(b"Sony Ericsson\x00");
 
-  let meta = exifast::parse_exif(&t).expect("parse ok").expect("TIFF");
+  let meta = exifast::parse_exif(&t).expect("TIFF");
   let mn = meta.maker_note().expect("MakerNote captured");
   assert!(
     mn.vendor().is_sony(),
@@ -1695,9 +1689,7 @@ fn leica10_dispatches_to_panasonic_main_image_quality() {
   use exifast::exif::makernotes::BaseRule;
   use exifast::value::TagValue;
 
-  let meta = exifast::parse_exif(LEICA10_TIFF)
-    .expect("parse ok")
-    .expect("TIFF recognized");
+  let meta = exifast::parse_exif(LEICA10_TIFF).expect("TIFF recognized");
   let mn = meta.maker_note().expect("MakerNote captured");
 
   // Dispatched as Leica10: Vendor::Leica, body_offset 18, inherit base.
@@ -1975,9 +1967,7 @@ fn leica1_dispatches_to_panasonic_main_image_quality() {
   use exifast::exif::makernotes::BaseRule;
   use exifast::value::TagValue;
 
-  let meta = exifast::parse_exif(LEICA1_TIFF)
-    .expect("parse ok")
-    .expect("TIFF recognized");
+  let meta = exifast::parse_exif(LEICA1_TIFF).expect("TIFF recognized");
   let mn = meta.maker_note().expect("MakerNote captured");
 
   // Dispatched as Leica1: Vendor::Leica, body_offset 8, inherit base.
@@ -2083,9 +2073,7 @@ fn leica1_serialized_keys_use_panasonic_group1() {
 #[cfg(all(feature = "exif", feature = "std", feature = "json"))]
 #[test]
 fn leica5_signature_make_not_leica_emits_no_panasonic() {
-  let meta = exifast::parse_exif(LEICA5_NEG_TIFF)
-    .expect("parse ok")
-    .expect("TIFF recognized");
+  let meta = exifast::parse_exif(LEICA5_NEG_TIFF).expect("TIFF recognized");
   let mn = meta.maker_note().expect("MakerNote captured");
   // Dispatched as Leica (a Leica5-signature blob), body_offset 8.
   assert!(mn.vendor().is_leica(), "vendor = Leica (Leica5 signature)");

--- a/tests/iter_tags.rs
+++ b/tests/iter_tags.rs
@@ -19,9 +19,7 @@ fn exif_iter_tags_carries_both_group_families() {
     "/tests/fixtures/Exif.tif"
   ))
   .unwrap();
-  let meta = exifast::parse_bytes(&data)
-    .unwrap()
-    .expect("TIFF recognized");
+  let meta = exifast::parse_bytes(&data).expect("TIFF recognized");
   assert!(matches!(meta, AnyMeta::Exif(_)), "got {meta:?}");
 
   let tags: Vec<exifast::Tag> = meta.iter_tags(ConvMode::PrintConv).collect();
@@ -105,9 +103,7 @@ fn quicktime_iter_tags_carries_quicktime_groups() {
     "/tests/fixtures/QuickTime_m4a.mov"
   ))
   .unwrap();
-  let meta = exifast::parse_bytes(&data)
-    .unwrap()
-    .expect("QuickTime recognized");
+  let meta = exifast::parse_bytes(&data).expect("QuickTime recognized");
   assert!(matches!(meta, AnyMeta::QuickTime(_)), "got {meta:?}");
 
   let tags: Vec<exifast::Tag> = meta.iter_tags(ConvMode::PrintConv).collect();
@@ -160,9 +156,7 @@ fn id3_iter_tags_family0_is_id3_not_frame_group() {
     "/tests/fixtures/ID3v2_3.mp3"
   ))
   .unwrap();
-  let meta = exifast::parse_bytes(&data)
-    .unwrap()
-    .expect("MP3 recognized");
+  let meta = exifast::parse_bytes(&data).expect("MP3 recognized");
   let tags: Vec<exifast::Tag> = meta.iter_tags(ConvMode::PrintConv).collect();
 
   // The ID3v2.3 frames carry family-0 `ID3`, family-1 `ID3v2_3`.
@@ -209,9 +203,7 @@ fn chained_id3v1_iter_tags_family0_is_id3() {
     "/tests/fixtures/Real.rm"
   ))
   .unwrap();
-  let meta = exifast::parse_bytes(&data)
-    .unwrap()
-    .expect("Real recognized");
+  let meta = exifast::parse_bytes(&data).expect("Real recognized");
   let tags: Vec<exifast::Tag> = meta.iter_tags(ConvMode::PrintConv).collect();
 
   // Container tags stay family-0 `Real`.

--- a/tests/no_panic.rs
+++ b/tests/no_panic.rs
@@ -14,3 +14,22 @@ proptest! {
         let _ = exifast::parse_bytes(&data);
     }
 }
+
+/// Golden-v2 Contract 3d — a couple of real truncated/nested fixtures must not
+/// panic through the public entry points (the `catch_unwind` backstop is the
+/// last line of defence; 3a/3b are the primary guarantee).
+#[test]
+fn truncated_and_nested_fixtures_never_panic() {
+  for name in ["ogg_truncated.ogg", "QuickTime_nested_trunc_mvhd.mov"] {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+      .join("tests")
+      .join("fixtures")
+      .join(name);
+    let Ok(data) = std::fs::read(&path) else {
+      // Fixture missing in this checkout — skip rather than fail.
+      continue;
+    };
+    let _ = exifast::parse_bytes(&data);
+    let _ = exifast::media_metadata(&data);
+  }
+}

--- a/tests/no_panic.rs
+++ b/tests/no_panic.rs
@@ -1,0 +1,16 @@
+//! Golden-v2 Contract 3b: public untrusted-input entry points must never panic.
+use proptest::prelude::*;
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 4096, ..ProptestConfig::default() })]
+    #[test] fn parse_bytes_never_panics(data in proptest::collection::vec(any::<u8>(), 0..4096)) { let _ = exifast::parse_bytes(&data); }
+    #[test] fn media_metadata_never_panics(data in proptest::collection::vec(any::<u8>(), 0..4096)) { let _ = exifast::media_metadata(&data); }
+    #[test] fn parse_exif_block_never_panics(data in proptest::collection::vec(any::<u8>(), 0..4096)) { let _ = exifast::parse_exif_block(&data); }
+}
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 4096, ..ProptestConfig::default() })]
+    #[test] fn parse_bytes_never_panics_atomish(chunks in proptest::collection::vec((any::<[u8;4]>(), any::<u32>()), 0..256)) {
+        let mut data = std::vec::Vec::new();
+        for (tag, size) in chunks { data.extend_from_slice(&size.to_be_bytes()); data.extend_from_slice(&tag); }
+        let _ = exifast::parse_bytes(&data);
+    }
+}

--- a/tests/png.rs
+++ b/tests/png.rs
@@ -29,9 +29,7 @@ fn read_fixture() -> Vec<u8> {
 #[test]
 fn bundled_png_parses_ihdr_dimensions_and_color_type() {
   let data = read_fixture();
-  let meta = parse_borrowed(&data)
-    .expect("parse_borrowed Ok")
-    .expect("PNG signature accepted");
+  let meta = parse_borrowed(&data).expect("PNG signature accepted");
   // PNG.png is 16x16, 1-bit grayscale (bundled `t/images/PNG.png`).
   assert_eq!(meta.dimensions(), Some((16, 16)));
   assert_eq!(meta.bit_depth(), Some(1));
@@ -44,7 +42,7 @@ fn bundled_png_parses_ihdr_dimensions_and_color_type() {
 #[test]
 fn bundled_png_captures_text_chunk_comment() {
   let data = read_fixture();
-  let meta = parse_borrowed(&data).expect("ok").expect("png");
+  let meta = parse_borrowed(&data).expect("png");
   // Bundled `perl exiftool -j t/images/PNG.png` emits `"Comment": "test
   // comment"` (tEXt chunk, PNG.pm:258-261). The on-disk keyword in this
   // fixture is lowercase `comment`; bundled's `ucfirst()` fallback
@@ -63,7 +61,7 @@ fn bundled_png_captures_text_chunk_comment() {
 #[test]
 fn bundled_png_captures_xmp_itxt_with_keyword() {
   let data = read_fixture();
-  let meta = parse_borrowed(&data).expect("ok").expect("png");
+  let meta = parse_borrowed(&data).expect("png");
   // iTXt with keyword `XML:com.adobe.xmp` — the XMP payload (bundled
   // PNG.pm:680-688 routes it to XMP::Main). Our port captures the
   // keyword + the UTF-8 body but DEFERS XMP dispatch.
@@ -79,7 +77,7 @@ fn bundled_png_captures_xmp_itxt_with_keyword() {
 #[test]
 fn bundled_png_warns_about_text_after_idat() {
   let data = read_fixture();
-  let meta = parse_borrowed(&data).expect("ok").expect("png");
+  let meta = parse_borrowed(&data).expect("png");
   // Bundled emits `Text/EXIF chunk(s) found after PNG IDAT (may be
   // ignored by some readers) [x2]` (PNG.pm:1595-1605) because the file
   // carries tEXt + iTXt AFTER the IDAT chunk.
@@ -2360,7 +2358,7 @@ fn engine_trailing_exif_typed_meta_records_trailer_boundary() {
     &[ihdr_gray_1x1(), chunk(b"IDAT", &zlib_store(&[0, 0]))],
     &chunk(b"eXIf", &exif),
   );
-  let meta = parse_borrowed(&bytes).expect("ok").expect("png");
+  let meta = parse_borrowed(&bytes).expect("png");
   // One EXIF event captured (the trailing eXIf).
   assert_eq!(meta.exif_events().len(), 1);
   // The first warning is the trailer warning (drives ExifTool:Warning).

--- a/tests/quicktime_stream.rs
+++ b/tests/quicktime_stream.rs
@@ -58,9 +58,7 @@ fn quicktime_mebx_timed_metadata_decodes_keys_table() {
   // value 123456. Bundled `-ee` ⇒ `Track1:GPSCoordinates = 123456`.
   let data = fixture("QuickTime_mebx_gps.mov");
   let golden = ee_golden("QuickTime_mebx_gps.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
   assert!(!stream.is_empty(), "mebx timed metadata must be decoded");
   // The keys-table mebx pair.
@@ -97,9 +95,7 @@ fn quicktime_mebx_float_array_value_reads_all_elements() {
   // `QuickTime_mebx_float.mov.ee.json`) ⇒ `Track1:TestMatrix = "1 2.5 -3 4.25"`.
   let data = fixture("QuickTime_mebx_float.mov");
   let golden = ee_golden("QuickTime_mebx_float.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
   let pairs = stream.mebx_samples();
   assert_eq!(pairs.len(), 1, "one mebx key/value pair");
@@ -134,9 +130,7 @@ fn quicktime_mebx_keys_table_name_resolution_and_value_conv() {
   //   Track1:SceneIlluminance = 1234, Track1:TestFooBar = "hi".
   let data = fixture("QuickTime_mebx_keys.mov");
   let golden = ee_golden("QuickTime_mebx_keys.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let pairs = meta.stream().mebx_samples();
   assert_eq!(pairs.len(), 2, "two mebx key/value pairs");
 
@@ -177,9 +171,7 @@ fn quicktime_mebx_live_photo_info_unpacks_le_blob() {
   //   -1000 200 250 -5 7 123456 2.5 -3.5 4 0.125 99 1000 65535".
   let data = fixture("QuickTime_mebx_livephoto.mov");
   let golden = ee_golden("QuickTime_mebx_livephoto.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let pairs = meta.stream().mebx_samples();
   assert_eq!(pairs.len(), 1, "one mebx key/value pair");
   assert_eq!(pairs[0].name(), "LivePhotoInfo");
@@ -217,9 +209,7 @@ fn quicktime_mebx_smartstyle_info_decodes_embedded_plist() {
   // in `QuickTimeStreamMeta::plist_subdir_tags`.
   let data = fixture("QuickTime_mebx_smartstyle.mov");
   let golden = ee_golden("QuickTime_mebx_smartstyle.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   // The embedded PLIST is NOT a scalar `mebx` pair (the SubDirectory replaces
   // the scalar) — it lands in the nested-PLIST tag list.
   assert!(
@@ -291,9 +281,7 @@ fn quicktime_mebx_detected_face_decodes_nested_atom_tree() {
   // toward +inf, NOT away-from-zero -2.345679).
   let data = fixture("QuickTime_mebx_detface.mov");
   let golden = ee_golden("QuickTime_mebx_detface.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
 
   // `detected-face` is a SubDirectory: its scalar form is NEVER emitted (the
@@ -384,9 +372,7 @@ fn quicktime_kenwood_gps_box_decodes_le_records() {
   // fix under `QuickTime:GPS*`.
   let data = fixture("QuickTime_gps_kenwood.mov");
   let golden = ee_golden("QuickTime_gps_kenwood.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
   assert_eq!(stream.gps_samples().len(), 2, "two Kenwood GPS records");
   let first = stream.first_fix().expect("a GPS fix");
@@ -419,9 +405,7 @@ fn quicktime_gps0_dudubell_decodes_binary_records() {
   // VSYS `gps0` box of 32-byte little-endian binary GPS records.
   let data = fixture("QuickTime_gps0.mov");
   let golden = ee_golden("QuickTime_gps0.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
   assert_eq!(stream.gps_samples().len(), 2, "two gps0 records");
   let first = stream.first_fix().expect("a GPS fix");
@@ -447,9 +431,7 @@ fn quicktime_gsen_dudubell_decodes_accelerometer() {
   // `gsen` box of 3-byte int8s accelerometer triples (scaled by 1/16).
   let data = fixture("QuickTime_gsen.mov");
   let golden = ee_golden("QuickTime_gsen.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
   assert_eq!(stream.gps_samples().len(), 2, "two gsen records");
   // First record: 16/16, -32/16, 48/16 ⇒ "1 -2 3" — exact match to the
@@ -467,9 +449,7 @@ fn quicktime_stream_empty_for_plain_video() {
   // A QuickTime file with no timed-metadata track ⇒ empty stream meta and no
   // embedded-Exif deferral (the existing SP1 fixture has neither).
   let data = fixture("QuickTime_sp1.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   assert!(
     meta.stream().is_empty(),
     "plain video has no timed metadata"
@@ -485,9 +465,7 @@ fn quicktime_media_metadata_projects_first_gps_fix() {
   // The normalized MediaMetadata projection fills GpsLocation from the FIRST
   // embedded timed-metadata GPS fix (SP3).
   let data = fixture("QuickTime_gps0.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let md = meta.media_metadata();
   let gps = md.gps().expect("GpsLocation projected from timed metadata");
   let lat = gps.latitude().expect("latitude");
@@ -504,9 +482,7 @@ fn quicktime_freegps_brute_force_scan_finds_block_in_mdat() {
   // and dispatch into `decode_type6_akaso`, producing one GPS sample
   // accessible via `Meta::stream`.
   let data = build_mov_with_freegps_in_mdat();
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
   assert_eq!(
     stream.gps_samples().len(),
@@ -532,9 +508,7 @@ fn quicktime_moov_gps_box_decodes_block_outside_mdat() {
   //   GPSDateTime 2024:07:15 14:30:45Z.
   let data = fixture("QuickTime_moov_gps.mov");
   let golden = ee_golden("QuickTime_moov_gps.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let stream = meta.stream();
   assert_eq!(
     stream.gps_samples().len(),
@@ -578,9 +552,7 @@ fn quicktime_frea_kodak_tags_decode_with_oracle_parity() {
   // the four tags under family-0 `MakerNotes`, family-1 `Kodak`.
   let data = fixture("QuickTime_frea_rexing17b.mov");
   let golden = ee_golden("QuickTime_frea_rexing17b.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
 
   // Typed accessor: the decoded `frea` values.
   let frea = meta.quicktime().kodak_frea();
@@ -593,7 +565,7 @@ fn quicktime_frea_kodak_tags_decode_with_oracle_parity() {
   // Rendered tag stream (the golden `Meta::tags()` path): the four tags emit
   // under family-0 `MakerNotes`, family-1 `Kodak`, with the bundled-parity
   // PrintConv values.
-  let any = parse_bytes(&data).expect("parse ok").expect("recognized");
+  let any = parse_bytes(&data).expect("recognized");
   assert!(matches!(any, AnyMeta::QuickTime(_)), "got {any:?}");
   let tags: Vec<exifast::Tag> = any.iter_tags(ConvMode::PrintConv).collect();
   let kodak: std::collections::HashMap<&str, &exifast::Tag> = tags
@@ -634,9 +606,7 @@ fn quicktime_frea_rexing_type17b_scales_gps_via_kodak_version() {
   // Bundled `-ee` ⇒ GPSLatitude 33.6697742486894, GPSLongitude
   // -112.096920485025 (verified vs ExifTool 13.59).
   let data = fixture("QuickTime_frea_rexing17b.mov");
-  let meta = parse_quicktime(&data)
-    .expect("parse ok")
-    .expect("recognized");
+  let meta = parse_quicktime(&data).expect("recognized");
   let fix = meta
     .stream()
     .first_fix()

--- a/tests/riff.rs
+++ b/tests/riff.rs
@@ -96,7 +96,7 @@ fn media_metadata_projection_from_riff() {
   let mut riff_meta = None;
   for cand in candidates {
     if let Some(p) = any_parser_for(cand.file_type())
-      && let Ok(Some(meta)) = p.parse_any(&data, &mut shared, Some("avi"), 0, None)
+      && let Some(meta) = p.parse_any(&data, &mut shared, Some("avi"), 0, None)
     {
       if let AnyMeta::Riff(rm) = meta {
         riff_meta = Some(rm);

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -187,9 +187,8 @@ fn typed_parse<'a>(fixture: &str, data: &'a [u8]) -> Option<exifast::AnyMeta<'a>
       cand.header_skip(),
       Some(cand.parent_type()),
     ) {
-      Ok(Some(meta)) => return Some(meta),
-      Ok(None) => shared = SharedFlags::new(),
-      Err(_) => shared = SharedFlags::new(),
+      Some(meta) => return Some(meta),
+      None => shared = SharedFlags::new(),
     }
   }
   None


### PR DESCRIPTION
Golden-v2 Phase A — the byte-/value-equivalent robustness + performance foundation (extends the L1–L4 golden pattern). Value-equivalent output throughout (conformance 331/0; spec §4 / jsondiff key-order-insensitive); Codex adversarial review: clean APPROVE.

**A.1 robustness (Contract 3):** recursion-depth budgets closing 3 stack-overflow DoS vectors (QuickTime atom walk + embedded-Exif descent; Flash AMF array walk; MXF SetGroups strong-ref tree — reachable from crafted large input); a proptest no-panic gate + a `cargo-fuzz` crate (`fuzz/`); a std-gated `catch_unwind` backstop at the public entry points.

**A.2 cleanup (spec §4):** deleted 26 uninhabited per-format error enums + the aggregate `AnyError` + the dead orchestrator `Err` arm; parse signatures (incl. public `parse_bytes`/`parse_exif`) now return `Option<Meta>` (honest — the never-`Err` `Result` was dead). `ByteReader` retained for a later phase.

**A.3 performance (Contract 4):** single-mode MakerNote vendor decode (was decoded twice, both ConvModes); O(1) `(family1,name)` last-wins `TagMap` dedup (was per-insert `format!` key + O(n²) scan) + direct JSON serialization (dropped the `serde_json::Map` round-trip); move-not-clone in `run_emission`; `SmolStr` for stored tag-name fields. **−46–56% allocations on camera files** (e.g. MakerNotes_Canon `-j` 2085→907). Pinned alloc-count regression test + criterion bench.

Tower campaign remains paused until all of golden-v2 lands.