### PR TITLE
fix(exif/canon): suppress mis-flagged Canon::Main SubDirectory parents + faithful ImageUniqueID (#223)

### DIFF
--- a/src/exif/makernotes/vendors/canon/body.rs
+++ b/src/exif/makernotes/vendors/canon/body.rs
@@ -366,10 +366,47 @@ pub fn walk_canon_in_tiff(
       | CanonEntryClass::SilentBadFormat { abort: true } => break,
       _ => continue,
     };
-    let avail = tiff_data.len() - value_data_offset;
-    let Some(mut raw) = read_value(tiff_data, value_data_offset, format, count, avail, order)
-    else {
-      continue;
+    // `0x28` `ImageUniqueID` forces `Format => 'undef'` (`Canon.pm:1729`).
+    // ExifTool's `ProcessExif` overrides the entry's declared numeric format
+    // with `undef` (`Exif.pm:6735-6744`) and re-derives `$count = int($size /
+    // $formatSize['undef'])` BEFORE `ReadValue` runs, so `ReadValue` reads the
+    // ORIGINAL `$size` on-disk bytes (`$size = $count * $formatSize[$declared]`)
+    // verbatim and NEVER runs the declared numeric decode — the verbose dump
+    // literally reads `int8u[16] read as undef[16]`. Take that raw-byte view
+    // HERE, BEFORE `read_value`, so the declared-format path is skipped
+    // entirely: we never enter `read_value`'s count-zero expansion (which would
+    // re-derive `$count` from the trailing buffer that ExifTool's `undef[0]`
+    // view, `$size == 0`, never touches — ExifTool's `ReadValue` returns `''`
+    // for a defined `$count == 0`, `ExifTool.pm:6296-6298`), and never allocate
+    // the discarded numeric `Vec` a large declared count would build. The
+    // window was already proved in-bounds by the `CanonEntryClass::Read`
+    // classification (`$valuePtr + $size <= dataLen` for out-of-line, or the
+    // ≤4-byte inline value inside the entry); recompute it with checked
+    // arithmetic + `get` so a truncated/oversized shape can only yield an empty
+    // (`undef`) value, never an OOB read or panic. The downstream
+    // RawConv (`$val eq "\0" x 16 ? undef : $val`) + hex `ValueConv` then
+    // operate on these original `undef` bytes — NOT on a lossy numeric decode
+    // (which would truncate an `int16u[8]` element > 255, zero out a
+    // `float`/`double`/`rational` shape, or NUL-trim the `Ascii` string). This
+    // makes `int8u[16]` / `int16u[8]` / `int32u[4]` / `undef[16]` / `float[4]`
+    // / `double[2]` / `rational[2]` all read the SAME bytes (oracle-verified
+    // identical hex), keeps embedded NULs, and emits the empty string for a
+    // count-0 entry (oracle: `undef[0]` ⇒ `Canon:ImageUniqueID = ""`).
+    let mut raw = if tag_id == 0x28 {
+      let window = format
+        .byte_size()
+        .checked_mul(count)
+        .and_then(|size| value_data_offset.checked_add(size))
+        .and_then(|end| tiff_data.get(value_data_offset..end))
+        .unwrap_or(&[]);
+      RawValue::Bytes(window.to_vec())
+    } else {
+      let avail = tiff_data.len() - value_data_offset;
+      let Some(decoded) = read_value(tiff_data, value_data_offset, format, count, avail, order)
+      else {
+        continue;
+      };
+      decoded
     };
     // `0x96` is a MODEL-CONDITIONAL LIST (`Canon.pm:1834-1846`):
     //

--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -905,10 +905,18 @@ pub fn parse_in_tiff(
           }
         }
         _ => {
-          // Deferred sub-table (Panorama / MyColors / FaceDetect1 / FaceDetect2
-          // / ContrastInfo / WBInfo / ProcessingInfo / MovieInfo / LensInfo —
-          // `is_walked() == false`). A SubDirectory row DESCENDS into a child
-          // table and NEVER emits the parent pointer as a value: ExifTool's
+          // Every deferred Canon::Main SubDirectory (`is_walked() == false`):
+          // the Phase-2 raw set (Panorama / MyColors / FaceDetect1 / FaceDetect2
+          // / ContrastInfo / WBInfo / ProcessingInfo / MovieInfo / LensInfo) PLUS
+          // the #223 swept-from-`None` set (CameraInfo / CropInfo /
+          // CustomFunctions{,1D,2} / AspectInfo / MeasuredColor / ColorData /
+          // AFMicroAdj / UnknownD30 / FaceDetect3 / TimeInfo / PersonalFunctions
+          // / PersonalFunctionValues / CanonFlags / ModifiedInfo /
+          // PreviewImageInfo / ColorInfo / VignettingCorr{,2} / LightingOpt /
+          // AmbienceInfo / MultiExp / FilterInfo / HDRInfo / LogInfo / AFConfig /
+          // RawBurstModeRoll / FocusBracketingInfo / LevelInfo). A SubDirectory
+          // row DESCENDS into a child table and NEVER emits the parent pointer as
+          // a value: ExifTool's
           // `ProcessExif` enters the `if ($subdir)` block (`Exif.pm:6919`),
           // processes the sub-directory, then hits `next unless $doMaker or
           // $$et{REQ_TAG_LOOKUP}{…} or $$tagInfo{BlockExtract}`
@@ -942,6 +950,46 @@ pub fn parse_in_tiff(
       // `internal_serial_number` stays unset. Previously this arm emitted the
       // raw `SerialInfo` value, leaking a bogus `Canon:SerialInfo` parent that
       // ExifTool never emits.
+    } else if entry.tag_id == 0x28 {
+      // `ImageUniqueID` (`Canon.pm:1726-1735`): the table forces
+      // `Format => 'undef'`, so the walker captured the ORIGINAL on-disk
+      // value bytes as `RawValue::Bytes` ([`body::walk_canon_in_tiff`]) —
+      // ExifTool reads `int8u[16]` / `int16u[8]` / `int32u[4]` / `undef[16]`
+      // / `float[4]` / `double[2]` / `rational[2]` all as the SAME literal
+      // bytes (the verbose dump: `int8u[16] read as undef[16]`;
+      // oracle-verified identical hex across every shape and both byte
+      // orders). `RawConv => '$val eq "\0" x 16 ? undef : $val'` drops the
+      // value ONLY when it is EXACTLY sixteen NUL bytes (Perl string
+      // equality — NOT `/^\0+$/`, so a SHORT all-zero value of any other
+      // length is NOT dropped); `ValueConv => 'unpack("H*", $val)'` renders
+      // the survivor as lowercase hex. Operate on the original undef bytes,
+      // never the lossy numeric decode.
+      let val_bytes: &[u8] = match &entry.value {
+        // The faithful `Format => 'undef'` view captured at walk time.
+        RawValue::Bytes(b) => b,
+        // Defensive: if the walker did not rewrite this entry (it always
+        // does for an in-bounds 0x28), treat as no value — emit nothing.
+        _ => &[],
+      };
+      // `$val eq "\0" x 16` — EXACTLY sixteen NUL bytes (oracle: an all-zero
+      // `int8u[16]` is dropped, but an all-zero `int8u[8]` emits
+      // "0000000000000000"). A length other than 16 — or any non-NUL byte —
+      // is NOT equal and survives the RawConv.
+      let is_undef = val_bytes.len() == 16 && val_bytes.iter().all(|&b| b == 0);
+      if is_undef {
+        // RawConv undef ⇒ tag not extracted (emit NOTHING; the typed
+        // `image_unique_id` stays unset).
+      } else {
+        let hex = hex_lower(val_bytes);
+        typed.image_unique_id = Some(SmolStr::from(&hex));
+        // No `PrintConv` on 0x28, so `-j` and `-n` agree (the ValueConv hex
+        // is the final value). `Writable`, non-`Unknown` ⇒ `unknown = false`.
+        emissions.push(VendorEmission::new(
+          "ImageUniqueID".into(),
+          TagValue::Str(SmolStr::from(hex)),
+          false,
+        ));
+      }
     } else {
       // Leaf tag: apply PrintConv + emit. `model` threads the parent
       // body `$$self{Model}` into the conditional SerialNumber PrintConv
@@ -950,7 +998,7 @@ pub fn parse_in_tiff(
       // (`Canon.pm:1840-1845`) — the `0xff` strip already ran in
       // `walk_canon_in_tiff`.
       let val = def.conv().apply(&entry.value, print_conv, model);
-      populate_typed(&mut typed, entry, &val);
+      populate_typed(&mut typed, entry);
       // Carry the tag's `Unknown` flag (the single Unknown Canon::Main tag,
       // `0x03 CanonFlashInfo`, lands here); the engine suppresses it.
       emissions.push(VendorEmission::new(
@@ -989,8 +1037,11 @@ pub fn parse_into_metadata(
   }
 }
 
-/// Populate the typed struct from one Main-IFD leaf-tag emission.
-fn populate_typed(typed: &mut MakerNotesCanon, entry: &CanonEntry, val: &TagValue) {
+/// Populate the typed struct from one Main-IFD leaf-tag emission. Reads the
+/// entry's pre-PrintConv [`RawValue`] directly (every typed source here is a
+/// string/integer leaf, not a PrintConv string), so the converted `TagValue`
+/// is not needed.
+fn populate_typed(typed: &mut MakerNotesCanon, entry: &CanonEntry) {
   match entry.tag_id {
     0x06 => {
       if let RawValue::Text { text: s, .. } = &entry.value {
@@ -1030,12 +1081,9 @@ fn populate_typed(typed: &mut MakerNotesCanon, entry: &CanonEntry, val: &TagValu
         typed.model_name = model_ids::lookup_name(id);
       }
     }
-    0x28 => {
-      // ImageUniqueID — undef[16]; PrintConv emits hex.
-      if let TagValue::Str(s) = val {
-        typed.image_unique_id = Some(s.clone());
-      }
-    }
+    // 0x28 (`ImageUniqueID`) is handled in the dispatch loop's dedicated
+    // `Format => 'undef'` arm (raw-byte RawConv + hex ValueConv) and never
+    // reaches the generic leaf path, so it has no `populate_typed` case.
     0x95 => {
       if let RawValue::Text { text: s, .. } = &entry.value {
         typed.lens_model_string = Some(s.as_str().into());
@@ -1101,6 +1149,17 @@ fn first4_all_zero(blob: &[u8]) -> bool {
   blob
     .get(..4)
     .is_some_and(|head| head.iter().all(|&b| b == 0))
+}
+
+/// Lowercase, separator-free hex of a byte string — ExifTool's
+/// `unpack("H*", $val)` (the `ImageUniqueID` ValueConv, `Canon.pm:1733`).
+fn hex_lower(bytes: &[u8]) -> std::string::String {
+  use std::fmt::Write;
+  let mut out = std::string::String::with_capacity(bytes.len() * 2);
+  for &b in bytes {
+    let _ = write!(&mut out, "{b:02x}");
+  }
+  out
 }
 
 /// Reserialize a RawValue (int16s/int16u/Bytes) back into bytes in the

--- a/src/exif/makernotes/vendors/canon/tags.rs
+++ b/src/exif/makernotes/vendors/canon/tags.rs
@@ -10,9 +10,30 @@
 //!   0x04, Panorama 0x05, AFInfo 0x12, AFInfo2 0x26, FileInfo 0x93,
 //!   ProcessingInfo 0x10/etc.) trigger a SECONDARY sub-table parse — the
 //!   port handles CameraSettings + FileInfo natively (see
-//!   [`super::camera_settings`] / [`super::file_info`]); the rest are
-//!   captured as raw bytes (Phase-2 deferred — see follow-up issue
-//!   linked from #62 umbrella).
+//!   [`super::camera_settings`] / [`super::file_info`]). Every `SubDirectory`
+//!   tag carries `sub_table: Some(..)`; the deferred ones
+//!   (`is_walked() == false`) are SUPPRESSED, not emitted as a raw parent
+//!   value — a SubDirectory pointer descends into its child table and never
+//!   emits its own value (`Exif.pm:7103-7104`), so the faithful default
+//!   output omits the parent (issue #177). EVERY `%Canon::Main` `SubDirectory`
+//!   tag ID carries `sub_table: Some(..)` — the full set was swept against
+//!   `Canon.pm` in #223 (first the 8 siblings
+//!   `CanonCameraInfo`/`CropInfo`/`CustomFunctions2`/`AspectInfo`/
+//!   `MeasuredColor`/`ColorData`/`AFMicroAdj`, then the remaining 23:
+//!   `UnknownD30` 0x0a, `CustomFunctions` 0x0f, `FaceDetect3` 0x2f,
+//!   `TimeInfo` 0x35, `CustomFunctions1D` 0x90, `PersonalFunctions` 0x91,
+//!   `PersonalFunctionValues` 0x92, `CanonFlags` 0xb0, `ModifiedInfo` 0xb1,
+//!   `PreviewImageInfo` 0xb6, `ColorInfo` 0x4003, `VignettingCorr` 0x4015,
+//!   `VignettingCorr2` 0x4016, `LightingOpt` 0x4018, `AmbienceInfo` 0x4020,
+//!   `MultiExp` 0x4021, `FilterInfo` 0x4024, `HDRInfo` 0x4025, `LogInfo`
+//!   0x4026, `AFConfig` 0x4028, `RawBurstModeRoll` 0x403f,
+//!   `FocusBracketingInfo` 0x4053, `LevelInfo` 0x4059). The ONLY exception is
+//!   tag 0x96, whose `SerialInfo` `SubDirectory` lives in a model-conditional
+//!   FIRST arm — it stays `sub_table: None` and is suppressed in a dedicated
+//!   `parse_in_tiff` arm (the SECOND arm `InternalSerialNumber` is a real leaf
+//!   for non-EOS-5D bodies). The `canon_tags_subdirectory_rows_are_marked`
+//!   invariant test guards the whole set. The child leaves stay Phase-2
+//!   deferred (see the #62 umbrella).
 //! - Model-specific `CanonCameraInfoXXX` conditional sub-directories at
 //!   tag 0x0d (`Canon.pm:1307-1494`) are DEFERRED — each model has its
 //!   own micro-table.
@@ -138,6 +159,95 @@ pub enum SubTable {
   /// `%Canon::ColorBalance` (`Canon.pm:7268-7293`) — Main tag 0xa9. FORMAT
   /// int16s, FIRST_ENTRY 0. The `WB_RGGBLevels{Auto,Daylight,…}` quads.
   ColorBalance,
+  /// `CanonCameraInfo` conditional SubDirectory list — Main tag 0x0d
+  /// (`Canon.pm:1308-1494`). Per-model `Canon::CameraInfo<Model>` micro-tables.
+  /// DEFERRED (children unported, issue #85): `is_walked() == false` so the
+  /// parent pointer is suppressed (no bogus raw value).
+  CameraInfo,
+  /// `%Canon::CropInfo` (`Canon.pm:1880-1882`) — Main tag 0x98. DEFERRED.
+  CropInfo,
+  /// `CanonCustom::Functions2` (`Canon.pm:1884-1889`) — Main tag 0x99
+  /// (`CustomFunctions2`). DEFERRED (issue #87).
+  CustomFunctions2,
+  /// `%Canon::AspectInfo` (`Canon.pm:1891-1893`) — Main tag 0x9a. DEFERRED.
+  AspectInfo,
+  /// `%Canon::MeasuredColor` (`Canon.pm:1913-1918`) — Main tag 0xaa. DEFERRED.
+  MeasuredColor,
+  /// `Canon::ColorData<N>` conditional SubDirectory list — Main tag 0x4001
+  /// (`Canon.pm:1973-2046`). Count-selected `ColorData1..12`. DEFERRED
+  /// (issue #84): `is_walked() == false` so the parent pointer is suppressed.
+  ColorData,
+  /// `%Canon::AFMicroAdj` (`Canon.pm:2088-2095`) — Main tag 0x4013. DEFERRED.
+  AfMicroAdj,
+  /// `%Canon::UnknownD30` (`Canon.pm:1275-1281`) — Main tag 0x0a. DEFERRED.
+  UnknownD30,
+  /// `CanonCustom::Functions<Model>` conditional SubDirectory list — Main tag
+  /// 0x0f (`Canon.pm:1501-1583`): `CustomFunctions1D`/`5D`/`10D`/`20D`/`30D`/
+  /// `350D`/`400D`/`D30`/`D60`/`Unknown`, all `SubDirectory` arms. DEFERRED
+  /// (issue #87): the parent pointer is suppressed.
+  CustomFunctions,
+  /// `%Canon::FaceDetect3` (`Canon.pm:1741-1747`) — Main tag 0x2f. DEFERRED.
+  FaceDetect3,
+  /// `%Canon::TimeInfo` (`Canon.pm:1750-1756`) — Main tag 0x35. DEFERRED.
+  TimeInfo,
+  /// `CanonCustom::Functions1D` (`Canon.pm:1796-1802`) — Main tag 0x90
+  /// (`CustomFunctions1D`, used by 1D/1Ds). DEFERRED (issue #87).
+  CustomFunctions1D,
+  /// `CanonCustom::PersonalFuncs` (`Canon.pm:1803-1809`) — Main tag 0x91
+  /// (`PersonalFunctions`). DEFERRED (issue #87).
+  PersonalFunctions,
+  /// `CanonCustom::PersonalFuncValues` (`Canon.pm:1810-1816`) — Main tag 0x92
+  /// (`PersonalFunctionValues`). DEFERRED (issue #87).
+  PersonalFunctionValues,
+  /// `%Canon::Flags` (`Canon.pm:1924-1930`) — Main tag 0xb0 (`CanonFlags`).
+  /// DEFERRED.
+  CanonFlags,
+  /// `%Canon::ModifiedInfo` (`Canon.pm:1931-1937`) — Main tag 0xb1
+  /// (`ModifiedInfo`). DEFERRED.
+  ModifiedInfo,
+  /// `%Canon::PreviewImageInfo` (`Canon.pm:1949-1957`) — Main tag 0xb6
+  /// (`PreviewImageInfo`). DEFERRED.
+  PreviewImageInfo,
+  /// `%Canon::ColorInfo` (`Canon.pm:2056-2059`) — Main tag 0x4003
+  /// (`ColorInfo`). DEFERRED.
+  ColorInfo,
+  /// `Canon::VignettingCorr` conditional SubDirectory list — Main tag 0x4015
+  /// (`Canon.pm:2098-2122`): `VignettingCorr`/`VignettingCorrUnknown1`/
+  /// `VignettingCorrUnknown2`, all `SubDirectory` arms. DEFERRED.
+  VignettingCorr,
+  /// `%Canon::VignettingCorr2` (`Canon.pm:2123-2130`) — Main tag 0x4016
+  /// (`VignettingCorr2`). DEFERRED.
+  VignettingCorr2,
+  /// `%Canon::LightingOpt` (`Canon.pm:2131-2137`) — Main tag 0x4018
+  /// (`LightingOpt`). DEFERRED.
+  LightingOpt,
+  /// `%Canon::Ambience` (`Canon.pm:2144-2151`) — Main tag 0x4020
+  /// (`AmbienceInfo`). DEFERRED.
+  AmbienceInfo,
+  /// `%Canon::MultiExp` (`Canon.pm:2152-2158`) — Main tag 0x4021 (`MultiExp`).
+  /// DEFERRED.
+  MultiExp,
+  /// `%Canon::FilterInfo` (`Canon.pm:2159-2165`) — Main tag 0x4024
+  /// (`FilterInfo`). DEFERRED.
+  FilterInfo,
+  /// `%Canon::HDRInfo` (`Canon.pm:2166-2172`) — Main tag 0x4025 (`HDRInfo`).
+  /// DEFERRED.
+  HdrInfo,
+  /// `%Canon::LogInfo` (`Canon.pm:2173-2179`) — Main tag 0x4026 (`LogInfo`).
+  /// DEFERRED.
+  LogInfo,
+  /// `%Canon::AFConfig` (`Canon.pm:2180-2186`) — Main tag 0x4028 (`AFConfig`).
+  /// DEFERRED.
+  AfConfig,
+  /// `%Canon::RawBurstInfo` (`Canon.pm:2188-2194`) — Main tag 0x403f
+  /// (`RawBurstModeRoll`). DEFERRED.
+  RawBurstModeRoll,
+  /// `%Canon::FocusBracketingInfo` (`Canon.pm:2196-2202`) — Main tag 0x4053
+  /// (`FocusBracketingInfo`). DEFERRED.
+  FocusBracketingInfo,
+  /// `%Canon::LevelInfo` (`Canon.pm:2203-2209`) — Main tag 0x4059
+  /// (`LevelInfo`). DEFERRED.
+  LevelInfo,
 }
 
 impl SubTable {
@@ -244,12 +354,14 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0x0a — UnknownD30 (`Canon.pm:1274-1280`) — sub-table, raw.
+  // 0x0a — UnknownD30 (`Canon.pm:1275-1281`) — SubDirectory to
+  // `Canon::UnknownD30`. DEFERRED child walk: suppressed (no bogus raw parent),
+  // issue #177.
   CanonTag {
     id: 0x0a,
     name: "UnknownD30",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::UnknownD30),
     unknown: false,
   },
   // 0x0c — SerialNumber (`Canon.pm:1281-1306`) — conditional Print format.
@@ -260,12 +372,15 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0x0d — CanonCameraInfo (`Canon.pm:1307-1494`) — conditional model-specific.
+  // 0x0d — CanonCameraInfo (`Canon.pm:1307-1494`) — conditional model-specific
+  // SubDirectory list. DEFERRED child walk (issue #85): a SubDirectory pointer
+  // descends into the child table and never emits the parent value, so mark it
+  // `Some(..)` (suppressed by the deferred-SubDirectory arm, issue #177).
   CanonTag {
     id: 0x0d,
     name: "CanonCameraInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::CameraInfo),
     unknown: false,
   },
   // 0x0e — CanonFileLength (`Canon.pm:1495-1499`) — int32u
@@ -276,12 +391,15 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0x0f — CustomFunctions (`Canon.pm:1500-1582`) — model-specific.
+  // 0x0f — CustomFunctions (`Canon.pm:1501-1583`) — model-specific
+  // SubDirectory list (every arm is a `CanonCustom::Functions<Model>`
+  // SubDirectory). DEFERRED child walk (issue #87): suppressed (no bogus raw
+  // parent), issue #177.
   CanonTag {
     id: 0x0f,
     name: "CustomFunctions",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::CustomFunctions),
     unknown: false,
   },
   // 0x10 — CanonModelID (`Canon.pm:1583-1589`) — int32u, printConv via canonModelID.
@@ -412,20 +530,22 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: Some(SubTable::WbInfo),
     unknown: false,
   },
-  // 0x2f — FaceDetect3 (`Canon.pm:1740-1745`)
+  // 0x2f — FaceDetect3 (`Canon.pm:1741-1747`) — SubDirectory to
+  // `Canon::FaceDetect3`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x2f,
     name: "FaceDetect3",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::FaceDetect3),
     unknown: false,
   },
-  // 0x35 — TimeInfo (`Canon.pm:1748-1754`)
+  // 0x35 — TimeInfo (`Canon.pm:1750-1756`) — SubDirectory to `Canon::TimeInfo`.
+  // DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x35,
     name: "TimeInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::TimeInfo),
     unknown: false,
   },
   // 0x38 — BatteryType (`Canon.pm:1757-1764`) — string
@@ -471,29 +591,33 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0x90 — CustomFunctions1D (`Canon.pm:1796-1801`) — SubDirectory
-  // (CanonCustom::Functions1D), deferred → emit raw.
+  // 0x90 — CustomFunctions1D (`Canon.pm:1796-1802`) — SubDirectory to
+  // `CanonCustom::Functions1D` (used by 1D/1Ds). DEFERRED child walk
+  // (issue #87): suppressed (no bogus raw parent), issue #177.
   CanonTag {
     id: 0x90,
     name: "CustomFunctions1D",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::CustomFunctions1D),
     unknown: false,
   },
-  // 0x91 — PersonalFunctions (`Canon.pm:1804-1808`)
+  // 0x91 — PersonalFunctions (`Canon.pm:1803-1809`) — SubDirectory to
+  // `CanonCustom::PersonalFuncs`. DEFERRED child walk (issue #87): suppressed.
   CanonTag {
     id: 0x91,
     name: "PersonalFunctions",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::PersonalFunctions),
     unknown: false,
   },
-  // 0x92 — PersonalFunctionValues (`Canon.pm:1811-1815`)
+  // 0x92 — PersonalFunctionValues (`Canon.pm:1810-1816`) — SubDirectory to
+  // `CanonCustom::PersonalFuncValues`. DEFERRED child walk (issue #87):
+  // suppressed.
   CanonTag {
     id: 0x92,
     name: "PersonalFunctionValues",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::PersonalFunctionValues),
     unknown: false,
   },
   // 0x93 — CanonFileInfo (`Canon.pm:1816-1822`)
@@ -544,28 +668,31 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0x98 — CropInfo (`Canon.pm:1880-1882`)
+  // 0x98 — CropInfo (`Canon.pm:1880-1882`) — SubDirectory to `Canon::CropInfo`.
+  // DEFERRED child walk: suppressed (no bogus raw parent), issue #177.
   CanonTag {
     id: 0x98,
     name: "CropInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::CropInfo),
     unknown: false,
   },
-  // 0x99 — CustomFunctions2 (`Canon.pm:1884-1888`)
+  // 0x99 — CustomFunctions2 (`Canon.pm:1884-1889`) — SubDirectory to
+  // `CanonCustom::Functions2`. DEFERRED child walk (issue #87): suppressed.
   CanonTag {
     id: 0x99,
     name: "CustomFunctions2",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::CustomFunctions2),
     unknown: false,
   },
-  // 0x9a — AspectInfo (`Canon.pm:1891-1893`)
+  // 0x9a — AspectInfo (`Canon.pm:1891-1893`) — SubDirectory to
+  // `Canon::AspectInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x9a,
     name: "AspectInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::AspectInfo),
     unknown: false,
   },
   // 0xa0 — ProcessingInfo (`Canon.pm:1897-1901`)
@@ -617,12 +744,13 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: Some(SubTable::ColorBalance),
     unknown: false,
   },
