### PR TITLE
feat(exif/tiff): content-based DNG/CR2 FileType detection (#181)

### DIFF
--- a/src/exif/ifd.rs
+++ b/src/exif/ifd.rs
@@ -428,6 +428,26 @@ impl RawValue {
     }
   }
 
+  /// Perl boolean truthiness of this value's post-`ReadValue` `$val` — the
+  /// test an `if ($val)` (or `if ($$self{Member})` after a `RawConv` storing
+  /// `$val`) applies. Perl treats a scalar as FALSE only when it is the empty
+  /// string `""` or the one-character string `"0"`; every other value
+  /// (including `"0.0"`, `"0 0 0 0"`, or a multi-element join) is TRUE. The
+  /// `$val` form is taken from [`Self::val_bytes`] (numeric shapes → the
+  /// space-joined `join(' ', @vals)` string `ReadValue` returns; `Text`/`Bytes`
+  /// → the original bytes), so this matches ExifTool's truthiness for any
+  /// shape. A count-0 numeric value yields the empty `$val` (`""`), hence false.
+  ///
+  /// Used by the `DNGVersion` (0xc612) `RawConv` DataMember tap to gate
+  /// `OverrideFileType('DNG')` (`ExifTool.pm:8763` `if ($$self{DNGVersion} …`):
+  /// `int8u[4]` `1 1 0 0`/`0 0 0 0` are TRUE → DNG, while a count-0 (empty) or a
+  /// scalar `0` `DNGVersion` is FALSE → the file stays its non-DNG type.
+  #[must_use]
+  pub fn is_perl_truthy(&self) -> bool {
+    let val = self.val_bytes();
+    !val.is_empty() && &*val != b"0"
+  }
+
   /// The first integer of a SubIFD pointer, as a SIGNED `i64`, accepting BOTH
   /// `U64` and `I64` shapes. `%intFormat` (Exif.pm:125-136) treats the signed
   /// formats (`int8s`/`int16s`/`int32s`/`int64s`) as valid integer offsets, so

--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -452,7 +452,12 @@ pub fn redispatch_ctmd_makernote_diagnostics(
   // The 1:1 `ProcessExif` IFD0 gate. A header that does not parse ⇒ `None` ⇒ no
   // diagnostic (bundled `ProcessTIFF` `return 0`, no warning).
   let Some(meta) = crate::exif::parse_standalone_tiff_with_base(
-    tiff_block, /* base */ 0, /* tiff_type_is_tiff */ false, /* file_type */ None,
+    tiff_block, /* base */ 0, /* tiff_type_is_tiff */ false,
+    // An embedded `MakerNoteCanon` blob re-dispatched FROM MEMORY is not a
+    // top-level `$raf`-backed file, so the CR2 magic is NOT checked (this
+    // caller reads only the IFD0 structural diagnostics, never `is_cr2_magic`).
+    /* standalone_tiff */
+    false, /* file_type */ None,
   ) else {
     return Vec::new();
   };

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -918,6 +918,33 @@ pub struct ExifMeta<'a> {
   /// inside the engine except for that single CTMD read (exposed via
   /// [`ExifMeta::dispatcher_model`]).
   captured_model: Option<smol_str::SmolStr>,
+  /// `$$self{DNGVersion}` — `true` when IFD0 carried a TRUTHY `DNGVersion`
+  /// (0xc612) value (the walker's [`Walker::dng_version`] tap; Perl-truthiness
+  /// of the RawConv'd `$val`, so a count-0 / scalar-`0` value does NOT set it).
+  /// The engine's TIFF finalization reads it via [`ExifMeta::has_dng_version`]
+  /// to apply
+  /// `DoProcessTIFF`'s `OverrideFileType('DNG')` (`ExifTool.pm:8763-8765`) when
+  /// the container `$$self{FILE_TYPE}` is `TIFF` and the resolved type is not
+  /// already `DNG`/`GPR`. Always `false` for an embedded Exif block (a JPEG /
+  /// PNG / QuickTime / RIFF container is never `$$self{FILE_TYPE} eq 'TIFF'`,
+  /// so the DNG override there is unreachable in bundled).
+  dng_version: bool,
+  /// `true` when this standalone-TIFF header carries the Canon CR2 magic
+  /// `CR\x02\0` at byte 8 (`ExifTool.pm:8633-8641`): TIFF identifier 0x2a,
+  /// IFD0 offset ≥ 16, the full 8-byte signature read at byte 8 succeeds
+  /// (`data[8..16]` exists — `$raf->Read($sig, 8) == 8`, 8634), and its first
+  /// four bytes are `CR\x02\0`. `DoProcessTIFF` sets
+  /// `$fileType = 'CR2'` from this signature, so the engine finalizes
+  /// `File:FileType = CR2` (`image/x-canon-cr2`) regardless of extension —
+  /// including a CR2 body renamed to another RAW extension (`.dng`/`.nef`/
+  /// `.arw`), since the read is gated on the standalone-TIFF `$raf` path
+  /// (`standalone_tiff`, `ExifTool.pm:8629`), NOT on the extension-derived
+  /// `TIFF_TYPE eq 'TIFF'` PageCount gate. Read via [`ExifMeta::is_cr2_magic`].
+  /// Always `false` for an embedded Exif block (a JPEG `APP1` / PNG `eXIf` /
+  /// QuickTime `EXIF` / RIFF `exif` TIFF, the Canon CTMD `0x8769` re-dispatch,
+  /// the CR3 `CMT4` GPS block — none has a top-level `$raf`) — bundled never
+  /// detects CR2 from an embedded block.
+  cr2_magic: bool,
 }
 
 impl<'a> ExifMeta<'a> {
@@ -968,6 +995,31 @@ impl<'a> ExifMeta<'a> {
   #[inline(always)]
   pub const fn multi_page_count(&self) -> Option<u32> {
     self.multi_page_count
+  }
+
+  /// `$$self{DNGVersion}` — `true` when IFD0 carried a TRUTHY `DNGVersion`
+  /// (0xc612) value (Perl-truthiness of the RawConv'd `$val`; a count-0 /
+  /// scalar-`0` value is falsy and does NOT set it).
+  /// `DoProcessTIFF` (`ExifTool.pm:8763`) reads this to override
+  /// `File:FileType` to `DNG` for a TIFF-structured file whose container
+  /// `$$self{FILE_TYPE}` is `TIFF` (regardless of extension). `false` for an
+  /// embedded Exif block (a JPEG/PNG/QuickTime/RIFF container is never
+  /// `FILE_TYPE eq 'TIFF'`, so the override is unreachable there).
+  #[must_use]
+  #[inline(always)]
+  pub const fn has_dng_version(&self) -> bool {
+    self.dng_version
+  }
+
+  /// `true` when this standalone-TIFF header carries the Canon CR2 magic
+  /// `CR\x02\0` at byte 8 (`ExifTool.pm:8633-8641`). The engine reads this to
+  /// finalize `File:FileType = CR2` (`image/x-canon-cr2`) regardless of
+  /// extension. `false` for an embedded Exif block (the CR2 signature read is
+  /// gated on `$raf`, which only the standalone-TIFF dispatch has).
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_cr2_magic(&self) -> bool {
+    self.cr2_magic
   }
 
   /// The container's detected FILE_TYPE (`$$self{FILE_TYPE}`) — see the field
@@ -1048,6 +1100,12 @@ impl<'a> ExifMeta<'a> {
       // only from a standalone `0x8769` TIFF (`parse_standalone_tiff_with_base`),
       // never from a JPEG `APP1` merge — so `None` here is correct.
       captured_model: None,
+      // A JPEG container's `$$self{FILE_TYPE}` is "JPEG", never "TIFF", and the
+      // CR2 signature read is gated on the standalone-TIFF `$raf`, so neither
+      // the DNG override (`ExifTool.pm:8763`) nor the CR2 magic
+      // (`ExifTool.pm:8629`) is reachable for an `APP1` Exif merge.
+      dng_version: false,
+      cr2_magic: false,
     }
   }
 
@@ -1111,7 +1169,8 @@ impl FormatParser for ProcessExif {
     // `parse_standalone_tiff_with_base`), so `file_type = None`. A `.tif` is
     // never a CRW, so the ShotInfo pos-22 CRW clause is correctly off.
     parse_tiff(
-      data, /* tiff_type_is_tiff */ true, /* file_type */ None,
+      data, /* tiff_type_is_tiff */ true, /* standalone_tiff */ true,
+      /* file_type */ None,
     )
   }
 }
@@ -1128,7 +1187,8 @@ pub fn parse_borrowed(data: &[u8]) -> Option<ExifMeta<'_>> {
   // Direct standalone-TIFF lib entry — no candidate `Parent`, so `file_type =
   // None` (see [`ProcessExif::parse`]).
   parse_tiff(
-    data, /* tiff_type_is_tiff */ true, /* file_type */ None,
+    data, /* tiff_type_is_tiff */ true, /* standalone_tiff */ true,
+    /* file_type */ None,
   )
 }
 
@@ -1158,9 +1218,11 @@ pub fn parse_borrowed(data: &[u8]) -> Option<ExifMeta<'_>> {
 pub fn parse_exif_block(block: &[u8]) -> Option<ExifMeta<'_>> {
   // Embedded Exif block (QuickTime/RIFF/PNG/MakerNotes seam) — the container's
   // `$$self{FILE_TYPE}` is the OUTER type, never "CRW", so `file_type = None`
-  // (the ShotInfo pos-22 CRW clause stays off).
+  // (the ShotInfo pos-22 CRW clause stays off). `standalone_tiff = false`: an
+  // embedded block has no `$raf`, so the CR2 magic is NOT checked here.
   parse_tiff(
-    block, /* tiff_type_is_tiff */ false, /* file_type */ None,
+    block, /* tiff_type_is_tiff */ false, /* standalone_tiff */ false,
+    /* file_type */ None,
   )
 }
 
@@ -1179,8 +1241,11 @@ pub fn parse_exif_block(block: &[u8]) -> Option<ExifMeta<'_>> {
 pub fn parse_exif_block_with_base(block: &[u8], base: u32) -> Option<ExifMeta<'_>> {
   // Embedded Exif block (JPEG `APP1`, etc.) — the OUTER container type is never
   // "CRW", so `file_type = None` (the ShotInfo pos-22 CRW clause stays off).
