### PR TITLE
feat(quicktime): CR3 CMT Exif/MakerNote (#148) + HEIF ispe image dimensions (#146)

### DIFF
--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -1239,8 +1239,38 @@ pub fn parse_standalone_tiff_with_base<'a>(
 #[must_use]
 pub fn parse_ctmd_exif_ifd_redispatch(block: &[u8]) -> Option<ExifMeta<'_>> {
   parse_tiff_with_base_no_raf(
-    block, /* base */ 0, /* tiff_type_is_tiff */ false, /* file_type */ None,
+    block,
+    /* base */ 0,
+    /* tiff_type_is_tiff */ false,
+    /* file_type */ None,
     /* no_raf */ true,
+    /* ifd0_kind */ IfdKind::Ifd0,
+  )
+}
+
+/// Parse a standalone TIFF block whose TOP-LEVEL directory IS a GPS IFD —
+/// the Canon CR3 `CMT4` box (Canon.pm:9719-9726
+/// `SubDirectory { Name => 'GPSInfo', TagTable => GPS::Main, ProcessProc =>
+/// ProcessTIFF, DirName => 'GPS' }`).
+///
+/// IDENTICAL to [`parse_exif_block`] (the embedded-block `ProcessTIFF` entry:
+/// `base == 0`, `tiff_type_is_tiff == false`, `file_type == None`, RAF-backed)
+/// EXCEPT IFD0 is walked against the `GPS::Main` table ([`IfdKind::Gps`]) instead
+/// of `Exif::Main`. A standard [`parse_exif_block`] would mis-decode `CMT4`: its
+/// IFD0 holds GPS tag IDs (`GPSVersionID` `0x0000`, …) that the `Exif::Main`
+/// table reads as unrelated / unknown tags — so the GPS table MUST drive the top
+/// directory, exactly as ExifTool's `CMT4` SubDirectory specifies. The recovered
+/// tags carry the family-1 group `"GPS"`. `None` for a block with no valid TIFF
+/// header (bad byte-order marker / IFD0 offset < 8).
+#[must_use]
+pub fn parse_gps_block(block: &[u8]) -> Option<ExifMeta<'_>> {
+  parse_tiff_with_base_no_raf(
+    block,
+    /* base */ 0,
+    /* tiff_type_is_tiff */ false,
+    /* file_type */ None,
+    /* no_raf */ false,
+    /* ifd0_kind */ IfdKind::Gps,
   )
 }
 
@@ -1310,18 +1340,29 @@ fn parse_tiff_with_base<'a>(
     tiff_type_is_tiff,
     file_type,
     /* no_raf */ false,
+    /* ifd0_kind */ IfdKind::Ifd0,
   )
 }
 
 /// [`parse_tiff_with_base`] with the no-RAF framing made explicit. `no_raf` is
 /// `false` for every caller except the Canon CTMD `0x8769` ExifIFD re-dispatch
 /// ([`parse_ctmd_exif_ifd_redispatch`]) — see [`Walker::no_raf`].
+///
+/// `ifd0_kind` is the [`IfdKind`] the TOP-LEVEL directory is walked as — almost
+/// always [`IfdKind::Ifd0`] (the standard `ProcessTIFF` entry, whose IFD0 uses
+/// `Exif::Main` and reaches GPS/ExifIFD/Interop via SubIFD pointers). The Canon
+/// CR3 `CMT4` box is the sole exception: ExifTool dispatches it through
+/// `SubDirectory { TagTable => GPS::Main, ProcessProc => ProcessTIFF }`
+/// (Canon.pm:9719-9726), so its top-level directory IS the GPS IFD —
+/// [`parse_gps_block`] passes [`IfdKind::Gps`] to walk IFD0 against the GPS
+/// table directly.
 fn parse_tiff_with_base_no_raf<'a>(
   data: &'a [u8],
   base: u32,
   tiff_type_is_tiff: bool,
   file_type: Option<&str>,
   no_raf: bool,
+  ifd0_kind: IfdKind,
 ) -> Option<ExifMeta<'a>> {
   // `length $$dataPt < 8` — the TIFF header is 8 bytes.
   if data.len() < 8 {
@@ -1385,8 +1426,10 @@ fn parse_tiff_with_base_no_raf<'a>(
     warn_count: 0,
   };
   // Walk the IFD0 → IFD1 chain (the next-IFD pointer). ExifIFD/GPS/Interop
-  // are reached as SubDirectories from inside the walk.
-  w.walk_ifd_chain(ifd0_offset, IfdKind::Ifd0);
+  // are reached as SubDirectories from inside the walk. `ifd0_kind` is `Ifd0`
+  // for the standard `ProcessTIFF` entry; the CR3 `CMT4` GPS block passes
+  // `Gps` so the top directory walks against the GPS table (Canon.pm:9719-9726).
+  w.walk_ifd_chain(ifd0_offset, ifd0_kind);
   // The Owned guard never raises a cross-source cycle-guard warning, so this
   // is always empty on the common path — assert it to lock the invariant.
   debug_assert!(

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -4573,6 +4573,10 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // offset 0, so the folded `h.abs_start` offsets stay file-absolute.
   let mut heif_meta = crate::metadata::HeifMeta::new();
   let mut cr3_meta = crate::metadata::Cr3Meta::new();
+  // The file-walk `$$self{Model}` for the Canon `uuid` CMT3 dispatch — a single
+  // value threaded across the whole brand walk so a CMT3 sees the most-recent
+  // preceding CMT1 `Model`, even one in an earlier Canon `uuid` atom.
+  let mut canon_uuid_model: Option<smol_str::SmolStr> = None;
   crate::formats::quicktime_brands::scan_quicktime_brands(
     scan_data,
     0,
@@ -4580,6 +4584,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
     0,
     &mut heif_meta,
     &mut cr3_meta,
+    &mut canon_uuid_model,
   );
 
   // SP4 — CR3 / CRM file-type override. Canon.pm:9667 `OverrideFileType
@@ -4897,9 +4902,6 @@ impl crate::diagnostics::Diagnose for Meta<'_> {
       out.push(crate::diagnostics::Diagnostic::warn(w));
     }
     if heif_first && let Some(w) = self.warning() {
-      out.push(crate::diagnostics::Diagnostic::warn(w));
-    }
-    if let Some(w) = self.cr3().warning() {
       out.push(crate::diagnostics::Diagnostic::warn(w));
     }
     if let Some(w) = self.ligogps().warning() {
@@ -7052,6 +7054,17 @@ impl crate::emit::Taggable for Meta<'_> {
         false,
       ));
     }
+    // CR3 CMT1-4 Exif / GPS / Canon-MakerNote (#148). The `Image::ExifTool::
+    // Canon::uuid` table re-dispatches each CMT box body — a self-contained TIFF
+    // — through `ProcessTIFF` / `ProcessCMT3` (Canon.pm:9686-9726):
+    //   CMT1 → IFD0    (`Exif::Main`)      → `EXIF:IFD0`
+    //   CMT2 → ExifIFD (`Exif::Main`)      → `EXIF:ExifIFD`
+    //   CMT3 → MakerNoteCanon (`Canon::Main` via `ProcessCMT3`) → `MakerNotes:Canon`
+    //   CMT4 → GPSInfo (`GPS::Main`)       → `EXIF:GPS`
+    // The blocks were parsed EAGERLY at walk time and their tags rendered for
+    // both modes onto `Cr3Meta`; emit the active mode's slice here (the
+    // always-on document axis, regardless of `-ee`).
+    emit_cr3_cmt(self.cr3(), print_conv, &mut tags);
     // HEIF PrimaryItemReference (`%QuickTime::Meta` pitm, QuickTime.pm:2883):
     // the `$$self{PrimaryItem}` id under `QuickTime`/`Meta` (the `%QuickTime::
     // Meta` table `GROUPS => { 1 => 'Meta' }`). No PrintConv (the RawConv
@@ -7065,6 +7078,29 @@ impl crate::emit::Taggable for Meta<'_> {
         false,
       ));
     }
+    // HEIF `File:ImageWidth` / `File:ImageHeight` (#146) from the PRIMARY item's
+    // `ispe` (ImageSpatialExtent, QuickTime.pm:3034-3047). The `ispe` `RawConv`
+    // `FoundTag(ImageWidth/ImageHeight)` runs only for the primary (main-document)
+    // item; the `%Image::ExifTool::Extra` `ImageWidth`/`ImageHeight` tags have
+    // GROUPS `File,File` and no PrintConv ⇒ a bare int in both modes. ImageWidth
+    // BEFORE ImageHeight (the `ispe` RawConv FoundTag order). Oracle
+    // (QuickTime.heic): `File:ImageWidth = 1596`, `File:ImageHeight = 1064`.
+    if let Some(w) = self.heif().image_width() {
+      tags.push(EmittedTag::new(
+        Group::new("File", "File"),
+        "ImageWidth".into(),
+        TagValue::U64(u64::from(w)),
+        false,
+      ));
+    }
+    if let Some(h) = self.heif().image_height() {
+      tags.push(EmittedTag::new(
+        Group::new("File", "File"),
+        "ImageHeight".into(),
+        TagValue::U64(u64::from(h)),
+        false,
+      ));
+    }
 
     // NOTE: the SP3 embedded-Exif hop deferral warning is NOT part of the
     // `Taggable` stream (`run_emission` has no warning channel). It flows
@@ -7072,6 +7108,42 @@ impl crate::emit::Taggable for Meta<'_> {
     // the `ProcessMOV` warning.
     tags.into_iter()
   }
+}
+
+/// Emit the Canon CR3 `CMT1`/`CMT2`/`CMT3`/`CMT4` recovered tags (#148).
+///
+/// The `Image::ExifTool::Canon::uuid` table (Canon.pm:9686-9726) re-dispatches
+/// each CMT box body — a self-contained TIFF block carrying its own `II*\0` /
+/// `MM\0*` header + IFD — through `ProcessTIFF` (CMT1/2/4) or `ProcessCMT3`
+/// (CMT3). The four blocks map to four faithful family-0/1 groups:
+///
+/// | box  | ExifTool `Name`/table          | emitted group        |
+/// |------|--------------------------------|----------------------|
+/// | CMT1 | `IFD0` / `Exif::Main`          | `EXIF:IFD0`          |
+/// | CMT2 | `ExifIFD` / `Exif::Main`       | `EXIF:ExifIFD`       |
+/// | CMT3 | `MakerNoteCanon` / `Canon::Main` | `MakerNotes:Canon` |
+/// | CMT4 | `GPSInfo` / `GPS::Main`        | `EXIF:GPS`           |
+///
+/// The blocks are parsed EAGERLY during the Canon-`uuid` walk
+/// ([`walk_canon_uuid`](crate::formats::quicktime_brands::walk_canon_uuid)),
+/// in the file order ExifTool's `ProcessMOV` encountered them, with
+/// `$$self{Model}` threaded from each preceding CMT1 IFD0 (so a CMT3 before any
+/// CMT1 sees no Model, a model-less CMT1 leaves an earlier Model in place) and
+/// the IFD0 re-stamp / `MakerNotes:Canon` routing / `File:ExifByteOrder`
+/// passthrough applied at the walk. The decoded tags are rendered for BOTH conv
+/// modes and stored on [`Cr3Meta`](crate::metadata::Cr3Meta); this emitter just
+/// pushes the slice for the active mode (the raw box bytes are never retained,
+/// so there is nothing to re-parse here). The sink dedups the three identical
+/// `File:ExifByteOrder` copies. For a real CR3 (one CMT1<CMT2<CMT3<CMT4) the
+/// file order equals the type order ⇒ emission is byte-identical to the prior
+/// re-parse-at-emit pass.
+#[cfg(feature = "alloc")]
+fn emit_cr3_cmt(
+  cr3: &crate::metadata::Cr3Meta,
+  print_conv: bool,
+  out: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  out.extend(cr3.cmt_tags(print_conv).iter().cloned());
 }
 
 /// Emit a timed-metadata GPS sample series faithfully. `extract_embedded=false`

--- a/src/formats/quicktime_brands.rs
+++ b/src/formats/quicktime_brands.rs
@@ -59,12 +59,18 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "alloc")]
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{
+  collections::{BTreeMap, BTreeSet},
+  string::String,
+  vec::Vec,
+};
 
 use smol_str::SmolStr;
 
 use crate::formats::quicktime::MAX_ATOM_DEPTH;
-use crate::metadata::{Cr3Block, Cr3Meta, HeifExtent, HeifItem, HeifMeta, Jp2Block, Jp2Meta};
+use crate::metadata::{
+  Cr3Block, Cr3CmtKind, Cr3Meta, HeifExtent, HeifItem, HeifMeta, Jp2Block, Jp2Meta,
+};
 
 // ===========================================================================
 // %ftypLookup brand → (file_type, MIME)