-  // 0xaa — MeasuredColor (`Canon.pm:1914-1919`)
+  // 0xaa — MeasuredColor (`Canon.pm:1913-1918`) — SubDirectory to
+  // `Canon::MeasuredColor`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0xaa,
     name: "MeasuredColor",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::MeasuredColor),
     unknown: false,
   },
   // 0xae — ColorTemperature (`Canon.pm:1921-1924`)
@@ -633,20 +761,22 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0xb0 — CanonFlags (`Canon.pm:1925-1933`)
+  // 0xb0 — CanonFlags (`Canon.pm:1924-1930`) — SubDirectory to `Canon::Flags`.
+  // DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0xb0,
     name: "CanonFlags",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::CanonFlags),
     unknown: false,
   },
-  // 0xb1 — ModifiedInfo (`Canon.pm:1932-1939`)
+  // 0xb1 — ModifiedInfo (`Canon.pm:1931-1937`) — SubDirectory to
+  // `Canon::ModifiedInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0xb1,
     name: "ModifiedInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::ModifiedInfo),
     unknown: false,
   },
   // 0xb2 — ToneCurveMatching (`Canon.pm:1940`)
@@ -673,12 +803,13 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0xb6 — PreviewImageInfo (`Canon.pm:1951-1958`)
+  // 0xb6 — PreviewImageInfo (`Canon.pm:1949-1957`) — SubDirectory to
+  // `Canon::PreviewImageInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0xb6,
     name: "PreviewImageInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::PreviewImageInfo),
     unknown: false,
   },
   // 0xd0 — VRDOffset (`Canon.pm:1959-1966`) — int32u