+  // `standalone_tiff = false`: an embedded `APP1` TIFF has no `$raf`, so the CR2
+  // magic is NOT checked here (a JPEG's embedded TIFF must never become CR2).
   parse_tiff_with_base(
-    block, base, /* tiff_type_is_tiff */ false, /* file_type */ None,
+    block, base, /* tiff_type_is_tiff */ false, /* standalone_tiff */ false,
+    /* file_type */ None,
   )
 }
 
@@ -1206,17 +1271,26 @@ pub fn parse_exif_block_with_base(block: &[u8], base: u32) -> Option<ExifMeta<'_
 /// `Some(parent_type)`; it is WRITE-ONLY apart from that single pos-22 read.
 /// (A standalone TIFF/RAW is never a CRW — the CRW path is the unported CIFF
 /// front-end — so this changes no output today.)
+///
+/// `standalone_tiff` is the CR2-magic `$raf` gate (`ExifTool.pm:8629`): the
+/// genuine top-level standalone-TIFF dispatch passes `true` (the CR2 magic IS
+/// checked, regardless of the extension-derived subtype — see
+/// [`parse_tiff_with_base_no_raf`]); the Canon CTMD `MakerNoteCanon`
+/// IFD0-diagnostics re-dispatch passes `false` (an embedded MakerNote blob is
+/// not a top-level `$raf`-backed file, and that caller reads only the IFD0
+/// structural diagnostics — never `is_cr2_magic`).
 #[must_use]
 pub fn parse_standalone_tiff_with_base<'a>(
   block: &'a [u8],
   base: u32,
   tiff_type_is_tiff: bool,
+  standalone_tiff: bool,
   file_type: Option<&str>,
 ) -> Option<ExifMeta<'a>> {
   // The returned `ExifMeta<'a>` borrows ONLY from `block` (the IFD bytes); the
   // `file_type` is copied into an owned `SmolStr` inside `parse_tiff_with_base`,
   // so its lifetime is independent and need not appear in the return type.
-  parse_tiff_with_base(block, base, tiff_type_is_tiff, file_type)
+  parse_tiff_with_base(block, base, tiff_type_is_tiff, standalone_tiff, file_type)
 }
 
 /// The Canon CTMD `ProcessExifInfo` `0x8769` ExifIFD re-dispatch
@@ -1242,6 +1316,7 @@ pub fn parse_ctmd_exif_ifd_redispatch(block: &[u8]) -> Option<ExifMeta<'_>> {
     block,
     /* base */ 0,
     /* tiff_type_is_tiff */ false,
+    /* standalone_tiff */ false,
     /* file_type */ None,
     /* no_raf */ true,
     /* ifd0_kind */ IfdKind::Ifd0,
@@ -1268,6 +1343,7 @@ pub fn parse_gps_block(block: &[u8]) -> Option<ExifMeta<'_>> {
     block,
     /* base */ 0,
     /* tiff_type_is_tiff */ false,
+    /* standalone_tiff */ false,
     /* file_type */ None,
     /* no_raf */ false,
     /* ifd0_kind */ IfdKind::Gps,
@@ -1300,9 +1376,10 @@ pub fn parse_gps_block(block: &[u8]) -> Option<ExifMeta<'_>> {
 fn parse_tiff<'a>(
   data: &'a [u8],
   tiff_type_is_tiff: bool,
+  standalone_tiff: bool,
   file_type: Option<&str>,
 ) -> Option<ExifMeta<'a>> {
-  parse_tiff_with_base(data, 0, tiff_type_is_tiff, file_type)
+  parse_tiff_with_base(data, 0, tiff_type_is_tiff, standalone_tiff, file_type)
 }
 
 /// Parse a TIFF block whose start sits at file offset `base` (`$$dirInfo{Base}`).
@@ -1321,6 +1398,11 @@ fn parse_tiff<'a>(
 /// stays the outer container's name and never becomes "TIFF" in those
 /// recursive `ProcessTIFF` calls.
 ///
+/// `standalone_tiff` is the CR2-magic `$raf` gate (`ExifTool.pm:8629`): `true`
+/// only for the standalone-TIFF dispatch, `false` for the embedded-block
+/// callers — DISTINCT from `tiff_type_is_tiff` (see
+/// [`parse_tiff_with_base_no_raf`]).
+///
 /// `file_type` is the container's detected `$$self{FILE_TYPE}` — stored on the
 /// resulting [`ExifMeta`] and threaded to the Canon MakerNote decoder for the
 /// `Canon::ShotInfo` pos-22 CRW-allows-0 RawConv (`Canon.pm:2977`/`:2990`).
@@ -1332,12 +1414,14 @@ fn parse_tiff_with_base<'a>(
   data: &'a [u8],
   base: u32,
   tiff_type_is_tiff: bool,
+  standalone_tiff: bool,
   file_type: Option<&str>,
 ) -> Option<ExifMeta<'a>> {
   parse_tiff_with_base_no_raf(
     data,
     base,
     tiff_type_is_tiff,
+    standalone_tiff,
     file_type,
     /* no_raf */ false,
     /* ifd0_kind */ IfdKind::Ifd0,
@@ -1347,6 +1431,19 @@ fn parse_tiff_with_base<'a>(
 /// [`parse_tiff_with_base`] with the no-RAF framing made explicit. `no_raf` is
 /// `false` for every caller except the Canon CTMD `0x8769` ExifIFD re-dispatch
 /// ([`parse_ctmd_exif_ifd_redispatch`]) — see [`Walker::no_raf`].
+///
+/// `standalone_tiff` stands in for ExifTool's `$raf` gate on the CR2-magic read
+/// (`ExifTool.pm:8629`): it is `true` ONLY for the standalone-TIFF parse path
+/// (the top-level `$raf`-backed file — [`parse_tiff`] via [`ProcessExif::parse`]
+/// / [`parse_borrowed`], and [`parse_standalone_tiff_with_base`]), and `false`
+/// for every embedded block (a JPEG `APP1` / PNG `eXIf` / QuickTime `EXIF` /
+/// RIFF `exif` TIFF, the Canon CTMD `0x8769` re-dispatch, the CR3 `CMT4` GPS
+/// block). It is DISTINCT from `tiff_type_is_tiff` (the extension-derived
+/// `$$self{TIFF_TYPE} eq 'TIFF'` PageCount gate, `ExifTool.pm:8767`): the CR2
+/// magic must be computed for EVERY standalone TIFF regardless of the
+/// extension-derived subtype, so a CR2 body renamed `.dng`/`.nef`/`.arw` (whose
+/// extension maps to a RAW subtype ⇒ `tiff_type_is_tiff` false) STILL records
+/// the byte-8 signature and finalizes `File:FileType = CR2` (oracle-verified).
 ///
 /// `ifd0_kind` is the [`IfdKind`] the TOP-LEVEL directory is walked as — almost
 /// always [`IfdKind::Ifd0`] (the standard `ProcessTIFF` entry, whose IFD0 uses
@@ -1360,6 +1457,7 @@ fn parse_tiff_with_base_no_raf<'a>(
   data: &'a [u8],
   base: u32,
   tiff_type_is_tiff: bool,
+  standalone_tiff: bool,
   file_type: Option<&str>,
   no_raf: bool,
   ifd0_kind: IfdKind,
@@ -1394,6 +1492,62 @@ fn parse_tiff_with_base_no_raf<'a>(
   if ifd0_offset < 8 {
     return None;
   }
+  // Canon CR2 magic (`ExifTool.pm:8629-8645`): gated on `$raf` (8629 — the
+  // standalone-TIFF dispatch has one; embedded `APP1`/`eXIf` blocks do not, so
+  // `standalone_tiff` stands in for it) and `$identifier == 0x2a and $offset
+  // >= 16` (8633), then an 8-byte signature read at byte 8 (8634:
+  // `$raf->Read($sig, 8) == 8 or return 0`). A leading `CR\x02\0` (8636/8641)
+  // makes `$fileType = 'CR2'`, so the engine finalizes `File:FileType = CR2`
+  // (`image/x-canon-cr2`) regardless of extension. The gate is
+  // `standalone_tiff`, NOT `tiff_type_is_tiff`: the latter is the
+  // extension-derived `TIFF_TYPE eq 'TIFF'` PageCount gate (false for a CR2
+  // body renamed `.dng`/`.nef`/`.arw`, whose extension maps to a RAW subtype),
+  // and ExifTool's `$raf` CR2 check runs for EVERY standalone TIFF before any
+  // extension-derived subtype is consulted — so the magic wins over the RAW
+  // extension (oracle: CanonRaw.cr2 as foo.dng/foo.nef → CR2). We detect ONLY
+  // the `CR2` signature here (the `\xba\xb0\xac\xbb` "Canon 1D RAW" arm has no
+  // bundled fixture / is out of #181 scope).
+  //
+  // The 8-byte read at 8634 is a HARD prerequisite — and ExifTool's `return 0`
+  // there rejects the WHOLE TIFF, not merely the CR2 arm. Faithful to
+  // `ExifTool.pm:8629-8634`:
+  //
+  // ```perl
+  // if ($raf) {                                    # 8629
+  //     if ($identifier == 0x2a and $offset >= 16) {  # 8633
+  //         $raf->Read($sig, 8) == 8 or return 0;      # 8634
+  // ```
+  //
+  // i.e. for a `$raf`-backed (standalone) classic TIFF whose IFD0 offset is
+  // already ≥ 16, an 8-byte read at byte 8 that comes up short aborts
+  // `DoProcessTIFF` BEFORE any IFD walk — yielding `File format error` / NO
+  // `File:FileType`. So a standalone classic TIFF (`magic == 0x2a`) declaring
+  // `ifd0_offset >= 16` yet shorter than 16 bytes must REJECT the candidate
+  // (return `None`) here, rather than fall through to the lenient IFD walker
+  // (which would recover it to a plain `TIFF` — a divergence). The reject is
+  // PRECISE: it fires only for this malformed/truncated shape (the IFD0 offset
+  // already points past EOF, so the walk would fail/recover anyway); a valid
+  // small TIFF (`ifd0_offset < 16`, or ≥ 16 bytes present) is untouched, as is
+  // every embedded `APP1`/`eXIf` block (gated by `standalone_tiff`). The engine
+  // then exhausts the candidate loop and emits the same finalization `Error`
+  // ExifTool does (`File format error` for a recognized `.tif`, `Unknown file
+  // type` for a dotless name) — oracle-verified on a crafted 12/13/15-byte
+  // `II*\0` + offset-16 header.
+  if standalone_tiff && magic == 0x2a && ifd0_offset >= 16 && data.get(8..16).is_none() {
+    return None;
+  }
+  // The CR2 signature: now that the 8-byte read at byte 8 is guaranteed
+  // satisfiable under the same gate (the reject above bailed otherwise), test
+  // only its leading four bytes for `CR\x02\0` (8636/8641 — `$fileType =
+  // 'CR2'`, so the engine finalizes `File:FileType = CR2` regardless of
+  // extension). The `data.get(8..16).is_some()` clause is retained so this stays
+  // self-evidently panic-free in isolation (bounds-checked `.get()`, no slicing);
+  // it is redundant after the reject but a cheap guard, not a behavior change.
+  let cr2_magic = standalone_tiff
+    && magic == 0x2a
+    && ifd0_offset >= 16
+    && data.get(8..16).is_some()
+    && data.get(8..12) == Some(b"CR\x02\0".as_slice());
 
   // The container `$$self{FILE_TYPE}` — owned once so it can be both threaded
   // to the Canon MakerNote decoder (the pos-22 CRW gate, read at walk time)
@@ -1416,6 +1570,7 @@ fn parse_tiff_with_base_no_raf<'a>(
     active_ifd_offsets: Vec::new(),
     page_count: 0,
     multi_page: false,
+    dng_version: false,
     file_type: file_type.clone(),
     // RAF-backed framing — every caller of this function has an effective RAF
     // (the block IS the whole readable buffer). The no-RAF CTMD `0x8769` hop
@@ -1438,13 +1593,19 @@ fn parse_tiff_with_base_no_raf<'a>(
   );
 
   // `File:PageCount` synthesis (`ExifTool.pm:8756-8757`): emitted ONLY when