@@ -611,6 +617,15 @@ pub fn walk_heif_meta(body: &[u8], meta_abs_offset: u64, child_start: usize, out
     .enumerate()
     .map(|(idx, it)| (it.id(), idx))
     .collect();
+  // #146 — the `iprp` property store: each decoded `ispe`'s 1-based `ipco`
+  // property index + dims, plus the `ipma` item→property associations. Both are
+  // collected during the walk and resolved into `File:ImageWidth`/`Height` AFTER
+  // it completes, mirroring ExifTool's delayed `ipco` processing (QuickTime.pm:
+  // 10361-10364 defers `ipco` until `ipma` + `pitm` are known). The property
+  // index is a `u32` with a checked increment so an `ipco` with >65535 children
+  // cannot overflow a narrower counter and alias one property index onto another.
+  let mut ispe_props: Vec<(u32, u32, u32)> = Vec::new();
+  let mut ipma_assoc: Vec<(u32, Vec<u16>)> = Vec::new();
   walk_boxes(children, children_abs, Size0Behavior::Stop, |h| {
     match h.tag {
       // pitm — PrimaryItemReference (QuickTime.pm:2883-2892).
@@ -764,17 +779,67 @@ pub fn walk_heif_meta(body: &[u8], meta_abs_offset: u64, child_start: usize, out
       }
       // iprp — ItemProperties (QuickTime.pm:2897-2900). A container whose
       // children are `ipco` (the property store) and `ipma` (the item→
-      // property associations). SP4 descends only far enough to run the
-      // `ipma` order check (the sibling of the `iinf` out-of-order warning)
-      // and surface ipco/ipma PRESENCE.
-      // TODO(#146): the `ipco` property EXTRACTION (ImageSpatialExtent /
-      // Rotation / Mirroring / ColorSpec) and the per-item `ipma`
-      // Association/Essential VALUES are deferred; this arm discards the
-      // association bytes and only emits the out-of-order warning.
+      // property associations).
+      //
+      // #146 — decode the `ipco` `ispe` (ImageSpatialExtent) property boxes
+      // keyed by their 1-based property index, AND capture the `ipma`
+      // associations, so the primary item's `ispe` resolves to
+      // `File:ImageWidth`/`File:ImageHeight` after the walk. `ipma_order_walk`
+      // also keeps the out-of-order warning (the sibling of the `iinf` check).
+      // The `irot`/`colr`/`pixi` properties are NOT surfaced (no bundled HEIC
+      // fixture exercises them to ground-truth the group/PrintConv).
       b"iprp" => {
         walk_boxes(h.body, 0, Size0Behavior::Stop, |child| {
-          if child.tag == b"ipma" {
-            ipma_order_walk(child.body, meta_abs_offset, out);
+          match child.tag {
+            b"ipco" => {
+              // The `ipco` children are property boxes in declaration order;
+              // ExifTool addresses them by 1-based index (QuickTime.pm:9119,
+              // the `ipma` Association indices). Record each `ispe`'s decoded
+              // dims at its index for the deferred-resolution pass below.
+              //
+              // A SECOND `ipco` in the same `meta` REPLACES the first — it does
+              // NOT accumulate. ExifTool DEFERS the `ipco` directory by a plain
+              // ASSIGNMENT `$$et{ItemPropertyContainer} = [ \%dirInfo, ... ]`
+              // (QuickTime.pm:10363) and `%dupDirOK` whitelists `ipco`
+              // (QuickTime.pm:510), so a later `ipco` overwrites the stored
+              // container and ONLY the LAST one is processed after the meta walk
+              // (QuickTime.pm:9530-9534). The `ipma` association indices then
+              // refer into the LAST `ipco`'s property list. So decode each
+              // `ipco` into a FRESH per-container list and OVERWRITE the pending
+              // `ispe_props` — a stale earlier-`ipco` `ispe` must not survive
+              // (oracle: ipco#1[ispe…] + ipco#2[ispe(W×H)] → the dims resolve
+              // against ipco#2 only).
+              //
+              // The counter is a `u32` with a CHECKED increment so an `ipco`
+              // with >65535 children cannot overflow a narrower type (a debug
+              // panic / release wrap that would alias a high property index
+              // onto a low one). EVERY decoded `ispe` is recorded regardless of
+              // index: ExifTool walks every `ipco` child positionally and a
+              // property is bound to an item only by an `ipma` association, so
+              // an `ispe` at a high index that no `ipma` row references is still
+              // a "main-document" property and FoundTags `ImageWidth`/`Height`
+              // (oracle: a lone `ispe` at `ipco` index 65537 → `File:ImageWidth`
+              // = its width). The list is input-bounded — each `ispe` box is
+              // ≥20 bytes in the file, so the count cannot exceed `len / 20`.
+              let mut this_ipco: Vec<(u32, u32, u32)> = Vec::new();
+              let mut prop_index: u32 = 0;
+              walk_boxes(child.body, 0, Size0Behavior::Stop, |prop| {
+                let Some(next) = prop_index.checked_add(1) else {
+                  return;
+                };
+                prop_index = next;
+                if prop.tag == b"ispe"
+                  && let Some((w, hh)) = decode_ispe(prop.body)
+                {
+                  this_ipco.push((prop_index, w, hh));
+                }
+              });
+              ispe_props = this_ipco;
+            }
+            b"ipma" => {
+              ipma_order_walk(child.body, meta_abs_offset, out, &mut ipma_assoc);
+            }
+            _ => {}
           }
         });
       }
@@ -785,6 +850,21 @@ pub fn walk_heif_meta(body: &[u8], meta_abs_offset: u64, child_start: usize, out
       _ => {}
     }
   });
+  // #146 — emit `File:ImageWidth`/`ImageHeight` from the `ipco` `ispe` boxes.
+  // Done AFTER the walk so `pitm` + `ipma` are known regardless of box order
+  // (ExifTool defers `ipco` until both are set, QuickTime.pm:10361-10364).
+  //
+  // Run whenever THIS meta decoded at least one `ispe`; the association list may
+  // be empty (an unassociated `ispe` is still main-document, see
+  // [`emit_ispe_dimensions`]). `scan_quicktime_brands` walks EVERY `meta` box
+  // into the SAME `HeifMeta`; ExifTool FoundTags `ImageWidth`/`Height` per
+  // main-document `ispe` cumulatively over the whole file, so this NEVER clears
+  // — a later `meta` with no main-document `ispe` (or no `ispe` at all) leaves
+  // the earlier dims intact, and a later main-document `ispe` overrides them
+  // (last-wins).
+  if !ispe_props.is_empty() {
+    emit_ispe_dimensions(&ispe_props, &ipma_assoc, out);
+  }
 }
 
 /// Parse a single `infe` box body into a [`HeifItem`]. Faithful port of
@@ -910,7 +990,12 @@ fn parse_infe(buf: &[u8]) -> Option<HeifItem> {
 /// sibling of the `iinf` out-of-order warning. `meta_abs_offset` is the
 /// enclosing `meta` box's absolute file offset, recorded alongside the warning
 /// (first-wins) so the document-level drain can order it by file position (#159).
-fn ipma_order_walk(body: &[u8], meta_abs_offset: u64, out: &mut HeifMeta) {
+fn ipma_order_walk(
+  body: &[u8],
+  meta_abs_offset: u64,
+  out: &mut HeifMeta,
+  assoc_out: &mut Vec<(u32, Vec<u16>)>,
+) {
   // QuickTime.pm:9295 `return undef if $len < 8`.
   if body.len() < 8 {
     return;
@@ -966,7 +1051,9 @@ fn ipma_order_walk(body: &[u8], meta_abs_offset: u64, out: &mut HeifMeta) {
     };
     pos += 1;
     // QuickTime.pm:9313-9328 — 2 bytes per association when the flags low bit
-    // is set, else 1 byte. The association VALUES are #146; advance past them.
+    // is set, else 1 byte. The low 15/7 bits are the 1-based `ipco` property
+    // index; the top bit is the Essential flag (#146 records the index only —
+    // the property store dispatch needs it to resolve the primary item's `ispe`).
     let assoc_bytes = if flg & 0x01 != 0 {
       usize::from(n) * 2
     } else {
@@ -976,6 +1063,23 @@ fn ipma_order_walk(body: &[u8], meta_abs_offset: u64, out: &mut HeifMeta) {
     if pos + assoc_bytes > len {
       return;
     }
+    let mut indices: Vec<u16> = Vec::with_capacity(usize::from(n));
+    if flg & 0x01 != 0 {
+      // 2-byte entries: `Get16u & 0x7fff` (QuickTime.pm:9317).
+      for j in 0..usize::from(n) {
+        if let Some(tmp) = be_u16(body, pos + j * 2) {
+          indices.push(tmp & 0x7fff);
+        }
+      }
+    } else {
+      // 1-byte entries: `Get8u & 0x7f` (QuickTime.pm:9324).
+      for j in 0..usize::from(n) {
+        if let Some(&tmp) = body.get(pos + j) {
+          indices.push(u16::from(tmp & 0x7f));
+        }
+      }
+    }
+    assoc_out.push((id, indices));
     pos += assoc_bytes;
     // QuickTime.pm:9334 `Warn(...) unless $id > $lastID`; 9335 `$lastID = $id`.
     if let Some(prev) = last_id
@@ -989,6 +1093,102 @@ fn ipma_order_walk(body: &[u8], meta_abs_offset: u64, out: &mut HeifMeta) {
       );
     }
     last_id = Some(id);
+  }
+}
+
+/// Decode an `ispe` (ImageSpatialExtent) box body → `(width, height)` (#146).
+///
+/// Faithful to QuickTime.pm:3034-3046: the box is `[version/flags 4 bytes]
+/// [width int32u BE][height int32u BE]`, gated on `Condition => $$valPt =~
+/// /^\0{4}/` (version/flags == 0). The `RawConv` `unpack("x4N*", $val)` skips
+/// the 4-byte FullBox header and reads the u32 BE dimension array; `return undef
+/// if @dim < 2`. Returns `None` for a non-zero version/flags word or a body
+/// shorter than 12 bytes.
+fn decode_ispe(body: &[u8]) -> Option<(u32, u32)> {
+  // `Condition => '$$valPt =~ /^\0{4}/'` — version/flags must be all-zero.
+  if body.get(..4) != Some(&[0, 0, 0, 0]) {
+    return None;
+  }
+  let width = be_u32(body, 4)?;
+  let height = be_u32(body, 8)?;
+  Some((width, height))
+}
+
+/// Emit `File:ImageWidth`/`File:ImageHeight` from this `meta`'s decoded `ipco`
+/// `ispe` boxes, applying ExifTool's `DOC_NUM` main-document gate (#146).
+///
+/// ExifTool FoundTags `ImageWidth`/`ImageHeight` from the `ispe` `RawConv`
+/// `unless ($$self{DOC_NUM})` (QuickTime.pm:3037-3045). The `ipco` container is
+/// processed LAST (after `ipma` + `pitm`, QuickTime.pm:10361-10364) with
+/// `IsItemProperty` set, and `DOC_NUM` is then derived per property index from
+/// the item→property associations (QuickTime.pm:10196-10238):
+///   * A property whose index NO item associates → `DOC_NUM` left undef → main
+///     document → emits.
+///   * A property associated with the PRIMARY item (`pitm`) → main document →
+///     emits. (For `ispe`, `%dontInherit{ispe} == 1` (QuickTime.pm:497) disables
+///     the refers-to-primary inheritance branches, so ONLY a direct primary
+///     association — or no association at all — counts as main-document.)
+///   * A property associated ONLY by non-primary item(s) → a sub-document
+///     `DOC_NUM` → gated OUT (no dims).
+///
+/// Among all main-document `ispe`, ExifTool's duplicate-`ImageWidth` handling is
+/// last-FoundTag-wins (the non-list `File:ImageWidth` is overwritten in `ipco`
+/// walk order). So this walks `ispe_props` in `ipco` order and keeps the LAST
+/// main-document one (oracle: two unassociated `ispe` 640×480 then 1280×960 →
+/// `File:ImageWidth` = 1280; QuickTime.heic's primary `ispe` at index 2 →
+/// 1596×1064, its index-4 thumbnail `ispe` gated out).
+///
+/// NEVER clears `out`: ExifTool's FoundTag is cumulative across the whole file,
+/// so a later `meta` with no main-document `ispe` leaves the earlier dims intact
+/// (oracle: meta1 primary `ispe` 640×480 + meta2 whose `ispe` is associated only
+/// to a non-primary item → `File:ImageWidth` stays 640), while a later
+/// main-document `ispe` overrides (oracle: meta2's primary `ispe` 11×22 wins).
+fn emit_ispe_dimensions(
+  ispe_props: &[(u32, u32, u32)],
+  assoc: &[(u32, Vec<u16>)],
+  out: &mut HeifMeta,
+) {
+  // `$$et{PrimaryItem} || 0` (QuickTime.pm:10199): ExifTool's Perl `|| 0` folds
+  // a MISSING `pitm` (or a `pitm` of 0) to the EFFECTIVE primary item id `0`. So
+  // an `ipma` row for item id 0 then matches the primary (`$id == $primary`) and
+  // its associated `ispe` is main-document — a no-`pitm` file with an item-0
+  // association DOES emit dims (oracle: no `pitm` + `ipma`{0 → ispe(111×222)} →
+  // `File:ImageWidth` 111). With no `pitm` and only non-zero-id associations,
+  // item 0 has no row so every associated `ispe` is a sub-document and only
+  // UNassociated `ispe` stay main-document.
+  let primary = out.primary_item().unwrap_or(0);
+
+  // Precompute the effective association ONCE, instead of rescanning `assoc`
+  // per `ispe`. A duplicate `ipma` row for an id overwrites the prior one
+  // (QuickTime.pm:9331 `$$items{$id}{Association} = \@association`, a plain `=`),
+  // so the LAST row per id is authoritative. Iterating rows in file order and
+  // overwriting the per-id entry reproduces that last-wins rule (the old
+  // `rfind`-per-distinct-id walk computed the same set, just quadratically).
+  let mut effective: BTreeMap<u32, BTreeSet<u32>> = BTreeMap::new();
+  for (id, indices) in assoc {
+    effective.insert(*id, indices.iter().map(|&i| u32::from(i)).collect());
+  }
+
+  // Derive the two per-`ipco`-index lookups in one pass over the effective sets:
+  // every property index referenced by ANY item, and those referenced by the
+  // PRIMARY item. Total work is O(distinct ids × associations per id) = O(input),
+  // done once rather than once per `ispe`.
+  let mut associated_by_any: BTreeSet<u32> = BTreeSet::new();
+  let mut associated_by_primary: BTreeSet<u32> = BTreeSet::new();
+  for (id, indices) in &effective {
+    associated_by_any.extend(indices.iter().copied());
+    if *id == primary {
+      associated_by_primary = indices.clone();
+    }
+  }
+
+  // Walk `ispe_props` in `ipco` order ONCE. Main-document iff no item associates
+  // the index OR the primary does; the in-order walk keeps the LAST such `ispe`.
+  for &(index, w, h) in ispe_props {
+    if !associated_by_any.contains(&index) || associated_by_primary.contains(&index) {
+      out.set_image_width(Some(w));
+      out.set_image_height(Some(h));
+    }
   }
 }
 
@@ -1178,13 +1378,141 @@ const CANON_UUID: [u8; 16] = [
   0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0, 0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48,
 ];
 
+/// Render one parsed CMT Exif block (`ExifMeta`) into [`EmittedTag`]s for the
+/// requested conv mode, re-stamping its TOP-LEVEL `IFD0` directory to
+/// `top_family1` (CMT1 → `"IFD0"`; CMT2 → `"ExifIFD"`). The
+/// `File:ExifByteOrder` marker (family-0 `File`) and any NESTED sub-IFD group
+/// (ExifIFD/GPS/InteropIFD/IFD1) pass through verbatim — mirroring the CTMD
+/// re-stamp. `meta` is borrowed, so this is called twice (once per mode) on the
+/// SAME parse.
+#[cfg(feature = "alloc")]
+fn render_exif_block(
+  meta: &crate::exif::ExifMeta<'_>,
+  top_family1: &str,
+  print_conv: bool,
+) -> Vec<crate::emit::EmittedTag> {
+  use crate::emit::{EmittedTag, Taggable};
+  use crate::value::Group;
+  let opts =
+    crate::emit::EmitOptions::g1(crate::emit::ConvMode::from_print_conv(print_conv), false);
+  let mut out = Vec::new();
+  for tag in meta.tags(opts) {
+    let unknown = tag.unknown();
+    let (group, name, value) = tag.into_tag().into_parts();
+    let restamped = if group.family0() == "File" {
+      // `File:ExifByteOrder` (and the gated `File:PageCount`, never set for an
+      // embedded block) keep their `File:File` group.
+      group
+    } else if group.family1() == "IFD0" {
+      // The generic walker's top-level directory → the box's SubDirectory Name.
+      Group::new("EXIF", top_family1)
+    } else {
+      // A nested sub-IFD (ExifIFD/GPS/InteropIFD/IFD1) keeps its DirName.
+      group
+    };
+    out.push(EmittedTag::new(restamped, name, value, unknown));
+  }
+  out
+}
+
+/// Render a CMT3 Canon-MakerNote block (a self-contained TIFF whose IFD0 IS the
+/// Canon MakerNote) into `MakerNotes:Canon` [`EmittedTag`]s for the requested
+/// mode, threading `model` (`$$self{Model}` of the most-recent PRECEDING CMT1)
+/// into `Canon::Main` for its model-conditional sub-tables. Routes through
+/// [`redispatch_ctmd_makernote`](crate::exif::makernotes::vendors::canon::redispatch_ctmd_makernote)
+/// (the SAME `ProcessTIFF`-under-`Canon::Main` machinery CTMD's `0x927c` uses).
+#[cfg(feature = "alloc")]
+fn render_cmt3_block(
+  body: &[u8],
+  print_conv: bool,
+  model: Option<&str>,
+) -> Vec<crate::emit::EmittedTag> {
+  use crate::emit::EmittedTag;
+  use crate::value::Group;
+  let group = Group::new("MakerNotes", "Canon");
+  crate::exif::makernotes::vendors::canon::redispatch_ctmd_makernote(body, print_conv, model)
+    .into_iter()
+    .map(|e| {
+      EmittedTag::new(
+        group.clone(),
+        smol_str::SmolStr::new(e.name()),
+        e.value().clone(),
+        e.unknown(),
+      )
+    })
+    .collect()
+}
+
+/// Render a CMT4 GPS block (walked top-level against the GPS table) into
+/// [`EmittedTag`]s for the requested mode. `meta` is borrowed, so this is
+/// called twice (once per mode) on the SAME parse.
+#[cfg(feature = "alloc")]
+fn render_gps_block(
+  meta: &crate::exif::ExifMeta<'_>,
+  print_conv: bool,
+) -> Vec<crate::emit::EmittedTag> {
+  use crate::emit::Taggable;
+  let opts =
+    crate::emit::EmitOptions::g1(crate::emit::ConvMode::from_print_conv(print_conv), false);
+  meta.tags(opts).collect()
+}
+
 /// Walk a Canon-UUID atom body and populate `out`. The UUID prefix has
 /// ALREADY been stripped — `body` is the post-`Start => 16` payload
 /// (QuickTime.pm:1240).
 ///
 /// `abs_offset` is the absolute file offset of `body`'s first byte —
 /// used so CMT block offsets stay file-absolute.
+///
+/// Each CMT1-4 box is a self-contained TIFF / Canon-MakerNote block that
+/// ExifTool re-dispatches through `ProcessTIFF` / `ProcessCMT3`
+/// (Canon.pm:9686-9726): CMT1 → IFD0 (`Exif::Main`), CMT2 → ExifIFD
+/// (`Exif::Main`), CMT3 → MakerNoteCanon (`Canon::Main` via `ProcessCMT3`),
+/// CMT4 → GPS (`GPS::Main`). Those bodies are parsed EAGERLY here, in FILE
+/// order, while the input buffer is in scope — the body is a SUB-SLICE of the
+/// loaded input ([`walk_boxes`] rejects any box whose declared length exceeds
+/// the buffer), so the parse borrows it with NO copy. The decoded tags are
+/// rendered for BOTH conv modes (`-j` PrintConv + `-n` ValueConv, since
+/// emission is mode-dependent) and the resulting OWNED [`EmittedTag`]s stored
+/// on `out` ([`Cr3Meta::push_cmt_tags`]). The raw box bytes are NEVER retained;
+/// only the box LOCATION (offset + length) is recorded
+/// ([`Cr3Meta::record_cmt_location`], a fixed per-kind slot).
+///
+/// This bounds the total CMT allocation to the parsed TAG count (the Exif
+/// walker already caps IFD entries) — proportional to the input size, with NO
+/// per-box growth (an empty CMT box yields no tags) and NO per-`uuid`-atom
+/// amplification (every box appends to the SAME `out`, there is no running
+/// per-atom budget to reset). So multiple moov-level Canon `uuid` atoms, or
+/// millions of tiny / empty CMT boxes, can neither blow memory nor spin CPU.
+///
+/// `$$self{Model}` is FILE-WALK object state, NOT per-`uuid`-atom: ExifTool sets
+/// it whenever ANY IFD0 / CMT1 `Model` (0x0110) is handled, and it persists for
+/// the rest of the moov tree walk. So a CMT3's model-conditional dispatch reads
+/// the most-recent PRECEDING CMT1 `Model` even when that CMT1 was in an EARLIER
+/// Canon `uuid` atom. To match that, the model state is owned by the SCAN
+/// ([`scan_quicktime_brands`]) and threaded in through `current_model` so it
+/// survives across multiple Canon `uuid` atoms in file order. This entry point
+/// is a thin wrapper that runs an ISOLATED walk with a FRESH `None` state (for
+/// standalone callers); the scan uses [`walk_canon_uuid_with_state`] directly.
+/// ExifTool only ASSIGNS `$$self{Model}` when a `Model` tag is handled, so a
+/// model-LESS CMT1 does NOT clear an earlier Model, and a CMT3 before ANY CMT1
+/// sees `None`.
 pub fn walk_canon_uuid(body: &[u8], abs_offset: u64, out: &mut Cr3Meta) {
+  let mut current_model: Option<SmolStr> = None;
+  walk_canon_uuid_with_state(body, abs_offset, out, &mut current_model);
+}
+
+/// [`walk_canon_uuid`] threaded with the FILE-WALK `$$self{Model}` state
+/// (`current_model`) so it persists across multiple Canon `uuid` atoms — the
+/// IFD0 `Model` of the most-recent PRECEDING CMT1 that actually carried one. A
+/// CMT1 with a `Model` UPDATES it; a model-less CMT1 leaves it; a CMT3 READS it
+/// for model-conditional Canon MakerNote sub-tables (Canon.pm:1834, `0x96`).
+pub fn walk_canon_uuid_with_state(
+  body: &[u8],
+  abs_offset: u64,
+  out: &mut Cr3Meta,
+  current_model: &mut Option<SmolStr>,
+) {
   walk_boxes(body, abs_offset, Size0Behavior::Stop, |h| {
     match h.tag {
       // CNCV — CompressorVersion (Canon.pm:9666-9669). The body is an ASCII
@@ -1222,49 +1550,71 @@ pub fn walk_canon_uuid(body: &[u8], abs_offset: u64, out: &mut Cr3Meta) {
           out.set_compressor_version(Some(SmolStr::from(s)));
         }
       }
-      // CMT1 / CMT2 / CMT3 / CMT4 — file-offset + length records.
+      // CMT1 — IFD0 (`Exif::Main`). Parsed ONCE; the parse both updates the
+      // file-walk `$$self{Model}` (read by a later CMT3, even one in a LATER
+      // Canon `uuid` atom) and renders the IFD0 tags for both modes. The Model
+      // is updated ONLY when this CMT1 actually carries one (a model-less CMT1
+      // does not clear an earlier Model).
       b"CMT1" => {
-        let mut b = Cr3Block::new();
-        // Offset is the absolute start of the box payload (past the real
-        // header), and length is the exact payload byte count.
-        b.set_offset(h.body_abs_start)
-          .set_length(h.body.len() as u64);
-        out.set_cmt1(Some(b));
+        out.record_cmt_location(
+          Cr3CmtKind::Cmt1,
+          Cr3Block::at(h.body_abs_start, h.body.len() as u64),
+        );
+        if let Some(meta) = crate::exif::parse_exif_block(h.body) {
+          if let Some(model) = meta.dispatcher_model() {
+            *current_model = Some(SmolStr::new(model));
+          }
+          let print = render_exif_block(&meta, "IFD0", true);
+          let value = render_exif_block(&meta, "IFD0", false);
+          out.push_cmt_tags(print, value);
+        }
       }
+      // CMT2 — ExifIFD (`Exif::Main`).
       b"CMT2" => {
-        let mut b = Cr3Block::new();
-        b.set_offset(h.body_abs_start)
-          .set_length(h.body.len() as u64);
-        out.set_cmt2(Some(b));
+        out.record_cmt_location(
+          Cr3CmtKind::Cmt2,
+          Cr3Block::at(h.body_abs_start, h.body.len() as u64),
+        );
+        if let Some(meta) = crate::exif::parse_exif_block(h.body) {
+          let print = render_exif_block(&meta, "ExifIFD", true);
+          let value = render_exif_block(&meta, "ExifIFD", false);
+          out.push_cmt_tags(print, value);
+        }
       }
+      // CMT3 — MakerNoteCanon (`Canon::Main` via `ProcessCMT3`), threaded with
+      // the file-walk `$$self{Model}` of the most-recent PRECEDING CMT1 (or
+      // `None`) — which may have been set in an EARLIER Canon `uuid` atom.
       b"CMT3" => {
-        let mut b = Cr3Block::new();
-        b.set_offset(h.body_abs_start)
-          .set_length(h.body.len() as u64);
-        out.set_cmt3(Some(b));
+        out.record_cmt_location(
+          Cr3CmtKind::Cmt3,
+          Cr3Block::at(h.body_abs_start, h.body.len() as u64),
+        );
+        let print = render_cmt3_block(h.body, true, current_model.as_deref());
+        let value = render_cmt3_block(h.body, false, current_model.as_deref());
+        out.push_cmt_tags(print, value);
       }
+      // CMT4 — GPS (`GPS::Main`).
       b"CMT4" => {
-        let mut b = Cr3Block::new();
-        b.set_offset(h.body_abs_start)
-          .set_length(h.body.len() as u64);
-        out.set_cmt4(Some(b));
+        out.record_cmt_location(
+          Cr3CmtKind::Cmt4,
+          Cr3Block::at(h.body_abs_start, h.body.len() as u64),
+        );
+        if let Some(meta) = crate::exif::parse_gps_block(h.body) {
+          let print = render_gps_block(&meta, true);
+          let value = render_gps_block(&meta, false);
+          out.push_cmt_tags(print, value);
+        }
       }
       // CNTH — CanonCNTH preview (Canon.pm:9670-9673).
       b"CNTH" => {
-        let mut b = Cr3Block::new();
-        b.set_offset(h.body_abs_start)
-          .set_length(h.body.len() as u64);
-        out.set_cnth(Some(b));
+        out.set_cnth(Some(Cr3Block::at(h.body_abs_start, h.body.len() as u64)));
       }
       // THMB — ThumbnailImage (Canon.pm:9727-9733).
       // TODO(#159-followup: CR3 ThumbnailImage): only the THMB block location
       // is recorded; the `(Binary data N bytes, …)` ThumbnailImage extraction
       // is out of camera-indexing scope.
       b"THMB" => {
-        let mut b = Cr3Block::new();
-        b.set_offset(h.body_abs_start)
-          .set_length(h.body.len() as u64);
-        out.set_thmb(Some(b));
+        out.set_thmb(Some(Cr3Block::at(h.body_abs_start, h.body.len() as u64)));
       }
       _ => {}
     }
@@ -1398,12 +1748,18 @@ impl QtTable {
 ///    `QuickTime::Meta` table holds the HEIF item parsers (`iinf`/`iloc`/
 ///    `pitm`/`iprp`) in EVERY position, so a `moov/meta` / `trak/meta` / etc.
 ///    carrying item info IS parsed — at the position-correct offset.
-///  - a Canon-prefix `uuid` box → dispatched to [`walk_canon_uuid`] ONLY when
-///    `table.dispatches_canon_uuid()` (i.e. `table == Movie`,
+///  - a Canon-prefix `uuid` box → dispatched to [`walk_canon_uuid_with_state`]
+///    ONLY when `table.dispatches_canon_uuid()` (i.e. `table == Movie`,
 ///    QuickTime.pm:1239); otherwise it is IGNORED (a top-level / `trak` /
 ///    `udta` Canon `uuid` is not in those tables, so the file stays CRX).
 ///  - any other box that is a recursion edge ([`QtTable::child_table`]) →
 ///    recurse into it with the child table.
+///
+/// `current_model` is the file-walk `$$self{Model}` — a single mutable value
+/// threaded through the WHOLE recursive walk in file order so a CMT3's
+/// model-conditional Canon MakerNote dispatch reads the most-recent preceding
+/// CMT1 `Model` even across multiple Canon `uuid` atoms (or recursion edges).
+/// The top-level caller seeds it with `None`.
 ///
 /// `boxes` is the atom's payload, `abs_offset` its absolute file offset
 /// (folded into per-extent / per-block offsets), `depth` the recursion
@@ -1421,6 +1777,7 @@ pub fn scan_quicktime_brands(
   depth: u32,
   heif: &mut HeifMeta,
   cr3: &mut Cr3Meta,
+  current_model: &mut Option<SmolStr>,
 ) {
   if depth >= MAX_ATOM_DEPTH {
     return;
@@ -1439,12 +1796,21 @@ pub fn scan_quicktime_brands(
     {
       // A Canon-prefix `uuid` is dispatched (CNCV + CR3/CRM override) ONLY
       // from `%Movie` (QuickTime.pm:1239); elsewhere it is not in the table,
-      // so leave the file as CRX.
+      // so leave the file as CRX. The file-walk `$$self{Model}` is threaded
+      // in so a CMT3 here sees a CMT1 `Model` from an EARLIER Canon uuid.
       if table.dispatches_canon_uuid() {
-        walk_canon_uuid(rest, h.body_abs_start + 16, cr3);
+        walk_canon_uuid_with_state(rest, h.body_abs_start + 16, cr3, current_model);
       }
     } else if let Some(child) = table.child_table(h.tag) {
-      scan_quicktime_brands(h.body, h.body_abs_start, child, depth + 1, heif, cr3);
+      scan_quicktime_brands(
+        h.body,
+        h.body_abs_start,
+        child,
+        depth + 1,
+        heif,
+        cr3,
+        current_model,
+      );
     }
   });
 }
@@ -2614,7 +2980,8 @@ mod tests {
   /// standalone `scan_heif_meta` entry point.
   fn scan_heif_meta(data: &[u8], out: &mut HeifMeta) {
     let mut cr3 = Cr3Meta::new();
-    scan_quicktime_brands(data, 0, QtTable::Main, 0, out, &mut cr3);
+    let mut model = None;
+    scan_quicktime_brands(data, 0, QtTable::Main, 0, out, &mut cr3, &mut model);
   }
 
   /// Test shim: run the unified [`scan_quicktime_brands`] from `%Main` over
@@ -2625,7 +2992,8 @@ mod tests {
   /// never dispatched and `cr3` stays empty).
   fn scan_canon_uuid(data: &[u8], out: &mut Cr3Meta) -> bool {
     let mut heif = HeifMeta::new();
-    scan_quicktime_brands(data, 0, QtTable::Main, 0, &mut heif, out);
+    let mut model = None;
+    scan_quicktime_brands(data, 0, QtTable::Main, 0, &mut heif, out, &mut model);
     !out.is_empty()
   }
 

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -83,7 +83,9 @@ pub use project::Project;
 pub use quicktime::{
   HandlerKind, KodakFrea, MediaTrack, QuickTimeGps, QuickTimeKeys, QuickTimeMeta, QuickTimeUserData,
 };
-pub use quicktime_brand::{Cr3Block, Cr3Meta, HeifExtent, HeifItem, HeifMeta, Jp2Block, Jp2Meta};
+pub use quicktime_brand::{
+  Cr3Block, Cr3CmtKind, Cr3Meta, HeifExtent, HeifItem, HeifMeta, Jp2Block, Jp2Meta,
+};
 pub(crate) use quicktime_stream::GpsOrigin;
 pub use quicktime_stream::{GpsSample, MebxSample, QuickTimeStreamMeta};
 pub use sony_rtmd::{

--- a/src/metadata/quicktime_brand.rs
+++ b/src/metadata/quicktime_brand.rs
@@ -366,6 +366,14 @@ pub struct HeifMeta {
   items: Vec<HeifItem>,
   idat_offset: Option<u64>,
   idat_length: Option<u64>,
+  /// `File:ImageWidth` from a main-document `ispe` (ImageSpatialExtent)
+  /// property in `ipco` (QuickTime.pm:3034-3047). The last main-document
+  /// `ispe` in `ipco` order wins (last-FoundTag-wins); a main-document `ispe`
+  /// is one no item associates, or one the primary item associates. `None`
+  /// when no main-document `ispe` was decoded (e.g. a non-HEIF `meta` box). #146.
+  image_width: Option<u32>,
+  /// `File:ImageHeight` from the same main-document `ispe` (#146).
+  image_height: Option<u32>,
   warning: Option<String>,
   /// The absolute file offset of the `meta` box whose walk produced
   /// [`Self::warning`] — recorded first-wins alongside the warning so the
@@ -388,6 +396,8 @@ impl HeifMeta {
       items: Vec::new(),
       idat_offset: None,
       idat_length: None,
+      image_width: None,
+      image_height: None,
       warning: None,
       warning_offset: None,
     }
@@ -424,6 +434,21 @@ impl HeifMeta {
   #[inline(always)]
   pub const fn idat_length(&self) -> Option<u64> {
     self.idat_length
+  }
+
+  /// `File:ImageWidth` — the last main-document `ispe` width (#146). `None`
+  /// when no main-document `ispe` was decoded.
+  #[must_use]
+  #[inline(always)]
+  pub const fn image_width(&self) -> Option<u32> {
+    self.image_width
+  }
+
+  /// `File:ImageHeight` — the last main-document `ispe` height (#146).
+  #[must_use]
+  #[inline(always)]
+  pub const fn image_height(&self) -> Option<u32> {
+    self.image_height
   }
 
   /// First non-fatal warning surfaced during the meta-box walk
@@ -543,6 +568,20 @@ impl HeifMeta {
     self
   }
 
+  /// Setter (`File:ImageWidth` — main-document `ispe` width).
+  #[inline(always)]
+  pub const fn set_image_width(&mut self, v: Option<u32>) -> &mut Self {
+    self.image_width = v;
+    self
+  }
+
+  /// Setter (`File:ImageHeight` — main-document `ispe` height).
+  #[inline(always)]
+  pub const fn set_image_height(&mut self, v: Option<u32>) -> &mut Self {
+    self.image_height = v;
+    self
+  }
+
   /// Setter (warning — first-wins, mirroring the SP1 convention). Leaves
   /// [`Self::warning_offset`] untouched (no position recorded); the production
   /// meta-box walk uses [`Self::set_warning_at`] so the document-level
@@ -606,6 +645,67 @@ impl HeifMeta {
 // Cr3Meta — Canon CR3 / CRM identity
 // ===========================================================================
 
+/// Which Canon `uuid` CMT block a [`Cr3Block`] location is, used to drive the
+/// re-dispatch table (`Image::ExifTool::Canon::uuid`, Canon.pm:9684-9726):
+/// `Cmt1` → IFD0 (`Exif::Main`), `Cmt2` → ExifIFD (`Exif::Main`), `Cmt3` →
+/// MakerNoteCanon (`Canon::Main` via `ProcessCMT3`), `Cmt4` → GPS (`GPS::Main`).
+/// The Canon-`uuid` walk uses it to dispatch each box's eager parse and to
+/// record the box LOCATION in the matching [`Cr3Meta`] slot
+/// ([`Cr3Meta::record_cmt_location`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cr3CmtKind {
+  /// `CMT1` — IFD0 (`Exif::Main`); its IFD0 `Model` seeds `$$self{Model}`.
+  Cmt1,
+  /// `CMT2` — ExifIFD (`Exif::Main`).
+  Cmt2,
+  /// `CMT3` — MakerNoteCanon (`Canon::Main` via `ProcessCMT3`).
+  Cmt3,
+  /// `CMT4` — GPS (`GPS::Main`).
+  Cmt4,
+}
+
+impl Cr3CmtKind {
+  /// The block's 4CC tag as a string (`"CMT1"`..`"CMT4"`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn as_str(&self) -> &'static str {
+    match self {
+      Self::Cmt1 => "CMT1",
+      Self::Cmt2 => "CMT2",
+      Self::Cmt3 => "CMT3",
+      Self::Cmt4 => "CMT4",
+    }
+  }
+
+  /// True iff this is [`Self::Cmt1`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_cmt1(&self) -> bool {
+    matches!(self, Self::Cmt1)
+  }
+
+  /// True iff this is [`Self::Cmt2`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_cmt2(&self) -> bool {
+    matches!(self, Self::Cmt2)
+  }
+
+  /// True iff this is [`Self::Cmt3`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_cmt3(&self) -> bool {
+    matches!(self, Self::Cmt3)
+  }
+
+  /// True iff this is [`Self::Cmt4`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_cmt4(&self) -> bool {
+    matches!(self, Self::Cmt4)
+  }
+}
+
 /// Typed mirror of the Canon CR3 / CRM (`crx ` brand) container identity
 /// — the `Image::ExifTool::Canon::uuid` atom set (Canon.pm:9657-9738)
 /// reached via the QuickTime UUID-Canon dispatch (QuickTime.pm:1236-1242).
@@ -636,25 +736,50 @@ pub struct Cr3Meta {
   /// 3-char file-type override extracted from `compressor_version`:
   /// `Canon(\w{3})` → `CR3` or `CRM` (Canon.pm:9667).
   override_file_type: Option<SmolStr>,
-  /// Offset / length of CMT1 (IFD0 / TIFF) body — Canon.pm:9684-9692.
+  /// Location (file-absolute offset + length) of the LAST CMT1 box seen
+  /// (Exif IFD0). Last-wins per kind, mirroring ExifTool's `FoundTag`
+  /// last-wins-in-place: a duplicate `CMT1` overwrites this slot. This is a
+  /// FIXED slot, NOT a per-box list — a crafted CR3 with millions of CMT
+  /// boxes cannot grow it (the COUNT-amplification surface is gone).
   cmt1: Option<Cr3Block>,
-  /// Offset / length of CMT2 (ExifIFD) — Canon.pm:9693-9701.
+  /// Location of the last CMT2 box (ExifIFD) — see [`Self::cmt1`].
   cmt2: Option<Cr3Block>,
-  /// Offset / length of CMT3 (Canon MakerNotes) — Canon.pm:9702-9716.
+  /// Location of the last CMT3 box (Canon MakerNotes) — see [`Self::cmt1`].
   cmt3: Option<Cr3Block>,
-  /// Offset / length of CMT4 (GPS) — Canon.pm:9717-9726.
+  /// Location of the last CMT4 box (GPS) — see [`Self::cmt1`].
   cmt4: Option<Cr3Block>,
+  /// The CMT1-4 tags RENDERED for `-j` (PrintConv), in file-walk order. The
+  /// CMT box bodies are TIFF/Canon-MakerNote sub-slices of the input buffer
+  /// that ExifTool re-dispatches through `ProcessTIFF` / `ProcessCMT3`
+  /// (Canon.pm:9686-9726); they are parsed EAGERLY during the Canon-`uuid`
+  /// walk (where the input buffer is in scope) and the resulting OWNED
+  /// [`EmittedTag`]s stored here — the raw bodies are NEVER retained. This
+  /// bounds CMT storage to the parsed TAG count (the Exif walker already caps
+  /// IFD entries), proportional to input size, with NO per-box and NO
+  /// per-`uuid`-atom amplification.
+  cmt_print: Vec<crate::emit::EmittedTag>,
+  /// The CMT1-4 tags rendered for `-n` (ValueConv), in file-walk order — the
+  /// `-n` counterpart of [`Self::cmt_print`] (the same blocks, rendered in the
+  /// other [`ConvMode`](crate::emit::ConvMode); emission is mode-dependent, so
+  /// both renderings are produced once at walk time).
+  cmt_value: Vec<crate::emit::EmittedTag>,
   /// Offset / length of CNTH (CanonCNTH preview) — Canon.pm:9670-9673.
   cnth: Option<Cr3Block>,
   /// Offset / length of THMB (ThumbnailImage) — Canon.pm:9727-9733.
   thmb: Option<Cr3Block>,
-  warning: Option<String>,
 }
 
-/// One Canon CR3 CMT-family block: an absolute file offset + length
-/// into a TIFF/Exif body. Faithful to the Canon::uuid SubDirectory
-/// pattern (Canon.pm:9687-9691).
-#[derive(Debug, Clone, Default)]
+/// One Canon CR3 CMT-family block LOCATION: an absolute file offset + length.
+/// Faithful to the Canon::uuid SubDirectory pattern (Canon.pm:9687-9691).
+///
+/// This records ONLY where a CMT1-4 / CNTH / THMB box sits — it carries NO box
+/// body. The CMT1-4 TIFF/Canon-MakerNote bodies are parsed EAGERLY during the
+/// Canon-`uuid` walk and their decoded tags stored on
+/// [`Cr3Meta::cmt_print`](Cr3Meta) / [`Cr3Meta::cmt_value`](Cr3Meta); keeping
+/// no raw bytes here is what makes a file-controlled wholesale-clone of a
+/// crafted multi-MB CMT box STRUCTURALLY impossible (there is no field to copy
+/// it into).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Cr3Block {
   offset: u64,
   length: u64,
@@ -669,6 +794,14 @@ impl Cr3Block {
       offset: 0,
       length: 0,
     }
+  }
+
+  /// A block at `offset` of `length` bytes (the common ctor — the walk records
+  /// each box's location in one call).
+  #[must_use]
+  #[inline(always)]
+  pub const fn at(offset: u64, length: u64) -> Self {
+    Self { offset, length }
   }
 
   /// The block's absolute file offset.
@@ -712,9 +845,10 @@ impl Cr3Meta {
       cmt2: None,
       cmt3: None,
       cmt4: None,
+      cmt_print: Vec::new(),
+      cmt_value: Vec::new(),
       cnth: None,
       thmb: None,
-      warning: None,
     }
   }
 
@@ -734,33 +868,48 @@ impl Cr3Meta {
     self.override_file_type.as_deref()
   }
 
-  /// The CMT1 block (Exif IFD0 — Canon.pm:9684-9692). `None` when no
-  /// CMT1 child was present in the Canon UUID atom.
+  /// The CMT1 block location (Exif IFD0 — Canon.pm:9684-9692). `None` when no
+  /// CMT1 child was present. Last-wins on a duplicate (the LAST CMT1's
+  /// location).
   #[must_use]
   #[inline(always)]
   pub const fn cmt1(&self) -> Option<&Cr3Block> {
     self.cmt1.as_ref()
   }
 
-  /// The CMT2 block (ExifIFD — Canon.pm:9693-9701).
+  /// The CMT2 block location (ExifIFD — Canon.pm:9693-9701; last-wins).
   #[must_use]
   #[inline(always)]
   pub const fn cmt2(&self) -> Option<&Cr3Block> {
     self.cmt2.as_ref()
   }
 
-  /// The CMT3 block (Canon MakerNotes — Canon.pm:9702-9716).
+  /// The CMT3 block location (Canon MakerNotes — Canon.pm:9702-9716; last-wins).
   #[must_use]
   #[inline(always)]
   pub const fn cmt3(&self) -> Option<&Cr3Block> {
     self.cmt3.as_ref()
   }
 
-  /// The CMT4 block (GPS — Canon.pm:9717-9726).
+  /// The CMT4 block location (GPS — Canon.pm:9717-9726; last-wins).
   #[must_use]
   #[inline(always)]
   pub const fn cmt4(&self) -> Option<&Cr3Block> {
     self.cmt4.as_ref()
+  }
+
+  /// The CMT1-4 tags decoded during the Canon-`uuid` walk, rendered for the
+  /// requested [`ConvMode`](crate::emit::ConvMode) (`print_conv` ⇒ `-j`
+  /// PrintConv, else `-n` ValueConv), in file-walk order. The emission path
+  /// pushes these verbatim (the parse already happened at walk time).
+  #[must_use]
+  #[inline(always)]
+  pub fn cmt_tags(&self, print_conv: bool) -> &[crate::emit::EmittedTag] {
+    if print_conv {
+      self.cmt_print.as_slice()
+    } else {
+      self.cmt_value.as_slice()
+    }
   }
 
   /// The CNTH block (CanonCNTH preview — Canon.pm:9670-9673).
@@ -777,13 +926,6 @@ impl Cr3Meta {
     self.thmb.as_ref()
   }
 
-  /// First non-fatal warning surfaced during the Canon UUID walk.
-  #[must_use]
-  #[inline(always)]
-  pub fn warning(&self) -> Option<&str> {
-    self.warning.as_deref()
-  }
-
   /// `true` when no Canon UUID atom (`85 c0 b6 87 82 0f 11 e0 81 11
   /// f4 ce 46 2b 6a 48`) was found in the file's moov tree.
   #[must_use]
@@ -794,9 +936,10 @@ impl Cr3Meta {
       && self.cmt2.is_none()
       && self.cmt3.is_none()
       && self.cmt4.is_none()
+      && self.cmt_print.is_empty()
+      && self.cmt_value.is_empty()
       && self.cnth.is_none()
       && self.thmb.is_none()
-      && self.warning.is_none()
   }
 
   /// Setter (compressor version).
@@ -813,31 +956,34 @@ impl Cr3Meta {
     self
   }
 
-  /// Setter (CMT1).
+  /// Record the LOCATION of a CMT1-4 box (last-wins per kind — a duplicate
+  /// overwrites the slot, mirroring ExifTool's `FoundTag` last-wins-in-place).
+  /// Stores no body; the decoded tags are added separately via
+  /// [`Self::push_cmt_tags`].
   #[inline(always)]
-  pub fn set_cmt1(&mut self, v: Option<Cr3Block>) -> &mut Self {
-    self.cmt1 = v;
+  pub fn record_cmt_location(&mut self, kind: Cr3CmtKind, block: Cr3Block) -> &mut Self {
+    match kind {
+      Cr3CmtKind::Cmt1 => self.cmt1 = Some(block),
+      Cr3CmtKind::Cmt2 => self.cmt2 = Some(block),
+      Cr3CmtKind::Cmt3 => self.cmt3 = Some(block),
+      Cr3CmtKind::Cmt4 => self.cmt4 = Some(block),
+    }
     self
   }
 
-  /// Setter (CMT2).
+  /// Append one CMT block's decoded tags for BOTH conv modes (`-j` PrintConv
+  /// in `print`, `-n` ValueConv in `value`), in file-walk order. Called once
+  /// per CMT box from the Canon-`uuid` walk after the body is parsed; an empty
+  /// box (no parseable TIFF / no tags) appends nothing, so the buffers grow
+  /// with the parsed TAG count, never the box count.
   #[inline(always)]
-  pub fn set_cmt2(&mut self, v: Option<Cr3Block>) -> &mut Self {
-    self.cmt2 = v;
-    self
-  }
-
-  /// Setter (CMT3).
-  #[inline(always)]
-  pub fn set_cmt3(&mut self, v: Option<Cr3Block>) -> &mut Self {
-    self.cmt3 = v;
-    self
-  }
-
-  /// Setter (CMT4).
-  #[inline(always)]
-  pub fn set_cmt4(&mut self, v: Option<Cr3Block>) -> &mut Self {
-    self.cmt4 = v;
+  pub fn push_cmt_tags(
+    &mut self,
+    print: Vec<crate::emit::EmittedTag>,
+    value: Vec<crate::emit::EmittedTag>,
+  ) -> &mut Self {
+    self.cmt_print.extend(print);
+    self.cmt_value.extend(value);
     self
   }
 
@@ -852,15 +998,6 @@ impl Cr3Meta {
   #[inline(always)]
   pub fn set_thmb(&mut self, v: Option<Cr3Block>) -> &mut Self {
     self.thmb = v;
-    self
-  }
-
-  /// Setter (warning).
-  #[inline(always)]
-  pub fn set_warning(&mut self, v: Option<String>) -> &mut Self {
-    if self.warning.is_none() {
-      self.warning = v;
-    }
     self
   }
 }
@@ -1572,13 +1709,14 @@ mod tests {
     let mut m = Cr3Meta::new();
     m.set_compressor_version(Some(SmolStr::new_static("CanonCR3 0.1.00")))
       .set_override_file_type(Some(SmolStr::new_static("CR3")));
-    let mut b1 = Cr3Block::new();
-    b1.set_offset(0x100).set_length(0x40);
-    m.set_cmt1(Some(b1));
+    // CMT box LOCATIONS go in fixed per-kind slots (last-wins); the eager
+    // walk records them with `record_cmt_location`.
+    m.record_cmt_location(Cr3CmtKind::Cmt1, Cr3Block::at(0x100, 0x40));
     assert!(!m.is_empty());
     assert_eq!(m.compressor_version(), Some("CanonCR3 0.1.00"));
     assert_eq!(m.override_file_type(), Some("CR3"));
     assert_eq!(m.cmt1().unwrap().offset(), 0x100);
+    assert_eq!(m.cmt1().unwrap().length(), 0x40);
   }
 
   #[test]

--- a/tests/quicktime_brands.rs
+++ b/tests/quicktime_brands.rs
@@ -55,6 +55,68 @@ fn synthetic_heic() -> Vec<u8> {
   data
 }
 
+/// Build a HEIC with an `iprp`(`ipco`[ispe,ispe], `ipma`) property store + two
+/// items, the primary (id 2) pointing at the FIRST `ispe` (640x480) and a
+/// thumbnail (id 3) at the SECOND `ispe` (80x60). Mirrors the bundled
+/// QuickTime.heic shape so the primary-item `ispe` resolution (#146) is covered
+/// portably (without EXIFTOOL_T_IMAGES).
+fn synthetic_heic_with_ispe() -> Vec<u8> {
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  // pitm v0 → primary item id 2.
+  let mut pitm_body = Vec::new();
+  pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+  pitm_body.extend_from_slice(&2u16.to_be_bytes());
+  let pitm = box_bytes(b"pitm", &pitm_body);
+
+  // ispe box body: [version/flags 4][width u32][height u32].
+  let ispe = |w: u32, h: u32| -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    box_bytes(b"ispe", &b)
+  };
+  // ipco children: index 1 = ispe(640x480), index 2 = ispe(80x60).
+  let mut ipco_body = Vec::new();
+  ipco_body.extend(ispe(640, 480));
+  ipco_body.extend(ispe(80, 60));
+  let ipco = box_bytes(b"ipco", &ipco_body);
+
+  // ipma v0 flags0: item 2 → [prop 1], item 3 → [prop 2] (1 byte per assoc).
+  let mut ipma_body = Vec::new();
+  ipma_body.extend_from_slice(&[0, 0, 0, 0]); // version/flags
+  ipma_body.extend_from_slice(&2u32.to_be_bytes()); // entry count
+  ipma_body.extend_from_slice(&2u16.to_be_bytes()); // item id 2
+  ipma_body.push(1); // 1 association
+  ipma_body.push(1); // prop index 1 (essential bit clear)
+  ipma_body.extend_from_slice(&3u16.to_be_bytes()); // item id 3
+  ipma_body.push(1);
+  ipma_body.push(2); // prop index 2
+  let ipma = box_bytes(b"ipma", &ipma_body);
+
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(ipco);
+  iprp_body.extend(ipma);
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]); // FullBox version+flags
+  meta_body.extend(pitm);
+  meta_body.extend(iprp);
+  let meta = box_bytes(b"meta", &meta_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(meta);
+  data
+}
+
 /// Build a minimal AVIF: ftyp(major=avif, compat=[mif1,avif]) + meta.
 fn synthetic_avif() -> Vec<u8> {
   let mut ftyp_body = Vec::new();
@@ -128,6 +190,157 @@ fn synthetic_heic_file_type_heic_with_mif1_only() {
   assert_eq!(m.quicktime().major_brand(), Some("heic"));
   assert_eq!(m.heif().primary_item(), Some(1));
   assert!(!m.heif().is_empty());
+}
+
+#[test]
+fn synthetic_heic_primary_ispe_resolves_dimensions() {
+  // #146 — the primary item (id 2) associates the FIRST `ispe` (640x480) so it
+  // is main-document and emits; the SECOND `ispe` (80x60) is associated only by
+  // the thumbnail item 3 → a sub-document `DOC_NUM` → gated out. Oracle (bundled
+  // `exiftool -G1 -j` on this exact box layout): File:ImageWidth 640,
+  // File:ImageHeight 480.
+  let data = synthetic_heic_with_ispe();
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(m.heif().primary_item(), Some(2));
+  assert_eq!(m.heif().image_width(), Some(640));
+  assert_eq!(m.heif().image_height(), Some(480));
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn synthetic_heic_emits_file_image_dimensions() {
+  // #146 — the resolved primary `ispe` reaches the output stream as
+  // `File:ImageWidth`/`File:ImageHeight` (bare ints, `File,File` group).
+  let data = synthetic_heic_with_ispe();
+  let json = exifast::parser::extract_info("synthetic.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":640"#) && json.contains(r#""File:ImageHeight":480"#),
+    "got: {json}"
+  );
+  // The thumbnail dimensions must NOT leak (they belong to the non-primary item).
+  assert!(
+    !json.contains(r#""File:ImageWidth":80"#),
+    "thumbnail ispe leaked: {json}"
+  );
+}
+
+/// Build a HEIC: ftyp(heic) + meta(pitm(primary) + iprp(ipco[ispe…], ipma rows)).
+/// `ispes` is `&[(w, h)]` (declaration order = 1-based ipco index); `rows` is
+/// `&[(item_id, &[prop_index])]` for the `ipma` (v0, flags0, 1-byte assoc).
+fn heic_with_ispes_and_ipma(primary: u16, ispes: &[(u32, u32)], rows: &[(u16, &[u8])]) -> Vec<u8> {
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  let mut pitm_body = Vec::new();
+  pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+  pitm_body.extend_from_slice(&primary.to_be_bytes());
+  let pitm = box_bytes(b"pitm", &pitm_body);
+
+  let mut ipco_body = Vec::new();
+  for &(w, h) in ispes {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    ipco_body.extend(box_bytes(b"ispe", &b));
+  }
+  let ipco = box_bytes(b"ipco", &ipco_body);
+
+  let mut ipma_body = Vec::new();
+  ipma_body.extend_from_slice(&[0, 0, 0, 0]);
+  ipma_body.extend_from_slice(&(rows.len() as u32).to_be_bytes());
+  for &(id, props) in rows {
+    ipma_body.extend_from_slice(&id.to_be_bytes());
+    ipma_body.push(props.len() as u8);
+    ipma_body.extend_from_slice(props);
+  }
+  let ipma = box_bytes(b"ipma", &ipma_body);
+
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(ipco);
+  iprp_body.extend(ipma);
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]);
+  meta_body.extend(pitm);
+  meta_body.extend(iprp);
+  let meta = box_bytes(b"meta", &meta_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(meta);
+  data
+}
+
+#[test]
+fn heif_unassociated_ispe_emits_dimensions() {
+  // #146 — an `ispe` that NO `ipma` row references is still MAIN-DOCUMENT and
+  // emits `File:ImageWidth`/`Height`. ExifTool's `ispe` `RawConv` FoundTags the
+  // dims `unless ($$self{DOC_NUM})` (QuickTime.pm:3037-3045); the deferred `ipco`
+  // walk only sets `DOC_NUM` for a property associated with a NON-primary item
+  // (QuickTime.pm:10196-10238), so an unassociated property stays main-document.
+  // Layout: primary item 2, ipco[ispe(640x480)], EMPTY ipma. Oracle (bundled
+  // `exiftool -G1 -j` on this layout): File:ImageWidth 640, File:ImageHeight 480.
+  let data = heic_with_ispes_and_ipma(2, &[(640, 480)], &[]);
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(m.heif().primary_item(), Some(2));
+  assert_eq!(
+    m.heif().image_width(),
+    Some(640),
+    "an unassociated ispe must still emit its dims (main-document)"
+  );
+  assert_eq!(m.heif().image_height(), Some(480));
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_multiple_ispe_winner_matches_exiftool() {
+  // #146 — with TWO unassociated `ispe` of different sizes (640x480 then
+  // 1280x960), both are main-document and FoundTag `ImageWidth`; the non-list
+  // `File:ImageWidth` is overwritten in `ipco` order, so the LAST one wins.
+  // Oracle (bundled `exiftool -G1 -j` on ipco[ispe(640x480), ispe(1280x960)] +
+  // EMPTY ipma): File:ImageWidth 1280, File:ImageHeight 960.
+  let data = heic_with_ispes_and_ipma(2, &[(640, 480), (1280, 960)], &[]);
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(
+    m.heif().image_width(),
+    Some(1280),
+    "last main-document ispe in ipco order must win"
+  );
+  assert_eq!(m.heif().image_height(), Some(960));
+
+  let json = exifast::parser::extract_info("multi.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":1280"#) && json.contains(r#""File:ImageHeight":960"#),
+    "expected 1280x960 (last ispe), got: {json}"
+  );
+  assert!(
+    !json.contains(r#""File:ImageWidth":640"#),
+    "the earlier 640 ispe must be overwritten, got: {json}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_primary_associated_ispe_gates_out_nonprimary() {
+  // #146 — when the primary associates the FIRST ispe and a thumbnail the
+  // SECOND, the second is a SUB-document (`DOC_NUM` set) and is gated out even
+  // though it is later in ipco order. Layout: ipco[ispe(640x480), ispe(1280x960)],
+  // primary 2→[1], thumb 3→[2]. Oracle: File:ImageWidth 640 (NOT 1280).
+  let data = heic_with_ispes_and_ipma(2, &[(640, 480), (1280, 960)], &[(2, &[1]), (3, &[2])]);
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(m.heif().image_width(), Some(640));
+  assert_eq!(m.heif().image_height(), Some(480));
+  let json = exifast::parser::extract_info("gated.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":640"#) && !json.contains(r#""File:ImageWidth":1280"#),
+    "the non-primary (sub-document) ispe must be gated out, got: {json}"
+  );
 }
 
 #[test]
@@ -791,4 +1004,1383 @@ fn real_fixture_heic_emits_primary_item_reference() {
     json.contains(r#""Meta:PrimaryItemReference":20002"#),
     "got: {json}"
   );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn real_fixture_cr3_emits_exif_make_model_serial_lens() {
+  // #148 — the Canon CR3 `Image::ExifTool::Canon::uuid` CMT1-4 boxes
+  // (Canon.pm:9686-9726) re-dispatch through `ProcessTIFF` / `ProcessCMT3`:
+  //   CMT1 → IFD0 (`Exif::Main`)        → EXIF:IFD0:*
+  //   CMT2 → ExifIFD (`Exif::Main`)     → EXIF:ExifIFD:*
+  //   CMT3 → MakerNoteCanon (`Canon::Main` via ProcessCMT3) → MakerNotes:Canon:*
+  //   CMT4 → GPSInfo (`GPS::Main`)      → EXIF:GPS:*
+  // Each box body is a self-contained TIFF (its own header + IFD); the IFD
+  // offsets are relative to the box body start (base 0). Oracle
+  // (bundled `exiftool -G1 -j CanonRaw.cr3`), each tag at its faithful group
+  // (the `extract_info` JSON keys are `<family1>:<name>`):
+  //   IFD0:Make=Canon, IFD0:Model=Canon EOS M50, IFD0:ImageWidth=6000,
+  //   IFD0:ImageHeight=4000; ExifIFD:SerialNumber=613040000565,
+  //   ExifIFD:FNumber=3.5, ExifIFD:ExposureTime=1/80, ExifIFD:ISO=12800,
+  //   ExifIFD:FocalLength=15.0 mm, ExifIFD:DateTimeOriginal=2018:02:21 12:08:56;
+  //   Canon:LensModel=EF-M15-45mm f/3.5-6.3 IS STM; GPS:GPSVersionID=2.3.0.0.
+  let Some(data) = exiftool_fixture("CanonRaw.cr3") else {
+    return;
+  };
+  let json = exifast::parser::extract_info("CanonRaw.cr3", &data, true);
+  for needle in [
+    // CMT1 → IFD0.
+    r#""IFD0:Make":"Canon""#,
+    r#""IFD0:Model":"Canon EOS M50""#,
+    r#""IFD0:ImageWidth":6000"#,
+    r#""IFD0:ImageHeight":4000"#,
+    // CMT2 → ExifIFD.
+    r#""ExifIFD:SerialNumber":613040000565"#,
+    r#""ExifIFD:FNumber":3.5"#,
+    r#""ExifIFD:ExposureTime":"1/80""#,
+    r#""ExifIFD:ISO":12800"#,
+    r#""ExifIFD:FocalLength":"15.0 mm""#,
+    r#""ExifIFD:DateTimeOriginal":"2018:02:21 12:08:56""#,
+    r#""ExifIFD:LensModel":"EF-M15-45mm f/3.5-6.3 IS STM""#,
+    // CMT3 → Canon MakerNote.
+    r#""Canon:LensModel":"EF-M15-45mm f/3.5-6.3 IS STM""#,
+    r#""Canon:LensType":"Canon EF-M 15-45mm f/3.5-6.3 IS STM""#,
+    // CMT4 → GPS.
+    r#""GPS:GPSVersionID":"2.3.0.0""#,
+    // The first DoProcessTIFF FoundTag's File:ExifByteOrder (deduped once).
+    r#""File:ExifByteOrder":"Little-endian (Intel, II)""#,
+    // The pre-existing CR3 CompressorVersion must NOT regress.
+    r#""Canon:CompressorVersion":"CanonCR3_001/00.09.00/00.00.00""#,
+  ] {
+    assert!(
+      json.contains(needle),
+      "missing {needle}\n--- got ---\n{json}"
+    );
+  }
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn real_fixture_heic_emits_image_dimensions() {
+  // #146 — the HEIF primary item's `ispe` (ImageSpatialExtent) property in
+  // `ipco` (QuickTime.pm:3034-3047) emits `File:ImageWidth`/`File:ImageHeight`.
+  // The `ispe` body is `[version/flags 4][width u32 BE][height u32 BE]`; the
+  // primary item (`pitm` = 20002) is associated (via `ipma`) with the `ispe` at
+  // `ipco` index 2 → 1596x1064 (the 320x240 thumbnail `ispe` belongs to the
+  // non-primary item 20003 and is gated out by `DOC_NUM`). Oracle (bundled
+  // `exiftool -G1 -j QuickTime.heic`): File:ImageWidth=1596, File:ImageHeight=1064.
+  let Some(data) = exiftool_fixture("QuickTime.heic") else {
+    return;
+  };
+  let json = exifast::parser::extract_info("QuickTime.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":1596"#),
+    "missing File:ImageWidth 1596\n--- got ---\n{json}"
+  );
+  assert!(
+    json.contains(r#""File:ImageHeight":1064"#),
+    "missing File:ImageHeight 1064\n--- got ---\n{json}"
+  );
+  // The primary-item reference must NOT regress.
+  assert!(
+    json.contains(r#""Meta:PrimaryItemReference":20002"#),
+    "PrimaryItemReference regressed\n--- got ---\n{json}"
+  );
+}
+
+// ============================================================================
+// SP4 robustness — F1 / F2 / F3 (oversized ipco, stale primary dims, CMT clone)
+// ============================================================================
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_oversized_ipco_property_count_no_panic_emits_unassociated_ispe() {
+  // An `ipco` with MORE than `u16::MAX` property boxes must not overflow the
+  // 1-based property-index counter (a `u16` would debug-panic / release-wrap and
+  // alias one index onto another). The counter is a `u32` with a checked
+  // increment, so the walk stays sound; memory stays bounded because each `ispe`
+  // box is ≥20 bytes in the file.
+  //
+  // Layout: the primary item (id 2) associates `ipco` property index 1 — a
+  // FILLER `free` box (NOT an `ispe`). A real `ispe` (9999x9999) is planted at
+  // the 65537th `ipco` child. That `ispe` is UNassociated (no `ipma` row
+  // references index 65537), so ExifTool treats it as main-document and FoundTags
+  // its dims — index size is irrelevant to the `ispe` `RawConv`; only an `ipma`
+  // association to a non-primary item gates an `ispe` out. Oracle (bundled
+  // `exiftool -G1 -j` on this exact layout): File:ImageWidth 9999,
+  // File:ImageHeight 9999.
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  // pitm v0 → primary item id 2.
+  let mut pitm_body = Vec::new();
+  pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+  pitm_body.extend_from_slice(&2u16.to_be_bytes());
+  let pitm = box_bytes(b"pitm", &pitm_body);
+
+  // ipco: a sequence of empty 8-byte `free` boxes with a single `ispe` planted
+  // at child index 65537 (= u16::MAX + 2 ⇒ the wrap target of a buggy u16 counter).
+  let ispe = |w: u32, h: u32| -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    box_bytes(b"ispe", &b)
+  };
+  let planted_at = (u16::MAX as usize) + 2; // 65537
+  let free_box = box_bytes(b"free", &[]); // 8-byte header, empty body
+  let mut ipco_body = Vec::with_capacity(planted_at * free_box.len() + 20);
+  for idx in 1..=planted_at {
+    if idx == planted_at {
+      ipco_body.extend_from_slice(&ispe(9999, 9999));
+    } else {
+      ipco_body.extend_from_slice(&free_box);
+    }
+  }
+  let ipco = box_bytes(b"ipco", &ipco_body);
+
+  // ipma v0 flags0: item 2 → [prop index 1] (the filler `free`, not an ispe).
+  let mut ipma_body = Vec::new();
+  ipma_body.extend_from_slice(&[0, 0, 0, 0]);
+  ipma_body.extend_from_slice(&1u32.to_be_bytes());
+  ipma_body.extend_from_slice(&2u16.to_be_bytes());
+  ipma_body.push(1);
+  ipma_body.push(1); // association → property index 1
+  let ipma = box_bytes(b"ipma", &ipma_body);
+
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(ipco);
+  iprp_body.extend(ipma);
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]);
+  meta_body.extend(pitm);
+  meta_body.extend(iprp);
+  let meta = box_bytes(b"meta", &meta_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(meta);
+
+  // Must not panic (debug) / wrap (release) on the 65537-child ipco.
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(m.heif().primary_item(), Some(2));
+  // The unassociated high-index `ispe` is main-document and emits (oracle: 9999).
+  assert_eq!(
+    m.heif().image_width(),
+    Some(9999),
+    "unassociated ispe at a high ipco index must still emit (main-document)"
+  );
+  assert_eq!(m.heif().image_height(), Some(9999));
+
+  // And the emitted JSON carries the faithful File:ImageWidth/Height.
+  let json = exifast::parser::extract_info("oversized.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":9999"#) && json.contains(r#""File:ImageHeight":9999"#),
+    "expected faithful 9999x9999 dims, got: {json}"
+  );
+}
+
+#[test]
+fn heif_many_zero_association_ipma_rows_near_linear() {
+  // CPU-DoS guard: the `ispe` main-document resolution must be near-linear in the
+  // `ipma` row count. A zero-association `ipma` row is only ~3 bytes (2-byte id +
+  // 1-byte count 0), so a tiny crafted HEIC can carry tens of thousands of rows
+  // alongside several `ispe`; an O(N·M²) resolver (rescanning every row per
+  // `ispe`) would do billions of comparisons and hang. The faithful precompute +
+  // single pass stays O((N+M) log M), so this completes effectively instantly.
+  //
+  // The dims must STILL match the faithful rule, unchanged by the extra rows:
+  // primary item 2 associates `ipco` index 1 (640x480); index 2 (1280x960) is
+  // UNassociated ⇒ main-document, and it is LAST in `ipco` order ⇒ it wins. The
+  // 50k extra rows are distinct non-primary items (ids 3.. ascending, so no
+  // out-of-order warning) whose association list is EMPTY — they reference no
+  // property index and so cannot gate either `ispe`. Oracle (the same faithful
+  // determination as `heif_multiple_ispe_winner_matches_exiftool`): the last
+  // unassociated `ispe` wins ⇒ File:ImageWidth 1280, File:ImageHeight 960.
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  // pitm v0 → primary item id 2.
+  let mut pitm_body = Vec::new();
+  pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+  pitm_body.extend_from_slice(&2u16.to_be_bytes());
+  let pitm = box_bytes(b"pitm", &pitm_body);
+
+  let ispe = |w: u32, h: u32| -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    box_bytes(b"ispe", &b)
+  };
+  // ipco: index 1 = ispe(640x480), index 2 = ispe(1280x960).
+  let mut ipco_body = Vec::new();
+  ipco_body.extend(ispe(640, 480));
+  ipco_body.extend(ispe(1280, 960));
+  let ipco = box_bytes(b"ipco", &ipco_body);
+
+  // ipma v0 flags0: the primary (item 2) associates property index 1, then a
+  // flood of 50_000 zero-association rows for ascending non-primary ids.
+  const ZERO_ROWS: u32 = 50_000;
+  let mut ipma_body = Vec::new();
+  ipma_body.extend_from_slice(&[0, 0, 0, 0]); // version/flags
+  ipma_body.extend_from_slice(&(1 + ZERO_ROWS).to_be_bytes()); // entry count
+  ipma_body.extend_from_slice(&2u16.to_be_bytes()); // item 2 (primary)
+  ipma_body.push(1); // 1 association
+  ipma_body.push(1); // → property index 1
+  for id in 3u32..3 + ZERO_ROWS {
+    ipma_body.extend_from_slice(&(id as u16).to_be_bytes()); // ascending id
+    ipma_body.push(0); // 0 associations (the cheap-bytes attack)
+  }
+  let ipma = box_bytes(b"ipma", &ipma_body);
+
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(ipco);
+  iprp_body.extend(ipma);
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]);
+  meta_body.extend(pitm);
+  meta_body.extend(iprp);
+  let meta = box_bytes(b"meta", &meta_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(meta);
+
+  // Completes near-instantly (no O(N·M²) hang) AND yields the faithful dims.
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(m.heif().primary_item(), Some(2));
+  assert_eq!(
+    m.heif().image_width(),
+    Some(1280),
+    "the last unassociated ispe must win regardless of the ipma row flood"
+  );
+  assert_eq!(m.heif().image_height(), Some(960));
+}
+
+#[test]
+fn heif_primary_change_across_meta_boxes_keeps_main_doc_dims() {
+  // `walk_heif_meta` can be called more than once into the same `HeifMeta` (the
+  // persistent `$$et{ItemInfo}`), and a later `meta` can change the primary item.
+  // ExifTool's `ispe` FoundTag is cumulative over the WHOLE file (QuickTime.pm:
+  // 3040): a later `meta` that produces no MAIN-DOCUMENT `ispe` does NOT erase
+  // the dims an earlier `meta` already emitted. (A later main-document `ispe`
+  // overrides — see `heif_two_meta_primary_ispe_overrides`.)
+  //
+  // Pass 1: primary = item 2, associating ispe(640x480) ⇒ main-document ⇒ 640x480.
+  // Pass 2 (same HeifMeta): a new `pitm` changes the primary to item 9, AND the
+  // meta supplies an `ipco`[ispe(11x22)] + `ipma` associating that ispe with a
+  // DIFFERENT item (3), not the primary 9 ⇒ that ispe is a SUB-document ⇒ gated
+  // out ⇒ the earlier 640x480 must REMAIN (not clear). Oracle (bundled
+  // `exiftool -G1 -j` on the equivalent two-meta-box file): File:ImageWidth 640,
+  // File:ImageHeight 480, Meta:PrimaryItemReference 9.
+  use exifast::formats::quicktime_brands::walk_heif_meta;
+  use exifast::metadata::HeifMeta;
+
+  let ispe = |w: u32, h: u32| -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    box_bytes(b"ispe", &b)
+  };
+
+  // Pass-1 meta BODY: pitm(2) + iprp(ipco[ispe(640x480)], ipma{2→1}).
+  let mut pitm1 = Vec::new();
+  pitm1.extend_from_slice(&[0, 0, 0, 0]);
+  pitm1.extend_from_slice(&2u16.to_be_bytes());
+  let ipco1 = box_bytes(b"ipco", &ispe(640, 480));
+  let mut ipma1 = Vec::new();
+  ipma1.extend_from_slice(&[0, 0, 0, 0]);
+  ipma1.extend_from_slice(&1u32.to_be_bytes());
+  ipma1.extend_from_slice(&2u16.to_be_bytes());
+  ipma1.push(1);
+  ipma1.push(1);
+  let mut iprp1 = Vec::new();
+  iprp1.extend(ipco1);
+  iprp1.extend(box_bytes(b"ipma", &ipma1));
+  let mut body1 = Vec::new();
+  body1.extend_from_slice(&[0, 0, 0, 0]); // meta version+flags
+  body1.extend(box_bytes(b"pitm", &pitm1));
+  body1.extend(box_bytes(b"iprp", &iprp1));
+
+  let mut m = HeifMeta::new();
+  walk_heif_meta(&body1, 0, 4, &mut m);
+  assert_eq!(m.primary_item(), Some(2));
+  assert_eq!(m.image_width(), Some(640));
+  assert_eq!(m.image_height(), Some(480));
+
+  // Pass-2 meta BODY into the SAME HeifMeta: pitm changes the primary to 9, and
+  // the meta DOES supply a property store (ipco[ispe(11x22)] + ipma{3→1}) — but
+  // item 9 (the primary) is NOT associated with that ispe; only the non-primary
+  // item 3 is ⇒ the ispe is a sub-document ⇒ gated out ⇒ the earlier 640x480
+  // stays (cumulative FoundTag, never cleared).
+  let mut pitm2 = Vec::new();
+  pitm2.extend_from_slice(&[0, 0, 0, 0]);
+  pitm2.extend_from_slice(&9u16.to_be_bytes());
+  let ipco2 = box_bytes(b"ipco", &ispe(11, 22));
+  let mut ipma2 = Vec::new();
+  ipma2.extend_from_slice(&[0, 0, 0, 0]);
+  ipma2.extend_from_slice(&1u32.to_be_bytes());
+  ipma2.extend_from_slice(&3u16.to_be_bytes()); // associate ispe with item 3, not 9
+  ipma2.push(1);
+  ipma2.push(1);
+  let mut iprp2 = Vec::new();
+  iprp2.extend(ipco2);
+  iprp2.extend(box_bytes(b"ipma", &ipma2));
+  let mut body2 = Vec::new();
+  body2.extend_from_slice(&[0, 0, 0, 0]);
+  body2.extend(box_bytes(b"pitm", &pitm2));
+  body2.extend(box_bytes(b"iprp", &iprp2));
+
+  walk_heif_meta(&body2, 0, 4, &mut m);
+  assert_eq!(m.primary_item(), Some(9), "pitm overwrote the primary");
+  assert_eq!(
+    m.image_width(),
+    Some(640),
+    "pass-2 ispe is a sub-document (associated to non-primary item 3) — earlier \
+     main-document 640 must remain, not clear"
+  );
+  assert_eq!(m.image_height(), Some(480));
+}
+
+#[test]
+fn heif_two_meta_primary_ispe_overrides() {
+  // The complement of `heif_primary_change_across_meta_boxes_keeps_main_doc_dims`:
+  // a later `meta` whose `ispe` IS main-document (associated with that meta's
+  // primary) overrides the earlier dims (last-FoundTag-wins over the whole file).
+  //
+  // Pass 1: primary 2, ispe(640x480) assoc{2→1} ⇒ 640x480. Pass 2: primary 9,
+  // ispe(11x22) assoc{9→1} (the PRIMARY) ⇒ main-document ⇒ overrides to 11x22.
+  // Oracle (bundled `exiftool -G1 -j` on the equivalent two-meta-box file):
+  // File:ImageWidth 11, File:ImageHeight 22.
+  use exifast::formats::quicktime_brands::walk_heif_meta;
+  use exifast::metadata::HeifMeta;
+
+  let ispe = |w: u32, h: u32| -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    box_bytes(b"ispe", &b)
+  };
+  // Build a meta body: pitm(primary) + iprp(ipco[ispe(w,h)] , ipma{assoc_id→1}).
+  let meta_body = |primary: u16, w: u32, h: u32, assoc_id: u16| -> Vec<u8> {
+    let mut pitm = Vec::new();
+    pitm.extend_from_slice(&[0, 0, 0, 0]);
+    pitm.extend_from_slice(&primary.to_be_bytes());
+    let ipco = box_bytes(b"ipco", &ispe(w, h));
+    let mut ipma = Vec::new();
+    ipma.extend_from_slice(&[0, 0, 0, 0]);
+    ipma.extend_from_slice(&1u32.to_be_bytes());
+    ipma.extend_from_slice(&assoc_id.to_be_bytes());
+    ipma.push(1);
+    ipma.push(1);
+    let mut iprp = Vec::new();
+    iprp.extend(ipco);
+    iprp.extend(box_bytes(b"ipma", &ipma));
+    let mut body = Vec::new();
+    body.extend_from_slice(&[0, 0, 0, 0]);
+    body.extend(box_bytes(b"pitm", &pitm));
+    body.extend(box_bytes(b"iprp", &iprp));
+    body
+  };
+
+  let mut m = HeifMeta::new();
+  walk_heif_meta(&meta_body(2, 640, 480, 2), 0, 4, &mut m);
+  assert_eq!(m.image_width(), Some(640));
+  // Pass 2: ispe(11x22) associated with the NEW primary 9 ⇒ overrides.
+  walk_heif_meta(&meta_body(9, 11, 22, 9), 0, 4, &mut m);
+  assert_eq!(m.primary_item(), Some(9));
+  assert_eq!(
+    m.image_width(),
+    Some(11),
+    "main-document later ispe must override"
+  );
+  assert_eq!(m.image_height(), Some(22));
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn cr3_many_empty_cmt_boxes_bounded() {
+  // R4 [high] — the CMT block COUNT must be bounded. Storing each CMT box's
+  // decoded TAGS (eager parse at walk time), not its raw body, means an empty
+  // (size-8) CMT box yields ZERO tags and only updates a FIXED per-kind
+  // location slot — so a crafted CR3 with a huge N of empty CMT boxes can
+  // neither grow an unbounded list nor spin the emit loop. There is no raw-body
+  // Vec and no per-box list to amplify (that surface is gone structurally).
+  //
+  // This builds a Canon `uuid` payload with a large N of size-8 empty CMT1
+  // boxes and asserts the walk completes promptly without OOM/hang, the CMT1
+  // location slot holds the LAST box (last-wins), and NO CMT tags were produced
+  // (an empty body has no parseable TIFF).
+  use exifast::formats::quicktime_brands::walk_canon_uuid;
+  use exifast::metadata::Cr3Meta;
+
+  // 2,000,000 size-8 empty CMT1 boxes — the old per-box list would have grown
+  // to millions of entries; the fixed-slot design stays O(1) in storage.
+  const N: usize = 2_000_000;
+  let mut payload = Vec::new();
+  payload.extend(box_bytes(b"CNCV", b"CanonCR3_001/00.09.00/00.00.00"));
+  // A size-8 box is header-only (4-byte size + 4-byte tag), empty body.
+  for _ in 0..N {
+    payload.extend_from_slice(&8u32.to_be_bytes());
+    payload.extend_from_slice(b"CMT1");
+  }
+
+  let mut m = Cr3Meta::new();
+  walk_canon_uuid(&payload, 0, &mut m); // must complete without OOM/hang
+
+  // The CNCV still decoded (the walk ran to completion past all the empties).
+  assert_eq!(
+    m.compressor_version(),
+    Some("CanonCR3_001/00.09.00/00.00.00")
+  );
+  // A CMT1 location slot is present (last-wins): millions of boxes collapse to
+  // ONE fixed slot, not a list.
+  let blk = m.cmt1().expect("a CMT1 location slot is recorded");
+  assert_eq!(blk.length(), 0, "an empty CMT1 box has a zero-length body");
+  // No CMT tags were produced — an empty body has no parseable TIFF, so the
+  // rendered-tag buffers stay empty regardless of box count (∝ parsed tags).
+  assert!(
+    m.cmt_tags(true).is_empty() && m.cmt_tags(false).is_empty(),
+    "empty CMT boxes must yield no rendered tags"
+  );
+}
+
+// ============================================================================
+// SP4 R2 — reordered / duplicate-input fidelity (F1 dup ipma, F2 CMT file order)
+// ============================================================================
+
+/// Build a minimal little-endian TIFF block holding a single IFD0 entry. The
+/// IFD lives at offset 8 (just past the `II*\0` + ifd0-offset header); the
+/// value bytes go out-of-line just after the IFD. Used to synthesize the
+/// self-contained CMT1 (IFD0) / CMT3 (Canon MakerNote) TIFF blocks a Canon
+/// `uuid` re-dispatches.
+fn tiff_le_one_entry(tag: u16, ifd_type: u16, value: &[u8]) -> Vec<u8> {
+  let count = value.len() as u32;
+  // header(8) + [count(2) + 1 entry(12) + next-ifd(4)] = 8 + 18 = 26; value at 26.
+  let ool_off = 26u32;
+  let mut out = Vec::new();
+  out.extend_from_slice(b"II");
+  out.extend_from_slice(&0x2au16.to_le_bytes());
+  out.extend_from_slice(&8u32.to_le_bytes()); // IFD0 offset
+  out.extend_from_slice(&1u16.to_le_bytes()); // entry count
+  out.extend_from_slice(&tag.to_le_bytes());
+  out.extend_from_slice(&ifd_type.to_le_bytes());
+  out.extend_from_slice(&count.to_le_bytes());
+  out.extend_from_slice(&ool_off.to_le_bytes()); // value offset (out-of-line)
+  out.extend_from_slice(&0u32.to_le_bytes()); // next IFD = 0
+  out.extend_from_slice(value);
+  out
+}
+
+/// Build a CR3 (`crx ` brand) whose Canon `uuid` carries CNCV + the given
+/// CMT blocks IN THE GIVEN ORDER. Each `(tag, body)` is emitted as a child
+/// box in sequence, so the caller controls the file order of CMT1/CMT3.
+fn cr3_with_cmt_order(blocks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"crx ");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 1]);
+  ftyp_body.extend_from_slice(b"crx ");
+  ftyp_body.extend_from_slice(b"isom");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  const CANON_UUID: [u8; 16] = [
+    0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0, 0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48,
+  ];
+  let mut uuid_body = Vec::new();
+  uuid_body.extend_from_slice(&CANON_UUID);
+  uuid_body.extend(box_bytes(b"CNCV", b"CanonCR3_001/00.09.00/00.00.00"));
+  for (tag, body) in blocks {
+    uuid_body.extend(box_bytes(tag, body));
+  }
+  let uuid = box_bytes(b"uuid", &uuid_body);
+  let moov = box_bytes(b"moov", &uuid);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(moov);
+  data
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_duplicate_ipma_last_association_wins() {
+  // ExifTool assigns `$$items{$id}{Association} = \@association` per `ipma` ROW
+  // (QuickTime.pm:9331), a plain `=`: a DUPLICATE row for the primary id
+  // OVERWRITES the earlier association (last-wins) while STILL warning ("Item
+  // property association entries are out of order"). The deferred `ipco` walk
+  // then gates each `ispe` by that effective association: ispe index 1 (640) is
+  // referenced only by the FIRST (overwritten) primary row and by the thumbnail
+  // item 3, so it ends up a SUB-document (associated to non-primary item 3) and
+  // is gated out; ispe index 2 (1280) is the primary's effective association ⇒
+  // main-document ⇒ wins.
+  //
+  // Ground-truthed against `exiftool -G1 -j` on this exact shape: it emits
+  // File:ImageWidth=1280 / File:ImageHeight=960 (the LAST row's ispe, prop 2),
+  // NOT 640x480 (the first row's prop 1), plus the out-of-order warning.
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  // pitm v0 → primary item id 2.
+  let mut pitm_body = Vec::new();
+  pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+  pitm_body.extend_from_slice(&2u16.to_be_bytes());
+  let pitm = box_bytes(b"pitm", &pitm_body);
+
+  let ispe = |w: u32, h: u32| -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    box_bytes(b"ispe", &b)
+  };
+  // ipco: index 1 = ispe(640x480), index 2 = ispe(1280x960).
+  let mut ipco_body = Vec::new();
+  ipco_body.extend(ispe(640, 480));
+  ipco_body.extend(ispe(1280, 960));
+  let ipco = box_bytes(b"ipco", &ipco_body);
+
+  // ipma v0 flags0 with THREE rows, TWO of them for the primary item 2:
+  //   row A: item 2 → [prop 1]  (640x480)
+  //   row B: item 2 → [prop 2]  (1280x960)  ← duplicate id, LAST wins
+  //   row C: item 3 → [prop 1]
+  let mut ipma_body = Vec::new();
+  ipma_body.extend_from_slice(&[0, 0, 0, 0]);
+  ipma_body.extend_from_slice(&3u32.to_be_bytes()); // entry count
+  ipma_body.extend_from_slice(&2u16.to_be_bytes()); // item 2
+  ipma_body.push(1);
+  ipma_body.push(1); // prop 1
+  ipma_body.extend_from_slice(&2u16.to_be_bytes()); // item 2 AGAIN
+  ipma_body.push(1);
+  ipma_body.push(2); // prop 2
+  ipma_body.extend_from_slice(&3u16.to_be_bytes()); // item 3
+  ipma_body.push(1);
+  ipma_body.push(1);
+  let ipma = box_bytes(b"ipma", &ipma_body);
+
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(ipco);
+  iprp_body.extend(ipma);
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]);
+  meta_body.extend(pitm);
+  meta_body.extend(iprp);
+  let meta = box_bytes(b"meta", &meta_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(meta);
+
+  let m = parse_quicktime(&data).expect("accepted");
+  // The LAST association (prop 2 → 1280x960) wins, NOT the first (640x480).
+  assert_eq!(m.heif().primary_item(), Some(2));
+  assert_eq!(
+    m.heif().image_width(),
+    Some(1280),
+    "duplicate ipma rows: the LAST association must win (1280, not 640)"
+  );
+  assert_eq!(m.heif().image_height(), Some(960));
+
+  // The duplicate/out-of-order warning is still raised (ExifTool warns per the
+  // `unless $id > $lastID` check even though the row overwrites).
+  assert_eq!(
+    m.heif().warning(),
+    Some("Item property association entries are out of order"),
+    "the out-of-order warning must be preserved on the duplicate row"
+  );
+
+  // And the emitted JSON carries the LAST association's dims, not the first.
+  let json = exifast::parser::extract_info("dup_ipma.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":1280"#) && json.contains(r#""File:ImageHeight":960"#),
+    "got: {json}"
+  );
+  assert!(
+    !json.contains(r#""File:ImageWidth":640"#),
+    "the first (overwritten) association leaked: {json}"
+  );
+}
+
+#[test]
+fn heif_unrelated_later_meta_does_not_erase_dims() {
+  // `scan_quicktime_brands` walks EVERY `meta` box into the SAME `HeifMeta`.
+  // ExifTool's `ispe` FoundTag is cumulative over the whole file (QuickTime.pm:
+  // 3040); a later meta that produces NO main-document `ispe` does NOT remove the
+  // earlier dims. So an earlier HEIF meta that emits 640x480, followed by an
+  // UNRELATED later meta (no `iprp`/`ispe` — e.g. an iTunes-style metadata meta),
+  // must LEAVE the dims at 640x480.
+  use exifast::formats::quicktime_brands::walk_heif_meta;
+  use exifast::metadata::HeifMeta;
+
+  let ispe = |w: u32, h: u32| -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&[0, 0, 0, 0]);
+    b.extend_from_slice(&w.to_be_bytes());
+    b.extend_from_slice(&h.to_be_bytes());
+    box_bytes(b"ispe", &b)
+  };
+
+  // Meta 1: pitm(2) + iprp(ipco[ispe(640x480)], ipma{2→1}) ⇒ resolves 640x480.
+  let mut pitm1 = Vec::new();
+  pitm1.extend_from_slice(&[0, 0, 0, 0]);
+  pitm1.extend_from_slice(&2u16.to_be_bytes());
+  let ipco1 = box_bytes(b"ipco", &ispe(640, 480));
+  let mut ipma1 = Vec::new();
+  ipma1.extend_from_slice(&[0, 0, 0, 0]);
+  ipma1.extend_from_slice(&1u32.to_be_bytes());
+  ipma1.extend_from_slice(&2u16.to_be_bytes());
+  ipma1.push(1);
+  ipma1.push(1);
+  let mut iprp1 = Vec::new();
+  iprp1.extend(ipco1);
+  iprp1.extend(box_bytes(b"ipma", &ipma1));
+  let mut body1 = Vec::new();
+  body1.extend_from_slice(&[0, 0, 0, 0]);
+  body1.extend(box_bytes(b"pitm", &pitm1));
+  body1.extend(box_bytes(b"iprp", &iprp1));
+
+  let mut m = HeifMeta::new();
+  walk_heif_meta(&body1, 0, 4, &mut m);
+  assert_eq!(m.image_width(), Some(640));
+  assert_eq!(m.image_height(), Some(480));
+
+  // Meta 2 into the SAME HeifMeta: an UNRELATED meta with NO iprp/ipma/pitm
+  // (only an unrelated hdlr child). It establishes NO property-resolution state,
+  // so the earlier 640x480 must STAY (not be erased).
+  let mut body2 = Vec::new();
+  body2.extend_from_slice(&[0, 0, 0, 0]);
+  body2.extend(box_bytes(b"hdlr", &[0u8; 24]));
+
+  walk_heif_meta(&body2, 0, 4, &mut m);
+  assert_eq!(
+    m.image_width(),
+    Some(640),
+    "an unrelated later meta (no iprp/ipma) erased the earlier HEIF dims"
+  );
+  assert_eq!(m.image_height(), Some(480));
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn cr3_cmt3_before_cmt1_no_model_threaded() {
+  // F2 — ExifTool processes the Canon `uuid` child atoms in FILE order, and
+  // `$$self{Model}` (set by a CMT1 IFD0) is a stateful single-pass value. The
+  // Canon MakerNote (CMT3 → `Canon::Main` via ProcessCMT3) is walked with the
+  // Model of the most-recent PRECEDING CMT1. So a CMT3 BEFORE any CMT1 runs with
+  // NO Model in state; a CMT1-before-CMT3 threads the Model.
+  //
+  // The clean model-gated observable is Canon Main tag `0x96` (Canon.pm:1834):
+  //   - Model =~ /EOS 5D/  ⇒ FIRST arm `SerialInfo` (a SubDirectory; exifast
+  //     surfaces it as the raw blob) ⇒ `InternalSerialNumber` is ABSENT.
+  //   - no/other Model      ⇒ SECOND arm `InternalSerialNumber` (the trailing
+  //     `0xff` strip applies) ⇒ `Canon:InternalSerialNumber` IS emitted.
+  // Ground-truthed against `exiftool -G1 -j`: the reordered file emits
+  // `Canon:InternalSerialNumber":"ABC123"` while the in-order file does not.
+
+  // CMT1 IFD0 with Model (0x0110) ASCII = "Canon EOS 5D\0".
+  let cmt1 = tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
+  // CMT3 (Canon MakerNote) IFD0 with 0x96 ASCII = "ABC123\xff\xff\xff".
+  let cmt3 = tiff_le_one_entry(0x0096, 2, b"ABC123\xff\xff\xff");
+
+  // In-order [CMT1, CMT3]: the Model is in state at the CMT3 walk ⇒ 0x96 routes
+  // to the SerialInfo arm ⇒ InternalSerialNumber is NOT emitted.
+  let in_order = cr3_with_cmt_order(&[(b"CMT1", cmt1.clone()), (b"CMT3", cmt3.clone())]);
+  let json_in = exifast::parser::extract_info("cr3_inorder.cr3", &in_order, true);
+  assert!(
+    json_in.contains(r#""IFD0:Model":"Canon EOS 5D""#),
+    "in-order CMT1 Model missing: {json_in}"
+  );
+  assert!(
+    !json_in.contains("InternalSerialNumber"),
+    "in-order: Model in state ⇒ 0x96 is SerialInfo, InternalSerialNumber must be absent: {json_in}"
+  );
+
+  // Reordered [CMT3, CMT1]: the Model is NOT yet in state at the CMT3 walk ⇒
+  // 0x96 falls to the InternalSerialNumber arm (stripped of trailing 0xff). The
+  // Model is still emitted (CMT1 is processed after, in file order).
+  let reordered = cr3_with_cmt_order(&[(b"CMT3", cmt3), (b"CMT1", cmt1)]);
+  let json_re = exifast::parser::extract_info("cr3_reorder.cr3", &reordered, true);
+  assert!(
+    json_re.contains(r#""IFD0:Model":"Canon EOS 5D""#),
+    "reordered CMT1 Model missing: {json_re}"
+  );
+  assert!(
+    json_re.contains(r#""Canon:InternalSerialNumber":"ABC123""#),
+    "reordered: CMT3-before-CMT1 ⇒ no Model in state ⇒ 0x96 InternalSerialNumber (stripped): {json_re}"
+  );
+}
+
+// ============================================================================
+// SP4 R4 — CMT memory discipline (no raw-body storage; bounded ∝ parsed tags)
+// + model-state on the degradation path
+// ============================================================================
+
+/// Build a CR3 (`crx ` brand) moov carrying MANY Canon `uuid` atoms, each with
+/// the given CMT blocks. Mirrors a crafted file with repeated moov-level Canon
+/// uuid boxes (ExifTool re-runs `Canon::uuid` per box in file order).
+fn cr3_with_n_canon_uuids(n: usize, blocks: &[(&[u8; 4], Vec<u8>)]) -> Vec<u8> {
+  const CANON_UUID: [u8; 16] = [
+    0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0, 0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48,
+  ];
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"crx ");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 1]);
+  ftyp_body.extend_from_slice(b"crx ");
+  ftyp_body.extend_from_slice(b"isom");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  let mut moov_body = Vec::new();
+  for _ in 0..n {
+    let mut uuid_body = Vec::new();
+    uuid_body.extend_from_slice(&CANON_UUID);
+    uuid_body.extend(box_bytes(b"CNCV", b"CanonCR3_001/00.09.00/00.00.00"));
+    for (tag, body) in blocks {
+      uuid_body.extend(box_bytes(tag, body));
+    }
+    moov_body.extend(box_bytes(b"uuid", &uuid_body));
+  }
+  let moov = box_bytes(b"moov", &moov_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(moov);
+  data
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn cr3_multiple_canon_uuid_atoms_bounded() {
+  // R4 [high] — the aggregate CMT allocation must NOT reset per Canon `uuid`
+  // atom. ExifTool re-runs `Canon::uuid` for EVERY moov-level Canon uuid box in
+  // file order; the old design carried a PER-ATOM byte budget, so each atom
+  // could copy up to the cap (unbounded across atoms). The eager-parse design
+  // stores decoded TAGS, not raw bodies, and threads ONE shared `Cr3Meta`
+  // across every `walk_canon_uuid` call — there is no per-atom budget to reset,
+  // and allocation is bounded by the total parsed tag count (∝ input).
+  //
+  // This builds a moov with many Canon uuid atoms, each carrying a small real
+  // CMT2 (ExifIFD) TIFF, and asserts: the parse completes (no OOM/hang), and the
+  // CMT2 ExifIFD tag surfaces (the per-atom walk accumulates into the shared
+  // view — it is not silently dropped by a stale per-atom budget).
+  const N: usize = 50_000;
+  // CMT2 (ExifIFD) carrying a single ASCII LensModel (0xa434) — a plain
+  // string passthrough that surfaces as `ExifIFD:LensModel` (the real-fixture
+  // test proves this tag emits). ASCII (type 2) ⇒ count == byte length, which
+  // is what `tiff_le_one_entry` writes.
+  let cmt2 = tiff_le_one_entry(0xa434, 2, b"PROBE-LENS ");
+  let data = cr3_with_n_canon_uuids(N, &[(b"CMT2", cmt2)]);
+
+  // Must complete promptly without OOM/hang despite N atoms.
+  let json = exifast::parser::extract_info("cr3_multi_uuid.cr3", &data, true);
+
+  // The CMT2 ExifIFD tag surfaces — the per-atom walk accumulated into the
+  // SHARED Cr3Meta (no per-atom budget reset silently dropped it). Last-wins on
+  // the duplicate key collapses the N identical copies to one.
+  assert!(
+    json.contains(r#""ExifIFD:LensModel":"PROBE-LENS""#),
+    "CMT2 ExifIFD tag must surface across multiple uuid atoms: {json}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn cr3_overbudget_or_dropped_cmt1_no_stale_model_for_cmt3() {
+  // R4 [medium] — the file-order `$$self{Model}` threading must be correct on
+  // the degradation path. The old design stored each CMT1 BODY and re-parsed it
+  // at emit; a dropped (over-budget) CMT1 became an EMPTY body that parsed to NO
+  // model, leaving the EARLIER CMT1's Model STALE for the next CMT3 — flipping
+  // the model-conditional `0x96` arm. The eager-parse design captures each
+  // CMT1's Model AT WALK POSITION in file order (no drop, no re-parse), so a
+  // later CMT1's Model correctly SUPERSEDES an earlier one and a model-less CMT1
+  // never clears it. This test pins BOTH directions.
+  //
+  // Discriminating observable is Canon Main tag `0x96` (Canon.pm:1834):
+  //   - Model =~ /EOS 5D/ ⇒ `SerialInfo` SubDirectory arm ⇒ InternalSerialNumber
+  //     ABSENT.
+  //   - other / no Model  ⇒ `InternalSerialNumber` arm (trailing 0xff stripped)
+  //     ⇒ present.
+  // Ground-truthed against `exiftool -G1 -j`.
+
+  let cmt1_5d = || tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
+  let cmt1_r5 = || tiff_le_one_entry(0x0110, 2, b"Canon EOS R5\0");
+  let cmt1_nomodel = || tiff_le_one_entry(0x0131, 2, b"exifast\0");
+  let cmt3 = || tiff_le_one_entry(0x0096, 2, b"ABC123\xff\xff\xff");
+
+  // (a) The spec scenario — CMT1(5D), then a model-LESS CMT1, then CMT3. The 5D
+  // Model must STILL thread (the model-less CMT1 does not clear it) ⇒ 0x96 is
+  // SerialInfo ⇒ InternalSerialNumber ABSENT.
+  let data_a = cr3_with_cmt_order(&[
+    (b"CMT1", cmt1_5d()),
+    (b"CMT1", cmt1_nomodel()),
+    (b"CMT3", cmt3()),
+  ]);
+  let json_a = exifast::parser::extract_info("cr3_a.cr3", &data_a, true);
+  assert!(
+    json_a.contains(r#""IFD0:Model":"Canon EOS 5D""#),
+    "the 5D Model is emitted (the model-less CMT1 carries no Model tag): {json_a}"
+  );
+  assert!(
+    !json_a.contains("InternalSerialNumber"),
+    "model-less middle CMT1 must NOT clear the 5D Model: 0x96 stays SerialInfo \
+     ⇒ InternalSerialNumber absent: {json_a}"
+  );
+
+  // (b) The supersede direction (the exact R4 drop-bug inverse) — CMT1(5D),
+  // then a DIFFERENT real CMT1(R5), then CMT3. The LATER R5 Model must
+  // supersede the 5D (the drop-bug would have left a stale 5D) ⇒ R5 does NOT
+  // match /EOS 5D/ ⇒ 0x96 is the InternalSerialNumber arm ⇒ present (stripped).
+  let data_b = cr3_with_cmt_order(&[
+    (b"CMT1", cmt1_5d()),
+    (b"CMT1", cmt1_r5()),
+    (b"CMT3", cmt3()),
+  ]);
+  let json_b = exifast::parser::extract_info("cr3_b.cr3", &data_b, true);
+  assert!(
+    json_b.contains(r#""IFD0:Model":"Canon EOS R5""#),
+    "the LAST CMT1 Model wins (last-wins per kind): {json_b}"
+  );
+  assert!(
+    json_b.contains(r#""Canon:InternalSerialNumber":"ABC123""#),
+    "the later R5 Model must SUPERSEDE the 5D (no stale earlier model): R5 ≠ \
+     /EOS 5D/ ⇒ 0x96 is InternalSerialNumber (stripped): {json_b}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn cr3_modelless_cmt1_does_not_clear_threaded_model() {
+  // F2 — `$$self{Model}` (set by a CMT1 IFD0 Model) is a stateful single-pass
+  // value that ExifTool only ASSIGNS when a Model (0x0110) tag is handled. A
+  // CMT1 that parses but lacks a Model does NOT clear an earlier Model. So a
+  // sequence CMT1(Model), CMT1(no-Model), CMT3 must walk the CMT3 with the FIRST
+  // CMT1's Model still threaded — overwriting it with `None` on the model-less
+  // CMT1 would be wrong.
+  //
+  // Discriminating observable is Canon Main tag `0x96` (Canon.pm:1834): with
+  // Model =~ /EOS 5D/ ⇒ the `SerialInfo` SubDirectory arm (InternalSerialNumber
+  // ABSENT); with no Model in state ⇒ the `InternalSerialNumber` arm (present,
+  // trailing 0xff stripped). The threaded model is therefore "Canon EOS 5D" (the
+  // model the `0x96` condition actually keys on), so the assertion is meaningful:
+  // if the model-less CMT1 wrongly cleared the Model, InternalSerialNumber would
+  // appear. Ground-truthed against `exiftool -G1 -j`.
+
+  // CMT1 #1: IFD0 with Model (0x0110) = "Canon EOS 5D\0".
+  let cmt1_model = tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
+  // CMT1 #2: a model-LESS IFD0 (Software 0x0131 instead of Model) — parses, but
+  // `dispatcher_model()` is None, so it must NOT overwrite the threaded Model.
+  let cmt1_nomodel = tiff_le_one_entry(0x0131, 2, b"exifast\0");
+  // CMT3 (Canon MakerNote) IFD0 with 0x96 = "ABC123\xff\xff\xff".
+  let cmt3 = tiff_le_one_entry(0x0096, 2, b"ABC123\xff\xff\xff");
+
+  let data = cr3_with_cmt_order(&[
+    (b"CMT1", cmt1_model),
+    (b"CMT1", cmt1_nomodel),
+    (b"CMT3", cmt3),
+  ]);
+  let json = exifast::parser::extract_info("cr3_modelless.cr3", &data, true);
+
+  // The CMT1 Model is still emitted (last-wins per kind on IFD0; the model-less
+  // CMT1 carries no Model tag to overwrite it).
+  assert!(
+    json.contains(r#""IFD0:Model":"Canon EOS 5D""#),
+    "CMT1 Model missing: {json}"
+  );
+  // The CMT3 walk saw the threaded Model (NOT cleared by the model-less CMT1) ⇒
+  // 0x96 routes to SerialInfo ⇒ InternalSerialNumber must be ABSENT.
+  assert!(
+    !json.contains("InternalSerialNumber"),
+    "model-less CMT1 must NOT clear the threaded Model: with EOS 5D in state, \
+     0x96 is SerialInfo and InternalSerialNumber must be absent: {json}"
+  );
+}
+
+// ============================================================================
+// SP4 R5 — file-walk `$$self{Model}` threads ACROSS Canon `uuid` atoms
+// ============================================================================
+
+/// Build a CR3 (`crx ` brand) moov carrying ONE Canon `uuid` atom PER inner
+/// slice, each atom holding CNCV + that slice's CMT blocks (in order). Lets a
+/// test place CMT1 in one Canon `uuid` and CMT3 in a LATER one — the layout
+/// ExifTool walks as a single moov-level pass with persistent `$$self{Model}`.
+fn cr3_with_canon_uuids(uuids: &[&[(&[u8; 4], Vec<u8>)]]) -> Vec<u8> {
+  const CANON_UUID: [u8; 16] = [
+    0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0, 0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48,
+  ];
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"crx ");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 1]);
+  ftyp_body.extend_from_slice(b"crx ");
+  ftyp_body.extend_from_slice(b"isom");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  let mut moov_body = Vec::new();
+  for blocks in uuids {
+    let mut uuid_body = Vec::new();
+    uuid_body.extend_from_slice(&CANON_UUID);
+    uuid_body.extend(box_bytes(b"CNCV", b"CanonCR3_001/00.09.00/00.00.00"));
+    for (tag, body) in *blocks {
+      uuid_body.extend(box_bytes(tag, body));
+    }
+    moov_body.extend(box_bytes(b"uuid", &uuid_body));
+  }
+  let moov = box_bytes(b"moov", &moov_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(moov);
+  data
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn cr3_cmt1_in_earlier_uuid_threads_model_to_cmt3_in_later_uuid() {
+  // R5 [high] — ExifTool's `$$self{Model}` is FILE-WALK object state, not
+  // per-`uuid`-atom: it is set when ANY IFD0 / CMT1 `Model` (0x0110) is handled
+  // and persists for the rest of the moov tree walk. So a CMT3 in a LATER Canon
+  // `uuid` atom must see the `Model` of a CMT1 in an EARLIER Canon `uuid` atom.
+  // The old per-uuid-local model reset this between atoms, silently flipping the
+  // model-conditional `0x96` arm (Canon.pm:1834):
+  //   - Model =~ /EOS 5D/ ⇒ `SerialInfo` SubDirectory arm ⇒ InternalSerialNumber
+  //     ABSENT.
+  //   - no/other Model     ⇒ `InternalSerialNumber` arm (trailing 0xff stripped)
+  //     ⇒ present.
+  // Ground-truthed against `exiftool -G1 -j` on this multi-uuid layout.
+
+  let cmt1_5d = || tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
+  let cmt3 = || tiff_le_one_entry(0x0096, 2, b"ABC123\xff\xff\xff");
+
+  // uuid#1 { CMT1(Model="Canon EOS 5D") }, then uuid#2 { CMT3(0x96) }. The 5D
+  // Model set while walking uuid#1 must STILL be in state at the uuid#2 CMT3 ⇒
+  // 0x96 routes to SerialInfo ⇒ InternalSerialNumber ABSENT.
+  let threaded = cr3_with_canon_uuids(&[&[(b"CMT1", cmt1_5d())], &[(b"CMT3", cmt3())]]);
+  let json = exifast::parser::extract_info("cr3_cross_uuid.cr3", &threaded, true);
+  assert!(
+    json.contains(r#""IFD0:Model":"Canon EOS 5D""#),
+    "the uuid#1 CMT1 Model is emitted: {json}"
+  );
+  assert!(
+    !json.contains("InternalSerialNumber"),
+    "R5: a CMT1 Model in an EARLIER Canon uuid must thread to a CMT3 in a LATER \
+     uuid ⇒ 0x96 is SerialInfo ⇒ InternalSerialNumber absent: {json}"
+  );
+
+  // Non-vacuousness: the SAME 0x96 bytes WITHOUT a preceding CMT1 Model take the
+  // OTHER arm. Reversing the atom order — uuid#1 { CMT3(0x96) } BEFORE uuid#2
+  // { CMT1(5D) } — leaves the CMT3 with NO model in state ⇒ 0x96 is
+  // InternalSerialNumber (stripped). This proves the assertion above is
+  // observable (it would FAIL if the model state were per-uuid-local: the
+  // threaded case would also fall to InternalSerialNumber).
+  let reversed = cr3_with_canon_uuids(&[&[(b"CMT3", cmt3())], &[(b"CMT1", cmt1_5d())]]);
+  let json_rev = exifast::parser::extract_info("cr3_cross_uuid_rev.cr3", &reversed, true);
+  assert!(
+    json_rev.contains(r#""IFD0:Model":"Canon EOS 5D""#),
+    "the uuid#2 CMT1 Model is still emitted (file order): {json_rev}"
+  );
+  assert!(
+    json_rev.contains(r#""Canon:InternalSerialNumber":"ABC123""#),
+    "CMT3 before any CMT1 (even cross-uuid) ⇒ no model in state ⇒ 0x96 is \
+     InternalSerialNumber (stripped): {json_rev}"
+  );
+}
+
+// ============================================================================
+// HEIF item-property shape matrix (pitm / ipco / ipma / ispe)
+//
+// Every assertion below is ground-truthed against the bundled
+// `perl exiftool 13.59 -fast -G1 -j -FileType -ImageWidth -ImageHeight` on the
+// EXACT byte layout the builder produces (a synthetic HEIC: `ftyp(heic)` +
+// `meta`). These pin the full association-shape class: the effective-primary-0
+// fold (`$$et{PrimaryItem} || 0`), duplicate-`ipco` last-container-wins, the
+// `ispe` version/flags `Condition` gate, the `@dim < 2` short-`ispe` guard, and
+// the essential-bit index width.
+// ============================================================================
+
+/// Build a HEIC with an arbitrary `ipco` byte body + an explicit `ipma` body
+/// (already serialized), an optional `pitm`. `pitm` is `Some(primary)` for a
+/// `pitm` v0 box, or `None` to OMIT the box entirely (effective primary 0).
+/// Lets the sweep tests craft `ispe` boxes with non-zero version/flags or a
+/// truncated body that the typed `heic_with_ispes_and_ipma` builder cannot.
+fn heic_with_raw_ipco_ipma(primary: Option<u16>, ipco_body: &[u8], ipma_body: &[u8]) -> Vec<u8> {
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(box_bytes(b"ipco", ipco_body));
+  iprp_body.extend(box_bytes(b"ipma", ipma_body));
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]);
+  if let Some(p) = primary {
+    let mut pitm_body = Vec::new();
+    pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+    pitm_body.extend_from_slice(&p.to_be_bytes());
+    meta_body.extend(box_bytes(b"pitm", &pitm_body));
+  }
+  meta_body.extend(iprp);
+  let meta = box_bytes(b"meta", &meta_body);
+
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(meta);
+  data
+}
+
+/// Serialize an `ispe` box with an explicit 4-byte version/flags prefix and a
+/// caller-controlled body length (`body_len` truncates the `[verflags][w][h]`
+/// payload to exercise the `@dim < 2` short-box guard).
+fn ispe_box_raw(verflags: [u8; 4], w: u32, h: u32, body_len: usize) -> Vec<u8> {
+  let mut b = Vec::new();
+  b.extend_from_slice(&verflags);
+  b.extend_from_slice(&w.to_be_bytes());
+  b.extend_from_slice(&h.to_be_bytes());
+  b.truncate(body_len);
+  box_bytes(b"ispe", &b)
+}
+
+/// Serialize a v0 `ipma` body: `[version=0|flags:3][num:u32]` then, per row,
+/// `[id:u16][count:u8]` and `count` 1-byte (or 2-byte when `low_flag`)
+/// association entries (the raw entry byte, INCLUDING any essential top bit).
+fn ipma_v0_raw(low_flag: bool, rows: &[(u16, &[u16])]) -> Vec<u8> {
+  let flags: u32 = u32::from(low_flag);
+  let mut body = Vec::new();
+  body.extend_from_slice(&flags.to_be_bytes());
+  body.extend_from_slice(&(rows.len() as u32).to_be_bytes());
+  for &(id, entries) in rows {
+    body.extend_from_slice(&id.to_be_bytes());
+    body.push(entries.len() as u8);
+    for &e in entries {
+      if low_flag {
+        body.extend_from_slice(&e.to_be_bytes());
+      } else {
+        body.push(e as u8);
+      }
+    }
+  }
+  body
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_missing_pitm_item0_primary_emits() {
+  // ExifTool's `my $primary = $$et{PrimaryItem} || 0`
+  // (QuickTime.pm:10200) folds a MISSING `pitm` to the effective primary id 0,
+  // so an `ipma` row for item id 0 matches the primary (`$id == $primary`) and
+  // its `ispe` is MAIN-DOCUMENT. Layout: NO `pitm`, ipco[ispe(111×222)],
+  // ipma{0 → prop 1}. Oracle (bundled `perl exiftool -fast -G1 -j` on this exact
+  // layout): File:ImageWidth 111, File:ImageHeight 222.
+  let ipco = ispe_box_raw([0, 0, 0, 0], 111, 222, 12);
+  let ipma = ipma_v0_raw(false, &[(0, &[1])]);
+  let data = heic_with_raw_ipco_ipma(None, &ipco, &ipma);
+  let m = parse_quicktime(&data).expect("accepted");
+  assert!(
+    m.heif().primary_item().is_none(),
+    "no pitm ⇒ primary_item None"
+  );
+  assert_eq!(
+    m.heif().image_width(),
+    Some(111),
+    "missing pitm ⇒ effective primary 0; the item-0 ipma row makes its ispe main-document"
+  );
+  assert_eq!(m.heif().image_height(), Some(222));
+  let json = exifast::parser::extract_info("nopitm0.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":111"#) && json.contains(r#""File:ImageHeight":222"#),
+    "expected 111x222: {json}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_missing_pitm_nonzero_item_gated_out() {
+  // With NO `pitm` (effective primary 0) and the `ispe`
+  // associated ONLY by a NON-zero item id (5), no item 0 row exists, so the
+  // `ispe` is associated-but-not-by-primary ⇒ a SUB-document ⇒ gated out.
+  // Layout: NO `pitm`, ipco[ispe(111×222)], ipma{5 → prop 1}. Oracle
+  // (`perl exiftool -fast -G1 -j`): NO File:ImageWidth / File:ImageHeight.
+  let ipco = ispe_box_raw([0, 0, 0, 0], 111, 222, 12);
+  let ipma = ipma_v0_raw(false, &[(5, &[1])]);
+  let data = heic_with_raw_ipco_ipma(None, &ipco, &ipma);
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(
+    m.heif().image_width(),
+    None,
+    "no pitm + association only by a non-zero item ⇒ sub-document ⇒ no dims"
+  );
+  assert_eq!(m.heif().image_height(), None);
+  let json = exifast::parser::extract_info("nopitm5.heic", &data, true);
+  assert!(
+    !json.contains(r#""File:ImageWidth""#),
+    "no File:ImageWidth expected: {json}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_duplicate_ipco_last_wins() {
+  // ExifTool DEFERS the `ipco` directory by a plain ASSIGNMENT
+  // `$$et{ItemPropertyContainer} = [ \%dirInfo, ... ]` (QuickTime.pm:10363) and
+  // `%dupDirOK` whitelists `ipco` (QuickTime.pm:510), so a SECOND `ipco` in the
+  // same `meta` OVERWRITES the first and only the LAST is processed once after
+  // the walk (QuickTime.pm:9530-9534). The `ipma` index then refers into the
+  // LAST `ipco`. Layout: iprp{ ipco#1[ispe(640×480)], ipco#2[ispe(1280×960)],
+  // ipma{primary 2 → prop 1} }. Oracle (`perl exiftool -fast -G1 -j`):
+  // File:ImageWidth 1280, File:ImageHeight 960 (NOT 640 — ipco#1 discarded).
+  let ispe = |w: u32, h: u32| ispe_box_raw([0, 0, 0, 0], w, h, 12);
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(box_bytes(b"ipco", &ispe(640, 480)));
+  iprp_body.extend(box_bytes(b"ipco", &ispe(1280, 960)));
+  iprp_body.extend(box_bytes(b"ipma", &ipma_v0_raw(false, &[(2, &[1])])));
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+  let mut pitm_body = Vec::new();
+  pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+  pitm_body.extend_from_slice(&2u16.to_be_bytes());
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]);
+  meta_body.extend(box_bytes(b"pitm", &pitm_body));
+  meta_body.extend(iprp);
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(box_bytes(b"meta", &meta_body));
+
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(
+    m.heif().image_width(),
+    Some(1280),
+    "duplicate ipco: the LAST ipco's ispe must win (1280, not the discarded 640)"
+  );
+  assert_eq!(m.heif().image_height(), Some(960));
+  let json = exifast::parser::extract_info("dupipco.heic", &data, true);
+  assert!(
+    json.contains(r#""File:ImageWidth":1280"#) && !json.contains(r#""File:ImageWidth":640"#),
+    "the first ipco's ispe must NOT survive: {json}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_duplicate_ipco_stale_unassociated_ispe_discarded() {
+  // The shape that distinguishes last-`ipco`-wins from accumulation: the LAST
+  // `ipco`'s `ispe` is GATED OUT while the FIRST `ipco` carries an UNassociated
+  // (main-document) `ispe`. Under last-`ipco`-wins (ExifTool) ipco#1 is
+  // discarded entirely, so the only surviving `ispe` (ipco#2 index 1) is
+  // associated by a NON-primary item ⇒ sub-document ⇒ NOTHING emits.
+  // Accumulating both containers would instead keep ipco#1's index-2
+  // `ispe(7777×8888)` as a main-document property and wrongly emit it.
+  //
+  // Layout: NO `pitm` association for the primary; iprp{ ipco#1[ispe(1×1),
+  // ispe(7777×8888)], ipco#2[ispe(640×480)], ipma{ item 3 → prop 1 } }. Oracle
+  // (`perl exiftool -fast -G1 -j` on this exact layout): NO File:ImageWidth.
+  let ispe = |w: u32, h: u32| ispe_box_raw([0, 0, 0, 0], w, h, 12);
+  let mut ipco1 = Vec::new();
+  ipco1.extend(ispe(1, 1));
+  ipco1.extend(ispe(7777, 8888));
+  let mut iprp_body = Vec::new();
+  iprp_body.extend(box_bytes(b"ipco", &ipco1));
+  iprp_body.extend(box_bytes(b"ipco", &ispe(640, 480)));
+  iprp_body.extend(box_bytes(b"ipma", &ipma_v0_raw(false, &[(3, &[1])])));
+  let iprp = box_bytes(b"iprp", &iprp_body);
+
+  let mut ftyp_body = Vec::new();
+  ftyp_body.extend_from_slice(b"heic");
+  ftyp_body.extend_from_slice(&[0, 0, 0, 0]);
+  ftyp_body.extend_from_slice(b"mif1");
+  ftyp_body.extend_from_slice(b"heic");
+  let ftyp = box_bytes(b"ftyp", &ftyp_body);
+  let mut pitm_body = Vec::new();
+  pitm_body.extend_from_slice(&[0, 0, 0, 0]);
+  pitm_body.extend_from_slice(&2u16.to_be_bytes());
+  let mut meta_body = Vec::new();
+  meta_body.extend_from_slice(&[0, 0, 0, 0]);
+  meta_body.extend(box_bytes(b"pitm", &pitm_body));
+  meta_body.extend(iprp);
+  let mut data = Vec::new();
+  data.extend(ftyp);
+  data.extend(box_bytes(b"meta", &meta_body));
+
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(
+    m.heif().image_width(),
+    None,
+    "the stale ipco#1 ispe(7777x8888) must be discarded; ipco#2's ispe is a sub-document"
+  );
+  let json = exifast::parser::extract_info("dupipco_stale.heic", &data, true);
+  assert!(
+    !json.contains(r#""File:ImageWidth":7777"#) && !json.contains(r#""File:ImageWidth""#),
+    "no dims expected (stale ipco#1 discarded, ipco#2 gated): {json}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_primary_without_ipma_row_only_nonprimary_gated_out() {
+  // `pitm` present, but the PRIMARY item has NO `ipma` row; only a
+  // NON-primary item associates the `ispe`. ExifTool's per-property loop
+  // (QuickTime.pm:10203-10227) only iterates items that HAVE an Association, so
+  // the primary never matches and the property is associated-by-non-primary ⇒ a
+  // sub-document ⇒ gated out. Layout: pitm=2, ipco[ispe(640×480)],
+  // ipma{ item 3 → prop 1 }. Oracle (`perl exiftool -fast -G1 -j`): NO dims.
+  let data = heic_with_ispes_and_ipma(2, &[(640, 480)], &[(3, &[1])]);
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(m.heif().primary_item(), Some(2));
+  assert_eq!(
+    m.heif().image_width(),
+    None,
+    "primary has no ipma row; the only association is non-primary ⇒ sub-document ⇒ no dims"
+  );
+  let json = exifast::parser::extract_info("prim_noassoc.heic", &data, true);
+  assert!(
+    !json.contains(r#""File:ImageWidth""#),
+    "no dims expected: {json}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_ispe_nonzero_version_not_emitted() {
+  // The `ispe` tag has `Condition => '$$valPt =~ /^\0{4}/'`
+  // (QuickTime.pm:3036): a non-zero version/flags word means the box is NOT the
+  // `ImageSpatialExtent` variant ExifTool decodes, so NO dims are produced. Both
+  // a non-zero VERSION byte and a non-zero FLAGS low byte must suppress.
+  let ipma = ipma_v0_raw(false, &[(2, &[1])]);
+
+  // (a) version byte = 1.
+  let data_v = heic_with_raw_ipco_ipma(Some(2), &ispe_box_raw([1, 0, 0, 0], 640, 480, 12), &ipma);
+  let mv = parse_quicktime(&data_v).expect("accepted");
+  assert_eq!(
+    mv.heif().image_width(),
+    None,
+    "ispe with version byte 1 fails the Condition gate ⇒ no dims"
+  );
+  let json_v = exifast::parser::extract_info("ispe_ver.heic", &data_v, true);
+  assert!(
+    !json_v.contains(r#""File:ImageWidth""#),
+    "no dims expected (version!=0): {json_v}"
+  );
+
+  // (b) flags low byte = 1.
+  let data_f = heic_with_raw_ipco_ipma(Some(2), &ispe_box_raw([0, 0, 0, 1], 640, 480, 12), &ipma);
+  let mf = parse_quicktime(&data_f).expect("accepted");
+  assert_eq!(
+    mf.heif().image_width(),
+    None,
+    "ispe with non-zero flags fails the Condition gate ⇒ no dims"
+  );
+  let json_f = exifast::parser::extract_info("ispe_flags.heic", &data_f, true);
+  assert!(
+    !json_f.contains(r#""File:ImageWidth""#),
+    "no dims expected (flags!=0): {json_f}"
+  );
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_ispe_too_short_no_dims() {
+  // The `ispe` `RawConv` is `my @dim = unpack("x4N*", $val); return
+  // undef if @dim < 2` (QuickTime.pm:3038-3039): a body shorter than 12 bytes
+  // yields fewer than two `int32u` dims ⇒ no emit, no panic. Cover an 8-byte
+  // (width only) and a 4-byte (verflags only) `ispe`.
+  let ipma = ipma_v0_raw(false, &[(2, &[1])]);
+
+  for body_len in [8usize, 4] {
+    let data = heic_with_raw_ipco_ipma(
+      Some(2),
+      &ispe_box_raw([0, 0, 0, 0], 640, 480, body_len),
+      &ipma,
+    );
+    let m = parse_quicktime(&data).expect("accepted");
+    assert_eq!(
+      m.heif().image_width(),
+      None,
+      "ispe body {body_len} bytes (@dim < 2) ⇒ no dims, no panic"
+    );
+    let json = exifast::parser::extract_info("ispe_short.heic", &data, true);
+    assert!(
+      !json.contains(r#""File:ImageWidth""#),
+      "no dims expected (body {body_len}): {json}"
+    );
+  }
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_ispe_extra_dims_uses_first_two() {
+  // `unpack("x4N*", ...)` reads ALL trailing `int32u`; only
+  // `$dim[0]`/`$dim[1]` become ImageWidth/ImageHeight. An `ispe` carrying THREE
+  // dims (an extra trailing u32) still emits the first two. Oracle
+  // (`perl exiftool -fast -G1 -j`): File:ImageWidth 640, File:ImageHeight 480.
+  let mut ispe_body = Vec::new();
+  ispe_body.extend_from_slice(&[0, 0, 0, 0]);
+  ispe_body.extend_from_slice(&640u32.to_be_bytes());
+  ispe_body.extend_from_slice(&480u32.to_be_bytes());
+  ispe_body.extend_from_slice(&7u32.to_be_bytes()); // extra trailing dim
+  let ipco = box_bytes(b"ispe", &ispe_body);
+  let data = heic_with_raw_ipco_ipma(Some(2), &ipco, &ipma_v0_raw(false, &[(2, &[1])]));
+  let m = parse_quicktime(&data).expect("accepted");
+  assert_eq!(m.heif().image_width(), Some(640));
+  assert_eq!(m.heif().image_height(), Some(480));
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn heif_ipma_essential_bit_masked_out_of_index() {
+  // `ParseItemPropAssoc` masks the property index with the
+  // essential-bit cleared: 1-byte entries `& 0x7f` (QuickTime.pm:9324), 2-byte
+  // entries (`flags & 1`) `& 0x7fff` (QuickTime.pm:9317). So an association byte
+  // with the top bit SET still resolves to the same `ipco` index. Both index
+  // widths must point at the `ispe` regardless of the essential bit.
+  let ispe = ispe_box_raw([0, 0, 0, 0], 640, 480, 12);
+
+  // (a) 1-byte assoc, essential bit (0x80) + index 1 ⇒ masked to index 1.
+  let ipma1 = ipma_v0_raw(false, &[(2, &[0x80 | 1])]);
+  let data1 = heic_with_raw_ipco_ipma(Some(2), &ispe, &ipma1);
+  let m1 = parse_quicktime(&data1).expect("accepted");
+  assert_eq!(
+    m1.heif().image_width(),
+    Some(640),
+    "1-byte essential bit must be masked out of the index ⇒ index 1 ⇒ emits"
+  );
+  assert_eq!(m1.heif().image_height(), Some(480));
+
+  // (b) 2-byte assoc (flags&1), essential bit (0x8000) + 15-bit index 1.
+  let ipma2 = ipma_v0_raw(true, &[(2, &[0x8000 | 1])]);
+  let data2 = heic_with_raw_ipco_ipma(Some(2), &ispe, &ipma2);
+  let m2 = parse_quicktime(&data2).expect("accepted");
+  assert_eq!(
+    m2.heif().image_width(),
+    Some(640),
+    "2-byte essential bit must be masked out of the 15-bit index ⇒ index 1 ⇒ emits"
+  );
+  assert_eq!(m2.heif().image_height(), Some(480));
 }


### PR DESCRIPTION
Closes #148, closes #146.

**#148 — Canon CR3 CMT1/2/3/4 → Exif / GPS / Canon-MakerNote.** Each CMT box (a self-contained TIFF) is parsed eagerly during the Canon-`uuid` walk and re-dispatched faithfully: CMT1→`EXIF:IFD0`, CMT2→`EXIF:ExifIFD`, CMT3→`MakerNotes:Canon` (via the existing CTMD `0x927c` redispatch, threading the file-order `$$self{Model}` for model-conditional sub-tables), CMT4→`EXIF:GPS` (`parse_gps_block`). CMT bodies are parsed into owned typed tags during the walk — no raw-body storage — so memory is bounded ∝ parsed-tag-count regardless of crafted box count/size, and the CMT1→CMT3 model state is file-walk-scoped (persists across multiple Canon `uuid` atoms, set-only-on-present). Byte-exact vs `exiftool -G1 -j CanonRaw.cr3`: IFD0 13/13, ExifIFD 39/39, GPS 1/1, Canon MakerNote per-tag. (Un-ported Canon raw sub-tables — ColorData/etc., #84 — emit the same SubDirectory placeholder the static/CTMD paths already do.)

**#146 — HEIF/HEIC ipco/ispe → File:ImageWidth/Height.** Faithful to QuickTime.pm:3037's `ispe` RawConv: emitted `unless DOC_NUM` (main-document) — an ispe with no ipma association OR associated to the effective primary (`PrimaryItem || 0`) emits; a non-primary-only ispe is gated out; last-in-ipco-order wins; ipco is last-container-wins. Version/flags `Condition` gate + `@dim<2` + essential-bit-index-width honored; resolution is O((N+M)logM). Byte-exact vs `exiftool -G1 -j QuickTime.heic`: 1596×1064.

**Verification:** `fmt --check` / `build` / `test --all-features --all-targets` (3689 passed, golden byte-exact) / `clippy --all-features` all green. Real-fixture tests (`CanonRaw.cr3`, `QuickTime.heic`) + synthetic crafted-shape tests, all ground-truthed against ExifTool 13.59.

Codex adversarial review: APPROVE (R9, no material findings). The loop closed five classes — CMT memory (structural), CMT model-state (file-walk scope), ispe DOC_NUM rule, ispe perf, ispe association-shape matrix — each ground-truthed against the real oracle.

First PR of the resolve-all-open-issues campaign.