@@ -698,12 +829,15 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: Some(SubTable::SensorInfo),
     unknown: false,
   },
-  // 0x4001 — ColorData (`Canon.pm:1974-2046`) — model-specific ColorDataN.
+  // 0x4001 — ColorData (`Canon.pm:1973-2046`) — count-selected ColorData<N>
+  // SubDirectory list. DEFERRED child walk (issue #84): a SubDirectory pointer
+  // descends into the child table and never emits the parent value, so mark it
+  // `Some(..)` (suppressed by the deferred-SubDirectory arm, issue #177).
   CanonTag {
     id: 0x4001,
     name: "ColorData",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::ColorData),
     unknown: false,
   },
   // 0x4002 — CRWParam (`Canon.pm:2048-2053`)
@@ -714,12 +848,13 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0x4003 — ColorInfo (`Canon.pm:2055-2057`)
+  // 0x4003 — ColorInfo (`Canon.pm:2056-2059`) — SubDirectory to
+  // `Canon::ColorInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4003,
     name: "ColorInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::ColorInfo),
     unknown: false,
   },
   // 0x4005 — Flavor (`Canon.pm:2059-2063`)
@@ -756,36 +891,41 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: None,
     unknown: false,
   },
-  // 0x4013 — AFMicroAdj (`Canon.pm:2087-2095`)
+  // 0x4013 — AFMicroAdj (`Canon.pm:2088-2095`) — SubDirectory to
+  // `Canon::AFMicroAdj`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4013,
     name: "AFMicroAdj",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::AfMicroAdj),
     unknown: false,
   },