-  // the outer file type is "TIFF" (`$$self{TIFF_TYPE} eq 'TIFF'`), i.e. the
-  // standalone-TIFF entry. The embedded paths (PNG `eXIf`, JPEG `APP1`,
+  // `$$self{TIFF_TYPE} eq 'TIFF'`. The embedded paths (PNG `eXIf`, JPEG `APP1`,
   // QuickTime EXIF atom, RIFF `exif` chunk — for those `TIFF_TYPE` is
   // 'PNG'/'APP1'/'QuickTime'/'RIFF') call [`parse_exif_block`] / the
-  // `_with_base` variant, which pass `tiff_type_is_tiff = false` and drop
-  // the synthesized tag. The standalone entry passes `true` and emits the
-  // count when `MultiPage` is set.
+  // `_with_base` variant, which pass `tiff_type_is_tiff = false` and drop the
+  // synthesized tag. The standalone entry passes `true`.
+  //
+  // A content-detected RAW subtype rewrites `$$self{TIFF_TYPE}` away from
+  // "TIFF" BEFORE this `PageCount` check: the CR2 magic sets it directly
+  // (`= 'CR2'`, `ExifTool.pm:8715`) and the `DNGVersion` override sets it to
+  // 'DNG' (`ExifTool.pm:8765`). Both run before `ExifTool.pm:8767`, so neither
+  // a CR2 nor a DNG ever emits `File:PageCount` — suppress it here when the
+  // standalone walk detected either signature.
+  let tiff_type_is_tiff = tiff_type_is_tiff && !cr2_magic && !w.dng_version;
   let multi_page_count = if tiff_type_is_tiff && w.multi_page {
     Some(w.page_count)
   } else {
@@ -1460,6 +1621,8 @@ fn parse_tiff_with_base_no_raf<'a>(
     multi_page_count,
     file_type,
     captured_model: w.captured_model.map(smol_str::SmolStr::from),
+    dng_version: w.dng_version,
+    cr2_magic,
   })
 }
 
@@ -1571,6 +1734,10 @@ fn parse_tiff_with_base_shared<'a>(
     // is gated to the standalone-TIFF dispatch (`tiff_type_is_tiff`).
     page_count: 0,
     multi_page: false,
+    // The `DNGVersion` tap still ticks, but this SHARED path is the embedded
+    // PNG `eXIf` / CTMD `0x8769` parse, never the standalone-TIFF dispatch, so
+    // the DNG override (gated on `FILE_TYPE eq 'TIFF'`) is unreachable from it.
+    dng_version: false,
     // Embedded block (PNG `eXIf`): `$$self{FILE_TYPE}` is "PNG", never "CRW",
     // so the ShotInfo pos-22 CRW clause is off — model it as `None`.
     file_type: None,
@@ -1596,6 +1763,11 @@ fn parse_tiff_with_base_shared<'a>(
     // Embedded block (PNG `eXIf`) — never "CRW" (see the Walker field above).
     file_type: None,
     captured_model: w.captured_model.map(smol_str::SmolStr::from),
+    // Embedded PNG `eXIf` / CTMD `0x8769` block: `$$self{FILE_TYPE}` is the
+    // OUTER container ("PNG"/…), never "TIFF", so the DNG override is
+    // unreachable; the CR2 magic read is gated on the standalone-TIFF `$raf`.
+    dng_version: false,
+    cr2_magic: false,
   };
   (Some(meta), cycle_guard_warnings)
 }
@@ -1761,6 +1933,17 @@ struct Walker<'a, 'g> {
   /// reached (`$$self{PageCount} > 1`). Gates the `File:PageCount`
   /// emission at `ExifTool.pm:8757`.
   multi_page: bool,
+  /// `$$self{DNGVersion}` — sticky flag set when a `DNGVersion` (0xc612) tag
+  /// with a TRUTHY value is seen during the walk, mirroring its `RawConv`
+  /// DataMember side effect (`Exif.pm:3365` `$$self{DNGVersion} = $val`) AND the
+  /// `if ($$self{DNGVersion} and …)` Perl-truthiness gate of `DoProcessTIFF`
+  /// (`ExifTool.pm:8763`), which tests it to override `File:FileType` to `DNG`
+  /// for a TIFF-structured file regardless of extension. The tag is NOT in the
+  /// port's leaf table, so the tap runs before the unknown-tag `return` in
+  /// [`Walker::emit`]; the value is gated through
+  /// [`RawValue::is_perl_truthy`](crate::exif::ifd::RawValue::is_perl_truthy)
+  /// (a count-0 / scalar-`0` `DNGVersion` is falsy → not set) but never emitted.
+  dng_version: bool,
   /// The container's detected `$$self{FILE_TYPE}` (`ExifTool.pm:8715`).
   /// Threaded into the Canon MakerNote decoder so `Canon::ShotInfo` position
   /// 22's RawConv (`Canon.pm:2977`/`:2990`) can keep a raw-0 ExposureTime for
@@ -3114,6 +3297,40 @@ impl Walker<'_, '_> {
           self.multi_page = true;
         }
       }
+    }
+
+    // `DNGVersion` (0xc612) `RawConv` DataMember tap (`Exif.pm:3365`
+    // `$$self{DNGVersion} = $val`). Like `OldSubfileType`, the tag is absent
+    // from the port's leaf table, so the side effect MUST run before the
+    // unknown-tag `return` below. `DoProcessTIFF` (`ExifTool.pm:8763`) reads
+    // `$$self{DNGVersion}` to override `File:FileType` to `DNG`. The DataMember
+    // stores the RawConv'd `$val`, and the override gate is `if
+    // ($$self{DNGVersion} and …)` (`ExifTool.pm:8763`) — PERL TRUTHINESS of that
+    // value, NOT mere tag presence. So the flag must reflect the decoded value's
+    // truthiness: an `int8u[4]` `1 1 0 0`/`0 0 0 0` is truthy → DNG, but a
+    // count-0 (empty `$val == ''`) or scalar-`0` (`$val == '0'`) DNGVersion is
+    // falsy → the file stays a plain TIFF (oracle-confirmed on ExifTool 13.59:
+    // empty/`0` → `FileType TIFF` + `PageCount`; `0 0 0 0` → `DNG`). The OUTER
+    // override is still gated separately on `$$self{FILE_TYPE} eq 'TIFF'`.
+    //
+    // ASSIGNMENT, NOT A LATCH: the RawConv `$$self{DNGVersion} = $val` runs each
+    // time the tag is handled, so the DataMember holds the LAST-handled value;
+    // `DoProcessTIFF` tests that final stored value. Mirror that — ASSIGN the
+    // truthiness on every occurrence (so a later falsy duplicate, e.g. a
+    // count-0/scalar-`0` 0xc612 after a truthy `1 1 0 0`, OVERWRITES the earlier
+    // truthy and the file stays a plain TIFF; the reverse leaves DNG). A sticky
+    // `set-true-only` latch would wrongly keep the earlier truthy.
+    //
+    // TABLE-SCOPED to `%Exif::Main`: DNGVersion's RawConv lives in `%Exif::Main`
+    // (Exif.pm:3353), which the walker applies in the IFD0 / ExifIFD / SubIFD /
+    // trailing-IFD / InteropIFD directories — every IFD walked against the Exif
+    // main [`tables`] table. The GPS IFD ([`IfdKind::Gps`]) is walked against
+    // `%GPS::Main` instead (the same `kind.is_gps()` split that routes the leaf
+    // lookup below to `gps::lookup`), and `%GPS::Main` has NO 0xc612 entry — so
+    // an unknown GPS-IFD tag with id 0xc612 must NOT touch the DataMember. Gate
+    // the assignment on `!kind.is_gps()` to match that scoping exactly.
+    if tag_id == tables::TAG_DNG_VERSION && !kind.is_gps() {
+      self.dng_version = raw.is_perl_truthy();
     }
 
     // `#### eval IsOffset ($val, $et) … $val += $offsetBase` (Exif.pm:7156-
