### PR TITLE
fix(exif/canon): suppress bogus MakerNote SubDirectory parent tags (#177)

### DIFF
--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -905,32 +905,43 @@ pub fn parse_in_tiff(
           }
         }
         _ => {
-          // Deferred sub-table — emit the SubDirectory tag's raw value
-          // so downstream users see "this sub-directory was present"
-          // (Phase 2+1 will walk these). Carry the tag's `Unknown` flag.
-          let val = def.conv().apply(&entry.value, print_conv, model);
-          emissions.push(VendorEmission::new(
-            def.name().into(),
-            val,
-            def.is_unknown(),
-          ));
+          // Deferred sub-table (Panorama / MyColors / FaceDetect1 / FaceDetect2
+          // / ContrastInfo / WBInfo / ProcessingInfo / MovieInfo / LensInfo —
+          // `is_walked() == false`). A SubDirectory row DESCENDS into a child
+          // table and NEVER emits the parent pointer as a value: ExifTool's
+          // `ProcessExif` enters the `if ($subdir)` block (`Exif.pm:6919`),
+          // processes the sub-directory, then hits `next unless $doMaker or
+          // $$et{REQ_TAG_LOOKUP}{…} or $$tagInfo{BlockExtract}`
+          // (`Exif.pm:7103-7104`) — for a plain SubDirectory tag in default
+          // output (no value emission) that `next` SKIPS `FoundTag`
+          // (`Exif.pm:7180`), so the parent is ABSENT from default `-j` output
+          // (every deferred `%Canon::Main` SubDirectory row here is a pure
+          // descend-no-parent-value pointer — none is `Writable`/`MakerNotes`/
+          // `BlockExtract`). The port DEFERS the child-table walk, so the
+          // faithful behaviour is to emit NEITHER the parent nor (for now) the
+          // children: skip the emission. Mirrors the Sony/Panasonic
+          // `if def.sub_table.is_some() { continue; }` guard (issue #177).
+          // Previously this arm emitted the SubDirectory's raw value, leaking a
+          // bogus `Canon:ProcessingInfo` (and the other deferred parents) that
+          // ExifTool never emits.
         }
       }
     } else if entry.tag_id == 0x96 && model.is_some_and(printconv::model_matches_eos_5d) {
       // `0x96` MODEL-CONDITIONAL LIST (`Canon.pm:1834-1846`): for an
-      // EOS-5D body the FIRST arm wins — `SerialInfo`, a SubDirectory to
-      // `Canon::SerialInfo`. That sub-table decode is DEFERRED (a deep
-      // binary table, like ShotInfo/ColorData), so we emit it the SAME
-      // way as the other deferred Canon::Main SubDirectories (the `_ =>`
-      // arm above): the first-arm `Name` paired with the raw value
-      // (`walk_canon_in_tiff` left it as un-stripped `RawValue::Bytes`).
-      // CRITICALLY: this is NOT `InternalSerialNumber` and the
-      // trailing-`0xff` `ValueConv` strip does NOT apply, so we also skip
-      // `populate_typed` (the typed `internal_serial_number` stays unset).
-      let val = CanonPrintConv::None.apply(&entry.value, print_conv, model);
-      // `0x96` is not `Unknown` (it is the conditional SerialInfo/
-      // InternalSerialNumber tag), so emit with `unknown = false`.
-      emissions.push(VendorEmission::new("SerialInfo".into(), val, false));
+      // EOS-5D body the FIRST arm wins — `SerialInfo`, a pure SubDirectory
+      // pointer to `Canon::SerialInfo` (`Canon.pm:1836-1838`; NO `Writable`,
+      // no value emission). Like every other deferred Canon::Main
+      // SubDirectory (the `_ =>` arm above), ExifTool descends into the child
+      // table and emits its leaves but NEVER the `SerialInfo` parent value
+      // (`Exif.pm:7103-7104` `next` skips `FoundTag` for a no-value
+      // SubDirectory). The port DEFERS that child walk, so the faithful
+      // behaviour is to emit nothing here — suppress the parent (issue #177;
+      // same bogus-parent class). CRITICALLY this is the SerialInfo branch,
+      // NOT `InternalSerialNumber`, so the trailing-`0xff` `ValueConv` strip
+      // does NOT apply and `populate_typed` is (correctly) not run — the typed
+      // `internal_serial_number` stays unset. Previously this arm emitted the
+      // raw `SerialInfo` value, leaking a bogus `Canon:SerialInfo` parent that
+      // ExifTool never emits.
     } else {
       // Leaf tag: apply PrintConv + emit. `model` threads the parent
       // body `$$self{Model}` into the conditional SerialNumber PrintConv
@@ -1277,11 +1288,16 @@ mod tests {
   }
 
   /// `0x96` MODEL-CONDITIONAL LIST (`Canon.pm:1834-1846`), FIRST arm: an
-  /// EOS-5D body routes `0x96` to the `SerialInfo` SubDirectory (deferred
-  /// raw blob), NOT `InternalSerialNumber`. The trailing-`0xff` strip
-  /// MUST NOT apply, and the typed `internal_serial_number` stays unset.
+  /// EOS-5D body routes `0x96` to the `SerialInfo` SubDirectory pointer
+  /// (`Canon.pm:1836-1838`; no `Writable`, no value emission), NOT
+  /// `InternalSerialNumber`. ExifTool descends into `Canon::SerialInfo` and
+  /// emits its leaves but NEVER the `SerialInfo` parent value; the port
+  /// defers that child walk, so it emits NEITHER `SerialInfo` (the bogus
+  /// parent, suppressed per #177) NOR `InternalSerialNumber` (the
+  /// trailing-`0xff` strip does NOT apply on this arm). The typed
+  /// `internal_serial_number` stays unset.
   #[test]
-  fn parse_eos_5d_0x96_emits_serialinfo_not_internal_serial() {
+  fn parse_eos_5d_0x96_suppresses_serialinfo_parent() {
     let value = b"ABC123\xff\xff\xff";
     let blob = one_main_entry_blob(0x96, 0x02, value.len() as u32, value);
     let (typed, emissions) = parse_in_tiff(
@@ -1293,25 +1309,25 @@ mod tests {
       Some("Canon EOS 5D Mark II"),
       None,
     );
-    // First arm: SerialInfo, raw (un-stripped) blob.
+    // The SerialInfo SubDirectory parent is suppressed (deferred child walk),
+    // and the second-arm InternalSerialNumber is NOT selected for an EOS-5D.
+    assert!(
+      !emissions.iter().any(|e| e.name() == "SerialInfo"),
+      "EOS 5D must NOT emit the bogus SerialInfo SubDirectory parent (#177)"
+    );
     assert!(
       !emissions.iter().any(|e| e.name() == "InternalSerialNumber"),
-      "EOS 5D must NOT emit InternalSerialNumber"
+      "EOS 5D must NOT emit InternalSerialNumber (it took the SerialInfo arm)"
     );
-    let v = emissions
-      .iter()
-      .find(|e| e.name() == "SerialInfo")
-      .map(|e| e.value().clone())
-      .expect("EOS 5D must emit SerialInfo");
-    assert_eq!(v, TagValue::Bytes(value.to_vec()));
     // Typed accessor for InternalSerialNumber stays unset.
     assert_eq!(typed.internal_serial_number(), None);
   }
 
   /// `/EOS 5D/` is an UNANCHORED substring (`Canon.pm:1837`) — base
-  /// "EOS 5D" matches just as "EOS 5D Mark IV" does.
+  /// "EOS 5D" matches just as "EOS 5D Mark IV" does; the SerialInfo
+  /// SubDirectory parent is suppressed (#177) for either spelling.
   #[test]
-  fn parse_eos_5d_base_model_0x96_emits_serialinfo() {
+  fn parse_eos_5d_base_model_0x96_suppresses_serialinfo_parent() {
     let value = b"WXYZ";
     let blob = one_main_entry_blob(0x96, 0x02, value.len() as u32, value);
     let (typed, emissions) = parse_in_tiff(
@@ -1323,7 +1339,7 @@ mod tests {
       Some("Canon EOS 5D"),
       None,
     );
-    assert!(emissions.iter().any(|e| e.name() == "SerialInfo"));
+    assert!(!emissions.iter().any(|e| e.name() == "SerialInfo"));
     assert!(!emissions.iter().any(|e| e.name() == "InternalSerialNumber"));
     assert_eq!(typed.internal_serial_number(), None);
   }

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -1186,6 +1186,58 @@ fn canon_unknown_tags_suppressed_in_default_output() {
   }
 }
 
+/// #177 — a DEFERRED (non-walked) Canon SubDirectory tag must NOT leak its raw
+/// value as a bogus `Canon:<parent>` key. ExifTool descends into the child
+/// table and emits its leaves but NEVER the SubDirectory PARENT (`Exif.pm` `next
+/// unless $doMaker or … or $$tagInfo{BlockExtract}` skips `FoundTag` for a
+/// no-value SubDirectory row); the port mirrors that by suppressing the parent
+/// in the Canon vendor walk's deferred-SubDirectory arm (same class as the
+/// merged #96 R14 Sony/Panasonic fix). `MakerNotes_Canon.jpg` (== bundled
+/// `t/images/Canon.jpg`) carries ONLY walked SubDirectories (CameraSettings /
+/// ShotInfo / FileInfo / ColorBalance / AFInfo), so none of the deferred
+/// parent names may ever appear — and the walked leaves stay present unchanged.
+/// (The Canon1DmkIII.jpg `EXIFTOOL_T_IMAGES` test exercises the `ProcessingInfo`
+/// trigger that this `Canon.jpg` lacks.)
+#[cfg(feature = "json")]
+#[test]
+fn canon_deferred_subdir_parents_not_emitted() {
+  // The Canon::Main names whose `SubDirectory` the port DEFERS (not walked):
+  // `CANON_DEFERRED_SUBDIR_PARENTS` is the `is_walked() == false` set.
+  const CANON_DEFERRED_SUBDIR_PARENTS: &[&str] = &[
+    "CanonPanorama",  // 0x05  Canon::Panorama
+    "MovieInfo",      // 0x11  Canon::MovieInfo
+    "MyColors",       // 0x1d  Canon::MyColors
+    "FaceDetect1",    // 0x24  Canon::FaceDetect1
+    "FaceDetect2",    // 0x25  Canon::FaceDetect2
+    "ContrastInfo",   // 0x27  Canon::ContrastInfo
+    "WBInfo",         // 0x29  Canon::WBInfo
+    "ProcessingInfo", // 0xa0  Canon::Processing
+    "LensInfo",       // 0x4019 Canon::LensInfo
+    "SerialInfo",     // 0x96 first arm (EOS 5D) Canon::SerialInfo
+  ];
+  for print_on in [true, false] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let map = extract_info_map("MakerNotes_Canon.jpg", print_on);
+    for parent in CANON_DEFERRED_SUBDIR_PARENTS {
+      assert!(
+        !map.contains_key(&format!("Canon:{parent}")),
+        "bogus deferred SubDirectory parent Canon:{parent} must not be emitted ({mode}); keys: {:?}",
+        map.keys().collect::<Vec<_>>()
+      );
+    }
+    // The WALKED leaves are unaffected — a CameraSettings leaf (LensType) and
+    // a ColorBalance leaf (WB_RGGBLevelsAuto) the oracle DOES emit stay present.
+    assert!(
+      map.contains_key("Canon:LensType"),
+      "walked CameraSettings leaf Canon:LensType must still be present ({mode})"
+    );
+    assert!(
+      map.contains_key("Canon:WB_RGGBLevelsAuto"),
+      "walked ColorBalance leaf Canon:WB_RGGBLevelsAuto must still be present ({mode})"
+    );
+  }
+}
+
 /// Unknown-tag suppression (Apple) — the `Unknown => 1` Apple MakerNote tags
 /// (`Apple.pm` AEMatrix 0x0002, ImageProcessingFlags 0x0019, SceneFlags
 /// 0x0025, …) are OMITTED from the default `-j -G1` output. This fixture
@@ -3271,4 +3323,66 @@ fn samsung_srw_body_without_tiff_type_does_not_reach_samsung2() {
      Samsung2, got {:?}",
     mn.vendor()
   );
+}
+
+// ===========================================================================
+// #177 — Canon1DmkIII.jpg (NOT bundled; gated on EXIFTOOL_T_IMAGES) is the real
+// fixture that carries a DEFERRED `ProcessingInfo` (0xa0) SubDirectory, the
+// concrete trigger for the bogus-parent bug. (The bundled Canon.jpg has only
+// walked SubDirectories, so it cannot exercise the deferred arm.)
+// ===========================================================================
+
+/// #177 — the deferred `ProcessingInfo` (0xa0 → Canon::Processing) SubDirectory
+/// in Canon1DmkIII.jpg must NOT leak as a bogus `Canon:ProcessingInfo` key,
+/// while the walked Canon tags the oracle emits stay present and unchanged.
+///
+/// Oracle (`perl exiftool -G1 -j t/images/Canon1DmkIII.jpg`) emits NO
+/// `Canon:ProcessingInfo` (it descends into `Canon::Processing` and emits its
+/// leaves but never the parent). The bundled fixtures dir is supplied via the
+/// `EXIFTOOL_T_IMAGES` env var (ExifTool's `t/images`); the test skips when it
+/// is unset so a checkout without the ExifTool sources still passes.
+#[cfg(feature = "json")]
+#[test]
+fn canon_1dmk3_real_fixture_no_bogus_processinginfo_parent() {
+  let Ok(dir) = std::env::var("EXIFTOOL_T_IMAGES") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES not set");
+    return;
+  };
+  let path = format!("{dir}/Canon1DmkIII.jpg");
+  let Ok(data) = std::fs::read(&path) else {
+    eprintln!("skipping: {path} not readable");
+    return;
+  };
+  for print_on in [true, false] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let json = exifast::parser::extract_info("Canon1DmkIII.jpg", &data, print_on);
+    let doc: serde_json::Value =
+      serde_json::from_str(&json).unwrap_or_else(|e| panic!("invalid JSON ({e}):\n{json}"));
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .unwrap_or_else(|| panic!("doc is not [{{…}}]:\n{json}"));
+    // The bug: a bogus `Canon:ProcessingInfo` parent (raw int16s array) that
+    // ExifTool never emits.
+    assert!(
+      !map.contains_key("Canon:ProcessingInfo"),
+      "bogus deferred SubDirectory parent Canon:ProcessingInfo must not be emitted ({mode})"
+    );
+    // The walked tags the oracle DOES emit stay present + unaffected:
+    // a CameraSettings leaf, the Main-IFD LensModel string (0x95), and a
+    // SensorInfo leaf (0xe0, a walked SubDirectory in this fixture).
+    assert!(
+      map.contains_key("Canon:LensModel"),
+      "walked Canon:LensModel must still be present ({mode})"
+    );
+    assert!(
+      map.contains_key("Canon:ContinuousDrive"),
+      "walked CameraSettings leaf Canon:ContinuousDrive must still be present ({mode})"
+    );
+    assert!(
+      map.contains_key("Canon:SensorWidth"),
+      "walked SensorInfo leaf Canon:SensorWidth must still be present ({mode})"
+    );
+  }
 }