-  // 0x4015 — VignettingCorr (`Canon.pm:2097-2120`) — conditional
+  // 0x4015 — VignettingCorr (`Canon.pm:2098-2122`) — conditional SubDirectory
+  // list (every arm is a SubDirectory to `Canon::VignettingCorr{,Unknown}`).
+  // DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4015,
     name: "VignettingCorr",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::VignettingCorr),
     unknown: false,
   },
-  // 0x4016 — VignettingCorr2 (`Canon.pm:2121-2128`)
+  // 0x4016 — VignettingCorr2 (`Canon.pm:2123-2130`) — SubDirectory to
+  // `Canon::VignettingCorr2`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4016,
     name: "VignettingCorr2",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::VignettingCorr2),
     unknown: false,
   },
-  // 0x4018 — LightingOpt (`Canon.pm:2130-2136`)
+  // 0x4018 — LightingOpt (`Canon.pm:2131-2137`) — SubDirectory to
+  // `Canon::LightingOpt`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4018,
     name: "LightingOpt",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::LightingOpt),
     unknown: false,
   },
   // 0x4019 — LensInfo (`Canon.pm:2137-2142`) — Phase-2: emit raw.
@@ -796,76 +936,85 @@ pub const CANON_TAGS: &[CanonTag] = &[
     sub_table: Some(SubTable::LensInfo),
     unknown: false,
   },
-  // 0x4020 — AmbienceInfo (`Canon.pm:2144-2151`) — SubDirectory, deferred.
+  // 0x4020 — AmbienceInfo (`Canon.pm:2144-2151`) — SubDirectory to
+  // `Canon::Ambience`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4020,
     name: "AmbienceInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::AmbienceInfo),
     unknown: false,
   },
-  // 0x4021 — MultiExp (`Canon.pm:2150-2156`)
+  // 0x4021 — MultiExp (`Canon.pm:2152-2158`) — SubDirectory to
+  // `Canon::MultiExp`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4021,
     name: "MultiExp",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::MultiExp),
     unknown: false,
   },
-  // 0x4024 — FilterInfo (`Canon.pm:2158-2163`)
+  // 0x4024 — FilterInfo (`Canon.pm:2159-2165`) — SubDirectory to
+  // `Canon::FilterInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4024,
     name: "FilterInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::FilterInfo),
     unknown: false,
   },
-  // 0x4025 — HDRInfo (`Canon.pm:2164-2170`)
+  // 0x4025 — HDRInfo (`Canon.pm:2166-2172`) — SubDirectory to `Canon::HDRInfo`.
+  // DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4025,
     name: "HDRInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::HdrInfo),
     unknown: false,
   },
-  // 0x4026 — LogInfo (`Canon.pm:2171-2178`)
+  // 0x4026 — LogInfo (`Canon.pm:2173-2179`) — SubDirectory to `Canon::LogInfo`.
+  // DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4026,
     name: "LogInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::LogInfo),
     unknown: false,
   },
-  // 0x4028 — AFConfig (`Canon.pm:2179-2184`)
+  // 0x4028 — AFConfig (`Canon.pm:2180-2186`) — SubDirectory to
+  // `Canon::AFConfig`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4028,
     name: "AFConfig",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::AfConfig),
     unknown: false,
   },
-  // 0x403f — RawBurstModeRoll (`Canon.pm:2186-2189`)
+  // 0x403f — RawBurstModeRoll (`Canon.pm:2188-2194`) — SubDirectory to
+  // `Canon::RawBurstInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x403f,
     name: "RawBurstModeRoll",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::RawBurstModeRoll),
     unknown: false,
   },
-  // 0x4053 — FocusBracketingInfo (`Canon.pm:2196-2202`)
+  // 0x4053 — FocusBracketingInfo (`Canon.pm:2196-2202`) — SubDirectory to
+  // `Canon::FocusBracketingInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4053,
     name: "FocusBracketingInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::FocusBracketingInfo),
     unknown: false,
   },
-  // 0x4059 — LevelInfo (`Canon.pm:2203-2209`)
+  // 0x4059 — LevelInfo (`Canon.pm:2203-2209`) — SubDirectory to
+  // `Canon::LevelInfo`. DEFERRED child walk: suppressed (issue #177).
   CanonTag {
     id: 0x4059,
     name: "LevelInfo",
     conv: CanonPrintConv::None,
-    sub_table: None,
+    sub_table: Some(SubTable::LevelInfo),
     unknown: false,
   },
 ];