@@ -5958,6 +6175,7 @@ mod tests {
       active_ifd_offsets: Vec::new(),
       page_count: 0,
       multi_page: false,
+      dng_version: false,
       file_type: None,
       // RAF-backed (the standalone-TIFF model the existing tests assume); the
       // no-RAF CTMD `0x8769` path is covered via `parse_ctmd_exif_ifd_redispatch`.

--- a/src/exif/tables.rs
+++ b/src/exif/tables.rs
@@ -96,6 +96,20 @@ pub const TAG_SUBFILE_TYPE: u16 = 0x00fe;
 /// the camera-relevant fixtures carry tag 0xff).
 pub const TAG_OLD_SUBFILE_TYPE: u16 = 0x00ff;
 
+/// `DNGVersion` (0xc612, `Exif.pm:3354-3365`) — the Digital Negative
+/// specification version (`int8u[4]`). Its `RawConv` (`Exif.pm:3365`
+/// `$$self{DNGVersion} = $val`) sets the `$$self{DNGVersion}` DataMember as a
+/// side effect of the IFD walk — even though the tag is itself absent from the
+/// port's leaf table (a deferred-table item, like [`TAG_OLD_SUBFILE_TYPE`]).
+/// That DataMember is what `DoProcessTIFF` (`ExifTool.pm:8763`) tests — via the
+/// Perl-truthiness gate `if ($$self{DNGVersion} and …)` — to override
+/// `File:FileType` to `DNG` for a TIFF-structured file regardless of extension.
+/// The walker taps it before the unknown-tag `next` (`Exif.pm:6757`) drops it
+/// from the emitted entries; the value's truthiness is tracked (a count-0 /
+/// scalar-`0` value is falsy → no override), but the value is never emitted
+/// (the port emits no `IFD0:DNGVersion` tag).
+pub const TAG_DNG_VERSION: u16 = 0xc612;
+
 // ===========================================================================
 // Conversion descriptor — `Conv`
 // ===========================================================================

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -1500,11 +1500,17 @@ impl AnyMeta<'_> {
           FileTypeFinalize::Detected
         }
       }
-      // Exif/TIFF: `DoProcessTIFF` calls `SetFileType($t)` (ExifTool.pm:
-      // 8683) — finalize to the DETECTED candidate type ("TIFF" for a
-      // standalone `.tif`). DNG/NEF/RAW overrides (ExifTool.pm:8754-8765)
-      // depend on MakerNote/DNGVersion tags — deferred to the MakerNotes
-      // wave; the camera-metadata-core TIFF fixtures finalize as TIFF.
+      // Exif/TIFF: `DoProcessTIFF` calls `SetFileType($t)` (ExifTool.pm:8694)
+      // — `Detected`, but the engine's Exif `Detected` arm does NOT use the
+      // bare resolution: it routes through `tiff_finalize_file_type_with_content`
+      // (parser.rs), which applies the extension/parent-type rule PLUS the two
+      // content-based RAW-subtype refinements read off the typed `ExifMeta` —
+      // the CR2 magic (`is_cr2_magic`, ExifTool.pm:8636-8641) and the
+      // `DNGVersion` override (`has_dng_version`, ExifTool.pm:8763-8765). So a
+      // misnamed DNG/CR2 still finalizes to DNG/CR2 from content. The remaining
+      // NEF/RW2/ORF/… body overrides depend on unported vendor tags and stay
+      // deferred. The `Detected` variant carries no payload — the per-Meta
+      // content signals come from the `ExifMeta` accessors, not the enum.
       #[cfg(feature = "exif")]
       AnyMeta::Exif(_) => FileTypeFinalize::Detected,
       // RIFF: `SetFileType($type, $mime)` where `$type` is the body TYPE