### PR DESCRIPTION
Closes #177.

Canon's MakerNote tag-walk emitted the raw value of un-walked SubDirectory parent tags (the `_ =>` deferred arm), which ExifTool never does — `Exif.pm` ProcessExif `next`-skips `FoundTag` for a no-value SubDirectory (Exif.pm:7103-7104,7180). Real divergence: `Canon1DmkIII.jpg` carries a deferred `0xa0 Canon::Processing` SubDirectory → exifast wrongly emitted `Canon:ProcessingInfo = "28 0 0 …"`. Fixed by suppressing the deferred-SubDirectory emission via `if def.sub_table.is_some() { continue; }` — the structural equivalent of the merged Sony (`sony/mod.rs:339`) / Panasonic (`panasonic/mod.rs:680`) guards (same class as #96 R14) — plus the same on the `0x96` EOS-5D `SerialInfo` SubDirectory pointer.

Byte-exact vs `exiftool -G1 -j`: the bogus `Canon:ProcessingInfo` parent is gone (Canon key count 108→107), zero value mismatches on every shared Canon key in `Canon.jpg` + `Canon1DmkIII.jpg`, walked CameraSettings/ShotInfo/FileInfo/ColorBalance/AFInfo/SensorInfo leaves all unchanged. Canon-only; Sony/Panasonic/other vendors untouched.

**Verification:** fmt/build/test (3689 passed, golden byte-exact)/clippy all green; real-fixture tests (`Canon.jpg`, `Canon1DmkIII.jpg` via EXIFTOOL_T_IMAGES) + the bundled `MakerNotes_Canon.jpg` test, oracle-cited.

Codex adversarial review: APPROVE (R1, no material findings).

A sibling defect class (8 Canon tags mis-marked `sub_table:None` hitting the LEAF arm, not this `_ =>` arm) was surfaced and filed as #223. Second PR of the resolve-all-open-issues campaign.