@@ -950,6 +1099,95 @@ mod tests {
   fn focus_bracketing_and_level_info_not_swapped() {
     assert_eq!(lookup(0x4053).unwrap().name, "FocusBracketingInfo");
     assert_eq!(lookup(0x4059).unwrap().name, "LevelInfo");
+  }
+
+  /// The COMPLETE set of `%Image::ExifTool::Canon::Main` tag IDs that carry a
+  /// `SubDirectory` (`Canon.pm:1222-2210`, every `SubDirectory => { TagTable
+  /// => … }` entry, including the conditional-list IDs where EVERY arm is a
+  /// SubDirectory). A `SubDirectory` pointer descends into its child table and
+  /// emits NO parent value (`Exif.pm:7103-7104`), so each must reach the
+  /// suppression path — either walked (`is_walked()`) or marked
+  /// `sub_table: Some(..)` (deferred). NONE may be `sub_table: None`, otherwise
+  /// it hits the leaf arm and leaks a bogus raw parent (the #177/#223 bug).
+  ///
+  /// 0x96 is the sole documented exception: its `SerialInfo` SubDirectory is a
+  /// model-conditional FIRST arm; the SECOND arm `InternalSerialNumber` is a
+  /// real leaf, so the row stays `None` and the SerialInfo suppression lives in
+  /// a dedicated `parse_in_tiff` arm (covered by the dispatch tests).
+  const CANON_MAIN_SUBDIRECTORY_IDS: &[u16] = &[
+    0x01, 0x02, 0x04, 0x05, 0x0a, 0x0d, 0x0f, 0x11, 0x12, 0x1d, 0x24, 0x25, 0x26, 0x27, 0x29, 0x2f,
+    0x35, 0x3c, 0x90, 0x91, 0x92, 0x93, /* 0x96 — model-conditional, see above */
+    0x98, 0x99, 0x9a, 0xa0, 0xa9, 0xaa, 0xb0, 0xb1, 0xb6, 0xe0, 0x4001, 0x4003, 0x4013, 0x4015,
+    0x4016, 0x4018, 0x4019, 0x4020, 0x4021, 0x4024, 0x4025, 0x4026, 0x4028, 0x403f, 0x4053, 0x4059,
+  ];
+
+  /// Table invariant (#223 class guard): every Canon::Main SubDirectory ID is
+  /// walked-or-deferred — i.e. `sub_table.is_some()` — so a future mis-mark to
+  /// `None` (which would leak a bogus raw parent) fails this test.
+  #[test]
+  fn canon_tags_subdirectory_rows_are_marked() {
+    for &id in CANON_MAIN_SUBDIRECTORY_IDS {
+      let t = lookup(id)
+        .unwrap_or_else(|| panic!("Canon::Main SubDirectory 0x{id:04x} missing from table"));
+      assert!(
+        t.sub_table().is_some(),
+        "Canon::Main SubDirectory 0x{id:04x} ({}) must be sub_table: Some(..) \
+         (walked or deferred) so it reaches the suppression path, not the leaf \
+         arm — else it leaks a bogus raw parent (#177/#223)",
+        t.name()
+      );
+    }
+    // 0x96 is the sole exception (model-conditional SerialInfo): it MUST stay
+    // None so the non-5D second-arm InternalSerialNumber leaf still emits.
+    assert_eq!(
+      lookup(0x96).and_then(CanonTag::sub_table),
+      None,
+      "0x96 must stay None — SerialInfo is a model-conditional arm handled in parse_in_tiff"
+    );
+  }
+
+  /// The 23 SubDirectory rows the SECOND #223 pass corrected from `None` to a
+  /// deferred `Some(..)` (the first pass had done 8). Spot-check the new
+  /// variants resolve and stay NON-walked (so they hit the suppression arm).
+  #[test]
+  fn canon_223_second_pass_rows_are_deferred_subdirs() {
+    for (id, name, sub) in [
+      (0x0au16, "UnknownD30", SubTable::UnknownD30),
+      (0x0f, "CustomFunctions", SubTable::CustomFunctions),
+      (0x2f, "FaceDetect3", SubTable::FaceDetect3),
+      (0x35, "TimeInfo", SubTable::TimeInfo),
+      (0x90, "CustomFunctions1D", SubTable::CustomFunctions1D),
+      (0x91, "PersonalFunctions", SubTable::PersonalFunctions),
+      (
+        0x92,
+        "PersonalFunctionValues",
+        SubTable::PersonalFunctionValues,
+      ),
+      (0xb0, "CanonFlags", SubTable::CanonFlags),
+      (0xb1, "ModifiedInfo", SubTable::ModifiedInfo),
+      (0xb6, "PreviewImageInfo", SubTable::PreviewImageInfo),
+      (0x4003, "ColorInfo", SubTable::ColorInfo),
+      (0x4015, "VignettingCorr", SubTable::VignettingCorr),
+      (0x4016, "VignettingCorr2", SubTable::VignettingCorr2),
+      (0x4018, "LightingOpt", SubTable::LightingOpt),
+      (0x4020, "AmbienceInfo", SubTable::AmbienceInfo),
+      (0x4021, "MultiExp", SubTable::MultiExp),
+      (0x4024, "FilterInfo", SubTable::FilterInfo),
+      (0x4025, "HDRInfo", SubTable::HdrInfo),
+      (0x4026, "LogInfo", SubTable::LogInfo),
+      (0x4028, "AFConfig", SubTable::AfConfig),
+      (0x403f, "RawBurstModeRoll", SubTable::RawBurstModeRoll),
+      (0x4053, "FocusBracketingInfo", SubTable::FocusBracketingInfo),
+      (0x4059, "LevelInfo", SubTable::LevelInfo),
+    ] {
+      let t = lookup(id).unwrap();
+      assert_eq!(t.name(), name, "0x{id:04x} name");
+      assert_eq!(t.sub_table(), Some(sub), "0x{id:04x} sub_table");
+      assert!(
+        !sub.is_walked(),
+        "0x{id:04x} ({name}) is a DEFERRED SubDirectory — must NOT be walked"
+      );
+    }
   }
 
   #[test]

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -3386,3 +3386,509 @@ fn canon_1dmk3_real_fixture_no_bogus_processinginfo_parent() {
     );
   }
 }