@@ -2106,9 +2112,15 @@ impl AnyParser {
         // offsets. The `File:PageCount` gate follows bundled's
         // `$$self{TIFF_TYPE} eq 'TIFF'` (`ExifTool.pm:8715`/`:8767`): ON for a
         // plain `TIFF` candidate Parent, OFF for a TIFF-rooted SUBTYPE
-        // (`DNG`/`NEF`/`CR2`/…), which reaches this arm via its `TIFF` candidate
-        // (`file_type() == "TIFF"`) but carries the subtype as its `parent_type`
-        // — so a multi-page RAW does NOT gain a non-bundled `File:PageCount`.
+        // (`DNG`/`NEF`/`CR2`/…) detected by EXTENSION, which reaches this arm via
+        // its `TIFF` candidate (`file_type() == "TIFF"`) but carries the subtype
+        // as its `parent_type`. A subtype detected by CONTENT instead (a misnamed
+        // DNG via its `DNGVersion` tag, or a CR2 via the `CR\x02\0` magic) passes
+        // `tiff_type_is_tiff = true` here — the parse itself then re-clears the
+        // gate inside `parse_standalone_tiff_with_base` once the walk/header
+        // reveals `TIFF_TYPE` is `DNG`/`CR2` (`ExifTool.pm:8715`/`:8765`), so
+        // neither an extension- nor a content-detected RAW gains a non-bundled
+        // `File:PageCount`.
         let base = u32::try_from(header_skip).unwrap_or(u32::MAX);
         let tiff_type_is_tiff = tiff_parent_type == Some("TIFF");
         // Thread the FINALIZED `$$self{FILE_TYPE}` — the SAME string the engine
@@ -2136,6 +2148,14 @@ impl AnyParser {
           body,
           base,
           tiff_type_is_tiff,
+          // The genuine top-level standalone-TIFF parse IS `$raf`-backed
+          // (`ExifTool.pm:8629`), so the CR2 magic is checked for EVERY such
+          // file regardless of the extension-derived subtype: a CR2 body
+          // renamed `.dng`/`.nef`/`.arw` (where `tiff_type_is_tiff` is false)
+          // still finalizes `File:FileType = CR2`. DISTINCT from
+          // `tiff_type_is_tiff` (the PageCount gate).
+          /* standalone_tiff */
+          true,
           Some(&file_type),
         )
         .map(AnyMeta::Exif)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -210,6 +210,64 @@ fn tiff_finalize_file_type(
   resolve_file_type(base_type, t, ext, print_conv)
 }
 
+/// [`tiff_finalize_file_type`] PLUS the two content-based RAW-subtype
+/// refinements `DoProcessTIFF` applies from the file body — faithful to the
+/// CR2-magic `$fileType = 'CR2'` (ExifTool.pm:8636-8641) and the post-walk
+/// `DNGVersion` override (ExifTool.pm:8763-8765), in that order.
+///
+/// `cr2_magic` (the `CR\x02\0` signature at byte 8) makes bundled set
+/// `$fileType = 'CR2'` BEFORE `SetFileType` (ExifTool.pm:8694), so the resolved
+/// type is `CR2` (`image/x-canon-cr2`) regardless of extension — modelled as
+/// `SetFileType('CR2')`, overriding the extension-derived `$t`.
+///
+/// `dng_version` (the `$$self{DNGVersion}` DataMember, set only when the
+/// decoded `DNGVersion` value is Perl-TRUTHY — a count-0 / scalar-`0`
+/// `DNGVersion` is falsy, matching `ExifTool.pm:8763`'s `if ($$self{DNGVersion}
+/// and …)` gate) then drives
+/// `OverrideFileType('DNG')` — but ONLY when the detection-time
+/// `$$self{FILE_TYPE}` is `TIFF` (`base_type == "TIFF"`, the sole `Detected`
+/// Exif dispatch) AND the already-resolved `File:FileType` is not `DNG`/`GPR`
+/// (the `$$self{FileType} !~ /^(DNG|GPR)$/` guard). So a `.dng`-named file
+/// (resolved `DNG` by extension) is NOT re-overridden, while a CR2-with-
+/// DNGVersion (resolved `CR2`) WOULD be promoted to `DNG` — exactly bundled's
+/// precedence (the override runs after, and past, the CR2 magic).
+#[cfg(feature = "exif")]
+fn tiff_finalize_file_type_with_content(
+  base_type: &str,
+  parent_type: &str,
+  ext: Option<&str>,
+  cr2_magic: bool,
+  dng_version: bool,
+  print_conv: bool,
+) -> FileTypeTriplet {
+  // ExifTool.pm:8636-8641 — the CR2 magic supplies `$fileType = 'CR2'`, which
+  // becomes the `SetFileType` argument (ExifTool.pm:8694), bypassing the
+  // extension-derived `$t`. Otherwise keep the extension/parent-type result.
+  let mut t = if cr2_magic {
+    resolve_file_type(base_type, Some("CR2"), ext, print_conv)
+  } else {
+    tiff_finalize_file_type(base_type, parent_type, ext, print_conv)
+  };
+  // ExifTool.pm:8763-8765 — `if ($$self{DNGVersion} and $$self{FILE_TYPE} eq
+  // 'TIFF' and $$self{FileType} !~ /^(DNG|GPR)$/) { OverrideFileType('DNG') }`.
+  // `$$self{FILE_TYPE}` is the detection `$type` (`base_type`), which is "TIFF"
+  // for the standalone-TIFF dispatch; `$$self{FileType}` is the value just
+  // resolved into `t.file_type`.
+  if dng_version && base_type == "TIFF" && !matches!(t.file_type.as_str(), "DNG" | "GPR") {
+    let (ov_ft, ov_ext, ov_mime) = resolve_override_file_type("DNG", print_conv);
+    t.file_type = ov_ft;
+    t.file_type_extension = ov_ext;
+    // ExifTool.pm:9734 `$$self{VALUE}{MIMEType} = $mimeType if $mimeType` — the
+    // in-place MIME rewrite only when a MIME is known. `DNG` has one
+    // (`image/x-adobe-dng`), so this always fires; keep the existing MIME if
+    // `resolve_override_file_type` ever returns `None` (defensive).
+    if let Some(mime) = ov_mime {
+      t.mime_type = mime;
+    }
+  }
+  t
+}
+
 /// The `$t` argument `DoProcessTIFF` feeds to `SetFileType` (ExifTool.pm:8685-
 /// 8690) — the COMPUTATION shared by [`tiff_finalize_file_type`] (which then
 /// resolves the full `File:*` triplet) and [`finalized_tiff_file_type`] (which
@@ -648,8 +706,19 @@ fn extract_info_typed(
           // them too — but routing it only through the Exif arm keeps the
           // TIFF/RAW-specific `$baseType` rule scoped to `DoProcessTIFF`.
           #[cfg(feature = "exif")]
-          let t = if matches!(&meta, crate::format_parser::AnyMeta::Exif(_)) {
-            tiff_finalize_file_type(ft, cand.parent_type(), ext_ref, print_conv_enabled)
+          let t = if let crate::format_parser::AnyMeta::Exif(em) = &meta {
+            // `DoProcessTIFF`'s `SetFileType($t)` (the extension-driven
+            // parent-type rule) THEN the content-based RAW-subtype refinements:
+            // the CR2 magic at byte 8 (`ExifTool.pm:8636-8641`) and the
+            // `DNGVersion` override (`ExifTool.pm:8763-8765`).
+            tiff_finalize_file_type_with_content(
+              ft,
+              cand.parent_type(),
+              ext_ref,
+              em.is_cr2_magic(),
+              em.has_dng_version(),
+              print_conv_enabled,
+            )
           } else {
             resolve_file_type(ft, None, ext_ref, print_conv_enabled)
           };

--- a/tests/tiff_subtype_filetype.rs
+++ b/tests/tiff_subtype_filetype.rs
@@ -1,0 +1,694 @@
+//! #181 — content/magic-based TIFF subtype detection → `File:FileType`.
+//!
+//! ExifTool's `DoProcessTIFF` refines a TIFF-structured file's `File:FileType`
+//! from the file BODY, not the extension:
+//!   - a `DNGVersion` (0xc612) tag in IFD0 → `OverrideFileType('DNG')`
+//!     (`ExifTool.pm:8763-8765`), regardless of extension;
+//!   - the `CR\x02\0` magic at byte 8 → `$fileType = 'CR2'`
+//!     (`ExifTool.pm:8636-8641`), regardless of extension.
+//! Both set `$$self{TIFF_TYPE}` away from `'TIFF'`, so neither emits the
+//! multi-page `File:PageCount` tag (`ExifTool.pm:8767`).
+//!
+//! These use the REAL bundled fixtures (`DNG.dng`, `CanonRaw.cr2`,
+//! `ExifTool.tif`, `GeoTiff.tif`) via the `EXIFTOOL_T_IMAGES` env var (ExifTool's
+//! `t/images`); each test skips when it is unset / unreadable so a checkout
+//! without the ExifTool sources still passes. Oracle values were captured with
+//! `perl exiftool -G1 -FileType -FileTypeExtension -MIMEType -PageCount` on
+//! ExifTool 13.59.
+#![cfg(feature = "json")]
+
+use exifast::parser::extract_info;
+use serde_json::Value;
+
+/// Read a real bundled fixture from `EXIFTOOL_T_IMAGES`, returning `None`
+/// (with a skip note) when the env var is unset or the file is unreadable.
+fn t_image(file: &str) -> Option<Vec<u8>> {
+  let dir = match std::env::var("EXIFTOOL_T_IMAGES") {
+    Ok(d) => d,
+    Err(_) => {
+      eprintln!("skipping: EXIFTOOL_T_IMAGES not set");
+      return None;
+    }
+  };
+  let path = format!("{dir}/{file}");
+  match std::fs::read(&path) {
+    Ok(d) => Some(d),
+    Err(_) => {
+      eprintln!("skipping: {path} not readable");
+      None
+    }
+  }
+}
+
+/// Parse `data` under the presented `name` and return the single document
+/// object (the `[{…}]` first element).
+fn doc(name: &str, data: &[u8], print_on: bool) -> serde_json::Map<String, Value> {
+  let json = extract_info(name, data, print_on);
+  let v: Value =
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("invalid JSON ({e}):\n{json}"));
+  v.as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .cloned()
+    .unwrap_or_else(|| panic!("doc is not [{{…}}]:\n{json}"))
+}
+
+/// Assert the `File:*` type triplet matches `(file_type, ext, mime)` and that
+/// NO `File:PageCount` is emitted, in BOTH `-j` and `-n` modes. `ext` is the
+/// LOWERCASE extension as the `-j` PrintConv `lc` emits it (`ExifTool.pm:1433`);
+/// `-n` emits the raw UPPERCASE form (`FoundTag('FileTypeExtension', uc …)`,
+/// `ExifTool.pm:9714`), so the expected value is upper-cased for that mode.
+fn assert_triplet_no_pagecount(name: &str, data: &[u8], file_type: &str, ext: &str, mime: &str) {
+  for print_on in [true, false] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let o = doc(name, data, print_on);
+    assert_eq!(
+      o.get("File:FileType").and_then(Value::as_str),
+      Some(file_type),
+      "{name} ({mode}): File:FileType"
+    );
+    let want_ext = if print_on {
+      ext.to_string()
+    } else {
+      ext.to_ascii_uppercase()
+    };
+    assert_eq!(
+      o.get("File:FileTypeExtension").and_then(Value::as_str),
+      Some(want_ext.as_str()),
+      "{name} ({mode}): File:FileTypeExtension"
+    );
+    assert_eq!(
+      o.get("File:MIMEType").and_then(Value::as_str),
+      Some(mime),
+      "{name} ({mode}): File:MIMEType"
+    );
+    assert!(
+      !o.contains_key("File:PageCount"),
+      "{name} ({mode}): a TIFF subtype must NOT emit File:PageCount: {o:?}"
+    );
+  }
+}
+
+/// DNG.dng → `File:FileType = DNG`, `dng`, `image/x-adobe-dng` (it carries
+/// IFD0 `DNGVersion` 1.1.0.0). The CORE of #181: the SAME bytes presented under
+/// a `.tif` extension OR a dotless name must STILL resolve to `DNG` — proving
+/// the detection taps CONTENT (`DNGVersion`), not the filename. Pre-fix exifast
+/// derived the subtype from the extension alone, so a misnamed DNG fell back to
+/// plain `TIFF` (the bug this closes).
+///
+/// Oracle: `perl exiftool -G1 -FileType -FileTypeExtension -MIMEType -PageCount`
+/// on `DNG.dng`, and on the same bytes copied to `foo.tif` / `foo` (no ext) →
+/// `DNG` / `dng` / `image/x-adobe-dng` in every case, no `PageCount`.
+#[test]
+fn real_fixture_dng_filetype_via_dngversion() {
+  let Some(data) = t_image("DNG.dng") else {
+    return;
+  };
+  // Correctly-named: DNG via either the extension OR the content.
+  assert_triplet_no_pagecount("DNG.dng", &data, "DNG", "dng", "image/x-adobe-dng");
+  // Misnamed `.tif`: extension says TIFF, but IFD0 `DNGVersion` forces DNG.
+  assert_triplet_no_pagecount("misnamed.tif", &data, "DNG", "dng", "image/x-adobe-dng");
+  // Dotless name (no extension hint at all): still DNG, from `DNGVersion`.
+  assert_triplet_no_pagecount("misnamed", &data, "DNG", "dng", "image/x-adobe-dng");
+}
+
+/// CanonRaw.cr2 → `File:FileType = CR2`, `cr2`, `image/x-canon-cr2`, detected
+/// from the `CR\x02\0` magic at byte 8 of the TIFF header
+/// (`ExifTool.pm:8636-8641`). The SAME bytes presented under a `.tif` extension
+/// must STILL resolve to `CR2` — proving the detection taps the MAGIC, not the
+/// filename (pre-fix the CR2 subtype came from the `.cr2` extension alone, so a
+/// misnamed CR2 fell back to plain `TIFF`).
+///
+/// Oracle: `perl exiftool -G1 -FileType -FileTypeExtension -MIMEType -PageCount`
+/// on `CanonRaw.cr2`, and on the same bytes copied to `foo.tif` → `CR2` / `cr2`
+/// / `image/x-canon-cr2`, no `PageCount`.
+#[test]
+fn real_fixture_cr2_filetype_via_magic() {
+  let Some(data) = t_image("CanonRaw.cr2") else {
+    return;
+  };
+  assert_triplet_no_pagecount("CanonRaw.cr2", &data, "CR2", "cr2", "image/x-canon-cr2");
+  // Misnamed `.tif`: extension says TIFF, but the `CR\x02\0` magic forces CR2.
+  assert_triplet_no_pagecount("misnamed.tif", &data, "CR2", "cr2", "image/x-canon-cr2");
+  // Dotless name: still CR2, from the byte-8 magic.
+  assert_triplet_no_pagecount("misnamed", &data, "CR2", "cr2", "image/x-canon-cr2");
+}
+
+/// The CR2 `CR\x02\0` magic (`ExifTool.pm:8633-8641`) is computed for EVERY
+/// standalone TIFF parse — ExifTool's `$raf` gate (`ExifTool.pm:8629`), NOT the
+/// extension-derived `TIFF_TYPE eq 'TIFF'` PageCount gate — so a CR2 body
+/// presented under ANOTHER RAW extension (`.dng`/`.nef`/`.arw`, whose extension
+/// maps to a RAW SUBTYPE) STILL resolves to `CR2`: the magic is a strong early
+/// signal that wins over the extension. This is the case the `.tif`/dotless
+/// tests above could not catch — those extensions map to plain `TIFF`, where
+/// the (buggy) `tiff_type_is_tiff` gate was already `true`; a RAW-subtype
+/// extension makes it `false`, which is where a CR2 was mis-finalized to
+/// `DNG`/`NEF`/`ARW` before this fix.
+///
+/// Oracle (ExifTool 13.59): `perl exiftool -G1 -FileType -FileTypeExtension
+/// -MIMEType -PageCount` on `CanonRaw.cr2` copied to `foo.dng` / `foo.nef` /
+/// `foo.arw` → `CR2` / `cr2` / `image/x-canon-cr2` in every case, no
+/// `PageCount`.
+#[test]
+fn cr2_magic_overrides_other_raw_extension() {
+  let Some(data) = t_image("CanonRaw.cr2") else {
+    return;
+  };
+  for name in ["foo.dng", "foo.nef", "foo.arw"] {
+    assert_triplet_no_pagecount(name, &data, "CR2", "cr2", "image/x-canon-cr2");
+  }
+}
+
+/// A standalone classic TIFF whose IFD0 offset is ≥ 16 but which is shorter than
+/// 16 bytes is REJECTED outright — no `File:FileType` at all — not recovered to a
+/// plain `TIFF`. `DoProcessTIFF` does `$raf->Read($sig, 8) == 8 or return 0`
+/// (`ExifTool.pm:8634`): for a `$raf`-backed (standalone) classic TIFF
+/// (`$identifier == 0x2a`) whose IFD0 offset is already ≥ 16 (`ExifTool.pm:8633`),
+/// it reads 8 bytes at byte 8 and `return 0`s — aborting the WHOLE TIFF (File
+/// format error, no `File:FileType`) BEFORE any IFD walk or the `CR\x02\0` regex.
+/// So the candidate must be rejected, not walked: a too-short header whose IFD0
+/// offset already points past EOF carries no recoverable directory.
+///
+/// The crafted inputs are 12/13/15-byte little-endian headers: `II*\0`, IFD0
+/// offset 16 (≥ 16, satisfying the offset gate), `CR\x02\0` at byte 8 — so bytes
+/// 8..16 do NOT exist (the 8-byte read at byte 8 fails). They are presented under
+/// a `.tif` AND a dotless name so the EXTENSION cannot itself imply a type. The
+/// reject is gated on the standalone-TIFF path, `magic == 0x2a`, `ifd0_offset >=
+/// 16`, and `data[8..16]` being absent — precise to this malformed shape; a valid
+/// small TIFF (`ifd0_offset < 16`, or ≥ 16 bytes present) and every embedded
+/// `APP1`/`eXIf` block are untouched.
+///
+/// Oracle (ExifTool 13.59, `perl exiftool -j -G1` on each crafted file): only
+/// `SourceFile` + an `ExifTool:Error` — `File format error` under the recognized
+/// `.tif` extension, `Unknown file type` under a dotless name — and NO
+/// `File:FileType`/`FileTypeExtension`/`MIMEType`/`PageCount`. (ExifTool also
+/// raises `Warning: Processing TIFF-like data after unknown 0-byte header`, which
+/// it emits only after its seek-back loop re-tries the terminal TIFF scan; the
+/// port's candidate-list model rejects the candidate without re-running it, so it
+/// emits the same `Error` with no triplet but not that warning — a warning-only
+/// trait of the engine, orthogonal to the load-bearing fact asserted here: the
+/// file yields NO `File:FileType`.)
+#[test]
+fn cr2_magic_rejects_truncated_signature_window() {
+  // II*\0 headers truncated at 12/13/15 bytes: IFD0 offset 16, CR\x02\0 at byte
+  // 8. The bytes 8..16 are absent in every one, so the 8-byte read at byte 8
+  // fails and `DoProcessTIFF` rejects the whole TIFF before any walk.
+  let header: [u8; 12] = [
+    0x49, 0x49, 0x2a, 0x00, // II*\0 (little-endian classic TIFF)
+    0x10, 0x00, 0x00, 0x00, // IFD0 offset = 16 (>= 16, the offset gate)
+    b'C', b'R', 0x02, 0x00, // the CR\x02\0 signature at byte 8 (bytes 8..12)
+  ];
+  for trunc_len in [12usize, 13, 15] {
+    let mut data = header.to_vec();
+    data.resize(trunc_len, 0); // pad 13/15 with NUL; bytes 8..16 still absent
+    assert_eq!(data.len(), trunc_len, "truncated window length");
+    assert!(
+      data.get(8..16).is_none(),
+      "bytes 8..16 must be absent (< 16 bytes)"
+    );
+
+    // `.tif` (recognized ⇒ `File format error`) AND dotless (`Unknown file
+    // type`): in BOTH the truncated candidate is rejected, so NO `File:*`
+    // triplet is emitted and the finalization `Error` matches the oracle.
+    for (name, want_err) in [
+      ("cr2trunc.tif", "File format error"),
+      ("cr2trunc", "Unknown file type"),
+    ] {
+      for print_on in [true, false] {
+        let mode = if print_on { "-j" } else { "-n" };
+        let o = doc(name, &data, print_on);
+        // The hard candidate-abort: NONE of the `File:*` type triplet is set.
+        for key in ["File:FileType", "File:FileTypeExtension", "File:MIMEType"] {
+          assert!(
+            !o.contains_key(key),
+            "{name} ({mode}, {trunc_len}B): a rejected truncated TIFF must emit no {key} \
+             (oracle: File format error / Unknown file type, no File:FileType): {o:?}"
+          );
+        }
+        assert!(
+          !o.contains_key("File:PageCount"),
+          "{name} ({mode}, {trunc_len}B): no File:PageCount on a rejected candidate: {o:?}"
+        );
+        // The engine surfaces the same finalization Error ExifTool does.
+        assert_eq!(
+          o.get("ExifTool:Error").and_then(Value::as_str),
+          Some(want_err),
+          "{name} ({mode}, {trunc_len}B): finalization Error: {o:?}"
+        );
+      }
+    }
+  }
+}
+
+/// A JPEG with an embedded `APP1` Exif/TIFF block must NEVER be misclassified
+/// from the embedded TIFF's content — the CR2-magic / DNGVersion taps are gated
+/// on the standalone-TIFF `$raf` path (`ExifTool.pm:8629`), which an embedded
+/// block does not have. Two checks:
+///  - real bundled JPEGs carrying EXIF (incl. a Canon MakerNote) stay `JPEG`
+///    (`perl exiftool -G1 -FileType` on `Canon.jpg`/`ExifTool.jpg`/`GPS.jpg` →
+///    `JPEG`);
+///  - a CRAFTED JPEG whose embedded `APP1` TIFF carries the `CR\x02\0`
+///    signature at byte 8 STAYS `JPEG` (the embedded path must not fire CR2
+///    magic — bundled never detects CR2 from an `APP1` block).
+#[test]
+fn embedded_app1_tiff_never_triggers_cr2_magic() {
+  for f in ["Canon.jpg", "ExifTool.jpg", "GPS.jpg"] {
+    let Some(data) = t_image(f) else {
+      continue;
+    };
+    let o = doc(f, &data, true);
+    assert_eq!(
+      o.get("File:FileType").and_then(Value::as_str),
+      Some("JPEG"),
+      "{f}: a JPEG with embedded EXIF must stay JPEG"
+    );
+  }
+
+  // Crafted JPEG: SOI + APP1("Exif\0\0" + a TIFF header whose byte 8 is the
+  // CR2 signature, IFD0 offset 16, empty IFD0) + EOI. The embedded TIFF carries
+  // the CR2 magic, but the embedded path is gated OFF, so this stays JPEG.
+  let mut tiff: Vec<u8> = vec![
+    0x49, 0x49, 0x2a, 0x00, // II*\0 (little-endian classic TIFF)
+    0x10, 0x00, 0x00, 0x00, // IFD0 offset = 16 (>= 16, the CR2 gate)
+    b'C', b'R', 0x02, 0x00, // the CR\x02\0 signature at byte 8
+    0x00, 0x00, 0x00, 0x00, // pad to offset 16
+    0x00, 0x00, // IFD0 entry count = 0
+    0x00, 0x00, 0x00, 0x00, // next-IFD pointer = 0
+  ];
+  let mut app1: Vec<u8> = b"Exif\0\0".to_vec();
+  app1.append(&mut tiff);
+  let seg_len = u16::try_from(app1.len() + 2).expect("APP1 fits in u16");
+  let mut jpeg: Vec<u8> = vec![0xff, 0xd8, 0xff, 0xe1]; // SOI + APP1 marker
+  jpeg.extend_from_slice(&seg_len.to_be_bytes());
+  jpeg.extend_from_slice(&app1);
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  let o = doc("crafted.jpg", &jpeg, true);
+  assert_eq!(
+    o.get("File:FileType").and_then(Value::as_str),
+    Some("JPEG"),
+    "a JPEG whose embedded APP1 TIFF carries CR2 magic must stay JPEG (embedded gate off): {o:?}"
+  );
+}
+
+/// Build an in-memory little-endian classic TIFF with two IFDs (a 2-page
+/// image: each IFD carries `NewSubfileType` = 2, the `$val == 2` MultiPage
+/// trigger of `Exif.pm:456`), optionally embedding a `DNGVersion` (0xc612,
+/// `int8u`) tag in IFD0 with `dngversion`'s bytes as the COUNT and an inline
+/// (≤4-byte) value field. With no `DNGVersion`, `OverrideFileType` never fires
+/// and the multi-page `File:PageCount` is emitted; whether a present
+/// `DNGVersion` promotes the file to DNG (and suppresses `PageCount`) is exactly
+/// the Perl-truthiness question this exercises.
+fn multipage_tiff_with_dngversion(dngversion: Option<&[u8]>) -> Vec<u8> {
+  // A 12-byte IFD entry: tag(2) type(2) count(4) value/offset(4, inline).
+  fn entry(tag: u16, typ: u16, count: u32, value: [u8; 4]) -> [u8; 12] {
+    let mut e = [0u8; 12];
+    e[0..2].copy_from_slice(&tag.to_le_bytes());
+    e[2..4].copy_from_slice(&typ.to_le_bytes());
+    e[4..8].copy_from_slice(&count.to_le_bytes());
+    e[8..12].copy_from_slice(&value);
+    e
+  }
+  // IFD0: NewSubfileType=2 (+ optional DNGVersion); IFD1: NewSubfileType=2.
+  // NewSubfileType (0x00FE) < DNGVersion (0xc612) keeps tag ids ascending.
+  let new_subfile = entry(0x00FE, 4, 1, 2u32.to_le_bytes()); // LONG = 2
+  let mut ifd0: Vec<[u8; 12]> = vec![new_subfile];
+  if let Some(bytes) = dngversion {
+    assert!(
+      bytes.len() <= 4,
+      "inline DNGVersion value must be <= 4 bytes"
+    );
+    let count = u32::try_from(bytes.len()).expect("len fits u32");
+    let mut value = [0u8; 4];
+    value[..bytes.len()].copy_from_slice(bytes); // left-justified, zero-padded
+    ifd0.push(entry(0xC612, 1, count, value)); // BYTE[count]
+  }
+  let ifd1: Vec<[u8; 12]> = vec![new_subfile];
+
+  let ifd_size = |n: usize| 2 + 12 * n + 4; // count(2) + entries + next-ptr(4)
+  let ifd0_off = 8u32; // right after the 8-byte header
+  let ifd1_off = ifd0_off + u32::try_from(ifd_size(ifd0.len())).expect("fits u32");
+
+  let mut out: Vec<u8> = Vec::new();
+  out.extend_from_slice(b"II"); // little-endian
+  out.extend_from_slice(&42u16.to_le_bytes()); // TIFF magic
+  out.extend_from_slice(&ifd0_off.to_le_bytes()); // IFD0 offset
+  // IFD0
+  out.extend_from_slice(&u16::try_from(ifd0.len()).expect("fits u16").to_le_bytes());
+  for e in &ifd0 {
+    out.extend_from_slice(e);
+  }
+  out.extend_from_slice(&ifd1_off.to_le_bytes()); // next IFD = IFD1
+  // IFD1
+  out.extend_from_slice(&u16::try_from(ifd1.len()).expect("fits u16").to_le_bytes());
+  for e in &ifd1 {
+    out.extend_from_slice(e);
+  }
+  out.extend_from_slice(&0u32.to_le_bytes()); // no further IFD
+  out
+}
+
+/// The `DNGVersion` (0xc612) `RawConv` DataMember drives `OverrideFileType('DNG')`
+/// ONLY when its decoded value is PERL-TRUTHY — `ExifTool.pm:8763`'s gate is
+/// `if ($$self{DNGVersion} and …)`, testing the truthiness of the RawConv'd
+/// `$val` (`Exif.pm:3365` `$$self{DNGVersion} = $val`), NOT mere tag presence.
+/// Perl treats a scalar as false only when it is `""` or `"0"`; an `int8u[4]`
+/// renders as the space-joined `$val` (`ReadValue`'s `join(' ', @vals)`):
+///
+///   - count-0 (empty `$val == ''`)  → FALSY → `FileType TIFF` + `PageCount`;
+///   - count-1 scalar `0` (`$val == '0'`) → FALSY → `FileType TIFF` + `PageCount`;
+///   - `int8u[4]` `0 0 0 0` (`$val == '0 0 0 0'`, non-empty) → TRUTHY → `DNG`;
+///   - `int8u[4]` `1 1 0 0` → TRUTHY → `DNG`.
+///
+/// Each crafted file is a 2-page TIFF (`NewSubfileType = 2` in both IFDs), so a
+/// non-promotion leaves it a plain multi-page TIFF that DOES emit
+/// `File:PageCount = 2` (`ExifTool.pm:8757`), while a promotion to DNG sets
+/// `$$self{TIFF_TYPE} = 'DNG'` and SUPPRESSES `PageCount`.
+///
+/// Oracle (ExifTool 13.59, `perl exiftool -G1 -FileType -FileTypeExtension
+/// -MIMEType -PageCount -DNGVersion` on each crafted file):
+///   empty/`0` → `TIFF`/`tif`/`image/tiff` + `PageCount 2`;
+///   `0 0 0 0`/`1 1 0 0` → `DNG`/`dng`/`image/x-adobe-dng`, no `PageCount`.
+#[test]
+fn empty_dngversion_stays_tiff() {
+  // Asserts the crafted file resolves to `(file_type, ext, mime)` and that
+  // `File:PageCount` is present iff `want_pagecount` (value 2), in both modes.
+  let check =
+    |label: &str, data: &[u8], file_type: &str, ext: &str, mime: &str, want_pagecount: bool| {
+      for print_on in [true, false] {
+        let mode = if print_on { "-j" } else { "-n" };
+        let o = doc("crafted.tif", data, print_on);
+        assert_eq!(
+          o.get("File:FileType").and_then(Value::as_str),
+          Some(file_type),
+          "{label} ({mode}): File:FileType"
+        );
+        let want_ext = if print_on {
+          ext.to_string()
+        } else {
+          ext.to_ascii_uppercase()
+        };
+        assert_eq!(
+          o.get("File:FileTypeExtension").and_then(Value::as_str),
+          Some(want_ext.as_str()),
+          "{label} ({mode}): File:FileTypeExtension"
+        );
+        assert_eq!(
+          o.get("File:MIMEType").and_then(Value::as_str),
+          Some(mime),
+          "{label} ({mode}): File:MIMEType"
+        );
+        assert_eq!(
+          o.get("File:PageCount").and_then(Value::as_u64),
+          want_pagecount.then_some(2),
+          "{label} ({mode}): File:PageCount (want present={want_pagecount}): {o:?}"
+        );
+      }
+    };
+
+  // FALSY DNGVersion → stays a plain multi-page TIFF (PageCount emitted).
+  let empty = multipage_tiff_with_dngversion(Some(&[]));
+  check(
+    "empty (count-0) DNGVersion",
+    &empty,
+    "TIFF",
+    "tif",
+    "image/tiff",
+    true,
+  );
+  let scalar0 = multipage_tiff_with_dngversion(Some(&[0]));
+  check(
+    "scalar-0 DNGVersion",
+    &scalar0,
+    "TIFF",
+    "tif",
+    "image/tiff",
+    true,
+  );
+
+  // TRUTHY DNGVersion → promoted to DNG (PageCount suppressed). `0 0 0 0` is the
+  // subtle case: all bytes zero, but the joined `$val == '0 0 0 0'` is non-empty
+  // and not `"0"`, so Perl-true (oracle: DNG).
+  let all_zero = multipage_tiff_with_dngversion(Some(&[0, 0, 0, 0]));
+  check(
+    "all-zero (0 0 0 0) DNGVersion",
+    &all_zero,
+    "DNG",
+    "dng",
+    "image/x-adobe-dng",
+    false,
+  );
+  let real = multipage_tiff_with_dngversion(Some(&[1, 1, 0, 0]));
+  check(
+    "nonzero (1 1 0 0) DNGVersion",
+    &real,
+    "DNG",
+    "dng",
+    "image/x-adobe-dng",
+    false,
+  );
+
+  // Sanity: with NO DNGVersion at all, the same 2-page skeleton is a plain TIFF
+  // with PageCount — proving the promotion is driven by the value, not the
+  // surrounding structure.
+  let none = multipage_tiff_with_dngversion(None);
+  check("no DNGVersion", &none, "TIFF", "tif", "image/tiff", true);
+}
+
+/// A 12-byte little-endian IFD entry — `tag(2) type(2) count(4) value/offset(4,
+/// inline)`. Shared by the duplicate-DNGVersion and GPS-IFD builders below.
+fn ifd_entry(tag: u16, typ: u16, count: u32, value: [u8; 4]) -> [u8; 12] {
+  let mut e = [0u8; 12];
+  e[0..2].copy_from_slice(&tag.to_le_bytes());
+  e[2..4].copy_from_slice(&typ.to_le_bytes());
+  e[4..8].copy_from_slice(&count.to_le_bytes());
+  e[8..12].copy_from_slice(&value);
+  e
+}
+
+/// A `DNGVersion` (0xc612, `int8u`) IFD entry whose value is `bytes` (the COUNT
+/// and the inline ≤4-byte value field). `bytes.len() == 0` is the falsy count-0
+/// shape (`$val == ''`); `[1, 1, 0, 0]` is the truthy `1 1 0 0`.
+fn dng_version_entry(bytes: &[u8]) -> [u8; 12] {
+  assert!(
+    bytes.len() <= 4,
+    "inline DNGVersion value must be <= 4 bytes"
+  );
+  let count = u32::try_from(bytes.len()).expect("len fits u32");
+  let mut value = [0u8; 4];
+  value[..bytes.len()].copy_from_slice(bytes);
+  ifd_entry(0xC612, 1, count, value)
+}
+
+/// Build a 2-page little-endian TIFF (`NewSubfileType = 2` in IFD0 and IFD1)
+/// whose IFD0 carries `dngversions`'s entries IN ORDER after `NewSubfileType`
+/// (`0x00FE < 0xc612`, so the ids stay ascending; duplicate 0xc612 ids are
+/// processed in file order). Used to exercise the LAST-WINS assignment: a later
+/// 0xc612 entry's truthiness OVERWRITES an earlier one's, so a truthy-then-falsy
+/// pair stays a plain TIFF (`PageCount`) and a falsy-then-truthy pair promotes to
+/// DNG — exactly as ExifTool's `$$self{DNGVersion} = $val` DataMember does.
+fn multipage_tiff_with_dngversions(dngversions: &[&[u8]]) -> Vec<u8> {
+  let new_subfile = ifd_entry(0x00FE, 4, 1, 2u32.to_le_bytes()); // LONG = 2
+  let mut ifd0: Vec<[u8; 12]> = vec![new_subfile];
+  for bytes in dngversions {
+    ifd0.push(dng_version_entry(bytes));
+  }
+  let ifd1: Vec<[u8; 12]> = vec![new_subfile];
+
+  let ifd_size = |n: usize| 2 + 12 * n + 4;
+  let ifd0_off = 8u32;
+  let ifd1_off = ifd0_off + u32::try_from(ifd_size(ifd0.len())).expect("fits u32");
+
+  let mut out: Vec<u8> = Vec::new();
+  out.extend_from_slice(b"II");
+  out.extend_from_slice(&42u16.to_le_bytes());
+  out.extend_from_slice(&ifd0_off.to_le_bytes());
+  out.extend_from_slice(&u16::try_from(ifd0.len()).expect("fits u16").to_le_bytes());
+  for e in &ifd0 {
+    out.extend_from_slice(e);
+  }
+  out.extend_from_slice(&ifd1_off.to_le_bytes());
+  out.extend_from_slice(&u16::try_from(ifd1.len()).expect("fits u16").to_le_bytes());
+  for e in &ifd1 {
+    out.extend_from_slice(e);
+  }
+  out.extend_from_slice(&0u32.to_le_bytes());
+  out
+}
+
+/// The `DNGVersion` (0xc612) DataMember is `$$self{DNGVersion} = $val`
+/// (`Exif.pm:3365`) — an ASSIGNMENT that runs EACH time the tag is handled, so
+/// the value `DoProcessTIFF` (`ExifTool.pm:8763`) tests is the LAST-handled
+/// 0xc612 in IFD0, NOT the first/any truthy one. Two duplicate IFD0 0xc612
+/// entries, processed in file order:
+///   - truthy `1 1 0 0` THEN falsy count-0 (`$val == ''`) → the falsy value
+///     wins → `FileType TIFF` + `File:PageCount 2` (a sticky set-true-only latch
+///     would WRONGLY keep the earlier truthy and finalize DNG);
+///   - falsy count-0 THEN truthy `1 1 0 0` → the truthy value wins → `DNG`,
+///     `PageCount` suppressed.
+///
+/// Oracle (ExifTool 13.59, `perl exiftool -G1 -FileType -FileTypeExtension
+/// -MIMEType -PageCount -DNGVersion` on each crafted file):
+///   `1 1 0 0` then count-0 → `TIFF`/`tif`/`image/tiff` + `PageCount 2`
+///   (DNGVersion empty); count-0 then `1 1 0 0` → `DNG`/`dng`/`image/x-adobe-dng`
+///   (DNGVersion `1.1.0.0`), no `PageCount`.
+#[test]
+fn duplicate_dngversion_last_wins_falsy_stays_tiff() {
+  let check =
+    |label: &str, data: &[u8], file_type: &str, ext: &str, mime: &str, want_pagecount: bool| {
+      for print_on in [true, false] {
+        let mode = if print_on { "-j" } else { "-n" };
+        let o = doc("crafted.tif", data, print_on);
+        assert_eq!(
+          o.get("File:FileType").and_then(Value::as_str),
+          Some(file_type),
+          "{label} ({mode}): File:FileType"
+        );
+        let want_ext = if print_on {
+          ext.to_string()
+        } else {
+          ext.to_ascii_uppercase()
+        };
+        assert_eq!(
+          o.get("File:FileTypeExtension").and_then(Value::as_str),
+          Some(want_ext.as_str()),
+          "{label} ({mode}): File:FileTypeExtension"
+        );
+        assert_eq!(
+          o.get("File:MIMEType").and_then(Value::as_str),
+          Some(mime),
+          "{label} ({mode}): File:MIMEType"
+        );
+        assert_eq!(
+          o.get("File:PageCount").and_then(Value::as_u64),
+          want_pagecount.then_some(2),
+          "{label} ({mode}): File:PageCount (want present={want_pagecount}): {o:?}"
+        );
+      }
+    };
+
+  // Truthy THEN falsy: the LAST (falsy count-0) wins → plain multi-page TIFF.
+  let truthy_then_falsy = multipage_tiff_with_dngversions(&[&[1, 1, 0, 0], &[]]);
+  check(
+    "DNGVersion 1 1 0 0 then count-0",
+    &truthy_then_falsy,
+    "TIFF",
+    "tif",
+    "image/tiff",
+    true,
+  );
+
+  // Falsy THEN truthy: the LAST (truthy `1 1 0 0`) wins → DNG.
+  let falsy_then_truthy = multipage_tiff_with_dngversions(&[&[], &[1, 1, 0, 0]]);
+  check(
+    "DNGVersion count-0 then 1 1 0 0",
+    &falsy_then_truthy,
+    "DNG",
+    "dng",
+    "image/x-adobe-dng",
+    false,
+  );
+}
+
+/// The `DNGVersion` RawConv lives ONLY in `%Exif::Main` (`Exif.pm:3353`), which
+/// the walker applies in the Exif-main directories (IFD0 / ExifIFD / SubIFD /
+/// trailing IFDs / InteropIFD). The GPS IFD is walked against `%GPS::Main`,
+/// which has NO 0xc612 entry — so a tag id 0xc612 in the GPS IFD is just an
+/// unknown GPS tag and must NOT set the `$$self{DNGVersion}` DataMember. A TIFF
+/// whose GPS IFD carries a (truthy-bytes) 0xc612, with NO IFD0/Exif DNGVersion,
+/// therefore stays a plain multi-page `TIFF` (+ `PageCount`).
+///
+/// Oracle (ExifTool 13.59, `perl exiftool -G1 -FileType -FileTypeExtension
+/// -MIMEType -PageCount` on the crafted file): `TIFF`/`tif`/`image/tiff` +
+/// `PageCount 2` (the GPS-IFD 0xc612 does not promote to DNG).
+#[test]
+fn gps_ifd_0xc612_does_not_promote_dng() {
+  // IFD0: NewSubfileType=2 + a GPSInfo (0x8825) pointer to the GPS IFD; IFD1:
+  // NewSubfileType=2 (the 2-page structure). The GPS IFD carries GPSVersionID
+  // (0x0000) + tag 0xc612 with truthy `1 1 0 0` bytes.
+  let new_subfile = ifd_entry(0x00FE, 4, 1, 2u32.to_le_bytes());
+
+  let ifd_size = |n: usize| 2 + 12 * n + 4;
+  let ifd0_off = 8u32;
+  let ifd0_len = 2usize; // NewSubfileType + GPSInfo pointer
+  let ifd1_off = ifd0_off + u32::try_from(ifd_size(ifd0_len)).expect("fits u32");
+  let ifd1_len = 1usize;
+  let gps_off = ifd1_off + u32::try_from(ifd_size(ifd1_len)).expect("fits u32");
+
+  // GPSInfo pointer (0x8825, LONG, count 1) → gps_off. 0x00FE < 0x8825 keeps the
+  // IFD0 tag ids ascending.
+  let gps_pointer = ifd_entry(0x8825, 4, 1, gps_off.to_le_bytes());
+  // GPS IFD leaves: GPSVersionID (0x0000, int8u[4]) then 0xc612 (truthy bytes).
+  let gps_version = ifd_entry(0x0000, 1, 4, [2, 3, 0, 0]);
+  let gps_c612 = ifd_entry(0xC612, 1, 4, [1, 1, 0, 0]);
+
+  let mut out: Vec<u8> = Vec::new();
+  out.extend_from_slice(b"II");
+  out.extend_from_slice(&42u16.to_le_bytes());
+  out.extend_from_slice(&ifd0_off.to_le_bytes());
+  // IFD0
+  out.extend_from_slice(&2u16.to_le_bytes());
+  out.extend_from_slice(&new_subfile);
+  out.extend_from_slice(&gps_pointer);
+  out.extend_from_slice(&ifd1_off.to_le_bytes());
+  // IFD1
+  out.extend_from_slice(&1u16.to_le_bytes());
+  out.extend_from_slice(&new_subfile);
+  out.extend_from_slice(&0u32.to_le_bytes());
+  // GPS IFD (terminal — next-IFD pointer 0)
+  out.extend_from_slice(&2u16.to_le_bytes());
+  out.extend_from_slice(&gps_version);
+  out.extend_from_slice(&gps_c612);
+  out.extend_from_slice(&0u32.to_le_bytes());
+
+  for print_on in [true, false] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let o = doc("crafted.tif", &out, print_on);
+    assert_eq!(
+      o.get("File:FileType").and_then(Value::as_str),
+      Some("TIFF"),
+      "{mode}: a GPS-IFD 0xc612 must NOT promote to DNG: {o:?}"
+    );
+    assert_eq!(
+      o.get("File:MIMEType").and_then(Value::as_str),
+      Some("image/tiff"),
+      "{mode}: GPS-IFD 0xc612 file MIME"
+    );
+    assert_eq!(
+      o.get("File:PageCount").and_then(Value::as_u64),
+      Some(2),
+      "{mode}: a non-promoted multi-page TIFF emits PageCount 2: {o:?}"
+    );
+  }
+}
+
+/// A genuine plain TIFF (no `DNGVersion`, no RAW magic) stays `File:FileType =
+/// TIFF` — the content taps must NOT mis-promote it. `ExifTool.tif` and
+/// `GeoTiff.tif` are single-page plain TIFFs, so they also carry no
+/// `File:PageCount` (oracle-confirmed). Guards against the content detection
+/// firing on the wrong bytes.
+#[test]
+fn plain_tiff_stays_tiff() {
+  for file in ["ExifTool.tif", "GeoTiff.tif"] {
+    let Some(data) = t_image(file) else {
+      continue;
+    };
+    for print_on in [true, false] {
+      let mode = if print_on { "-j" } else { "-n" };
+      let o = doc(file, &data, print_on);
+      assert_eq!(
+        o.get("File:FileType").and_then(Value::as_str),
+        Some("TIFF"),
+        "{file} ({mode}): plain TIFF must stay TIFF"
+      );
+      assert_eq!(
+        o.get("File:MIMEType").and_then(Value::as_str),
+        Some("image/tiff"),
+        "{file} ({mode}): plain TIFF MIME"
+      );
+      assert!(
+        !o.contains_key("File:PageCount"),
+        "{file} ({mode}): single-page plain TIFF emits no PageCount: {o:?}"
+      );
+    }
+  }
+}


### PR DESCRIPTION
Closes #181.

exifast derived the TIFF subtype from the extension only, so a DNG/CR2 under a `.tif`/dotless name fell back to plain TIFF. Ports ExifTool's content-based detection:

- **DNGVersion → DNG override** (ExifTool.pm:8763 / Exif.pm:3365): IFD0 `DNGVersion` (0xc612) sets the DataMember; gate is **Perl truthiness** of the RawConv value (not mere presence) — `1 1 0 0` or `0 0 0 0` → DNG, but empty/scalar-`0` → stays TIFF. Modeled as a **last-wins assignment** (duplicate truthy-then-falsy → TIFF) and **table-scoped to %Exif::Main** IFD kinds (IFD0/ExifIFD/SubIFD/**InteropIFD** — all inherit %Exif::Main; GPS uses %GPS::Main, excluded). DNG does not emit the multi-page PageCount.
- **CR2 magic** (ExifTool.pm:8633): `CR\x02\0` at byte 8 → CR2, regardless of extension. Gated to the **standalone** TIFF parse (embedded APP1/eXIf never trigger), requires the **full 8-byte read window** (`data.get(8..16)`), and a truncated standalone TIFF (short read at byte 8) is **hard-rejected** matching ExifTool's `return 0` (no File:FileType).

Byte-exact vs `exiftool -G1 -j` 13.59: DNG.dng→DNG, CanonRaw.cr2→CR2 (incl. misnamed `.tif`/`.nef`), plain TIFF→TIFF, empty/scalar-0/all-zero/duplicate DNGVersion, GPS/Interop 0xc612, truncated CR2 — all match. Gate green (3717); Codex APPROVE (R7). Unfixtured-deferred: Canon-1D-RAW magic, NEF/RW2/ORF body overrides.