+
+// ===========================================================================
+// #223 — sibling class of #177: Canon::Main tags that ARE real `SubDirectory`
+// pointers in Canon.pm were MIS-MARKED `sub_table: None`, so they missed the
+// deferred-SubDirectory suppression arm (#177) and instead hit the LEAF arm,
+// leaking a bogus raw-array PARENT value ExifTool never emits.
+//
+// The first pass corrected 7 SubDirectory pointers + the all-zero `ImageUniqueID`
+// RawConv (`ImageUniqueID` 0x28 is NOT a SubDirectory — `Canon.pm:1732`,
+// `$val eq "\0" x 16 ? undef : $val`). A FULL `%Canon::Main` sweep against
+// Canon.pm then found 23 MORE mis-marked SubDirectory IDs (0x90 CustomFunctions1D
+// was the one Codex flagged): UnknownD30 0x0a, CustomFunctions 0x0f, FaceDetect3
+// 0x2f, TimeInfo 0x35, CustomFunctions1D 0x90, PersonalFunctions 0x91,
+// PersonalFunctionValues 0x92, CanonFlags 0xb0, ModifiedInfo 0xb1,
+// PreviewImageInfo 0xb6, ColorInfo 0x4003, VignettingCorr 0x4015,
+// VignettingCorr2 0x4016, LightingOpt 0x4018, AmbienceInfo 0x4020, MultiExp
+// 0x4021, FilterInfo 0x4024, HDRInfo 0x4025, LogInfo 0x4026, AFConfig 0x4028,
+// RawBurstModeRoll 0x403f, FocusBracketingInfo 0x4053, LevelInfo 0x4059. All are
+// now `sub_table: Some(..)` (suppressed; children stay #84/#85/#87-deferred).
+// (None of the 3 available fixtures CARRIES any of these 23 — they appear only
+// on un-fixtured bodies (1D/1Ds for 0x90, newer bodies for the 0x40xx set) — so
+// the fix is verified by the `canon::tags` table-invariant test plus the
+// synthetic suppression test below, not a fixture diff.) The whole-table guard
+// lives in `canon::tags::canon_tags_subdirectory_rows_are_marked`.
+// ===========================================================================
+
+/// The seven Canon::Main `SubDirectory` parents that #223 corrected from
+/// `sub_table: None` to `Some(..)` — none may appear as a raw parent key (their
+/// child tables stay deferred). `CanonCameraInfo` (0x0d) and `MeasuredColor`
+/// (0xaa) are present in the bundled `MakerNotes_Canon.jpg` (== `t/images/
+/// Canon.jpg`); all seven plus an all-zero `ImageUniqueID` are present in
+/// `Canon1DmkIII.jpg` (`EXIFTOOL_T_IMAGES`).
+#[cfg(feature = "exif")]
+const CANON_223_MISMARKED_SUBDIR_PARENTS: &[&str] = &[
+  "CanonCameraInfo",  // 0x0d   Canon::CameraInfo<Model>
+  "CropInfo",         // 0x98   Canon::CropInfo
+  "CustomFunctions2", // 0x99   CanonCustom::Functions2
+  "AspectInfo",       // 0x9a   Canon::AspectInfo
+  "MeasuredColor",    // 0xaa   Canon::MeasuredColor
+  "ColorData",        // 0x4001 Canon::ColorData<N>
+  "AFMicroAdj",       // 0x4013 Canon::AFMicroAdj
+];
+
+/// #223 — none of the seven mis-marked SubDirectory parents (nor an all-zero
+/// `ImageUniqueID`) may be emitted, while real Canon tags stay present.
+/// Bundled `MakerNotes_Canon.jpg` runs in CI (carries `CanonCameraInfo` +
+/// `MeasuredColor` as the bogus parents — verified against the
+/// `perl exiftool -G1 -j` oracle, which emits NEITHER).
+#[cfg(feature = "json")]
+#[test]
+fn canon_mismarked_subdir_parents_not_emitted() {
+  for print_on in [true, false] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let map = extract_info_map("MakerNotes_Canon.jpg", print_on);
+    for parent in CANON_223_MISMARKED_SUBDIR_PARENTS {
+      assert!(
+        !map.contains_key(&format!("Canon:{parent}")),
+        "bogus mis-marked SubDirectory parent Canon:{parent} must not be emitted ({mode}); keys: {:?}",
+        map.keys().collect::<Vec<_>>()
+      );
+    }
+    // An all-zero ImageUniqueID (0x28) is dropped by the RawConv; this fixture
+    // has no ImageUniqueID at all, so it must be absent either way.
+    assert!(
+      !map.contains_key("Canon:ImageUniqueID"),
+      "Canon:ImageUniqueID must be absent for this fixture ({mode})"
+    );
+    // Real Canon tags the oracle DOES emit stay present + unchanged.
+    assert!(
+      map.contains_key("Canon:CanonImageType"),
+      "real Canon:CanonImageType must still be present ({mode})"
+    );
+    assert!(
+      map.contains_key("Canon:LensType"),
+      "walked CameraSettings leaf Canon:LensType must still be present ({mode})"
+    );
+  }
+}
+
+/// #223 — the real `Canon1DmkIII.jpg` (NOT bundled; gated on
+/// `EXIFTOOL_T_IMAGES`) carries ALL SEVEN mis-marked SubDirectory parents
+/// (`CanonCameraInfo`/`CropInfo`/`CustomFunctions2`/`AspectInfo`/
+/// `MeasuredColor`/`ColorData`/`AFMicroAdj`) AND an all-zero `ImageUniqueID`
+/// (0x28 = 16 NUL bytes). The `perl exiftool -G1 -j` oracle emits NONE of
+/// them (it descends the SubDirectories — emitting e.g. `ColorDataVersion`,
+/// `AFMicroAdjMode`, all #84/#85/#87-deferred children this port does not yet
+/// produce — and the RawConv drops the all-zero ImageUniqueID). Assert none of
+/// the eight bogus parents/values leak, while the walked Canon tags stay
+/// present and unchanged.
+#[cfg(feature = "json")]
+#[test]
+fn canon_1dmk3_real_fixture_no_mismarked_subdir_parents() {
+  let Ok(dir) = std::env::var("EXIFTOOL_T_IMAGES") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES not set");
+    return;
+  };
+  let path = format!("{dir}/Canon1DmkIII.jpg");
+  let Ok(data) = std::fs::read(&path) else {
+    eprintln!("skipping: {path} not readable");
+    return;
+  };
+  for print_on in [true, false] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let json = exifast::parser::extract_info("Canon1DmkIII.jpg", &data, print_on);
+    let doc: serde_json::Value =
+      serde_json::from_str(&json).unwrap_or_else(|e| panic!("invalid JSON ({e}):\n{json}"));
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .unwrap_or_else(|| panic!("doc is not [{{…}}]:\n{json}"));
+    for parent in CANON_223_MISMARKED_SUBDIR_PARENTS {
+      assert!(
+        !map.contains_key(&format!("Canon:{parent}")),
+        "bogus mis-marked SubDirectory parent Canon:{parent} must not be emitted ({mode}); keys: {:?}",
+        map.keys().collect::<Vec<_>>()
+      );
+    }
+    // The all-zero ImageUniqueID (0x28 = 16 NUL bytes) → undef RawConv → dropped.
+    assert!(
+      !map.contains_key("Canon:ImageUniqueID"),
+      "all-zero Canon:ImageUniqueID must be dropped by the RawConv ({mode})"
+    );
+    // The walked Canon tags the oracle DOES emit stay present + unaffected: a
+    // CameraSettings leaf, a SensorInfo leaf (0xe0, walked here), and the
+    // Main-IFD LensModel string (0x95) — proving the suppression is surgical
+    // (only the bogus parents removed). (`WB_RGGBLevels*` on this body come
+    // from the DEFERRED ColorData4 child of 0x4001, so they are oracle-only —
+    // the #84-deferral, out of #223 scope.)
+    assert!(
+      map.contains_key("Canon:ContinuousDrive"),
+      "walked CameraSettings leaf Canon:ContinuousDrive must still be present ({mode})"
+    );
+    assert!(
+      map.contains_key("Canon:SensorWidth"),
+      "walked SensorInfo leaf Canon:SensorWidth must still be present ({mode})"
+    );
+    assert!(
+      map.contains_key("Canon:LensModel"),
+      "Main-IFD leaf Canon:LensModel must still be present ({mode})"
+    );
+  }
+}
+
+/// Build a one-entry Canon Main IFD blob (little-endian) carrying tag 0x28
+/// `ImageUniqueID`, with `value_bytes` stored OUT-OF-LINE (>4 bytes) and the
+/// entry declaring TIFF format code `format` with element count `count`. The
+/// 16 on-disk value bytes are written verbatim regardless of the declared
+/// numeric shape — mirroring how ExifTool's `Format => 'undef'` reads the
+/// literal bytes. Mirrors [`canon_mn_one_int16u_array`].
+#[cfg(all(feature = "exif", feature = "std"))]
+fn canon_mn_image_unique_id_shape(format: u16, count: u32, value_bytes: &[u8]) -> Vec<u8> {
+  let mut blob: Vec<u8> = Vec::new();
+  blob.extend_from_slice(&1u16.to_le_bytes()); // entry count = 1
+  blob.extend_from_slice(&0x28u16.to_le_bytes()); // tag 0x28 ImageUniqueID
+  blob.extend_from_slice(&format.to_le_bytes()); // declared on-disk format
+  blob.extend_from_slice(&count.to_le_bytes()); // element count
+  // value offset: 2-byte count + one 12-byte entry + 4-byte next-IFD = 18.
+  let data_off = 2 + 12 + 4;
+  blob.extend_from_slice(&(data_off as u32).to_le_bytes());
+  blob.extend_from_slice(&0u32.to_le_bytes()); // next-IFD = 0
+  blob.extend_from_slice(value_bytes);
+  blob
+}
+
+/// #223 — `ImageUniqueID` (0x28) `Format => 'undef'` raw-byte handling
+/// (`Canon.pm:1726-1735`): `RawConv => '$val eq "\0" x 16 ? undef : $val'`
+/// then `ValueConv => 'unpack("H*", $val)'`.
+///
+/// ExifTool forces `Format => 'undef'` (`Exif.pm:6735-6744`: override the
+/// declared numeric format with `undef` and re-derive `$count = $size /
+/// $formatSize['undef']`, so `ReadValue` returns the ORIGINAL on-disk
+/// `$size` bytes — the verbose dump literally reads `int8u[16] read as
+/// undef[16]`). It therefore reads the SAME 16 raw value bytes whether the
+/// entry is declared `int8u[16]`, `int16u[8]`, `int32u[4]`, `undef[16]`,
+/// `float[4]`, `double[2]`, or `rational[2]` — a *16-NUL* value is dropped
+/// (undef), and a non-zero value is lowercase-hex-encoded to the SAME string
+/// across every shape. The expected hex string is oracle-cited: a crafted
+/// Canon TIFF with these bytes in each shape was confirmed against `perl
+/// exiftool -G1 -j` to yield
+/// `Canon:ImageUniqueID = "00112233445566778899aabbccddeeff"` identically
+/// (and identically under `-n`); the float/double/rational shapes were
+/// individually oracle-checked to yield the SAME hex (NOT a numeric decode).
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_image_unique_id_all_zero_dropped() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::vendors::canon;
+
+  // The oracle-cited 16 raw bytes and their `unpack("H*")` rendering.
+  const ID_BYTES: [u8; 16] = [
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+  ];
+  const ID_HEX: &str = "00112233445566778899aabbccddeeff";
+
+  // (format code, element count) for the same 16 raw bytes — every TIFF
+  // shape that multiplies out to 16 on-disk bytes: int8u[16], int16u[8],
+  // int32u[4], undef[16], AND the FLOAT (11) / DOUBLE (12) / RATIONAL (5)
+  // shapes that the previous decode-then-reserialize path zeroed out
+  // (`reserialize_value_bytes` fell through to `Vec::new()` for those).
+  // ExifTool's `undef` read ignores the numeric shape, so every shape yields
+  // the IDENTICAL result (each oracle-verified via `perl exiftool -G1 -j`).
+  for &(format, count) in &[
+    (1u16, 16u32), // int8u[16]
+    (3, 8),        // int16u[8]
+    (4, 4),        // int32u[4]
+    (7, 16),       // undef[16]
+    (11, 4),       // float[4]
+    (12, 2),       // double[2]
+    (5, 2),        // rational[2]
+  ] {
+    // All-zero 16-byte value ⇒ `$val eq "\0" x 16` ⇒ RawConv undef ⇒ dropped
+    // (no emission, typed surface unset). Oracle: an all-zero `int8u[16]`
+    // emits NO `Canon:ImageUniqueID`.
+    let zero_blob = canon_mn_image_unique_id_shape(format, count, &[0u8; 16]);
+    let (typed, em) = canon::parse(&zero_blob, ByteOrder::Little);
+    assert!(
+      !em.iter().any(|e| e.name() == "ImageUniqueID"),
+      "all-zero 16-byte ImageUniqueID must NOT be emitted (format {format}, count {count}); got {:?}",
+      em.iter().map(|e| e.name().to_string()).collect::<Vec<_>>()
+    );
+    assert!(
+      typed.image_unique_id().is_none(),
+      "all-zero 16-byte ImageUniqueID must not populate the typed surface (format {format}, count {count})"
+    );
+
+    // Non-zero ⇒ emitted hex-encoded, typed surface populated — SAME string
+    // across all shapes (the `undef` read sees the literal 16 bytes).
+    let nz_blob = canon_mn_image_unique_id_shape(format, count, &ID_BYTES);
+    let (typed, em) = canon::parse(&nz_blob, ByteOrder::Little);
+    let emitted = em
+      .iter()
+      .find(|e| e.name() == "ImageUniqueID")
+      .map(|e| e.value().clone());
+    assert_eq!(
+      emitted,
+      Some(exifast::value::TagValue::Str(ID_HEX.into())),
+      "non-zero ImageUniqueID must be hex-encoded from the raw 16 bytes (format {format}, count {count})"
+    );
+    assert_eq!(
+      typed.image_unique_id(),
+      Some(ID_HEX),
+      "non-zero ImageUniqueID must populate the typed surface (format {format}, count {count})"
+    );
+  }
+}
+
+/// #223 R3 — a SHORT all-zero `ImageUniqueID` is EMITTED, not dropped. The
+/// RawConv is `$val eq "\0" x 16` (Perl string equality to EXACTLY sixteen
+/// NUL bytes), NOT `/^\0+$/` — so an all-zero value of any length OTHER than
+/// 16 is NOT equal and survives. Oracle (`perl exiftool -G1 -j` on a crafted
+/// Canon TIFF, tag 0x28 declared `int8u[8]`/`int16u[4]` with eight NUL value
+/// bytes): `"Canon:ImageUniqueID": "0000000000000000"` (eight bytes ⇒ sixteen
+/// hex zeros) — it does NOT drop. The previous port wrongly suppressed ANY
+/// all-zero byte string (`val_bytes.iter().all(|&b| b == 0)`).
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_image_unique_id_short_all_zero_is_emitted() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::vendors::canon;
+
+  // Eight NUL bytes ⇒ NOT `"\0" x 16` ⇒ emitted as sixteen hex zeros.
+  const SHORT_ZERO_HEX: &str = "0000000000000000";
+
+  // int8u[8] and int16u[4] both multiply to 8 on-disk bytes; the `undef`
+  // read sees the SAME eight NUL bytes (oracle-identical hex for both).
+  for &(format, count) in &[(1u16, 8u32), (3, 4)] {
+    let blob = canon_mn_image_unique_id_shape(format, count, &[0u8; 8]);
+    let (typed, em) = canon::parse(&blob, ByteOrder::Little);
+    let emitted = em
+      .iter()
+      .find(|e| e.name() == "ImageUniqueID")
+      .map(|e| e.value().clone());
+    assert_eq!(
+      emitted,
+      Some(exifast::value::TagValue::Str(SHORT_ZERO_HEX.into())),
+      "a SHORT (8-byte) all-zero ImageUniqueID must be EMITTED as hex zeros, not dropped (format {format}, count {count})"
+    );
+    assert_eq!(
+      typed.image_unique_id(),
+      Some(SHORT_ZERO_HEX),
+      "a SHORT all-zero ImageUniqueID must populate the typed surface (format {format}, count {count})"
+    );
+  }
+}
+
+/// #223 R3 — a 16-byte value with EMBEDDED NULs (but not all-zero) keeps its
+/// NULs in the hex render — the `Format => 'undef'` read is byte-exact and
+/// does NOT NUL-trim (the previous `Ascii`/`Text` path would have truncated
+/// at the first NUL). Oracle (`perl exiftool -G1 -j` on a crafted Canon TIFF,
+/// tag 0x28 declared `int8u[16]` with bytes `00 ff 00 … 00 aa`):
+/// `"Canon:ImageUniqueID": "00ff00000000000000000000000000aa"` — the full 32
+/// hex chars, including the internal NULs.
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_image_unique_id_embedded_nuls_not_truncated() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::vendors::canon;
+
+  // Leading NUL, embedded NUL run, trailing non-NUL — not all-zero, so it
+  // survives the RawConv, and the hex must include every NUL byte.
+  const NUL_BYTES: [u8; 16] = [
+    0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa,
+  ];
+  const NUL_HEX: &str = "00ff00000000000000000000000000aa";
+
+  let blob = canon_mn_image_unique_id_shape(1, 16, &NUL_BYTES);
+  let (typed, em) = canon::parse(&blob, ByteOrder::Little);
+  let emitted = em
+    .iter()
+    .find(|e| e.name() == "ImageUniqueID")
+    .map(|e| e.value().clone());
+  assert_eq!(
+    emitted,
+    Some(exifast::value::TagValue::Str(NUL_HEX.into())),
+    "an ImageUniqueID with embedded NULs must hex-render the FULL 16 bytes (no NUL-trim)"
+  );
+  assert_eq!(typed.image_unique_id(), Some(NUL_HEX));
+}
+
+/// #223 R4 — a `0x28` entry with `count == 0` must take the `Format => 'undef'`
+/// raw-byte view BEFORE `read_value`, so the declared-format decode (and its
+/// count-zero expansion) is skipped: the `undef[0]` value is the EMPTY string,
+/// derived WITHOUT reading/allocating the trailing buffer that follows the IFD.
+///
+/// ExifTool overrides the format to `undef` and re-derives `$count =
+/// int($size / 1)` where `$size = $count_declared * $formatSize[$declared] = 0`
+/// (`Exif.pm:6740-6743`). With a DEFINED `$count == 0`, `ReadValue` returns `''`
+/// immediately (`ExifTool.pm:6296-6298` — it does NOT fall through to `$count =
+/// int($size / $len)`, which only runs for an UNDEFINED count). The `RawConv`
+/// (`'' eq "\0" x 16` is false) keeps `''`, and `unpack("H*", '')` is `''`.
+/// Oracle (`perl exiftool -G1 -j` on a crafted Canon TIFF, tag 0x28 declared
+/// `int8u[0]` with 16 trailing value bytes): `"Canon:ImageUniqueID": ""` — an
+/// EMPTY string, not the hex of the trailing bytes. The pre-R4 code called
+/// `read_value` first, which (seeing `count == 0`, `size == avail`) expanded
+/// `$count` from the WHOLE remaining buffer and allocated a discarded `Vec`
+/// before the `0x28` override replaced it with the (empty) `total_size` window.
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_0x28_count_zero_no_trailing_decode() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::vendors::canon;
+
+  // Sixteen NON-zero trailing bytes sit right after the IFD (the helper stores
+  // `value_bytes` at offset 18). A `count == 0` entry is classified INLINE
+  // (`$size == 0 <= 4`), so the raw window is the empty slice at `entry+8`; if
+  // the declared-numeric path ran instead, `read_value` would expand into
+  // these trailing bytes and the hex would be non-empty.
+  const TRAILING: [u8; 16] = [
+    0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01,
+  ];
+  // int8u[0] and int32u[0] both multiply to size 0 (inline, empty window).
+  for &(format, count) in &[(1u16, 0u32), (4, 0)] {
+    let blob = canon_mn_image_unique_id_shape(format, count, &TRAILING);
+    let (typed, em) = canon::parse(&blob, ByteOrder::Little);
+    let emitted = em
+      .iter()
+      .find(|e| e.name() == "ImageUniqueID")
+      .map(|e| e.value().clone());
+    // Oracle: `undef[0]` ⇒ empty string (the trailing bytes are NOT decoded).
+    assert_eq!(
+      emitted,
+      Some(exifast::value::TagValue::Str("".into())),
+      "count-0 ImageUniqueID must emit the EMPTY string (undef[0]), not decode the trailing buffer (format {format})"
+    );
+    assert_eq!(
+      typed.image_unique_id(),
+      Some(""),
+      "count-0 ImageUniqueID must populate the typed surface with the empty string (format {format})"
+    );
+  }
+}
+
+/// #223 R4 — a `0x28` entry declaring a HUGE element count must be bounds-safe:
+/// the checked window computation (`byte_size().checked_mul(count)` +
+/// `checked_add` + `get`) never panics and never allocates the discarded
+/// multi-gigabyte numeric `Vec` the pre-R4 `read_value`-first path would have.
+///
+/// `int32u[0x40000000]` ⇒ `$size = 0x40000000 * 4 = 0x1_0000_0000 >
+/// 0x7fffffff`, so `ProcessExif` warns `Invalid size (...)` and skips the entry
+/// (`Exif.pm:6505`); ExifTool emits NO `ImageUniqueID`. The exifast classifier
+/// reaches the SAME verdict (`CanonEntryClass::InvalidSize`, `body.rs`), so the
+/// entry never reaches the `0x28` raw-window code — proving the huge count is
+/// rejected WITHOUT a panic or a large allocation. Oracle (`perl exiftool -G1
+/// -j`): the tag is absent.
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_0x28_large_count_bounded() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::vendors::canon;
+
+  // int32u, count 0x40000000 → declared size 4 GiB, value region truncated to
+  // 16 bytes. Must not panic, must not allocate, must emit nothing.
+  let blob = canon_mn_image_unique_id_shape(4, 0x4000_0000, &[0u8; 16]);
+  let (typed, em) = canon::parse(&blob, ByteOrder::Little);
+  assert!(
+    !em.iter().any(|e| e.name() == "ImageUniqueID"),
+    "a huge-count (int32u[0x40000000]) ImageUniqueID must be rejected with no emission; got {:?}",
+    em.iter().map(|e| e.name().to_string()).collect::<Vec<_>>()
+  );
+  assert!(
+    typed.image_unique_id().is_none(),
+    "a huge-count ImageUniqueID must not populate the typed surface"
+  );
+}
+
+/// The 23 Canon::Main `SubDirectory` parents the SECOND #223 pass corrected
+/// from `sub_table: None` to a deferred `Some(..)` (`0x90 CustomFunctions1D` is
+/// the one Codex flagged). None appears in any available fixture, so the
+/// suppression is exercised SYNTHETICALLY: each is a real SubDirectory pointer
+/// that — left as `None` — would hit the leaf arm and leak a bogus raw-array
+/// parent ExifTool never emits.
+#[cfg(all(feature = "exif", feature = "std"))]
+const CANON_223_SECOND_PASS_PARENTS: &[(u16, &str)] = &[
+  (0x0a, "UnknownD30"),             // Canon::UnknownD30
+  (0x0f, "CustomFunctions"),        // CanonCustom::Functions<Model>
+  (0x2f, "FaceDetect3"),            // Canon::FaceDetect3
+  (0x35, "TimeInfo"),               // Canon::TimeInfo
+  (0x90, "CustomFunctions1D"),      // CanonCustom::Functions1D
+  (0x91, "PersonalFunctions"),      // CanonCustom::PersonalFuncs
+  (0x92, "PersonalFunctionValues"), // CanonCustom::PersonalFuncValues
+  (0xb0, "CanonFlags"),             // Canon::Flags
+  (0xb1, "ModifiedInfo"),           // Canon::ModifiedInfo
+  (0xb6, "PreviewImageInfo"),       // Canon::PreviewImageInfo
+  (0x4003, "ColorInfo"),            // Canon::ColorInfo
+  (0x4015, "VignettingCorr"),       // Canon::VignettingCorr{,Unknown}
+  (0x4016, "VignettingCorr2"),      // Canon::VignettingCorr2
+  (0x4018, "LightingOpt"),          // Canon::LightingOpt
+  (0x4020, "AmbienceInfo"),         // Canon::Ambience
+  (0x4021, "MultiExp"),             // Canon::MultiExp
+  (0x4024, "FilterInfo"),           // Canon::FilterInfo
+  (0x4025, "HDRInfo"),              // Canon::HDRInfo
+  (0x4026, "LogInfo"),              // Canon::LogInfo
+  (0x4028, "AFConfig"),             // Canon::AFConfig
+  (0x403f, "RawBurstModeRoll"),     // Canon::RawBurstInfo
+  (0x4053, "FocusBracketingInfo"),  // Canon::FocusBracketingInfo
+  (0x4059, "LevelInfo"),            // Canon::LevelInfo
+];
+
+/// #223 (second pass) — a Canon Main IFD carrying tag `id` as an int16u array
+/// must emit NO `Canon:<parent>` raw value: it is a deferred SubDirectory and
+/// is suppressed (the same descend-no-parent-value rule as #177). A co-present
+/// real leaf (`CanonImageType` 0x06) is still emitted, proving the suppression
+/// is surgical and the walk did run. Driven through the public standalone
+/// `canon::parse`, in BOTH `-j` (PrintConv on) and `-n` (off).
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_223_second_pass_subdir_parents_suppressed() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::vendors::canon;
+
+  for &(id, parent) in CANON_223_SECOND_PASS_PARENTS {
+    // Two-entry Main IFD (LE): the SubDirectory tag (out-of-line int16u[8]) +
+    // CanonImageType (0x06, ASCII, out-of-line). If `id` were mis-marked
+    // `None`, the int16u[8] would leak as a bogus `Canon:<parent>` array.
+    let words: [i16; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+    let image_type = b"CanonTest\x00"; // 10 bytes, out-of-line
+    let mut blob: Vec<u8> = Vec::new();
+    blob.extend_from_slice(&2u16.to_le_bytes()); // 2 entries
+    // Entry 1: the deferred SubDirectory tag, int16u(3) count 8, out-of-line.
+    let entries_end = 2 + 12 * 2 + 4; // count + 2 entries + next-IFD
+    let words_off = entries_end;
+    let it_off = words_off + words.len() * 2;
+    blob.extend_from_slice(&id.to_le_bytes());
+    blob.extend_from_slice(&3u16.to_le_bytes()); // int16u
+    blob.extend_from_slice(&(words.len() as u32).to_le_bytes());
+    blob.extend_from_slice(&(words_off as u32).to_le_bytes());
+    // Entry 2: CanonImageType 0x06, ASCII(2), out-of-line.
+    blob.extend_from_slice(&0x06u16.to_le_bytes());
+    blob.extend_from_slice(&2u16.to_le_bytes()); // ASCII
+    blob.extend_from_slice(&(image_type.len() as u32).to_le_bytes());
+    blob.extend_from_slice(&(it_off as u32).to_le_bytes());
+    blob.extend_from_slice(&0u32.to_le_bytes()); // next-IFD = 0
+    for &w in &words {
+      blob.extend_from_slice(&w.to_le_bytes());
+    }
+    blob.extend_from_slice(image_type);
+
+    for print_on in [true, false] {
+      let mode = if print_on { "-j" } else { "-n" };
+      let (_typed, em) = canon::parse_in_tiff(
+        &blob,
+        0,
+        blob.len(),
+        ByteOrder::Little,
+        print_on,
+        // Use a 1D body so the 0x0f/0x90 model-conditional SubDirectory arms
+        // resolve (they are SubDirectories for EVERY model; the body only
+        // affects WHICH child table, which we defer regardless).
+        Some("Canon EOS-1D"),
+        None,
+      );
+      assert!(
+        !em.iter().any(|e| e.name() == parent),
+        "deferred SubDirectory parent Canon:{parent} (0x{id:04x}) must NOT be emitted ({mode}); \
+         got {:?}",
+        em.iter().map(|e| e.name().to_string()).collect::<Vec<_>>()
+      );
+      // The co-present real leaf still emits — suppression is surgical.
+      assert!(
+        em.iter().any(|e| e.name() == "CanonImageType"),
+        "co-present real leaf Canon:CanonImageType must still be emitted ({mode}) for 0x{id:04x}"
+      );
+    }
+  }
+}


### PR DESCRIPTION
Closes #223 (sibling class of the merged #177).

**(1) SubDirectory parent suppression — full sweep.** 23 Canon::Main tags that are SubDirectory pointers in Canon.pm were mis-marked `sub_table: None`, so they missed #177's deferred-SubDirectory suppression and emitted bogus raw parent values ExifTool never produces. Swept the **complete 49-ID %Canon::Main SubDirectory set** → 48/49 now `sub_table: Some` (only 0x96 SerialInfo is the documented model-conditional exception), with a **table-invariant test** catching any future mis-mark.

**(2) ImageUniqueID (0x28) faithful to `Format=>'undef'`.** Reads the original on-disk bytes **before** `read_value` (no format decode, no count-0 expansion, no discarded Vec, checked window), applies Canon.pm:1732's exact 16-NUL-drop RawConv, renders lowercase hex. Byte-exact across all numeric shapes + byte orders; short-all-zero emits, 16-NUL drops, embedded NULs untruncated, count-0/large-count bounded.

Byte-exact vs `exiftool -G1 -j` on Canon.jpg / Canon1DmkIII.jpg / MakerNotes_Canon.jpg — zero exifast-only SubDirectory parents, real tags + walked children unchanged. Sony/Panasonic untouched. Gate green; Codex APPROVE (R5). Rebased on current main.