### PR TITLE
feat(exif/nikon): Nikon MakerNotes vendor port — Nikon::Main + Type2 + readable sub-tables (#62)

### DIFF
--- a/src/exif/ifd.rs
+++ b/src/exif/ifd.rs
@@ -349,6 +349,25 @@ impl Format {
     }
   }
 
+  /// `true` for an on-disk format code that `ProcessExif` accepts in a standard
+  /// TIFF/Exif IFD entry: the 13 standard TIFF types (`1..=13`) plus the
+  /// Exif-3.0 UTF-8 type (`129`) (`Exif.pm:6463-6464` `if (($format < 1 or
+  /// $format > 13) and $format != 129 …)`). Codes `14`/`15` (`unicode`/
+  /// `complex`) and the BigTIFF additions `16`/`17`/`18` (`int64u`/`int64s`/
+  /// `ifd64`) are NOT accepted on the IFD-walk decode path — a standard IFD
+  /// entry carrying one is `Bad format` (warned, then entry-0-abort vs
+  /// later-skip), never decoded.
+  ///
+  /// This is the SINGLE source of truth for the per-entry format-validity gate,
+  /// shared by the standalone-TIFF walker (`mod.rs`), the Canon MakerNote
+  /// classifier ([`crate::exif::makernotes::vendors::canon`]) and the Nikon
+  /// MakerNote walker — each `ProcessExif`-equivalent reuses it so the
+  /// `recognized` test cannot drift between vendors.
+  #[must_use]
+  pub const fn is_valid_ifd_code(code: u16) -> bool {
+    matches!(code, 1..=13 | 129)
+  }
+
   /// `true` for an integer format that may legitimately hold an IFD pointer
   /// (`%intFormat`, `Exif.pm:124-135`). The Exif IFD walker uses this to
   /// faithfully warn `Wrong format` when a SubIFD pointer has a non-integer

--- a/src/exif/makernotes/dispatcher.rs
+++ b/src/exif/makernotes/dispatcher.rs
@@ -2442,10 +2442,12 @@ mod tests {
     assert_eq!(Vendor::Sony.status(), VendorStatus::Phase3);
     assert_eq!(Vendor::Panasonic.status(), VendorStatus::Phase3);
     assert_eq!(Vendor::Dji.status(), VendorStatus::Phase4);
-    assert_eq!(Vendor::Nikon.status(), VendorStatus::Deferred);
+    assert_eq!(Vendor::Nikon.status(), VendorStatus::Phase5);
+    assert_eq!(Vendor::Pentax.status(), VendorStatus::Deferred);
     assert_eq!(Vendor::Unknown.status(), VendorStatus::Unknown);
     assert!(Vendor::Apple.status().is_scheduled());
-    assert!(Vendor::Nikon.status().is_deferred());
+    assert!(Vendor::Nikon.status().is_scheduled());
+    assert!(Vendor::Pentax.status().is_deferred());
     assert!(Vendor::Unknown.status().is_unknown());
   }
 

--- a/src/exif/makernotes/mod.rs
+++ b/src/exif/makernotes/mod.rs
@@ -64,7 +64,7 @@ pub use vendor::{Vendor, VendorStatus};
 #[cfg(feature = "alloc")]
 pub use vendors::VendorEmission;
 pub use vendors::{
-  AppleMakerNote, CanonMakerNote, DjiMakerNote, PanasonicMakerNote, SonyMakerNote,
+  AppleMakerNote, CanonMakerNote, DjiMakerNote, MakerNotesNikon, PanasonicMakerNote, SonyMakerNote,
 };
 
 /// Typed MakerNotes metadata — the top-level surface for vendor MakerNote
@@ -95,6 +95,10 @@ pub struct MakerNotesMeta {
   panasonic: Option<PanasonicMakerNote>,
   /// DJI decoded data — Phase 4.
   dji: Option<DjiMakerNote>,
+  /// Nikon decoded data — populated when [`Vendor::Nikon`] dispatched AND
+  /// the Nikon port runs (`%Nikon::Main`, the readable scalars + AFInfo +
+  /// the unencrypted ColorBalance0103).
+  nikon: Option<MakerNotesNikon>,
 }
 
 impl MakerNotesMeta {
@@ -111,6 +115,7 @@ impl MakerNotesMeta {
       sony: None,
       panasonic: None,
       dji: None,
+      nikon: None,
     }
   }
 
@@ -145,6 +150,12 @@ impl MakerNotesMeta {
   #[inline(always)]
   pub fn set_dji(&mut self, dji: DjiMakerNote) {
     self.dji = Some(dji);
+  }
+
+  /// Replace the Nikon slot — used by the IFD walker during walk.
+  #[inline(always)]
+  pub fn set_nikon(&mut self, nikon: MakerNotesNikon) {
+    self.nikon = Some(nikon);
   }
 
   /// Build a `MakerNotesMeta` and POPULATE the per-vendor slot when the
@@ -359,6 +370,30 @@ impl MakerNotesMeta {
         let (typed, _emissions) = vendors::dji::parse(blob, parent_order);
         meta.dji = Some(typed);
       }
+      // Nikon has THREE layouts with DIFFERENT base semantics, and only ONE is
+      // faithfully decodable from the captured blob ALONE — hence the `Nikon\0
+      // \x02` guard:
+      //   - type-3 (`Nikon\0\x02…`, `MakerNotes.pm:51-58`) carries a
+      //     SELF-CONTAINED embedded TIFF (`Base => '$start - 8'` rebases its
+      //     out-of-line offsets to blob offset 10) ⇒ the blob IS the TIFF
+      //     context, so the standalone-blob walk is faithful.
+      //   - type-2 (`Nikon\0\x01`, `MakerNotes.pm:539-545`) and headerless
+      //     Nikon3 (`MakerNotes.pm:546-554`) have NO `Base` override ⇒ their
+      //     out-of-line value offsets are PARENT-TIFF-relative. This blob-only
+      //     constructor has NO parent TIFF, so an absolute offset would index
+      //     INTO the blob and read out-of-line values from the wrong bytes
+      //     (garbage) or fall outside it. The production decode never reaches
+      //     here — `Exif`'s MakerNote arm calls `nikon::parse_in_tiff` with the
+      //     real parent TIFF (`src/exif/mod.rs`) — so this gate is purely
+      //     defensive for direct `from_blob`/`from_blob_with_context` callers
+      //     (tests/tools). They fall to the `_` arm below ⇒ the Nikon slot
+      //     stays UNPOPULATED (no mis-rebased garbage; the vendor is still
+      //     identified via `detected`).
+      // `model` threads the AFInfo byte-order + ShootingMode bit-5 `Condition`s.
+      Vendor::Nikon if blob.starts_with(b"Nikon\x00\x02") => {
+        let (typed, _emissions) = vendors::nikon::parse(blob, parent_order, model);
+        meta.nikon = Some(typed);
+      }
       _ => {}
     }
     meta
@@ -417,6 +452,14 @@ impl MakerNotesMeta {
   #[inline(always)]
   pub const fn dji(&self) -> Option<&DjiMakerNote> {
     self.dji.as_ref()
+  }
+
+  /// Nikon decoded data. `None` unless [`Vendor::Nikon`] dispatched and the
+  /// Nikon port ran.
+  #[must_use]
+  #[inline(always)]
+  pub const fn nikon(&self) -> Option<&MakerNotesNikon> {
+    self.nikon.as_ref()
   }
 }
 

--- a/src/exif/makernotes/vendor.rs
+++ b/src/exif/makernotes/vendor.rs
@@ -49,6 +49,9 @@ pub enum VendorStatus {
   Phase3,
   /// Phase 4 — GoPro/DJI.
   Phase4,
+  /// Phase 5 — Nikon (`%Nikon::Main` readable scalars + AFInfo +
+  /// unencrypted ColorBalance; the encrypted sub-tables stay deferred).
+  Phase5,
   /// Phase ∞ (deferred) — long-tail vendor. Identifies in Phase 1, but
   /// no Phase-N tag table is currently scheduled.
   Deferred,
@@ -68,18 +71,19 @@ impl VendorStatus {
       VendorStatus::Phase2 => "phase2",
       VendorStatus::Phase3 => "phase3",
       VendorStatus::Phase4 => "phase4",
+      VendorStatus::Phase5 => "phase5",
       VendorStatus::Deferred => "deferred",
       VendorStatus::Unknown => "unknown",
     }
   }
 
-  /// `true` if a per-vendor tag table is currently scheduled (Phase 2-4).
+  /// `true` if a per-vendor tag table is currently scheduled (Phase 2-5).
   #[must_use]
   #[inline(always)]
   pub const fn is_scheduled(self) -> bool {
     matches!(
       self,
-      VendorStatus::Phase2 | VendorStatus::Phase3 | VendorStatus::Phase4
+      VendorStatus::Phase2 | VendorStatus::Phase3 | VendorStatus::Phase4 | VendorStatus::Phase5
     )
   }
 
@@ -283,6 +287,11 @@ impl Vendor {
       // group is the vendor name `DJI` (DJI.pm:56 sets only family-0
       // `MakerNotes`), so `-G1` emits `DJI:Pitch` etc.
       Vendor::Dji => "DJI",
+      // Nikon MakerNotes route to `Image::ExifTool::Nikon::Main`
+      // (`Nikon.pm:1778`, `GROUPS => { 0 => 'MakerNotes', 2 => 'Camera' }`);
+      // the family-1 group is the module name `Nikon`, so `-G1` emits
+      // `Nikon:Quality` etc.
+      Vendor::Nikon => "Nikon",
       _ => "MakerNotes",
     }
   }
@@ -300,6 +309,7 @@ impl Vendor {
       Vendor::Apple | Vendor::Canon => VendorStatus::Phase2,
       Vendor::Sony | Vendor::Panasonic => VendorStatus::Phase3,
       Vendor::Dji => VendorStatus::Phase4,
+      Vendor::Nikon => VendorStatus::Phase5,
       Vendor::Unknown => VendorStatus::Unknown,
       Vendor::Casio
       | Vendor::Flir
@@ -315,7 +325,6 @@ impl Vendor {
       | Vendor::Leica
       | Vendor::Minolta
       | Vendor::Motorola
-      | Vendor::Nikon
       | Vendor::Nintendo
       | Vendor::Olympus
       | Vendor::Pentax

--- a/src/exif/makernotes/vendors/canon/body.rs
+++ b/src/exif/makernotes/vendors/canon/body.rs
@@ -200,7 +200,7 @@ pub(crate) fn classify_canon_entry(
   // `if (($format < 1 or $format > 13) and $format != 129 …)` (Exif.pm:6463).
   // The BigTIFF codes 14-18 map to real `Format`s but are BAD in a standard
   // Canon IFD entry (the Apple-ProRaw `$format == 16` carve-out is Apple-only).
-  let recognized = matches!(format_code, 1..=13 | 129);
+  let recognized = Format::is_valid_ifd_code(format_code);
   if !recognized {
     // `next if $index` (Exif.pm:6475) ⇒ skip for index ≠ 0; ELSE `return 0`
     // (abort). `if ($format or $validate)` (Exif.pm:6470) ⇒ a `0` code warns

--- a/src/exif/makernotes/vendors/mod.rs
+++ b/src/exif/makernotes/vendors/mod.rs
@@ -32,12 +32,14 @@
 pub mod apple;
 pub mod canon;
 pub mod dji;
+pub mod nikon;
 pub mod panasonic;
 pub mod sony;
 
 pub use apple::MakerNotesApple;
 pub use canon::MakerNotesCanon;
 pub use dji::MakerNotesDji;
+pub use nikon::MakerNotesNikon;
 pub use panasonic::MakerNotesPanasonic;
 pub use sony::MakerNotesSony;
 

--- a/src/exif/makernotes/vendors/nikon/body.rs
+++ b/src/exif/makernotes/vendors/nikon/body.rs
@@ -1,0 +1,1636 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Nikon MakerNote IFD body walker — the embedded-TIFF / headerless IFD walk
+//! that `%Image::ExifTool::Nikon::Main` (`Nikon.pm:1778`) runs over.
+//!
+//! ## Header layouts (`MakerNotes.pm:48-554`)
+//!
+//! Nikon writes three MakerNote layouts; the dispatcher
+//! ([`crate::exif::makernotes::dispatch`]) classifies them and supplies the
+//! `Start`/`Base`/`ByteOrder` directives:
+//!
+//! - **Type 3 (`MakerNoteNikon`, `MakerNotes.pm:51-58`)** — the modern DSLR
+//!   layout: 6-byte `"Nikon\0"` + a 2-byte version (`\x02\x10`/`\x02\x00`) +
+//!   2 pad bytes, then an EMBEDDED TIFF header at blob offset 10
+//!   (`MM`/`II` + `0x002a` magic + the 4-byte IFD0 offset). `Start =>
+//!   '$valuePtr + 18'` points at the IFD itself (`10 + 8`); the `Base =>
+//!   '$start - 8'` directive makes out-of-line value offsets relative to the
+//!   EMBEDDED TIFF header (blob offset 10), so the IFD is self-contained.
+//! - **Type 2 (`MakerNoteNikon2`, `MakerNotes.pm:539-545`)** — `"Nikon\0\x01"`
+//!   header; `Start => '$valuePtr + 8'`, no `Base` override (offsets
+//!   blob-relative), explicit `LittleEndian`.
+//! - **Type 1 / headerless (`MakerNoteNikon3`, `MakerNotes.pm:549-554`)** —
+//!   no `"Nikon"` prefix; `Make =~ /^NIKON/i`; the blob IS the IFD (`Start`
+//!   defaults to `$valuePtr`), `ByteOrder => 'Unknown'`.
+//!
+//! This module walks the IFD generically: the caller passes the IFD start
+//! offset within the blob (`ifd_offset`), the byte order, and the
+//! `value_base` (the blob offset that out-of-line value offsets are counted
+//! from). Type-3 sets `value_base = 10`; the headerless / type-2 layouts set
+//! `value_base = 0` (blob-relative). The walk is panic-free and bounded
+//! (every read is a checked `.get()`), faithful to ExifTool's `Warn`+`next`
+//! on a malformed entry.
+
+#![deny(clippy::indexing_slicing)]
+
+use super::tags::{NikonTable, NikonTag};
+use crate::exif::ifd::{ByteOrder, Format, RawValue, read_value};
+use crate::exif::makernotes::vendors::{FormatOverride, resolve_read_format};
+use crate::value::TagValue;
+use std::vec::Vec;
+
+/// One decoded IFD value (the post-Format-decode `$val`), wrapping
+/// [`RawValue`] with the Nikon conversion helpers.
+#[derive(Debug, Clone)]
+pub struct ParsedValue {
+  raw: RawValue,
+}
+
+impl ParsedValue {
+  /// Wrap a decoded [`RawValue`].
+  #[must_use]
+  #[inline(always)]
+  pub const fn new(raw: RawValue) -> Self {
+    Self { raw }
+  }
+
+  /// Borrow the underlying raw value.
+  #[must_use]
+  #[inline(always)]
+  pub const fn raw(&self) -> &RawValue {
+    &self.raw
+  }
+
+  /// The first scalar integer (signed), accepting `U64`/`I64`.
+  #[must_use]
+  pub fn first_i64(&self) -> Option<i64> {
+    match &self.raw {
+      RawValue::I64(v) => v.first().copied(),
+      RawValue::U64(v) => v.first().and_then(|&n| i64::try_from(n).ok()),
+      _ => None,
+    }
+  }
+
+  /// The first two unsigned integers (for `int16u[2]` ISO/ISOSetting).
+  #[must_use]
+  pub fn first_two_u64(&self) -> Option<(u64, u64)> {
+    match &self.raw {
+      RawValue::U64(v) if let [a, b, ..] = v.as_slice() => Some((*a, *b)),
+      RawValue::I64(v) if let [a, b, ..] = v.as_slice() => {
+        let a = u64::try_from(*a).ok()?;
+        let b = u64::try_from(*b).ok()?;
+        Some((a, b))
+      }
+      _ => None,
+    }
+  }
+
+  /// The display string of a `Text` value, or `None` for a non-text shape.
+  #[must_use]
+  pub fn as_text(&self) -> Option<&str> {
+    match &self.raw {
+      RawValue::Text { text, .. } => Some(text.as_str()),
+      _ => None,
+    }
+  }
+
+  /// The bytes of an `undef`/`string` value — for the `MakerNoteVersion`
+  /// ValueConv (`unpack("CCCC", $val)`), which inspects the raw on-disk
+  /// bytes. `Bytes` → verbatim; `Text` → the pre-FixUTF8 NUL-trimmed bytes.
+  #[must_use]
+  pub fn undef_or_text_bytes(&self) -> Vec<u8> {
+    match &self.raw {
+      RawValue::Bytes(b) => b.clone(),
+      RawValue::Text { raw, .. } => raw.to_vec(),
+      _ => Vec::new(),
+    }
+  }
+
+  /// The integer-array `$val` rendered as the space-joined decimal string
+  /// `ReadValue` produces (`join(' ', @vals)`, `ExifTool.pm:6319`) — for the
+  /// multi-`int16u` tags (`CropHiSpeed`/`RetouchHistory`/`NEFBitDepth`) whose
+  /// ValueConv/PrintConv operate on the whole space-joined record. Returns
+  /// `None` for a non-integer shape.
+  #[must_use]
+  pub fn int_list_val_string(&self) -> Option<std::string::String> {
+    let mut s = std::string::String::new();
+    match &self.raw {
+      RawValue::U64(v) => {
+        for (i, n) in v.iter().enumerate() {
+          if i > 0 {
+            s.push(' ');
+          }
+          s.push_str(&n.to_string());
+        }
+      }
+      RawValue::I64(v) => {
+        for (i, n) in v.iter().enumerate() {
+          if i > 0 {
+            s.push(' ');
+          }
+          s.push_str(&n.to_string());
+        }
+      }
+      _ => return None,
+    }
+    Some(s)
+  }
+
+  /// The shared Nikon `c3` signed-fraction ValueConv
+  /// (`my ($a,$b,$c)=unpack("c3",$val); $c ? $a*($b/$c) : 0`,
+  /// `Nikon.pm:1846` etc.). The value is a 4-byte `undef`; the first three
+  /// bytes are SIGNED (`c` = int8s).
+  #[must_use]
+  pub fn signed_fraction_c3(&self) -> Option<f64> {
+    let bytes = self.undef_or_text_bytes();
+    let a = *bytes.first()? as i8 as f64;
+    let b = *bytes.get(1)? as i8 as f64;
+    let c = *bytes.get(2)? as i8 as f64;
+    if c != 0.0 {
+      Some(a * (b / c))
+    } else {
+      Some(0.0)
+    }
+  }
+
+  /// A `rational64u`/`rational64s` array joined as space-separated DECIMAL
+  /// scalars (`ReadValue`'s `join(' ', @vals)` with `Rational::exiftool_val_str`)
+  /// — the `$val` `Exif::PrintLensInfo` splits on. `None` for a non-rational.
+  #[must_use]
+  pub fn rational_join_decimal(&self) -> Option<std::string::String> {
+    let RawValue::Rational(rs) = &self.raw else {
+      return None;
+    };
+    let mut s = std::string::String::new();
+    for (i, r) in rs.iter().enumerate() {
+      if i > 0 {
+        s.push(' ');
+      }
+      s.push_str(&r.exiftool_val_str());
+    }
+    Some(s)
+  }
+
+  /// Convert to the default [`TagValue`] (no PrintConv) via the shared
+  /// faithful `ReadValue` renderer (integers → `I64`/`U64`, floats → `F64`,
+  /// rationals → joined decimals, text → `Str`, bytes → `Bytes`).
+  #[must_use]
+  pub fn to_default_tag_value(&self) -> TagValue {
+    crate::exif::render::render_value(&self.raw, crate::emit::ConvMode::PrintConv)
+  }
+}
+
+/// One IFD entry parsed from the Nikon body — `(tag_id, format, count, value)`.
+#[derive(Debug, Clone)]
+pub struct NikonEntry {
+  /// Nikon tag ID (`Nikon::Main` hash key).
+  pub tag_id: u16,
+  /// On-disk format code (kept for `$format eq "undef"` conditions).
+  pub format: Format,
+  /// Element count (post-Format-override).
+  pub count: usize,
+  /// The decoded raw value.
+  pub value: RawValue,
+  /// The blob offset of the value's first byte (inline within the entry, or
+  /// the out-of-line target) — SubDirectory processors re-read from here.
+  pub value_offset: usize,
+  /// The byte length of the value as stored on disk (`elem_size * count`,
+  /// clamped to the buffer) — the SubDirectory's `$size`.
+  pub value_size: usize,
+}
+
+/// Walk the Nikon MakerNote IFD over `blob`.
+///
+/// - `ifd_offset` — the blob offset of the IFD's 2-byte entry count (the
+///   dispatcher's `Start` directive). Type-3 = 18; headerless = 0.
+/// - `order` — the resolved byte order (type-3 reads it from the embedded
+///   TIFF marker; type-2 is explicit LE; headerless probes/inherits).
+/// - `value_base` — the blob offset out-of-line value offsets are counted
+///   from (type-3 `Base => $start-8` ⇒ 10; else 0).
+/// - `table` — the tag table the walk is keyed against ([`NikonTable::Main`]
+///   for type-3 / headerless, [`NikonTable::Type2`] for the `"Nikon\0\x01"`
+///   layout). Used for BOTH the per-tag `Format`-override decode AND the
+///   unknown-tag value skip, so a type-2 IFD's 0x0003..0x000b resolve through
+///   `%Nikon::Type2` (an id absent from the selected table is `None` ⇒
+///   unknown ⇒ value decode skipped), keeping the gate set identical.
+///
+/// `blob` is the buffer the IFD lives in: the captured MakerNote (type-3,
+/// self-contained) or the WHOLE parent TIFF (type-2 / headerless, whose
+/// out-of-line offsets are parent-relative). The entry table is bounded to
+/// `blob.len()` — ExifTool's `ProcessExif` bounds the directory to the
+/// SubDirectory's `DataLen` (`Exif.pm:6394`), and for an in-place MakerNote
+/// `DataLen` is the parent EXIF buffer (NOT the shorter declared MakerNote
+/// length `DirLen`), so this matches ExifTool: a directory whose entry count
+/// runs to within the parent buffer is walked (`DirLen` only drives a
+/// "Short directory" *warning*, never a hard clamp, when `dirEnd <= DataLen`).
+///
+/// The DIRECTORY FRAMING is the SAME `ProcessExif` shape (`Exif.pm:6343-6400`)
+/// Canon's [`super::super::canon::body::classify_canon_directory`] and the
+/// shared EXIF walker (`src/exif/mod.rs`) run: the 2-byte `$numEntries` read,
+/// `$dirEnd = $dirStart + 2 + 12*$numEntries` (NO entry-count ceiling), the
+/// `$dirEnd > $dataLen` overrun reject (`:6394`), and the ILLEGAL-TAIL abort —
+/// a `$bytesFromEnd` (`$dataLen - $dirEnd`) of exactly `1` or `3` aborts the
+/// whole directory BEFORE any entry is walked (`:6394-6399`), while `0`/`2`/`>=
+/// 4` walk. A zero-entry directory walks zero entries.
+///
+/// Each entry is validated through the SAME `ProcessExif` entry-loop gate set
+/// the standalone-TIFF walker and Canon's `classify_canon_entry` run — the
+/// [`Format::is_valid_ifd_code`] format-code gate (entry-0-abort vs later-skip,
+/// rejecting codes `14..=18`), the `Invalid size` ceiling (`Exif.pm:6505`), the
+/// full-value EOF / `Bad offset` bound (`Exif.pm:6552`/`:6660`), the
+/// excessive-count guard (`Exif.pm:6763`), and the SUSPICIOUS-OFFSET gate
+/// (`Exif.pm:6539` raw offset `< 8` + `:6549`
+/// value-range-overlaps-the-IFD-entry-table, skipped non-verbose at
+/// `:6673-6677`) — so Nikon inherits the whole gate set rather than re-deriving
+/// a subset. (The validate-only `:6511-6529` checks are gated on `$validate and
+/// not $inMakerNotes`, so they do NOT run for a MakerNote and are excluded.)
+///
+/// The LOOP TERMINATION mirrors Canon/shared too: a per-directory `$warnCount`
+/// (`Exif.pm:6453`) is bumped for each counted per-entry warning (nonzero
+/// `Bad format` `:6472`, `Invalid size` `:6507`, no-RAF `Bad offset` `:6661`,
+/// `Suspicious … offset` `:6676` — NOT the excessive-count `:6767` plain `Warn`
+/// nor the `0`-code silent padding) and, BEFORE reading each next entry, a
+/// `$warnCount > 10` count aborts the directory (`:6455-6456`), returning only
+/// the entries accumulated so far.
+///
+/// Returns the entries in IFD walk order. A bad format code at entry 0 ABORTS
+/// the directory (only the entries accumulated BEFORE it are returned — for
+/// entry 0 that is none); any other malformed entry is skipped while the walk
+/// continues.
+///
+/// ## Malformed-entry warnings are intentionally DROPPED (engine-wide gap)
+///
+/// ExifTool's `ProcessExif` emits a `[minor] Bad format (N) for MakerNotes
+/// entry M` (`Exif.pm:6472`) and `[minor] Ignoring MakerNotes <tag> with
+/// excessive count` (`Exif.pm:6768`) for each malformed/over-count entry it
+/// SKIPS. This walker reproduces the SKIP/ABORT control flow byte-exactly but
+/// returns only `Vec<NikonEntry>` — it has no warning channel. That is
+/// CONSISTENT with every other ordinary MakerNote vendor walker: Canon
+/// ([`super::super::canon::body::walk_canon_in_tiff`]), Sony
+/// ([`super::super::sony::body::walk_sony_in_tiff`]), Panasonic and Apple all
+/// likewise `continue`/`break` on a malformed entry WITHOUT surfacing a
+/// per-entry diagnostic into `ExifMeta`. (The only MakerNote diagnostics that
+/// DO surface are Canon's CTMD `0x927c` re-dispatch STRUCTURAL warnings —
+/// `redispatch_ctmd_makernote_diagnostics`, a separate timed-metadata path, not
+/// the per-entry walk.) So this is an ENGINE-WIDE makernote-warning-channel gap,
+/// not a Nikon-specific omission; threading a Nikon-only channel here would make
+/// the diagnostics behavior INCONSISTENT across vendors. A real (valid) Nikon
+/// file emits no such warnings, so its output is unaffected. Adding the channel
+/// for ALL vendors uniformly is a deferred follow-up.
+#[must_use]
+pub fn walk_nikon_ifd(
+  blob: &[u8],
+  ifd_offset: usize,
+  order: ByteOrder,
+  value_base: usize,
+  table: NikonTable,
+) -> Vec<NikonEntry> {
+  let mut out = Vec::new();
+  let Some(num_entries) = read_u16(blob, ifd_offset, order) else {
+    return out;
+  };
+  let num_entries = num_entries as usize;
+  // NO entry-count ceiling: `ProcessExif` (`Exif.pm:6343-6400`) reads
+  // `$numEntries = Get16u(...)` (so at most 65535) and processes ALL of them,
+  // bounded ONLY by `$dirEnd <= $dataLen` (the `dir_end > blob.len()` gate
+  // below) and the per-entry validity gates — there is no maximum-entry
+  // special case. A formerly-imposed `num_entries > 1024` reject was
+  // non-ExifTool and would TRUNCATE a valid >1024-entry IFD; it is gone
+  // (oracle-verified against the Canon walker's `large_in_bounds_count_is_walked`
+  // — bundled walks a 2000-entry in-bounds IFD with no warning). A zero-entry
+  // directory walks zero entries (the loop runs zero times); the early return
+  // is just the empty-`out` shortcut.
+  if num_entries == 0 {
+    return out;
+  }
+  let entries_start = ifd_offset.saturating_add(2);
+  // The 12-byte entry array (`2 + 12*numEntries`, ExifTool's `$dirSize`,
+  // `Exif.pm:6347`) must fit inside the buffer — ExifTool's `$dirEnd > $dataLen`
+  // bound (`:6394`), where `$dataLen` is this same parent buffer.
+  let dir_end = entries_start.saturating_add(12usize.saturating_mul(num_entries));
+  if dir_end > blob.len() {
+    return out;
+  }
+  // Illegal-directory-size tail gate (`my $bytesFromEnd = $dataLen - $dirEnd; if
+  // ($bytesFromEnd < 4) { unless ($bytesFromEnd == 2 or $bytesFromEnd == 0) {
+  // Warn("Illegal $dir directory size ($numEntries entries)"); return 0 } }`,
+  // `Exif.pm:6394-6399`), checked BEFORE any entry is walked. ExifTool reads the
+  // IFD body from the file via RAF — the 2-byte count then `Read(12*n + 4)`
+  // capped at EOF — so the only LEGAL residue past `$dirEnd` is the 4-byte
+  // next-IFD pointer (`>= 4` ⇒ clamped to 4) or a deliberately truncated tail of
+  // `2` or `0` bytes; a residue of exactly `1` or `3` bytes is a malformed
+  // directory that ExifTool aborts wholesale (no tags). `dir_end <= blob.len()`
+  // above ⇒ the subtraction cannot underflow. Mirrors Canon's
+  // [`super::super::canon::body::classify_canon_directory`]
+  // (`CanonDirShape::AbortIllegalSize`, `body.rs` `bytes_from_end == 1 || == 3`)
+  // and the shared EXIF walker (`src/exif/mod.rs` `walk_one_ifd_body`, the
+  // `bytes_from_end == 1 || bytes_from_end == 3` abort): a `0`/`2`/`>= 4`-byte
+  // tail walks `num_entries`. Without it a type-3 (blob-as-buffer) Nikon
+  // MakerNote whose entry table is valid but is followed by a 1- or 3-byte tail
+  // emits Nikon tags ExifTool suppresses. The matching `Illegal … directory
+  // size` WARNING stays the engine-wide makernote-warning-channel gap (#230, see
+  // the fn-level note); only the TAG-suppression abort is reproduced here.
+  let bytes_from_end = blob.len() - dir_end;
+  if bytes_from_end == 1 || bytes_from_end == 3 {
+    return out;
+  }
+  // `$warnCount` (`Exif.pm:6453`, `my ($warnCount, $lastID) = (0, -1)`) — the
+  // PER-DIRECTORY validation-warning counter. ExifTool bumps it for each
+  // counted per-entry warning (`++$warnCount`) and, BEFORE reading each next
+  // entry, `if ($warnCount > 10) { Warn("Too many warnings -- $dir parsing
+  // aborted", 2); return 0 }` (`Exif.pm:6455-6456`) — so a directory that piles
+  // up more than ten counted warnings is abandoned (its later entries + next-IFD
+  // pointer NOT processed). Mirrors Canon's `walk_canon_in_tiff` per-directory
+  // `warn_count` (`body.rs`) and the shared EXIF walker's `Walker::warn_count`
+  // (`src/exif/mod.rs`). The counted classes are exactly those whose ExifTool
+  // site is immediately followed by `++$warnCount`: nonzero `Bad format`
+  // (`:6472`), `Invalid size` (`:6507`), the no-RAF `Bad offset` (`:6661`) and
+  // `Suspicious … offset` (`:6676`) — NOT the excessive-count warning (`:6767`
+  // uses a plain `Warn`, no `++$warnCount`) nor the `0`-code silent padding (no
+  // `Warn` at all). Grounded against the shared walker's `warn_counted` doc
+  // (`src/exif/mod.rs`) + Canon's [`CanonEntryClass::bumps_warn_count`].
+  let mut warn_count: u32 = 0;
+  for i in 0..num_entries {
+    // `if ($warnCount > 10) { … return 0 }` (`Exif.pm:6455-6456`) — abort the
+    // directory BEFORE reading any further entry, returning the entries
+    // accumulated so far. Mirrors Canon's loop-top guard (`body.rs`); without it
+    // a crafted Nikon MakerNote with >10 counted-malformed entries followed by a
+    // valid tag would still emit that late tag, whereas ExifTool aborts.
+    if warn_count > 10 {
+      break;
+    }
+    let entry_off = entries_start + 12 * i;
+    let Some(tag_id) = read_u16(blob, entry_off, order) else {
+      continue;
+    };
+    let Some(format_code) = read_u16(blob, entry_off + 2, order) else {
+      continue;
+    };
+    let Some(count) = read_u32(blob, entry_off + 4, order) else {
+      continue;
+    };
+    let count = count as usize;
+    // Per-entry format-validity gate — the shared `ProcessExif` entry classifier
+    // (`Exif.pm:6463-6477`), the SAME predicate the standalone-TIFF walker
+    // (`src/exif/mod.rs`) and Canon's `classify_canon_entry` use
+    // ([`Format::is_valid_ifd_code`]). `ProcessExif` accepts ONLY the format
+    // codes `1..=13 | 129`; ANY other nonzero code (incl. the BigTIFF/Unicode/
+    // Complex codes `14..=18`, which `Format::from_code` maps to real `Format`s
+    // with a NONZERO `byte_size`) is `Bad format`: `next if $index`
+    // (`Exif.pm:6476`) — a LATER bad entry is SKIPPED — ELSE (`$index == 0`)
+    // `return 0` (`Exif.pm:6475`), which ABORTS the whole directory ("assume
+    // corrupted IFD if this is our first entry"). A `0` code is silent IFD
+    // zero-padding (same abort-at-0 / skip-later control flow). This walk emits
+    // no warnings (it returns the accumulated entries; the `Bad format` minor
+    // warning is dropped, consistent with every vendor walker — see the
+    // fn-level note), so both arms reduce to break-vs-continue. Ground-truthed
+    // against `perl exiftool 13.59`: a Nikon MakerNote whose entry 0 has format
+    // 99 (or 14..=18) followed by a valid `LensType` emits NOTHING from the
+    // directory (abort); the same bad format at a LATER entry drops only that
+    // entry while the valid ones before/after still emit.
+    if !Format::is_valid_ifd_code(format_code) {
+      // `if ($format or $validate) { Warn("Bad format …"); ++$warnCount }`
+      // (`Exif.pm:6470-6472`): a NONZERO bad code counts toward the
+      // `$warnCount > 10` abort cap; a `0` code is silent IFD zero-padding (NO
+      // `Warn`, NO `++$warnCount`) — matching Canon's
+      // [`CanonEntryClass::bumps_warn_count`] (`BadFormat` counts,
+      // `SilentBadFormat` does not). The bump precedes the abort/skip just as
+      // ExifTool's `++$warnCount` precedes the `next if $index` / `return 0`
+      // (harmless on the entry-0 abort, which returns immediately).
+      if format_code != 0 {
+        warn_count = warn_count.saturating_add(1);
+      }
+      if i == 0 {
+        return out; // `return 0` — abort the directory (entry-0 bad format).
+      }
+      continue; // `next` — skip this entry, keep walking the IFD.
+    }
+    let format = Format::from_code(format_code);
+    // A `1..=13 | 129` code always has a nonzero `byte_size` (only `Unknown`
+    // reports 0, and the gate above rejected every code that maps to it).
+    let total_size = format.byte_size().saturating_mul(count);
+    // Invalid-size guard (`if ($size > 0x7fffffff and (not $tagInfo or not
+    // $$tagInfo{ReadFromRAF})) { Warn('Invalid size …'); ++$warnCount; next }`,
+    // `Exif.pm:6505-6509`): a `count * formatSize` past the signed-32-bit
+    // ceiling is the per-entry `next` (SKIP, not a directory abort) BEFORE the
+    // offset is read or the value decoded. No Nikon MakerNote leaf carries
+    // `ReadFromRAF` (it lives on 3 non-camera `Exif.pm` tags), so the guard
+    // reduces to `total_size > 0x7fffffff`. ExifTool nests this inside its
+    // `$size > 4` (out-of-line) block, but `total_size > 0x7fffffff` already
+    // implies `total_size > 4`, so testing it here — ahead of the inline/
+    // out-of-line split — is observationally identical: only an out-of-line
+    // entry can ever trip it. Mirrors the shared EXIF walker's `if size >
+    // 0x7fff_ffff` (`src/exif/mod.rs`) and Canon's `CanonEntryClass::InvalidSize`.
+    if total_size > 0x7fff_ffff {
+      warn_count = warn_count.saturating_add(1); // `++$warnCount` (Exif.pm:6507)
+      continue; // `next` — skip the entry, keep walking the IFD.
+    }
+    // Inline if it fits in 4 bytes; else an out-of-line offset relative to
+    // `value_base` (the embedded-TIFF base for type-3 / parent-TIFF-absolute
+    // for type-2 / headerless). The out-of-line target resolves against the
+    // PARENT TIFF (`blob.len()` is the parent TIFF length for those layouts),
+    // NOT the MakerNote end — Nikon offsets are parent-relative.
+    //
+    // `raw_offset` is the u32 stored in the entry's value field (ExifTool's
+    // `$valuePtr` at `Exif.pm:6510`, BEFORE the 6544/6546 conversion to a
+    // buffer pointer) — the suspicious-offset gate below tests it RAW.
+    let (value_data_offset, raw_offset) = if total_size <= 4 {
+      (entry_off + 8, None)
+    } else {
+      let Some(off) = read_u32(blob, entry_off + 8, order) else {
+        continue;
+      };
+      let Some(abs) = (off as usize).checked_add(value_base) else {
+        continue;
+      };
+      (abs, Some(off as usize))
+    };
+    // The FULL value must fit in the buffer (`$valuePtr + $size <= $dataLen`,
+    // `Exif.pm:6552`): when it does not and there is no RAF (the in-memory
+    // MakerNote case), ExifTool sets `$bad = 1` and emits NOTHING for the tag
+    // (`:6663-6668`) — it does NOT truncate to a partial tail. So reject the
+    // overrunning entry (skip it) rather than reading `total_size.min(avail)`.
+    // This is ExifTool's `Bad offset` path (`:6660`, `++$warnCount`); reaching
+    // PAST it means the value is in-bounds and readable — the precondition for
+    // the suspicious-offset gate's `$suspect == $warnCount` guard below.
+    let Some(value_end) = value_data_offset.checked_add(total_size) else {
+      // An offset/size that overflows `usize` is past EOF — the same Bad-offset
+      // drop as below; count it too (`++$warnCount`, Exif.pm:6661).
+      warn_count = warn_count.saturating_add(1);
+      continue;
+    };
+    if value_end > blob.len() {
+      // No-RAF `Bad offset for $dir $tagStr` (`Exif.pm:6660-6661`) — the
+      // in-memory MakerNote has no RAF, so an out-of-line value past the buffer
+      // is dropped (`$bad = 1`) and the walk CONTINUES, `++$warnCount` counting
+      // it toward the abort cap (Canon's `CanonEntryClass::BadOffset`, which
+      // `bumps_warn_count`).
+      warn_count = warn_count.saturating_add(1);
+      continue;
+    }
+    // Suspicious-offset gate (`Exif.pm:6537-6549` + the non-verbose skip at
+    // `6673-6677`), which `ProcessExif` runs for MakerNotes (it is OUTSIDE the
+    // `$validate and not $inMakerNotes` block). It applies ONLY to the
+    // out-of-line (`$size > 4`) path — ExifTool's whole suspect block lives
+    // inside `if ($size > 4)` (`:6504`), so an inline value is never suspect.
+    // An entry is SUSPECT when EITHER:
+    //   (a) the RAW stored offset is `< 8` (`:6539`) — it would point into the
+    //       TIFF header. Nikon does NOT set `$$dirInfo{ZeroOffsetOK}` (that
+    //       flag is Samsung-only, `Samsung.pm:1708`; Nikon.pm/MakerNotes.pm
+    //       have none — verified), so the `< 8` test applies unconditionally; OR
+    //   (b) the RESOLVED value range `[value_data_offset, value_data_offset +
+    //       total_size)` OVERLAPS the CURRENT IFD entry table `[ifd_offset,
+    //       dir_end)` (`:6549`, `$valuePtr < $dirEnd and $valuePtr+$size >
+    //       $dirStart`). `dir_end = ifd_offset + 2 + 12*num_entries`
+    //       (`$dirSize`, `:6347`) — the entry table only, NOT the trailing
+    //       4-byte next-IFD pointer.
+    // In the walker's coordinate model the buffer IS ExifTool's `$$dataPt`
+    // (`$dataPos == 0`), so `value_data_offset` equals `$valuePtr` after the
+    // `:6546` `-= $dataPos` (Nikon is not `EntryBased` — `Nikon.pm:14113`), and
+    // `ifd_offset`/`dir_end` are the `$dirStart`/`$dirEnd` it is compared to.
+    // When suspect AND the value is otherwise readable (we are past the
+    // Bad-offset `continue`), ExifTool emits a minor `Suspicious <dir> offset`
+    // warning and `next unless $verbose` — in non-verbose mode (this walker)
+    // it SKIPS the entry, emitting NO tag (oracle `perl exiftool 13.59`: a
+    // type-3 Nikon storing `Quality` as `ASCII[6]` at offset 0 emits ONLY
+    // `[minor] Suspicious MakerNotes offset for Quality` and NO `Nikon:Quality`
+    // — the pre-gate walk wrongly decoded the embedded `MM` header bytes as
+    // Quality). The warning itself stays DROPPED (the engine-wide
+    // makernote-warning-channel gap, consistent with the Bad-format / Bad-offset
+    // / excessive-count paths above); only the TAG-SKIP is reproduced here, so
+    // the emitted TAG set is byte-exact.
+    if let Some(raw_offset) = raw_offset {
+      let suspect_low = raw_offset < 8; // (a) Exif.pm:6539
+      let suspect_overlap = value_data_offset < dir_end && value_end > ifd_offset; // (b) :6549
+      if suspect_low || suspect_overlap {
+        // `if ($et->Warn("Suspicious …")) { ++$warnCount; next unless $verbose }`
+        // (`Exif.pm:6675-6677`) — counts toward the abort cap (Canon's
+        // `CanonEntryClass::Suspicious`, which `bumps_warn_count`).
+        warn_count = warn_count.saturating_add(1);
+        continue; // `next unless $verbose` (Exif.pm:6677) — skip, keep walking.
+      }
+    }
+    // SINGLE production-table lookup (against the layout-selected `table` —
+    // `%Nikon::Type2` for the type-2 layout, `%Nikon::Main` otherwise),
+    // reused for BOTH the per-tag `Format` override below AND the unknown-tag
+    // skip after the excessive-count gate. `parse_in_tiff` (`mod.rs`) drops
+    // any entry whose `table.lookup(tag_id)` is `None` — an UNKNOWN tag emits
+    // NOTHING (ExifTool extracts no Unknown tag without the `-u` option; oracle
+    // `perl exiftool 13.59`: a Nikon MakerNote whose only entry is an unknown
+    // id emits no `Nikon:*` tag in default mode, only `Nikon 0x….` under `-u`).
+    let tag_def = table.lookup(tag_id);
+    // Determine the `$readFormat` (`Exif.pm:6730-6733`): the tag's explicit
+    // `Format` directive, ELSE — for a SubDirectory tag that is NOT a `SubIFD`
+    // and has NO explicit `Format` — the IMPLICIT `'undef'`:
+    //   `$readFormat = 'undef' if $subdir and not $$tagInfo{SubIFD} and not
+    //    $readFormat;`   (`Exif.pm:6733`)
+    // "unless otherwise specified, all SubDirectory data except EXIF SubIFD
+    // offsets should be unformatted". A binary-block sub-table (AFInfo 0x0088,
+    // ColorBalance 0x0097, …) is read as `undef` so the WHOLE block reaches the
+    // child `ProcessBinaryData` walker; a `SubIFD` pointer (PreviewIFD 0x0011,
+    // NikonScanIFD 0x0e10 — `Flags => 'SubIFD'`, `Start => '$val'`) keeps its
+    // INTEGER on-disk format because its value is an IFD OFFSET, not a block.
+    // This MUST precede both the `Format`-override read AND the excessive-count
+    // guard (`Exif.pm:6733` runs before `:6763`): `undef` is one of the
+    // excessive-count exemptions (`$formatStr !~ /^(undef|string|binary)$/`,
+    // `:6763`), so a binary sub-table declared with a huge numeric count is NOT
+    // excessive-count-skipped — it is read as `undef` and its children still
+    // emit. Oracle (`perl exiftool 13.59`, an AFInfo 0x0088 as `int32u` count
+    // 100001 in-bounds): verbose `int32u[100001] read as undef[400004]` → the
+    // AFInfo BinaryData directory is processed (AFAreaMode/AFPoint/… emitted),
+    // whereas a non-SubDirectory `int32u` count 100001 (e.g. ContrastCurve
+    // 0x008c) yields `[Minor] Ignoring MakerNotes ContrastCurve with excessive
+    // count` and is dropped — the guard still fires for non-`undef` tags.
+    //
+    // NEUTRAL for real files: a REAL AFInfo/ColorBalance has a small count and
+    // its on-disk format is already `undef`/`int8u`-ish, so forcing `undef`
+    // produces the SAME `value_offset`/`value_size` block the child walker
+    // reads (the block bytes are byte-identical) — the override only changes
+    // the (here unused) leaf decode, never the sub-table dispatch. The
+    // `value_offset`/`value_size` recorded on the `NikonEntry` come from the
+    // ON-DISK `format`/`count` (computed above), independent of `read_format`,
+    // so the child block is unchanged.
+    let implicit_undef =
+      tag_def.is_some_and(|t| t.format().is_none() && t.sub_table().is_some() && !t.is_sub_ifd());
+    let table_override = match tag_def.and_then(NikonTag::format) {
+      ovr @ Some(_) => ovr,
+      // `$readFormat = 'undef'` (`Exif.pm:6733`): no `Count`, so the read count
+      // is the recomputed `int(size/1)` per `resolve_read_format`.
+      None if implicit_undef => Some(FormatOverride::new(Format::Undef, None)),
+      None => None,
+    };
+    let (read_format, read_count) = resolve_read_format(format, count, table_override);
+    // Excessive-count guard (`if ($count > 100000 and $formatStr !~
+    // /^(undef|string|binary)$/) { … next }`, `Exif.pm:6763-6770`): a numeric
+    // array with more than 100000 elements is SKIPPED (no decode, no
+    // allocation) rather than reformatted — ExifTool's "limit maximum length
+    // of data to reformat (avoids long delays … corrupted files)". Applied to
+    // the POST-`Format`-override `read_format`/`read_count` (Exif.pm:6763 runs
+    // after the 6729-6744 override), exactly like the shared EXIF walker. The
+    // `$formatStr !~ /^(undef|string|binary)$/` exclusion is `!matches!(_,
+    // Undef | Ascii)`: `string` == `Ascii`, `undef` == `Undef`, and `binary`
+    // is a synthetic ExifTool format never produced on this on-disk decode
+    // path (a `string`/`undef` huge count is instead shortened to the buffer
+    // by `read_value`). The `TransferFunction`/196608 carve-out (Exif.pm:6764)
+    // cannot apply — no Nikon tag is named `TransferFunction`. ExifTool then
+    // `next`s (the value is never decoded), so a crafted Nikon MakerNote with
+    // an in-bounds numeric entry of huge count emits NO tag from it while a
+    // valid LATER entry still walks. Oracle (`perl exiftool 13.59`, a Nikon
+    // `LensType` int32u count 100001 in-bounds): `[Minor] Ignoring MakerNotes
+    // LensType with excessive count` + the bad entry dropped, the good one kept.
+    if read_count > 100_000 && !matches!(read_format, Format::Undef | Format::Ascii) {
+      continue; // `next` (Exif.pm:6768) — skip the entry, keep walking the IFD.
+    }
+    // UNKNOWN-TAG VALUE SKIP — placed AFTER every gate that affects skip/abort/
+    // `warn_count` (`Bad format`, `Invalid size`, `Bad offset`, the suspicious
+    // offset<8 / table-overlap gates AND their `++$warnCount`, and the
+    // excessive-count `next`), so each STILL runs for an unknown entry and the
+    // `warn_count > 10` abort stays byte-exact; only the VALUE DECODE is
+    // skipped. An unknown tag id (`table.lookup` is `None`) is dropped by
+    // `parse_in_tiff` regardless, so this changes NO emitted tag — it only
+    // avoids cloning the (possibly large, in-bounds) value into a `RawValue`
+    // that would then be discarded. CLOSES a memory-amplification vector: a
+    // small MakerNote can hold MANY unknown `Ascii`/`Undef` entries (count
+    // <= 100000 is faithfully EXEMPT from the excessive-count skip) ALL
+    // pointing at one in-bounds ~100 KB value; without this skip each entry
+    // would `read_value`-clone that value into `out`, driving N * value_size
+    // heap growth from a sub-MB input even though those tags emit nothing.
+    if tag_def.is_none() {
+      continue; // Unknown tag — emits nothing (no `-u`); skip the value decode.
+    }
+    let Some(raw) = read_value(
+      blob,
+      value_data_offset,
+      read_format,
+      read_count,
+      total_size,
+      order,
+    ) else {
+      continue;
+    };
+    out.push(NikonEntry {
+      tag_id,
+      format,
+      count: read_count,
+      value: raw,
+      value_offset: value_data_offset,
+      value_size: total_size,
+    });
+  }
+  out
+}
+
+/// Resolve the embedded-TIFF header for the type-3 layout. `blob` is the whole
+/// MakerNote blob; the embedded TIFF starts at `tiff_at` (blob offset 10 for
+/// the modern layout). Returns `(byte_order, ifd_offset_in_blob)`.
+///
+/// ## The IFD start is FIXED at `tiff_at + 8`, NOT the embedded IFD0-offset field
+///
+/// `MakerNotes.pm:51-57` gives the type-3 SubDirectory as `Start =>
+/// '$valuePtr + 18'`, `Base => '$start - 8'`, `ByteOrder => 'Unknown'`.
+/// With the embedded TIFF at blob offset 10 (`valuePtr + 10`), `$valuePtr + 18`
+/// is `tiff_at + 8` — a FIXED offset. ExifTool reads the embedded `MM`/`II`
+/// marker to resolve endianness (that is the entire effect of `ByteOrder =>
+/// 'Unknown'`), but it does NOT consult the embedded TIFF header's 4-byte IFD0
+/// offset field to locate the Main IFD: the IFD is ALWAYS walked at the fixed
+/// `$valuePtr + 18`. Every real Nikon fixture happens to store `8` in that
+/// field (so `tiff_at + field == tiff_at + 8`), but a crafted blob whose field
+/// is some other in-bounds value must STILL be walked at `tiff_at + 8` — the
+/// field is ignored. (`Base => '$start - 8'` = `tiff_at` sets the out-of-line
+/// value base, which the caller passes as `value_base = 10`.)
+///
+/// `None` only when the marker is unreadable (no `MM`/`II`) or the fixed IFD
+/// start (plus its 2-byte entry count) does not fit the blob.
+#[must_use]
+pub fn parse_embedded_tiff(blob: &[u8], tiff_at: usize) -> Option<(ByteOrder, usize)> {
+  let header = blob.get(tiff_at..)?;
+  // Bytes 0-1 are the `MM`/`II` byte-order marker — the only thing ExifTool
+  // reads from the embedded header (`ByteOrder => 'Unknown'`). Bytes 2-3 are
+  // the `0x002a` magic and bytes 4-7 the embedded IFD0 offset, both of which
+  // ExifTool IGNORES for the type-3 layout (the IFD start is fixed below).
+  let order = ByteOrder::from_marker(header)?;
+  // The Main IFD always begins at the FIXED `$valuePtr + 18 == tiff_at + 8`
+  // (`MakerNotes.pm:54`), regardless of the embedded IFD0-offset field.
+  let ifd_offset = tiff_at.checked_add(8)?;
+  // Bounds-check the fixed IFD start: its 2-byte entry count must fit the blob
+  // (the walker re-checks the full entry table). A blob too short for even the
+  // entry count has no Main IFD — return `None` (no panic / OOB).
+  if ifd_offset.checked_add(2)? > blob.len() {
+    return None;
+  }
+  Some((order, ifd_offset))
+}
+
+fn read_u16(data: &[u8], pos: usize, order: ByteOrder) -> Option<u16> {
+  let arr: [u8; 2] = data.get(pos..pos + 2)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => u16::from_le_bytes(arr),
+    ByteOrder::Big => u16::from_be_bytes(arr),
+  })
+}
+
+fn read_u32(data: &[u8], pos: usize, order: ByteOrder) -> Option<u32> {
+  let arr: [u8; 4] = data.get(pos..pos + 4)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => u32::from_le_bytes(arr),
+    ByteOrder::Big => u32::from_be_bytes(arr),
+  })
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::super::tags;
+  use super::*;
+
+  /// Build a minimal type-3 Nikon blob: `"Nikon\0\x02\x10\0\0"` + an embedded
+  /// big-endian TIFF (`MM\0\x2a` + IFD0-offset 8) with one IFD entry.
+  fn type3_blob_one_entry(tag: u16, format: u16, count: u32, value: [u8; 4]) -> Vec<u8> {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // 10-byte header
+    // Embedded TIFF at offset 10.
+    b.extend_from_slice(b"MM"); // big-endian
+    b.extend_from_slice(&[0x00, 0x2a]); // magic 0x002a
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]); // IFD0 at embedded-offset 8
+    // IFD0 is at blob offset 10 + 8 = 18 = right here (entry count).
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    b.extend_from_slice(&tag.to_be_bytes());
+    b.extend_from_slice(&format.to_be_bytes());
+    b.extend_from_slice(&count.to_be_bytes());
+    b.extend_from_slice(&value);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+    b
+  }
+
+  /// The embedded-TIFF header parser resolves the order + IFD offset.
+  #[test]
+  fn parse_embedded_tiff_resolves_big_endian() {
+    let blob = type3_blob_one_entry(0x0004, 0x0002, 4, *b"FINE");
+    let (order, ifd_off) = parse_embedded_tiff(&blob, 10).expect("embedded TIFF");
+    assert!(order.is_big());
+    assert_eq!(ifd_off, 18); // 10 + 8
+  }
+
+  /// A type-3 IFD walk decodes an inline value at the correct base.
+  #[test]
+  fn type3_walk_decodes_inline_value() {
+    // Quality = "FINE" (string, count 4, inline).
+    let blob = type3_blob_one_entry(0x0004, 0x0002, 4, *b"FINE");
+    let (order, ifd_off) = parse_embedded_tiff(&blob, 10).unwrap();
+    let entries = walk_nikon_ifd(&blob, ifd_off, order, 10, NikonTable::Main);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].tag_id, 0x0004);
+    match &entries[0].value {
+      RawValue::Text { text, .. } => assert_eq!(text, "FINE"),
+      other => panic!("expected Text, got {other:?}"),
+    }
+  }
+
+  /// An out-of-line value resolves against `value_base` (the embedded TIFF
+  /// start, blob offset 10), NOT the IFD start — the `Base => '$start - 8'`
+  /// rebase.
+  #[test]
+  fn type3_walk_resolves_out_of_line_against_embedded_base() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // header (10)
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]); // IFD0 at embedded+8 = blob 18
+    // IFD0 at blob 18:
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    // Entry: tag 0x0084 (Lens), rational64u, count 4 (32 bytes > 4 ⇒ offset).
+    b.extend_from_slice(&[0x00, 0x84]);
+    b.extend_from_slice(&[0x00, 0x05]); // rational64u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4
+    // Value offset: relative to embedded TIFF base (blob 10). The value will
+    // live at blob offset 40, i.e. embedded-offset 30.
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x1e]); // 30 (embedded-relative)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // Pad to blob offset 40.
+    while b.len() < 40 {
+      b.push(0);
+    }
+    // 4 rationals: 18/1 70/1 35/10 45/10.
+    for (n, d) in [(18u32, 1u32), (70, 1), (35, 10), (45, 10)] {
+      b.extend_from_slice(&n.to_be_bytes());
+      b.extend_from_slice(&d.to_be_bytes());
+    }
+    let (order, ifd_off) = parse_embedded_tiff(&b, 10).unwrap();
+    let entries = walk_nikon_ifd(&b, ifd_off, order, 10, NikonTable::Main);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].tag_id, 0x0084);
+    match &entries[0].value {
+      RawValue::Rational(rs) => {
+        assert_eq!(rs.len(), 4);
+        assert_eq!(rs[0].numerator(), 18);
+        assert_eq!(rs[3].denominator(), 10);
+      }
+      other => panic!("expected Rational, got {other:?}"),
+    }
+  }
+
+  /// DIVERGENCE ORACLE: when the embedded IFD0-offset field is NOT 8 and points
+  /// at a SECOND, valid-looking IFD, ExifTool (`MakerNotes.pm:54`, `Start =>
+  /// '$valuePtr + 18'`) walks ONLY the IFD at the FIXED `tiff_at + 8` — the
+  /// decoy IFD the field points to is never reached. This blob carries a real
+  /// IFD (LensType 0x0083 = 6 → "G") at the fixed start and a decoy IFD
+  /// (Quality 0x0004 = "FAKE") at the field-pointed offset; the walk must emit
+  /// the real LensType and NONE of the decoy's tags.
+  #[test]
+  fn type3_walks_fixed_start_not_field_pointed_decoy() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // header (10)
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    // Embedded IFD0-offset field = 40 (NOT 8): if (wrongly) followed it points
+    // the Main IFD at tiff_at(10) + 40 = blob 50 — the DECOY IFD below.
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x28]);
+    // REAL IFD at the FIXED start = blob 18: LensType (0x0083) int8u = 6 → "G".
+    debug_assert_eq!(b.len(), 18);
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    b.extend_from_slice(&[0x00, 0x83]); // tag LensType
+    b.extend_from_slice(&[0x00, 0x01]); // int8u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // count 1
+    b.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]); // value 6 inline
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // Pad to blob 50, then the DECOY IFD: Quality (0x0004) string[4] = "FAKE".
+    while b.len() < 50 {
+      b.push(0);
+    }
+    debug_assert_eq!(b.len(), 50); // == tiff_at(10) + field(40)
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    b.extend_from_slice(&[0x00, 0x04]); // tag Quality
+    b.extend_from_slice(&[0x00, 0x02]); // string
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4
+    b.extend_from_slice(b"FAKE"); // inline value
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+
+    let (order, ifd_off) = parse_embedded_tiff(&b, 10).expect("embedded TIFF");
+    assert_eq!(
+      ifd_off, 18,
+      "IFD start is the FIXED tiff_at + 8, not field 40"
+    );
+    let entries = walk_nikon_ifd(&b, ifd_off, order, 10, NikonTable::Main);
+    // ONLY the real fixed-start IFD is walked: LensType present, decoy absent.
+    assert_eq!(entries.len(), 1, "only the fixed-start IFD is walked");
+    assert_eq!(entries[0].tag_id, 0x0083);
+    assert_eq!(entries[0].value, RawValue::U64(vec![6]));
+    assert!(
+      entries.iter().all(|e| e.tag_id != 0x0004),
+      "the decoy IFD (field-pointed) Quality tag must NOT be walked"
+    );
+  }
+
+  /// A truncated / implausible blob never panics and yields no entries.
+  #[test]
+  fn malformed_blob_is_bounded() {
+    assert!(walk_nikon_ifd(b"", 0, ByteOrder::Big, 0, NikonTable::Main).is_empty());
+    assert!(walk_nikon_ifd(b"Nikon\x00\x02", 18, ByteOrder::Big, 10, NikonTable::Main).is_empty());
+    // An entry count (0xffff = 65535) whose 12-byte entry table OVERRUNS the
+    // 6-byte buffer is rejected by the `dir_end > blob.len()` bound
+    // (`Exif.pm:6394`) — NOT by any count ceiling (there is none). No panic.
+    let blob = [0xff_u8, 0xff, 0, 0, 0, 0];
+    assert!(walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main).is_empty());
+    // parse_embedded_tiff on a non-marker header → None.
+    assert!(parse_embedded_tiff(b"\x00\x00\x00\x00\x00\x00\x00\x00", 0).is_none());
+  }
+
+  /// A headerless Nikon IFD with MORE than 1024 valid entries whose table FITS
+  /// the buffer is walked in FULL — `ProcessExif` (`Exif.pm:6343-6400`) imposes
+  /// no entry-count ceiling, only `$dirEnd <= $dataLen`. Guards against
+  /// re-introducing a non-ExifTool `num_entries > 1024` reject that would
+  /// TRUNCATE a valid large IFD. Mirrors the Canon walker's
+  /// `large_in_bounds_count_is_walked`; oracle: bundled walks a 2000-entry
+  /// in-bounds IFD with no warning.
+  #[test]
+  fn over_1024_entries_in_bounds_all_walked() {
+    let n: usize = 1500; // > 1024 — the former cap would have truncated to none
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&(n as u16).to_be_bytes());
+    for _ in 0..n {
+      // Each entry: KNOWN LensType (0x0083), int8u (1), count 1, inline value 6.
+      // A KNOWN id is required so the walk-completeness signal survives the
+      // unknown-tag value skip — every walked KNOWN entry pushes to `out`, so
+      // `out.len() == n` proves the loop reached all `n` entries (no ceiling).
+      // Duplicate ids are walked independently here (engine dedups later).
+      b.extend_from_slice(&[0x00, 0x83]); // LensType (known)
+      b.extend_from_slice(&[0x00, 0x01]); // int8u
+      b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // count 1
+      b.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]); // value 6 inline
+    }
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(
+      entries.len(),
+      n,
+      "a >1024-entry in-bounds Nikon IFD must be fully walked (no count ceiling)"
+    );
+  }
+
+  /// The embedded IFD0-offset field is IGNORED: the Main IFD is ALWAYS resolved
+  /// at the FIXED `tiff_at + 8` (`$valuePtr + 18`, `MakerNotes.pm:54`), NOT at
+  /// `tiff_at + field`. A non-8 in-bounds field that points at a DIFFERENT
+  /// valid-looking IFD must NOT move the walk — `parse_embedded_tiff` still
+  /// returns `tiff_at + 8`, so only that IFD is read and the decoy IFD the
+  /// field points to is never reached. (`ByteOrder => 'Unknown'` means ONLY
+  /// the `MM`/`II` marker is read from the embedded header; the offset field is
+  /// not consulted.)
+  #[test]
+  fn type3_embedded_ifd0_offset_field_is_ignored_fixed_start() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // 10-byte header
+    b.extend_from_slice(b"MM"); // big-endian embedded TIFF
+    b.extend_from_slice(&[0x00, 0x2a]); // magic 0x002a
+    // Embedded IFD0-offset field = 64 (NOT 8) — a value that, if (wrongly)
+    // followed, would walk the Main IFD at tiff_at(10) + 64 = blob 74.
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x40]);
+    // Pad out so a 64-byte-offset target would be in bounds (proving rejection
+    // is by the FIXED-start contract, not by the field running out of bounds).
+    while b.len() < 100 {
+      b.push(0);
+    }
+    let (order, ifd_off) = parse_embedded_tiff(&b, 10).expect("embedded TIFF");
+    assert!(order.is_big(), "byte order read from the MM marker");
+    assert_eq!(
+      ifd_off, 18,
+      "IFD start is the FIXED tiff_at + 8 (=18), ignoring the embedded field (64)"
+    );
+
+    // A blob too short to even hold the 2-byte entry count at the fixed start
+    // is rejected (`None`) — no panic, no OOB.
+    let short = b"Nikon\x00\x02\x10\x00\x00MM\x00\x2a\x00\x00\x00\x40"; // 18 bytes, IFD start = 18 == len
+    assert!(
+      parse_embedded_tiff(short, 10).is_none(),
+      "a blob too short for the entry count at the fixed IFD start yields None"
+    );
+  }
+
+  /// The directory entry table is bounded to the BUFFER length (ExifTool's
+  /// `$dirEnd > $dataLen` bound, `Exif.pm:6394`), not to a shorter declared
+  /// MakerNote length: an entry table that fits the buffer is walked in full
+  /// (matching ExifTool — for an in-place MakerNote `DataLen` is the parent
+  /// EXIF buffer, larger than the declared `DirLen`); an entry count that runs
+  /// PAST the buffer is rejected wholesale (no panic, no partial read).
+  #[test]
+  fn directory_table_bounded_to_buffer() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&[0x00, 0x02]); // 2 entries
+    // Entry 0: LensType 0x0083 int8u = 6 → "G".
+    b.extend_from_slice(&[0x00, 0x83]);
+    b.extend_from_slice(&[0x00, 0x01]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+    b.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]);
+    // Entry 1: Quality 0x0004 string[4] "FINE".
+    b.extend_from_slice(&[0x00, 0x04]);
+    b.extend_from_slice(&[0x00, 0x02]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]);
+    b.extend_from_slice(b"FINE");
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // Both entries fit the buffer ⇒ both decode (ExifTool reads up to DataLen).
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].tag_id, 0x0083);
+    assert_eq!(entries[1].tag_id, 0x0004);
+
+    // An entry count that runs PAST the buffer end is rejected wholesale.
+    let mut over: Vec<u8> = Vec::new();
+    over.extend_from_slice(&[0x00, 0x05]); // claims 5 entries (60 bytes) …
+    over.extend_from_slice(&[0x00, 0x83, 0x00, 0x01, 0, 0, 0, 1, 6, 0, 0, 0]); // … but only 1 present
+    assert!(walk_nikon_ifd(&over, 0, ByteOrder::Big, 0, NikonTable::Main).is_empty());
+  }
+
+  /// An out-of-line value whose START is in-bounds but whose FULL length runs
+  /// past EOF is REJECTED (skipped), not truncated to a partial tail — matching
+  /// ExifTool's `$valuePtr + $size > $dataLen` drop (`$bad = 1`, no emission,
+  /// `Exif.pm:6663`; verified: ExifTool emits only a `[minor] Bad offset`
+  /// warning and NO Lens tag), not a `total_size.min(avail)` partial read.
+  #[test]
+  fn out_of_line_value_past_eof_is_rejected_not_truncated() {
+    let mut b: Vec<u8> = Vec::new();
+    // Headerless IFD, 1 entry: Lens (0x0084) rational64u[4] = 32 bytes, stored
+    // out-of-line at offset 18, but the buffer is truncated mid-value.
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    b.extend_from_slice(&[0x00, 0x84]); // tag 0x0084
+    b.extend_from_slice(&[0x00, 0x05]); // rational64u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4 (32 bytes > 4)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x12]); // value offset 18
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // Value region begins at offset 18 but we only supply 8 of the 32 bytes.
+    while b.len() < 18 {
+      b.push(0);
+    }
+    b.extend_from_slice(&[0, 0, 0, 18, 0, 0, 0, 1]); // 8 bytes (one rational)
+    // 18 (start) + 32 (full size) > buffer ⇒ the entry is dropped, not read as
+    // a partial 1-rational tail.
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      entries.is_empty(),
+      "a value running past EOF must be rejected, not truncated to a tail"
+    );
+  }
+
+  /// SUSPICIOUS OFFSET, case (a) — RAW stored offset `< 8` (`Exif.pm:6539`,
+  /// Nikon has no `ZeroOffsetOK`): a type-3 Nikon whose `Quality` (0x0004) is
+  /// stored OUT-OF-LINE as `ASCII[6]` at offset 0 (which would resolve to the
+  /// embedded-TIFF base, blob offset 10, and decode the `MM\0\x2a\0\0` header
+  /// bytes) is SKIPPED — no `Nikon:Quality` entry, no header bytes decoded.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59` on the equivalent crafted
+  /// JPEG (`IFD0` Make=`NIKON CORPORATION` + a type-3 MakerNote whose only
+  /// entry is this offset-0 `Quality`): the oracle emits ONLY `[minor]
+  /// Suspicious MakerNotes offset for Quality` and NO `Nikon:Quality` — whereas
+  /// the pre-gate walk wrongly surfaced `Nikon:Quality = "MM"` (the byte-order
+  /// marker). The minor warning itself stays dropped (the engine-wide
+  /// makernote-warning-channel gap); only the tag-skip is reproduced here.
+  #[test]
+  fn type3_out_of_line_offset_below_8_skipped() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // 10-byte header
+    b.extend_from_slice(b"MM"); // big-endian embedded TIFF
+    b.extend_from_slice(&[0x00, 0x2a]); // magic
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]); // IFD0 at embedded+8 = blob 18
+    // IFD at blob 18: Quality (0x0004) ASCII count 6 ⇒ 6 bytes > 4 ⇒ out-of-line.
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    b.extend_from_slice(&[0x00, 0x04]); // tag Quality
+    b.extend_from_slice(&[0x00, 0x02]); // ASCII
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x06]); // count 6
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // stored offset 0 (< 8!)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // The resolved target (value_base 10 + 0 = blob 10) IS in bounds — so this
+    // is the IN-BOUNDS-but-suspicious case, NOT the Bad-offset case.
+    let (order, ifd_off) = parse_embedded_tiff(&b, 10).expect("embedded TIFF");
+    let entries = walk_nikon_ifd(&b, ifd_off, order, 10, NikonTable::Main);
+    assert!(
+      entries.iter().all(|e| e.tag_id != 0x0004),
+      "an out-of-line value at stored offset 0 (< 8) is suspicious ⇒ skipped"
+    );
+    assert!(
+      entries.is_empty(),
+      "the offset-0 Quality is the only entry; nothing is decoded"
+    );
+  }
+
+  /// SUSPICIOUS OFFSET, case (b) — the resolved value range OVERLAPS the
+  /// current IFD entry table `[ifd_offset, dir_end)` (`Exif.pm:6549`,
+  /// `$valuePtr < $dirEnd and $valuePtr+$size > $dirStart`). A headerless IFD
+  /// (value_base 0, ifd_offset 0, `dir_end = 2 + 12*num_entries`) with an
+  /// out-of-line value at a stored offset `>= 8` (so case (a) does NOT fire)
+  /// whose range lands INSIDE the entry table is SKIPPED — no tag.
+  #[test]
+  fn nikon_value_overlapping_ifd_table_skipped() {
+    // 2 entries ⇒ dir_end = 2 + 24 = 26. Entry 0 is out-of-line at offset 14
+    // (>= 8, so NOT case (a)) of size 8 ⇒ range [14, 22) ⊂ [0, 26) ⇒ overlaps
+    // the entry table (case (b)). The buffer is laid long enough that the value
+    // region is in-bounds (so this is suspicious, not Bad-offset).
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&[0x00, 0x02]); // 2 entries ⇒ dir_end = 26
+    // Entry 0: Lens (0x0084) rational64u count 1 = 8 bytes (> 4 ⇒ out-of-line).
+    b.extend_from_slice(&[0x00, 0x84]);
+    b.extend_from_slice(&[0x00, 0x05]); // rational64u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // count 1 (8 bytes)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x0e]); // stored offset 14 (>= 8)
+    // Entry 1: LensType (0x0083) int8u count 1 = 6 → "G" (inline, valid, NOT
+    // out-of-line ⇒ never suspicious — proves only the overlapping entry drops).
+    b.extend_from_slice(&[0x00, 0x83]);
+    b.extend_from_slice(&[0x00, 0x01]); // int8u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // count 1
+    b.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]); // value 6 inline
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD (blob 26..30)
+    // Pad past offset 22 so [14,22) is fully in-bounds (in-bounds-but-suspect).
+    while b.len() < 32 {
+      b.push(0);
+    }
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      entries.iter().all(|e| e.tag_id != 0x0084),
+      "an out-of-line value overlapping the IFD entry table is suspicious ⇒ skipped"
+    );
+    // The inline LensType (never out-of-line, never suspect) still emits.
+    assert_eq!(
+      entries.len(),
+      1,
+      "only the suspicious out-of-line entry drops"
+    );
+    assert_eq!(entries[0].tag_id, 0x0083);
+    assert_eq!(entries[0].value, RawValue::U64(vec![6]));
+  }
+
+  /// REGRESSION GUARD against OVER-SKIP — a LEGITIMATE out-of-line value at a
+  /// stored offset `>= 8` that does NOT overlap the IFD entry table is STILL
+  /// emitted (neither suspicious case fires). This mirrors every real Nikon
+  /// out-of-line tag (LensData/ColorBalance/ShotInfo/Lens at offsets `>> 8`
+  /// well past the entry table), which the gate must NOT touch.
+  #[test]
+  fn nikon_legitimate_out_of_line_value_still_emitted() {
+    // Headerless IFD, 1 entry ⇒ dir_end = 2 + 12 = 14; next-IFD at [14,18).
+    // Lens (0x0084) rational64u[4] = 32 bytes out-of-line at offset 18 — `>= 8`
+    // (not case (a)) and range [18, 50) ∩ [0, 14) = ∅ (not case (b)).
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry ⇒ dir_end = 14
+    b.extend_from_slice(&[0x00, 0x84]); // tag Lens
+    b.extend_from_slice(&[0x00, 0x05]); // rational64u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4 (32 bytes)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x12]); // stored offset 18 (>= 8, past table)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD (blob 14..18)
+    // 4 rationals at offset 18: 18/1 70/1 35/10 45/10 (the D70 18-70mm lens).
+    debug_assert_eq!(b.len(), 18);
+    for (n, d) in [(18u32, 1u32), (70, 1), (35, 10), (45, 10)] {
+      b.extend_from_slice(&n.to_be_bytes());
+      b.extend_from_slice(&d.to_be_bytes());
+    }
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(
+      entries.len(),
+      1,
+      "a legitimate out-of-line value (offset >= 8, no table overlap) still emits"
+    );
+    assert_eq!(entries[0].tag_id, 0x0084);
+    match &entries[0].value {
+      RawValue::Rational(rs) => {
+        assert_eq!(rs.len(), 4);
+        assert_eq!(rs[0].numerator(), 18);
+        assert_eq!(rs[3].denominator(), 10);
+      }
+      other => panic!("expected Rational, got {other:?}"),
+    }
+  }
+
+  /// The `signed_fraction_c3` ValueConv: `a*(b/c)` over the first 3 SIGNED
+  /// bytes; `c == 0` → 0.
+  #[test]
+  fn signed_fraction_c3_value_conv() {
+    // (-3, 1, 6) → -3*(1/6) = -0.5.
+    let v = ParsedValue::new(RawValue::Bytes(vec![0xfd, 0x01, 0x06, 0x00]));
+    assert!((v.signed_fraction_c3().unwrap() - (-0.5)).abs() < 1e-9);
+    // c == 0 → 0.
+    let v0 = ParsedValue::new(RawValue::Bytes(vec![0x05, 0x01, 0x00, 0x00]));
+    assert_eq!(v0.signed_fraction_c3(), Some(0.0));
+  }
+
+  /// The excessive-count + invalid-size guards (`Exif.pm:6505-6509` /
+  /// `6763-6770`) skip a hostile numeric entry BEFORE `read_value` — no large
+  /// `Vec` is allocated, no `NikonEntry` is produced for the bad entry — while
+  /// a valid LATER entry in the SAME IFD is still walked (a per-entry `next`,
+  /// not a directory abort).
+  ///
+  /// Ground-truthed against `perl exiftool 13.59` on the equivalent crafted
+  /// TIFF (a headerless Nikon MakerNote whose first `LensType` (0x0083) is an
+  /// in-bounds `int32u` of count 100001, followed by a valid `int8u` LensType
+  /// = 6): the oracle emits `[Minor] Ignoring MakerNotes LensType with
+  /// excessive count` and drops the bad entry, surfacing only the good
+  /// `Nikon:LensType = "G"`. The directory is NOT dropped.
+  #[test]
+  fn nikon_excessive_count_numeric_entry_skipped() {
+    // -- Excessive count (count > 100000, in-bounds): the value region is
+    //    fully present so ExifTool's EOF check (Exif.pm:6552) passes and the
+    //    excessive-count guard (Exif.pm:6763), not `Error reading value`, is
+    //    the deciding test — exactly as the oracle shows.
+    let count: u32 = 100_001; // *4 = 400004 bytes (> 100000, < 0x7fffffff)
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&[0x00, 0x02]); // 2 entries
+    // Entry 0: LensType (0x0083) int32u, huge count, OUT-OF-LINE at offset 30.
+    let dir_end: u32 = 2 + 12 * 2 + 4; // 30 — value region starts right after.
+    b.extend_from_slice(&[0x00, 0x83]);
+    b.extend_from_slice(&[0x00, 0x04]); // int32u
+    b.extend_from_slice(&count.to_be_bytes());
+    b.extend_from_slice(&dir_end.to_be_bytes()); // value offset 30
+    // Entry 1: LensType (0x0083) int8u count 1 = 6 → "G" (inline, valid).
+    b.extend_from_slice(&[0x00, 0x83]);
+    b.extend_from_slice(&[0x00, 0x01]); // int8u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // count 1
+    b.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]); // value 6 (inline)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    debug_assert_eq!(b.len() as u32, dir_end);
+    // Lay the FULL 400004-byte value region in-bounds (so the EOF check passes;
+    // the entry is dropped by the excessive-count guard, never decoded).
+    b.resize(dir_end as usize + (count as usize) * 4, 0);
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    // The huge entry is skipped (no 100001-element Vec); only the valid small
+    // entry survives — and it is the int8u LensType = 6.
+    assert_eq!(
+      entries.len(),
+      1,
+      "the excessive-count entry must be skipped, the valid entry kept"
+    );
+    assert_eq!(entries[0].tag_id, 0x0083);
+    assert_eq!(entries[0].count, 1);
+    assert_eq!(entries[0].value, RawValue::U64(vec![6]));
+
+    // -- Invalid size (count * formatSize > 0x7fffffff): rejected BEFORE the
+    //    offset is even read (Exif.pm:6505). A valid LATER entry still walks.
+    let huge: u32 = 0x4000_0000; // *4 = 0x1_0000_0000 > 0x7fffffff
+    let mut z: Vec<u8> = Vec::new();
+    z.extend_from_slice(&[0x00, 0x02]); // 2 entries
+    // Entry 0: Lens (0x0084) int32u, count 0x40000000 ⇒ size > 0x7fffffff.
+    z.extend_from_slice(&[0x00, 0x84]);
+    z.extend_from_slice(&[0x00, 0x04]); // int32u
+    z.extend_from_slice(&huge.to_be_bytes());
+    z.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // offset bytes (never read)
+    // Entry 1: LensType (0x0083) int8u count 1 = 6 → "G" (inline, valid).
+    z.extend_from_slice(&[0x00, 0x83]);
+    z.extend_from_slice(&[0x00, 0x01]);
+    z.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+    z.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]);
+    z.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    let entries = walk_nikon_ifd(&z, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(
+      entries.len(),
+      1,
+      "the invalid-size entry must be skipped, the valid entry kept"
+    );
+    assert_eq!(entries[0].tag_id, 0x0083);
+    assert_eq!(entries[0].value, RawValue::U64(vec![6]));
+  }
+
+  /// IMPLICIT-`undef` SubDirectory override (`Exif.pm:6733`): a BINARY-block
+  /// sub-table (AFInfo 0x0088) declared with a huge numeric on-disk format
+  /// (`int32u` count > 100000) is read as `undef` and so is EXEMPT from the
+  /// excessive-count guard (`:6763` `$formatStr !~ /^(undef|string|binary)$/`)
+  /// — its `NikonEntry` IS produced (whole block preserved for the child
+  /// walker), unlike a non-SubDirectory numeric entry of the same count, which
+  /// IS excessive-count-skipped (the contrast already proven by
+  /// `nikon_excessive_count_numeric_entry_skipped`; re-asserted here so the two
+  /// sit side by side). Ground-truthed against `perl exiftool 13.59`: an AFInfo
+  /// 0x0088 as `int32u[100001]` in-bounds → verbose `int32u[100001] read as
+  /// undef[400004]` and the AFInfo BinaryData children are emitted, whereas a
+  /// non-SubDirectory `int32u[100001]` (ContrastCurve 0x008c) yields `[Minor]
+  /// Ignoring MakerNotes ContrastCurve with excessive count` and is dropped.
+  #[test]
+  fn nikon_subdir_high_count_read_as_undef_not_skipped() {
+    let count: u32 = 100_001; // *4 = 400004 bytes (> 100000, < 0x7fffffff)
+    // AFInfo (0x0088, a BINARY sub-table, NOT a SubIFD, no explicit Format) as
+    // int32u with the huge count, OUT-OF-LINE; a valid LensType sentinel after.
+    let af = entry_offset(0x0088, 4, count, 2 + 12 * 2 + 4);
+    let lens = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]); // int8u = 6
+    let mut b = headerless_ifd(&[af, lens]);
+    // Lay the full 400004-byte value region in-bounds (EOF check at :6552 passes;
+    // the deciding test is then the undef carve-out at :6763).
+    b.resize(b.len() + (count as usize) * 4, 0);
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    // BOTH survive: AFInfo is read as `undef` (NOT skipped) + the LensType.
+    assert_eq!(
+      entries.len(),
+      2,
+      "an undef-overridden SubDirectory is EXEMPT from the excessive-count skip"
+    );
+    let af_entry = entries
+      .iter()
+      .find(|e| e.tag_id == 0x0088)
+      .expect("AFInfo entry must be produced (read as undef, not skipped)");
+    // Read as `undef`: count recomputed to the on-disk byte size (400004) and
+    // the value is the raw block (`Bytes`), exactly ExifTool's `undef[400004]`.
+    assert_eq!(af_entry.count, count as usize * 4);
+    assert!(
+      matches!(af_entry.value, RawValue::Bytes(_)),
+      "an undef-read SubDirectory value is the raw byte block"
+    );
+    assert!(entries.iter().any(|e| e.tag_id == 0x0083));
+
+    // CONTRAST: the SAME huge count on a NON-SubDirectory numeric tag
+    // (ContrastCurve 0x008c — a leaf, no sub-table) IS excessive-count-skipped;
+    // only the LensType sentinel survives. (The guard still fires for non-undef.)
+    let cc = entry_offset(0x008c, 4, count, 2 + 12 * 2 + 4);
+    let lens2 = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]);
+    let mut z = headerless_ifd(&[cc, lens2]);
+    z.resize(z.len() + (count as usize) * 4, 0);
+    let zentries = walk_nikon_ifd(&z, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(
+      zentries.len(),
+      1,
+      "a non-SubDirectory numeric entry of huge count is still excessive-count-skipped"
+    );
+    assert_eq!(zentries[0].tag_id, 0x0083);
+  }
+
+  /// A `SubIFD` pointer (PreviewIFD 0x0011, NikonScanIFD 0x0e10 —
+  /// `Flags => 'SubIFD'`, `Start => '$val'`) is EXCLUDED from the
+  /// implicit-`undef` override (`Exif.pm:6733` `not $$tagInfo{SubIFD}`): its
+  /// value is an IFD OFFSET read with an INTEGER format. A PreviewIFD whose
+  /// declared on-disk format were a huge numeric count WOULD therefore stay
+  /// non-`undef` and be excessive-count-skipped — but a REAL PreviewIFD is a
+  /// 4-byte `int32u[1]` offset (oracle `int32u[1]`), so its value reads as the
+  /// integer offset, NOT a raw block. Here the int32u[1] offset value is
+  /// decoded as a `U64`, proving the undef override did not fire for it.
+  #[test]
+  fn nikon_sub_ifd_pointer_excluded_from_undef_override() {
+    // Both Main SubIFD tags carry the flag; no other sub-table does.
+    assert!(tags::lookup(0x0011).unwrap().is_sub_ifd());
+    assert!(tags::lookup(0x0e10).unwrap().is_sub_ifd());
+    assert!(!tags::lookup(0x0088).unwrap().is_sub_ifd()); // AFInfo — binary block
+    assert!(!tags::lookup(0x0097).unwrap().is_sub_ifd()); // ColorBalance — binary
+    // PreviewIFD as a real int32u[1] offset (value 0x40) — read as the integer,
+    // NOT forced to undef (which would yield a `Bytes` block instead).
+    let preview = entry_inline(0x0011, 4, 1, [0x00, 0x00, 0x00, 0x40]);
+    let b = headerless_ifd(&[preview]);
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].tag_id, 0x0011);
+    assert_eq!(
+      entries[0].value,
+      RawValue::U64(vec![0x40]),
+      "a SubIFD offset is read with its integer format, NOT the undef override"
+    );
+  }
+
+  /// UNKNOWN-TAG VALUE SKIP closes a MEMORY-AMPLIFICATION vector: a SMALL
+  /// MakerNote with MANY unknown `Ascii`/`Undef` entries (count <= 100000 is
+  /// faithfully EXEMPT from the excessive-count skip) ALL pointing at ONE
+  /// in-bounds large value would, without the skip, `read_value`-clone that
+  /// value into a `NikonEntry` for EACH entry — `N * value_size` heap from a
+  /// sub-MB input — even though `parse_in_tiff` drops every one (unknown id ⇒
+  /// emits nothing, no `-u`). With the skip the unknown entries decode no
+  /// value, so the walk completes with ZERO entries. Here N = 300 unknown
+  /// `ASCII[64KB]` entries share one 64 KB value: a pre-fix walk would
+  /// allocate 300 * 64 KB ≈ 19 MB of `RawValue`s from a ~64 KB input; the fix
+  /// allocates none.
+  #[test]
+  fn nikon_unknown_tags_not_allocated() {
+    const N: u16 = 300; // many unknown entries …
+    const VAL: usize = 64 * 1024; // … all pointing at ONE 64 KB value
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&N.to_be_bytes()); // headerless IFD, N entries
+    // dir_end = 2 + 12*N; next-IFD at [dir_end, dir_end+4); the shared 64 KB
+    // value lives just past the next-IFD pointer, fully in-bounds.
+    let dir_end = 2 + 12 * (N as usize);
+    let value_off = dir_end + 4;
+    for i in 0..N {
+      // tag id in the 0x00f0.. range (NONE are in `Nikon::Main` ⇒ all unknown),
+      // ASCII count 64 KB > 4 ⇒ out-of-line at `value_off` (>= 8, well past the
+      // entry table ⇒ NOT suspicious), pointing at the SAME shared value.
+      let tag = 0x00f0u16.wrapping_add(i);
+      b.extend_from_slice(&tag.to_be_bytes());
+      b.extend_from_slice(&[0x00, 0x02]); // ASCII (string) — EXEMPT from the count skip
+      b.extend_from_slice(&(VAL as u32).to_be_bytes()); // count 64 KB
+      b.extend_from_slice(&(value_off as u32).to_be_bytes()); // shared offset
+    }
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+    debug_assert_eq!(b.len(), value_off);
+    b.resize(value_off + VAL, 0x41); // one shared in-bounds 64 KB value
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    // Every entry is an UNKNOWN tag id ⇒ value decode skipped ⇒ no `NikonEntry`
+    // (pre-fix this Vec held N clones of the 64 KB value). The emitted tag set
+    // is UNCHANGED: `parse_in_tiff` would have dropped all N unknown ids anyway.
+    assert!(
+      entries.is_empty(),
+      "unknown tags allocate no value (memory-amplification vector closed)"
+    );
+  }
+
+  /// The unknown-tag VALUE skip is placed AFTER the `warn_count`-bumping gates,
+  /// so UNKNOWN entries still bump `warn_count` and the `> 10` abort
+  /// (`Exif.pm:6455`) fires exactly as for known entries. Here 11 UNKNOWN
+  /// out-of-line entries each at stored offset 0 (`< 8` ⇒ suspicious,
+  /// `++$warnCount`) precede a VALID KNOWN inline `LensType` — the abort fires
+  /// at the top of the 12th iteration (before the lookup-skip even runs for the
+  /// suspicious entries, which are skipped earlier), so the late LensType is
+  /// ABSENT. Proves the gates precede the unknown-skip (the R8 ordering).
+  #[test]
+  fn nikon_unknown_entries_still_bump_warncount() {
+    let mut entries: Vec<Vec<u8>> = Vec::new();
+    // 11 UNKNOWN (0x00f0..) out-of-line entries at offset 0 (< 8 ⇒ suspicious,
+    // counted). rational64u count 1 = 8 bytes > 4 ⇒ out-of-line.
+    for i in 0..11u16 {
+      entries.push(entry_offset(0x00f0 + i, 5, 1, 0));
+    }
+    // 12th: a VALID KNOWN inline LensType (would emit "G" if reached).
+    entries.push(entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]));
+    let blob = headerless_ifd(&entries);
+    let out = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      out.iter().all(|e| e.tag_id != 0x0083),
+      "unknown entries still bump warn_count ⇒ the >10 abort drops the late KNOWN LensType"
+    );
+    assert!(
+      out.is_empty(),
+      "the 11 suspicious unknown entries are skipped before the abort ⇒ nothing emitted"
+    );
+  }
+
+  /// A 12-byte IFD entry with an inline 4-byte value (helper for the
+  /// bad-format tests).
+  fn entry_inline(tag: u16, format: u16, count: u32, value: [u8; 4]) -> Vec<u8> {
+    let mut e: Vec<u8> = Vec::new();
+    e.extend_from_slice(&tag.to_be_bytes());
+    e.extend_from_slice(&format.to_be_bytes());
+    e.extend_from_slice(&count.to_be_bytes());
+    e.extend_from_slice(&value);
+    e
+  }
+
+  /// A headerless big-endian Nikon IFD: `numEntries` + the 12-byte entries +
+  /// a `0` next-IFD pointer.
+  fn headerless_ifd(entries: &[Vec<u8>]) -> Vec<u8> {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&(entries.len() as u16).to_be_bytes());
+    for e in entries {
+      b.extend_from_slice(e);
+    }
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+    b
+  }
+
+  /// `ProcessExif` ABORTS the directory when ENTRY 0 carries a bad format code
+  /// (`Exif.pm:6475` `return 0` — "assume corrupted IFD if this is our first
+  /// entry"): a Nikon MakerNote whose entry 0 has format 99 (invalid) followed
+  /// by a VALID `LensType` emits NOTHING from the directory — the later
+  /// `LensType` is dropped with the bad entry.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59` on the equivalent crafted
+  /// TIFF (a `NIKON CORPORATION` IFD0 + a headerless Nikon MakerNote whose
+  /// entry 0 is `format 99` and entry 1 is `int8u LensType = 6`): the oracle
+  /// emits ONLY `[minor] Bad format (99) for MakerNotes entry 0` and NO
+  /// `Nikon:*` tag — the directory is aborted, not merely the one entry.
+  #[test]
+  fn nikon_entry0_bad_format_aborts_directory() {
+    let bad0 = entry_inline(0x0083, 99, 1, [0x00, 0x00, 0x00, 0x00]); // invalid fmt
+    let lenstype = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]); // int8u = 6 → "G"
+    let blob = headerless_ifd(&[bad0, lenstype]);
+    let entries = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      entries.is_empty(),
+      "an entry-0 bad format aborts the WHOLE directory (the later LensType is dropped)"
+    );
+  }
+
+  /// `ProcessExif` SKIPS (does NOT abort on) a bad format code at a LATER entry
+  /// (`Exif.pm:6476` `next if $index`): a Nikon MakerNote with a valid entry 0,
+  /// an invalid entry 1 (format 99), and a valid entry 2 emits entries 0 and 2
+  /// (the bad entry 1 is dropped, the directory is NOT aborted).
+  ///
+  /// Ground-truthed against `perl exiftool 13.59`: the equivalent crafted TIFF
+  /// (entry 0 `int8u LensType = 6`, entry 1 `format 99`, entry 2 `string[4]
+  /// Quality = "FINE"`) surfaces `Nikon:LensType = "G"` AND `Nikon:Quality`
+  /// with only `[minor] Bad format (99) for MakerNotes entry 1`.
+  #[test]
+  fn nikon_later_bad_format_skipped_valid_kept() {
+    let lenstype = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]); // int8u = 6 → "G"
+    let bad1 = entry_inline(0x0004, 99, 1, [0x00, 0x00, 0x00, 0x00]); // invalid fmt
+    let quality = entry_inline(0x0004, 2, 4, *b"FINE"); // string[4] "FINE"
+    let blob = headerless_ifd(&[lenstype, bad1, quality]);
+    let entries = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(
+      entries.len(),
+      2,
+      "a LATER bad format skips only that entry; the valid entries before/after are kept"
+    );
+    assert_eq!(entries[0].tag_id, 0x0083);
+    assert_eq!(entries[0].value, RawValue::U64(vec![6]));
+    assert_eq!(entries[1].tag_id, 0x0004);
+    match &entries[1].value {
+      RawValue::Text { text, .. } => assert_eq!(text, "FINE"),
+      other => panic!("expected Text, got {other:?}"),
+    }
+  }
+
+  /// The BigTIFF / Unicode / Complex format codes `14..=18` are REJECTED on the
+  /// IFD-walk decode path, exactly like any other invalid code — `ProcessExif`
+  /// accepts ONLY `1..=13 | 129` ([`Format::is_valid_ifd_code`]), so a code
+  /// `14`/`15`/`16`/`17`/`18` is `Bad format` (NOT decoded), even though
+  /// `Format::from_code` maps each to a real `Format` with a nonzero
+  /// `byte_size`. At entry 0 it aborts the directory.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59`: each of `format 14..18` at
+  /// entry 0 (followed by a valid `LensType`) emits ONLY `[minor] Bad format
+  /// (<code>) for MakerNotes entry 0` and NO `Nikon:*` tag — identical to the
+  /// `format 99` abort.
+  #[test]
+  fn nikon_format_14_to_18_rejected() {
+    for code in [14u16, 15, 16, 17, 18] {
+      let bad0 = entry_inline(0x0083, code, 1, [0x00, 0x00, 0x00, 0x00]);
+      let lenstype = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]);
+      let blob = headerless_ifd(&[bad0, lenstype]);
+      let entries = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+      assert!(
+        entries.is_empty(),
+        "format code {code} must be rejected as Bad format (entry 0 ⇒ directory abort)"
+      );
+    }
+    // …and a code 14..=18 at a LATER entry is skipped, not decoded, leaving the
+    // valid entries (mirrors the format-99 later-skip arm).
+    let lenstype = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]);
+    let bad1 = entry_inline(0x0004, 16, 1, [0x00, 0x00, 0x00, 0x00]); // int64u code
+    let quality = entry_inline(0x0004, 2, 4, *b"FINE");
+    let blob = headerless_ifd(&[lenstype, bad1, quality]);
+    let entries = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(
+      entries.len(),
+      2,
+      "a code 14..=18 at a later entry is skipped (not decoded), the valid entries kept"
+    );
+    assert_eq!(entries[0].tag_id, 0x0083);
+    assert_eq!(entries[1].tag_id, 0x0004);
+  }
+
+  /// A 12-byte IFD entry with an OUT-OF-LINE value (a 4-byte stored offset) —
+  /// helper for the suspicious-offset / warnCount tests.
+  fn entry_offset(tag: u16, format: u16, count: u32, offset: u32) -> Vec<u8> {
+    let mut e: Vec<u8> = Vec::new();
+    e.extend_from_slice(&tag.to_be_bytes());
+    e.extend_from_slice(&format.to_be_bytes());
+    e.extend_from_slice(&count.to_be_bytes());
+    e.extend_from_slice(&offset.to_be_bytes());
+    e
+  }
+
+  /// A headerless big-endian Nikon IFD whose buffer ENDS exactly `tail` bytes
+  /// past the entry table — i.e. `blob.len() == dir_end + tail`, where `dir_end
+  /// = 2 + 12*num_entries` (the count word + the entry array, ExifTool's
+  /// `$dirSize`, NOT including a next-IFD pointer). This lets a test set
+  /// `bytes_from_end` (`$dataLen - $dirEnd`) to an EXACT value (0/1/2/3/4…) to
+  /// exercise the illegal-tail gate. (Distinct from `headerless_ifd`, which
+  /// always appends a 4-byte next-IFD pointer ⇒ `bytes_from_end == 4`.)
+  fn headerless_ifd_with_tail(entries: &[Vec<u8>], tail: usize) -> Vec<u8> {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(&(entries.len() as u16).to_be_bytes());
+    for e in entries {
+      b.extend_from_slice(e);
+    }
+    // `dir_end = 2 + 12*num_entries` is now `b.len()`. Append exactly `tail`
+    // bytes so `bytes_from_end == tail`.
+    b.resize(b.len() + tail, 0xAA);
+    b
+  }
+
+  /// ILLEGAL-TAIL (Exif.pm:6394-6399): a directory whose `$bytesFromEnd`
+  /// (`$dataLen - $dirEnd`) is exactly `1` is a malformed directory — ExifTool
+  /// aborts it wholesale (`Illegal $dir directory size`, `return 0`) BEFORE
+  /// walking any entry, so NO Nikon tag is emitted. Here a headerless Nikon IFD
+  /// (the blob IS the buffer, `value_base = 0`) has a valid 1-entry table
+  /// (LensType = 6 → "G"); `dir_end = 2 + 12 = 14`, and the buffer ends 1 byte
+  /// past it (`bytes_from_end == 1`). The walk returns nothing.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59`: the IDENTICAL `ProcessExif`
+  /// directory-framing rule on a standalone TIFF whose IFD0 entry table is
+  /// followed by exactly 1 trailing byte (`$bytesFromEnd == 1`) emits
+  /// `[Warning] Illegal IFD0 directory size (1 entries)` and NO `IFD0:*` tag —
+  /// whereas a 0- or 2-byte tail emits the tag (see the 0/2 control below). The
+  /// Nikon walker mirrors Canon's `classify_canon_directory`
+  /// (`AbortIllegalSize`) and the shared EXIF walker on this same `:6397` gate.
+  /// The matching `Illegal …` WARNING stays #230-deferred; only the
+  /// TAG-suppression abort is reproduced here.
+  #[test]
+  fn nikon_illegal_tail_1_byte_aborts() {
+    let lenstype = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]);
+    let blob = headerless_ifd_with_tail(&[lenstype], 1); // bytes_from_end == 1
+    let entries = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      entries.is_empty(),
+      "a 1-byte directory tail is illegal ⇒ the whole directory is aborted, no tags"
+    );
+  }
+
+  /// ILLEGAL-TAIL (Exif.pm:6394-6399): a `$bytesFromEnd` of exactly `3` aborts
+  /// the directory just like `1`. Same headerless 1-entry IFD as the `1`-byte
+  /// case, with `bytes_from_end == 3`.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59`: a standalone TIFF whose IFD0
+  /// entry table is followed by exactly 3 trailing bytes emits `[Warning]
+  /// Illegal IFD0 directory size (1 entries)` and NO `IFD0:*` tag (identical to
+  /// the 1-byte case; the 0/2/≥4 tails all walk).
+  #[test]
+  fn nikon_illegal_tail_3_byte_aborts() {
+    let lenstype = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]);
+    let blob = headerless_ifd_with_tail(&[lenstype], 3); // bytes_from_end == 3
+    let entries = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      entries.is_empty(),
+      "a 3-byte directory tail is illegal ⇒ the whole directory is aborted, no tags"
+    );
+  }
+
+  /// REGRESSION GUARD against OVER-ABORT — a `$bytesFromEnd` of `0` or `2` is
+  /// LEGAL (`Exif.pm:6395`, `unless ($bytesFromEnd == 2 or $bytesFromEnd == 0)`)
+  /// and the directory is walked normally. The SAME headerless 1-entry IFD as
+  /// the 1/3-byte cases, with `bytes_from_end == 0` (the buffer ends exactly at
+  /// the entry table) and `bytes_from_end == 2`: the LensType STILL emits.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59`: a standalone TIFF whose IFD0
+  /// entry table is followed by a 0- or 2-byte tail emits `IFD0:Orientation`
+  /// (no `Illegal …` warning) — only the 1- and 3-byte tails abort.
+  #[test]
+  fn nikon_legal_tail_0_and_2_bytes_walked() {
+    let lenstype = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]);
+    // 0-byte tail: the buffer ends exactly at dir_end (= 2 + 12), so
+    // dataLen - dirEnd == 0.
+    let blob0 = headerless_ifd_with_tail(&[lenstype.clone()], 0);
+    let e0 = walk_nikon_ifd(&blob0, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(e0.len(), 1, "a 0-byte tail is legal ⇒ the entry is walked");
+    assert_eq!(e0[0].tag_id, 0x0083);
+    assert_eq!(e0[0].value, RawValue::U64(vec![6]));
+    // 2-byte tail.
+    let blob2 = headerless_ifd_with_tail(&[lenstype], 2); // bytes_from_end == 2
+    let e2 = walk_nikon_ifd(&blob2, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert_eq!(e2.len(), 1, "a 2-byte tail is legal ⇒ the entry is walked");
+    assert_eq!(e2[0].tag_id, 0x0083);
+  }
+
+  /// warnCount > 10 ABORT (`Exif.pm:6455-6456`): once MORE than ten counted
+  /// per-entry warnings (`++$warnCount`) accrue in a directory, `ProcessExif`
+  /// aborts it (`Too many warnings -- $dir parsing aborted`, `return 0`),
+  /// checked BEFORE reading each next entry — so a VALID entry that follows a
+  /// >10-warning run is NOT emitted. Here a headerless Nikon IFD has 11
+  /// out-of-line entries each with a stored offset of `0` (`< 8` ⇒ suspicious,
+  /// `++$warnCount`), then a 12th VALID inline `LensType` (0x0083 = 6 → "G").
+  /// The 11 suspicious entries push `warn_count` to 11; the guard fires at the
+  /// top of the 12th iteration (`warn_count > 10`), aborting before the
+  /// LensType — so it is ABSENT.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59` on the equivalent crafted
+  /// JPEG (`NIKON CORPORATION` IFD0 + a headerless Nikon MakerNote of 11
+  /// offset-0 out-of-line entries then a valid `int8u LensType = 6`): the
+  /// `-v3` trace shows eleven `[minor] Suspicious MakerNotes offset for …`
+  /// warnings followed by `[Minor] Too many warnings -- MakerNotes parsing
+  /// aborted`, and the JSON emits NO `Nikon:LensType` — whereas the 10-entry
+  /// control (below) DOES emit `Nikon:LensType = "G"`. Mirrors Canon's
+  /// `walk_canon_in_tiff` loop-top `if warn_count > 10 { break }`.
+  #[test]
+  fn nikon_warncount_over_10_aborts_directory() {
+    let mut entries: Vec<Vec<u8>> = Vec::new();
+    // 11 out-of-line entries, each stored offset 0 (< 8 ⇒ suspicious, counted).
+    // rational64u count 1 = 8 bytes > 4 ⇒ out-of-line.
+    for i in 0..11u16 {
+      entries.push(entry_offset(0x00a0 + i, 5, 1, 0));
+    }
+    // 12th: a VALID inline LensType (would emit "G" if reached).
+    entries.push(entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]));
+    let blob = headerless_ifd(&entries);
+    let out = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      out.iter().all(|e| e.tag_id != 0x0083),
+      "after >10 counted warnings the directory aborts ⇒ the late LensType is dropped"
+    );
+    assert!(
+      out.is_empty(),
+      "every entry before the abort was suspicious (skipped) ⇒ nothing emitted"
+    );
+  }
+
+  /// REGRESSION GUARD against OVER-ABORT — the cap is `> 10`, NOT `>= 10`
+  /// (`Exif.pm:6455`, `if ($warnCount > 10)`): EXACTLY ten counted warnings do
+  /// NOT trip it, so a valid entry after a 10-warning run STILL emits. Same
+  /// shape as the >10 test but with TEN offset-0 entries before the LensType.
+  ///
+  /// Ground-truthed against `perl exiftool 13.59`: the 10-entry control JPEG
+  /// emits `Nikon:LensType = "G"` (the directory is NOT aborted), confirming the
+  /// boundary is strictly `> 10`.
+  #[test]
+  fn nikon_warncount_exactly_10_still_emits_valid_tag() {
+    let mut entries: Vec<Vec<u8>> = Vec::new();
+    for i in 0..10u16 {
+      entries.push(entry_offset(0x00a0 + i, 5, 1, 0)); // 10 suspicious (counted)
+    }
+    entries.push(entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00])); // valid LensType
+    let blob = headerless_ifd(&entries);
+    let out = walk_nikon_ifd(&blob, 0, ByteOrder::Big, 0, NikonTable::Main);
+    // The 10 suspicious entries are each skipped, but the cap (> 10) is NOT
+    // tripped, so the 11th (valid) entry is reached and emitted.
+    assert_eq!(
+      out.len(),
+      1,
+      "exactly 10 warnings does not abort (> 10, not >= 10) ⇒ the valid entry emits"
+    );
+    assert_eq!(out[0].tag_id, 0x0083);
+    assert_eq!(out[0].value, RawValue::U64(vec![6]));
+  }
+}

--- a/src/exif/makernotes/vendors/nikon/mod.rs
+++ b/src/exif/makernotes/vendors/nikon/mod.rs
@@ -1,0 +1,1012 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Nikon MakerNotes — `%Image::ExifTool::Nikon::Main` (`Nikon.pm:1778`) +
+//! `%Image::ExifTool::Nikon::Type2` (`Nikon.pm:5369`) port.
+//!
+//! The dispatcher ([`crate::exif::makernotes::dispatch`]) classifies the three
+//! Nikon MakerNote layouts (type-3 `"Nikon\0\x02"`, type-2 `"Nikon\0\x01"`,
+//! headerless Nikon3 `Make =~ /^NIKON/i`); this module parses the body of
+//! whichever layout matched, walks the IFD against the layout-selected tag
+//! table ([`NikonTable`]: `%Nikon::Main` for type-3 / headerless,
+//! `%Nikon::Type2` for the old type-2 layout, `MakerNotes.pm:537-554`), and
+//! emits the readable tags under the `MakerNotes:Nikon` group (family-0
+//! `MakerNotes`, family-1 `Nikon` — see [`Vendor::group1`]).
+//!
+//! ## Header / embedded-TIFF base (the crux)
+//!
+//! The modern **type-3** layout (D70/D2Hs/most DSLRs) is `"Nikon\0"` + a
+//! 2-byte version + 2 pad bytes, then a SELF-CONTAINED embedded TIFF at blob
+//! offset 10 (`MM`/`II` + `0x002a` + the IFD0 offset). The IFD's out-of-line
+//! value offsets are relative to that embedded TIFF header (the bundled
+//! `Base => '$start - 8'` rebase, `MakerNotes.pm:56`), so this module walks
+//! the IFD with `value_base = 10`. The byte order is read from the embedded
+//! marker, NOT inherited from the parent (`ByteOrder => 'Unknown'`,
+//! `MakerNotes.pm:57`) — a NEF written big-endian inside a little-endian TIFF
+//! still decodes correctly.
+//!
+//! ## Scope
+//!
+//! See [`tags`]: every readable `%Nikon::Main` scalar + the two UNENCRYPTED
+//! fixture sub-tables (`AFInfo`, `ColorBalance0103`). The ENCRYPTED
+//! sub-tables (`LensData`/`ShotInfo`/`FlashInfo`/encrypted `ColorBalance`)
+//! are deferred (they need `Nikon::Decrypt`) — they carry a deferred
+//! [`tags::SubTable`] marker so the parent pointer is NOT emitted (the
+//! #177/#223 bogus-parent rule).
+
+#![deny(clippy::indexing_slicing)]
+
+pub mod body;
+pub mod printconv;
+pub mod tags;
+
+use crate::exif::ifd::{ByteOrder, Format, read_value};
+use crate::exif::makernotes::VendorEmission;
+use crate::value::{Group, Metadata, TagValue};
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+pub use body::{NikonEntry, ParsedValue, walk_nikon_ifd};
+pub use printconv::NikonConv;
+pub use tags::{NIKON_TAGS, NIKON_TYPE2_TAGS, NikonTable, NikonTag, SubTable};
+
+/// Decoded Nikon MakerNotes — the typed camera-identity surface populated by
+/// [`parse`].
+///
+/// D8: no public fields; accessor-only. `#[non_exhaustive]` so future Nikon
+/// sub-tables can add fields without a breaking change.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MakerNotesNikon {
+  /// `MakerNoteVersion` (0x0001) rendered string (e.g. `"2.10"`).
+  maker_note_version: Option<SmolStr>,
+  /// `Quality` (0x0004) — title-cased.
+  quality: Option<SmolStr>,
+  /// `WhiteBalance` (0x0005) — title-cased.
+  white_balance: Option<SmolStr>,
+  /// `FocusMode` (0x0007) — title-cased.
+  focus_mode: Option<SmolStr>,
+  /// `LensType` (0x0083) rendered string (e.g. `"G"`, `"D"`).
+  lens_type: Option<SmolStr>,
+  /// `Lens` (0x0084) rendered string (e.g. `"18-70mm f/3.5-4.5"`).
+  lens: Option<SmolStr>,
+  /// `ShootingMode` (0x0089) rendered string.
+  shooting_mode: Option<SmolStr>,
+  /// `SerialNumber` (0x001d / 0x00a0) string.
+  serial_number: Option<SmolStr>,
+  /// `ShutterCount` (0x00a7).
+  shutter_count: Option<i64>,
+}
+
+impl MakerNotesNikon {
+  /// Build an empty Nikon metadata bag.
+  #[must_use]
+  #[inline]
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// `MakerNoteVersion` (0x0001).
+  #[must_use]
+  #[inline]
+  pub fn maker_note_version(&self) -> Option<&str> {
+    self.maker_note_version.as_deref()
+  }
+
+  /// `Quality` (0x0004).
+  #[must_use]
+  #[inline]
+  pub fn quality(&self) -> Option<&str> {
+    self.quality.as_deref()
+  }
+
+  /// `WhiteBalance` (0x0005).
+  #[must_use]
+  #[inline]
+  pub fn white_balance(&self) -> Option<&str> {
+    self.white_balance.as_deref()
+  }
+
+  /// `FocusMode` (0x0007).
+  #[must_use]
+  #[inline]
+  pub fn focus_mode(&self) -> Option<&str> {
+    self.focus_mode.as_deref()
+  }
+
+  /// `LensType` (0x0083).
+  #[must_use]
+  #[inline]
+  pub fn lens_type(&self) -> Option<&str> {
+    self.lens_type.as_deref()
+  }
+
+  /// `Lens` (0x0084).
+  #[must_use]
+  #[inline]
+  pub fn lens(&self) -> Option<&str> {
+    self.lens.as_deref()
+  }
+
+  /// `ShootingMode` (0x0089).
+  #[must_use]
+  #[inline]
+  pub fn shooting_mode(&self) -> Option<&str> {
+    self.shooting_mode.as_deref()
+  }
+
+  /// `SerialNumber` (0x001d / 0x00a0).
+  #[must_use]
+  #[inline]
+  pub fn serial_number(&self) -> Option<&str> {
+    self.serial_number.as_deref()
+  }
+
+  /// `ShutterCount` (0x00a7).
+  #[must_use]
+  #[inline(always)]
+  pub const fn shutter_count(&self) -> Option<i64> {
+    self.shutter_count
+  }
+}
+
+/// Resolve the IFD layout from the captured MakerNote bytes + the parent TIFF
+/// context. Returns the slice to walk (`walk_in_blob`) plus the IFD start,
+/// byte order, out-of-line value base WITHIN that slice, and the TAG TABLE
+/// ([`NikonTable`]) the walk is keyed against. `None` for a blob too short /
+/// malformed to walk.
+///
+/// Mirrors the three `MakerNotes.pm` Nikon arms — their `TagTable` AND their
+/// `Base`/`ByteOrder`/`Start` semantics:
+///
+/// - `"Nikon\0\x02"` (type 3, `MakerNotes.pm:51-58`) → `%Nikon::Main`, an
+///   EMBEDDED TIFF at blob offset 10. `Base => '$start - 8'` makes out-of-line
+///   offsets relative to the EMBEDDED TIFF header, so the IFD is SELF-CONTAINED
+///   in the blob: walk the BLOB, `value_base = 10`. The byte order + IFD0
+///   offset come from the embedded marker (`ByteOrder => 'Unknown'`).
+/// - `"Nikon\0\x01"` (type 2, `MakerNotes.pm:537-545`) → `%Nikon::Type2`, IFD
+///   at offset 8, FIXED `LittleEndian` (NOT a marker probe), NO `Base` override
+///   ⇒ out-of-line offsets are PARENT-TIFF-relative: walk the parent `data`,
+///   IFD at `mn_offset + 8`, `value_base = 0` (offsets are already
+///   TIFF-absolute). The DIFFERENT table is the crux — IDs 0x0003..0x000b
+///   name different tags than `%Nikon::Main`.
+/// - headerless Nikon3 (`MakerNotes.pm:546-554`) → `%Nikon::Main`, the blob IS
+///   the IFD, NO `Base` override ⇒ PARENT-TIFF-relative: walk the parent
+///   `data`, IFD at `mn_offset`, `value_base = 0`. The byte order inherits the
+///   parent walk (`ByteOrder => 'Unknown'`).
+fn resolve_layout(blob: &[u8], parent_order: ByteOrder) -> Option<Layout> {
+  if blob.starts_with(b"Nikon\x00\x02") {
+    // Type 3: `%Nikon::Main`, self-contained embedded TIFF at blob offset 10.
+    let (order, ifd_offset) = body::parse_embedded_tiff(blob, 10)?;
+    Some(Layout {
+      table: NikonTable::Main,
+      walk_in_blob: true,
+      ifd_offset,
+      order,
+      value_base: 10,
+    })
+  } else if blob.starts_with(b"Nikon\x00\x01") {
+    // Type 2: `%Nikon::Type2`, IFD at blob offset 8, FIXED little-endian
+    // (`MakerNotes.pm:544`, NOT a marker probe); offsets are
+    // parent-TIFF-relative (walked in `data` by the caller).
+    Some(Layout {
+      table: NikonTable::Type2,
+      walk_in_blob: false,
+      ifd_offset: 8,
+      order: ByteOrder::Little,
+      value_base: 0,
+    })
+  } else {
+    // Headerless Nikon3: `%Nikon::Main`, the blob IS the IFD, offsets
+    // parent-TIFF-relative.
+    Some(Layout {
+      table: NikonTable::Main,
+      walk_in_blob: false,
+      ifd_offset: 0,
+      order: parent_order,
+      value_base: 0,
+    })
+  }
+}
+
+/// The resolved walk parameters (see [`resolve_layout`]).
+#[derive(Debug, Clone, Copy)]
+struct Layout {
+  /// The tag table this IFD is walked against (type-2 ⇒ [`NikonTable::Type2`];
+  /// type-3 / headerless ⇒ [`NikonTable::Main`]). Drives BOTH the walker's
+  /// unknown-tag skip and the emission-loop lookup, so a type-2 IFD's
+  /// 0x0003..0x000b are named by `%Nikon::Type2`, never `%Nikon::Main`.
+  table: NikonTable,
+  /// `true` ⇒ walk the captured blob (type-3, self-contained); `false` ⇒
+  /// walk the parent TIFF `data` (type-2 / headerless Nikon3).
+  walk_in_blob: bool,
+  /// IFD start offset within the chosen slice.
+  ifd_offset: usize,
+  /// Byte order of the IFD walk.
+  order: ByteOrder,
+  /// Out-of-line value base within the chosen slice (type-3 ⇒ 10; else 0).
+  value_base: usize,
+}
+
+/// Parse the captured Nikon MakerNote blob into a [`MakerNotesNikon`] + the
+/// ordered [`VendorEmission`] list for the `MakerNotes:Nikon` group.
+///
+/// Standalone-blob entry point: the blob IS the TIFF context (out-of-line
+/// offsets resolve against the blob itself). Correct for the SELF-CONTAINED
+/// type-3 layout; for type-2 / headerless Nikon3 (whose offsets are
+/// parent-TIFF-relative) use [`parse_in_tiff`] with the real TIFF block.
+///
+/// `parent_order` is the parent IFD walk's byte order (the headerless
+/// fallback); `model` threads the `ShootingMode` bit-5 + AFInfo byte-order
+/// `Condition`s.
+#[must_use]
+pub fn parse(
+  blob: &[u8],
+  parent_order: ByteOrder,
+  model: Option<&str>,
+) -> (MakerNotesNikon, Vec<VendorEmission>) {
+  parse_in_tiff(blob, 0, blob.len(), parent_order, true, model)
+}
+
+/// Standalone-blob parse with the PrintConv flag (`-n` toggle). Equivalent to
+/// [`parse_in_tiff`] over the whole blob; the type-3 layout is self-contained
+/// so this is faithful for it, and a standalone type-2 / Nikon3 blob (no
+/// parent TIFF) still walks its IFD (only its out-of-line offsets, which would
+/// be TIFF-relative, may not resolve — the captured-blob case the JSON walker
+/// uses passes the FULL parent TIFF via [`parse_in_tiff`]).
+#[must_use]
+pub fn parse_with_print_conv(
+  blob: &[u8],
+  parent_order: ByteOrder,
+  print_conv: bool,
+  model: Option<&str>,
+) -> (MakerNotesNikon, Vec<VendorEmission>) {
+  parse_in_tiff(blob, 0, blob.len(), parent_order, print_conv, model)
+}
+
+/// Like [`parse`] but resolves out-of-line offsets against the PARENT TIFF
+/// block (`data`), at `mn_offset`/`mn_len` — needed for the type-2 /
+/// headerless Nikon3 layouts whose offsets are TIFF-relative. The type-3
+/// embedded-TIFF layout is self-contained and walks the captured blob
+/// regardless of `data`.
+///
+/// `print_conv` toggles PrintConv (`-n` mode emits the post-ValueConv scalar).
+#[must_use]
+pub fn parse_in_tiff(
+  data: &[u8],
+  mn_offset: usize,
+  mn_len: usize,
+  parent_order: ByteOrder,
+  print_conv: bool,
+  model: Option<&str>,
+) -> (MakerNotesNikon, Vec<VendorEmission>) {
+  let mut typed = MakerNotesNikon::new();
+  let mut emissions: Vec<VendorEmission> = Vec::new();
+  // The captured MakerNote bytes (for header detection).
+  let mn_end = mn_offset.saturating_add(mn_len);
+  let Some(blob) = data.get(mn_offset..mn_end.min(data.len())) else {
+    return (typed, emissions);
+  };
+  let Some(layout) = resolve_layout(blob, parent_order) else {
+    return (typed, emissions);
+  };
+  // Choose the slice + IFD offset the walker operates on. Type-3 walks the
+  // captured blob (self-contained embedded TIFF); type-2 / headerless walk the
+  // PARENT TIFF (out-of-line offsets are TIFF-relative). The walker bounds the
+  // directory + values to the chosen buffer length, matching ExifTool's
+  // `ProcessExif` `DataLen` bound (the parent EXIF buffer for an in-place
+  // MakerNote — see [`walk_nikon_ifd`]).
+  let (walk_data, ifd_offset): (&[u8], usize) = if layout.walk_in_blob {
+    (blob, layout.ifd_offset)
+  } else {
+    (data, mn_offset.saturating_add(layout.ifd_offset))
+  };
+  let entries = walk_nikon_ifd(
+    walk_data,
+    ifd_offset,
+    layout.order,
+    layout.value_base,
+    layout.table,
+  );
+  for entry in &entries {
+    let Some(def) = layout.table.lookup(entry.tag_id) else {
+      continue; // Unknown tag — verbose-only in ExifTool; omit.
+    };
+    if let Some(sub) = def.sub_table() {
+      // SubDirectory tag: walk the readable sub-tables; DEFER (emit nothing —
+      // neither parent nor children) for the encrypted/long-tail ones. A
+      // SubDirectory pointer NEVER emits the parent value (`Exif.pm:7103`
+      // `next` skips `FoundTag`), so a deferred subdir is silent — the
+      // #177/#223 bogus-parent rule.
+      match sub {
+        SubTable::AfInfo => {
+          emit_af_info(walk_data, entry, layout, print_conv, model, &mut emissions);
+        }
+        SubTable::ColorBalance0103 => {
+          emit_color_balance(walk_data, entry, layout, print_conv, &mut emissions);
+        }
+        // Deferred (encrypted / unported child table): emit nothing.
+        SubTable::LensData
+        | SubTable::ShotInfo
+        | SubTable::FlashInfo
+        | SubTable::ColorBalanceEncrypted
+        | SubTable::OtherDeferred => {}
+      }
+      continue;
+    }
+    // Leaf tag.
+    let parsed = ParsedValue::new(entry.value.clone());
+    // A `None` is a `RawConv => … : undef` drop (only JPGCompression 0 among
+    // the ported tags) — the tag is NOT emitted (neither typed nor parity).
+    // `layout.order` is `GetByteOrder()` for the Main IFD (PowerUpTime RawConv).
+    let Some(value) = def.conv().apply(&parsed, print_conv, model, layout.order) else {
+      continue;
+    };
+    // The typed convenience surface ([`MakerNotesNikon`]) is keyed by the
+    // `%Nikon::Main` tag IDs it documents; the type-2 layout reuses those IDs
+    // (0x0003..0x000b) for DIFFERENT `%Nikon::Type2` tags, so populating the
+    // Main-semantic fields from a type-2 walk would mislabel them. Only the
+    // Main path feeds `typed`; the type-2 path emits through the authoritative
+    // `emissions` list alone (with its faithful `%Nikon::Type2` names).
+    if layout.table == NikonTable::Main {
+      populate_typed(&mut typed, entry.tag_id, &value, def.name());
+    }
+    emissions.push(VendorEmission::new(
+      def.name().into(),
+      value,
+      def.is_unknown(),
+    ));
+  }
+  (typed, emissions)
+}
+
+/// Emit the `%Nikon::AFInfo` (0x0088) leaves — a `ProcessBinaryData` table
+/// read BigEndian for DSLRs (`$$self{Model} =~ /^NIKON D/i`), LittleEndian
+/// otherwise (`Nikon.pm:2113-2158`). The AFInfo blob is the entry's value
+/// bytes (read fresh from the blob via the recorded `value_offset`/`size`).
+fn emit_af_info(
+  walk_data: &[u8],
+  entry: &NikonEntry,
+  layout: Layout,
+  print_conv: bool,
+  model: Option<&str>,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  // The AFInfo SubDirectory's own byte order (the table-level `ByteOrder`
+  // directive). DSLRs → BigEndian; else LittleEndian. The parent IFD's order
+  // does NOT carry into a `ProcessBinaryData` table with an explicit
+  // `ByteOrder`.
+  let sub_order = if model.is_some_and(model_is_nikon_dslr) {
+    ByteOrder::Big
+  } else {
+    ByteOrder::Little
+  };
+  let _ = layout;
+  let Some(sub) = walk_data.get(entry.value_offset..entry.value_offset + entry.value_size) else {
+    return;
+  };
+  for pos in tags::AF_INFO {
+    // Read `pos.format` at byte offset `pos.offset` within the sub-blob.
+    let elem = pos.format.byte_size();
+    if elem == 0 || pos.offset + elem > sub.len() {
+      continue;
+    }
+    let avail = sub.len() - pos.offset;
+    let Some(raw) = read_value(sub, pos.offset, pos.format, 1, avail, sub_order) else {
+      continue;
+    };
+    let parsed = ParsedValue::new(raw);
+    // No AFInfo position has a `RawConv … undef`, but honour the drop contract
+    // uniformly: a `None` skips emission. The sub-table byte order is the AFInfo
+    // `ByteOrder` directive (`sub_order`).
+    let Some(value) = pos.conv.apply(&parsed, print_conv, model, sub_order) else {
+      continue;
+    };
+    emissions.push(VendorEmission::new(pos.name.into(), value, false));
+  }
+}
+
+/// Emit `%Nikon::ColorBalance3` (0x0097, the `0103` D70/D70s variant):
+/// `Start => '$valuePtr + 20'`, then `WB_RGBGLevels = int16u[4]` at the
+/// SubDirectory's offset 0, in the SubDirectory's byte order (inherited from
+/// the embedded TIFF). UNENCRYPTED.
+///
+/// The other 0x0097 variants (encrypted `02xx`, the early `0100`/`0102`) are
+/// NOT walked here — the version prefix gates them; a non-`0103` prefix emits
+/// nothing (deferred). This keeps the byte-exact D70/.nef WB_RGBGLevels while
+/// the encrypted variants await `Nikon::Decrypt`.
+fn emit_color_balance(
+  walk_data: &[u8],
+  entry: &NikonEntry,
+  layout: Layout,
+  print_conv: bool,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  let Some(sub) = walk_data.get(entry.value_offset..entry.value_offset + entry.value_size) else {
+    return;
+  };
+  // The version prefix is the first 4 ASCII bytes of the ColorBalance value.
+  let prefix = sub.get(0..4).unwrap_or(&[]);
+  if prefix != b"0103" {
+    // Not the unencrypted D70 variant — deferred (encrypted or unported).
+    return;
+  }
+  // `Start => '$valuePtr + 20'` (`Nikon.pm:2705`) then `WB_RGBGLevels =
+  // int16u[4]` at the ColorBalance3 table's offset 0 (`Nikon.pm:5327-5335`) —
+  // 8 bytes. The child read is bounded by the PARENT tag's declared value
+  // (ExifTool's `ProcessBinaryData` `DirLen` = the parent value size adjusted
+  // by the `Start` delta, and it stops when no bytes remain), so read EXACTLY
+  // those 8 bytes from WITHIN `sub` at offset 20 — NOT from the remaining
+  // `walk_data` tail. A ColorBalance value shorter than 28 bytes (20-byte
+  // `Start` delta + the 8-byte record) cannot hold the record: emit nothing
+  // rather than over-reading the next IFD entry / trailing buffer.
+  let Some(record) = sub.get(20..28) else {
+    return;
+  };
+  // 4 × int16u, in the SubDirectory's inherited byte order.
+  let Some(raw) = read_value(record, 0, Format::Int16u, 4, record.len(), layout.order) else {
+    return;
+  };
+  let parsed = ParsedValue::new(raw);
+  // `NikonConv::Raw` never suppresses; the `else` is unreachable in practice.
+  let Some(value) = NikonConv::Raw.apply(&parsed, print_conv, None, layout.order) else {
+    return;
+  };
+  emissions.push(VendorEmission::new("WB_RGBGLevels".into(), value, false));
+}
+
+/// `$$self{Model} =~ /^NIKON D/i` (`Nikon.pm:2115`) — the AFInfo BigEndian
+/// gate (the Nikon DSLR `D`-series).
+fn model_is_nikon_dslr(model: &str) -> bool {
+  let m = model.trim_start();
+  // Case-insensitive `^NIKON D`.
+  let bytes = m.as_bytes();
+  let prefix = b"NIKON D";
+  if bytes.len() < prefix.len() {
+    return false;
+  }
+  bytes
+    .iter()
+    .zip(prefix.iter())
+    .all(|(a, b)| a.eq_ignore_ascii_case(b))
+}
+
+/// Populate the typed struct from a leaf tag's rendered value.
+fn populate_typed(typed: &mut MakerNotesNikon, tag_id: u16, value: &TagValue, _name: &str) {
+  let as_str = |v: &TagValue| -> Option<SmolStr> {
+    match v {
+      TagValue::Str(s) => Some(s.clone()),
+      _ => None,
+    }
+  };
+  match tag_id {
+    0x0001 => typed.maker_note_version = as_str(value),
+    0x0004 => typed.quality = as_str(value),
+    0x0005 => typed.white_balance = as_str(value),
+    0x0007 => typed.focus_mode = as_str(value),
+    0x0083 => typed.lens_type = as_str(value),
+    0x0084 => typed.lens = as_str(value),
+    0x0089 => typed.shooting_mode = as_str(value),
+    // SerialNumber: 0x001d (string) and 0x00a0 (string). 0x001d wins when both
+    // present (it is the canonical body serial); but `populate_typed` runs in
+    // IFD order, so the LATER one would overwrite — guard 0x00a0 to not clobber
+    // an existing 0x001d value.
+    0x001d => {
+      typed.serial_number = match value {
+        TagValue::Str(s) => Some(s.clone()),
+        TagValue::I64(n) => Some(SmolStr::new(n.to_string())),
+        _ => typed.serial_number.take(),
+      };
+    }
+    0x00a0 => {
+      if typed.serial_number.is_none() {
+        typed.serial_number = as_str(value);
+      }
+    }
+    0x00a7 => {
+      if let TagValue::I64(n) = value {
+        typed.shutter_count = Some(*n);
+      }
+    }
+    _ => {}
+  }
+}
+
+/// Emit Nikon MakerNotes into a [`Metadata`] sink under the
+/// `("MakerNotes","Nikon")` group — the family-0 `MakerNotes`, family-1
+/// `Nikon` axis bundled `exiftool -G1` uses.
+pub fn parse_into_metadata(
+  blob: &[u8],
+  parent_order: ByteOrder,
+  print_conv: bool,
+  model: Option<&str>,
+  into: &mut Metadata,
+) {
+  let group = Group::new("MakerNotes", "Nikon");
+  let (_typed, emissions) = parse_with_print_conv(blob, parent_order, print_conv, model);
+  for e in emissions {
+    if e.unknown() {
+      continue;
+    }
+    into.push(group.clone(), e.name(), e.value().clone());
+  }
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  /// A synthetic type-3 blob with Quality + LensType decodes through the full
+  /// parse path, emitting title-cased Quality + the LensType bitmask string.
+  #[test]
+  fn parse_type3_quality_and_lens_type() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]); // IFD0 at blob 18
+    b.extend_from_slice(&[0x00, 0x02]); // 2 entries
+    // Quality = "FINE" (string[4], inline).
+    b.extend_from_slice(&[0x00, 0x04]);
+    b.extend_from_slice(&[0x00, 0x02]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]);
+    b.extend_from_slice(b"FINE");
+    // LensType = 0x06 (int8u, inline) → "G".
+    b.extend_from_slice(&[0x00, 0x83]);
+    b.extend_from_slice(&[0x00, 0x01]); // int8u
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // count 1
+    b.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]); // value 6
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+
+    let (typed, emissions) = parse(&b, ByteOrder::Big, Some("NIKON D70"));
+    assert_eq!(typed.quality(), Some("Fine"));
+    assert_eq!(typed.lens_type(), Some("G"));
+    let names: Vec<&str> = emissions.iter().map(|e| e.name()).collect();
+    assert!(names.contains(&"Quality"));
+    assert!(names.contains(&"LensType"));
+    let q = emissions.iter().find(|e| e.name() == "Quality").unwrap();
+    assert_eq!(q.value(), &TagValue::Str(SmolStr::new("Fine")));
+  }
+
+  /// A deferred (encrypted) SubDirectory pointer (LensData 0x0098, ShotInfo
+  /// 0x0091, FlashInfo 0x00a8) emits NEITHER a parent NOR children — the
+  /// #177/#223 bogus-parent rule.
+  #[test]
+  fn deferred_encrypted_subdir_emits_no_parent() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]);
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    // ShotInfo (0x0091): undef, count 4 (inline "0206").
+    b.extend_from_slice(&[0x00, 0x91]);
+    b.extend_from_slice(&[0x00, 0x07]); // undef
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4
+    b.extend_from_slice(b"0206");
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+    let (_typed, emissions) = parse(&b, ByteOrder::Big, Some("NIKON D2Hs"));
+    // No "ShotInfo" parent, no ShotInfoVersion child.
+    assert!(
+      emissions.iter().all(|e| e.name() != "ShotInfo"),
+      "deferred ShotInfo parent must NOT be emitted"
+    );
+    assert!(
+      emissions.iter().all(|e| e.name() != "ShotInfoVersion"),
+      "deferred ShotInfo children must NOT be emitted (no Decrypt)"
+    );
+  }
+
+  /// `model_is_nikon_dslr` matches the `^NIKON D` (case-insensitive) gate.
+  #[test]
+  fn nikon_dslr_gate() {
+    assert!(model_is_nikon_dslr("NIKON D70"));
+    assert!(model_is_nikon_dslr("NIKON D2Hs"));
+    assert!(model_is_nikon_dslr("nikon d850"));
+    assert!(!model_is_nikon_dslr("NIKON E775")); // Coolpix
+    assert!(!model_is_nikon_dslr("COOLPIX P900"));
+  }
+
+  /// AFInfo (0x0088, BigEndian for DSLRs) decodes AFAreaMode/AFPoint at byte
+  /// offsets 0/1 — a synthetic blob mirroring the D70 record shape.
+  #[test]
+  fn af_info_subdir_decodes() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]);
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    // AFInfo (0x0088): undef, count 4 (inline) → [0,0,0,1].
+    // byte0 AFAreaMode=0 (Single Area), byte1 AFPoint=0 (Center),
+    // bytes2-3 AFPointsInFocus=0x0001 (Center).
+    b.extend_from_slice(&[0x00, 0x88]);
+    b.extend_from_slice(&[0x00, 0x07]); // undef
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+
+    let (_typed, emissions) = parse(&b, ByteOrder::Big, Some("NIKON D70"));
+    let get = |n: &str| {
+      emissions
+        .iter()
+        .find(|e| e.name() == n)
+        .map(|e| e.value().clone())
+    };
+    assert_eq!(
+      get("AFAreaMode"),
+      Some(TagValue::Str(SmolStr::new("Single Area")))
+    );
+    assert_eq!(get("AFPoint"), Some(TagValue::Str(SmolStr::new("Center"))));
+    assert_eq!(
+      get("AFPointsInFocus"),
+      Some(TagValue::Str(SmolStr::new("Center")))
+    );
+  }
+
+  /// END-TO-END of the implicit-`undef` SubDirectory override (`Exif.pm:6733`):
+  /// an AFInfo (0x0088) whose ON-DISK format is a huge numeric `int32u` count
+  /// (> 100000) is read as `undef` and so is NOT excessive-count-skipped — the
+  /// AFInfo children (AFAreaMode/AFPoint/AFPointsInFocus) STILL emit, exactly as
+  /// `perl exiftool 13.59` does (verbose: `int32u[100001] read as undef[400004]`
+  /// → AFInfo BinaryData directory processed). Pre-fix the entry was dropped by
+  /// the excessive-count guard and NO AFInfo child emitted.
+  #[test]
+  fn af_info_int32u_excessive_count_read_as_undef_emits_children() {
+    let count: u32 = 100_001; // *4 = 400004 bytes (> 100000)
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // header (10)
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]); // IFD0 at embedded+8 = blob 18
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    // AFInfo (0x0088): int32u, huge count, OUT-OF-LINE (400004 > 4). The value
+    // offset is embedded-relative (blob = 10 + embedded). Entry table is 18..32;
+    // next-IFD ptr 32..36; the AFInfo block starts at embedded offset 26 (blob
+    // 36), fully in-bounds.
+    let block_emb: u32 = 26; // blob 36
+    b.extend_from_slice(&[0x00, 0x88]);
+    b.extend_from_slice(&[0x00, 0x04]); // int32u
+    b.extend_from_slice(&count.to_be_bytes());
+    b.extend_from_slice(&block_emb.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    debug_assert_eq!(b.len(), 36); // == 10 + 26
+    // The AFInfo block: byte0 AFAreaMode=0 (Single Area), byte1 AFPoint=0
+    // (Center), bytes2-3 AFPointsInFocus=0x0001 (Center); then padded to the
+    // full declared 400004-byte size so the block is in-bounds.
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+    b.resize(36 + (count as usize) * 4, 0);
+
+    let (_typed, emissions) = parse(&b, ByteOrder::Big, Some("NIKON D70"));
+    let get = |n: &str| {
+      emissions
+        .iter()
+        .find(|e| e.name() == n)
+        .map(|e| e.value().clone())
+    };
+    assert_eq!(
+      get("AFAreaMode"),
+      Some(TagValue::Str(SmolStr::new("Single Area"))),
+      "AFInfo children emit (read as undef, NOT excessive-count-skipped)"
+    );
+    assert_eq!(get("AFPoint"), Some(TagValue::Str(SmolStr::new("Center"))));
+    assert_eq!(
+      get("AFPointsInFocus"),
+      Some(TagValue::Str(SmolStr::new("Center")))
+    );
+  }
+
+  /// A ColorBalance (0x0097) whose declared value is too short to hold the
+  /// `0103` record (count 4 = just the `"0103"` prefix) emits NO WB_RGBGLevels
+  /// and does NOT over-read into the adjacent IFD bytes. ExifTool bounds the
+  /// `ColorBalance3` child by the PARENT tag's value size (`Start => '$valuePtr
+  /// + 20'` then `int16u[4]` = needs 28 bytes); a 4-byte value cannot supply
+  /// the record, so nothing is produced. The trailing bytes here would, if
+  /// (wrongly) over-read from the buffer tail, decode a bogus level set —
+  /// guarding the over-read fix.
+  #[test]
+  fn color_balance_short_value_emits_no_levels() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]); // IFD0 at blob 18
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    // ColorBalance (0x0097): undef, count 4 = "0103" (inline — fits in 4 bytes).
+    b.extend_from_slice(&[0x00, 0x97]);
+    b.extend_from_slice(&[0x00, 0x07]); // undef
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4
+    b.extend_from_slice(b"0103"); // inline value (only the version prefix)
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // Trailing bytes that a buggy `value_offset + 20` over-read would pick up as
+    // a (bogus) int16u[4] WB_RGBGLevels — present to prove they are NOT read.
+    b.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]);
+
+    let (_typed, emissions) = parse(&b, ByteOrder::Big, Some("NIKON D70"));
+    assert!(
+      emissions.iter().all(|e| e.name() != "WB_RGBGLevels"),
+      "a short ColorBalance value must emit no WB_RGBGLevels (no over-read), got {emissions:?}"
+    );
+    // And no bogus ColorBalance parent (the SubDirectory pointer never emits it).
+    assert!(emissions.iter().all(|e| e.name() != "ColorBalance"));
+  }
+
+  /// An empty / too-short blob yields nothing (no panic).
+  #[test]
+  fn empty_blob_is_empty() {
+    let (typed, emissions) = parse(b"", ByteOrder::Big, None);
+    assert_eq!(typed, MakerNotesNikon::new());
+    assert!(emissions.is_empty());
+  }
+
+  /// DIVERGENCE ORACLE (end-to-end): the embedded-TIFF IFD0-offset field is
+  /// IGNORED — `Start => '$valuePtr + 18'` (`MakerNotes.pm:54`) walks the Main
+  /// IFD at the FIXED `tiff_at + 8` regardless of the field. A blob whose field
+  /// points at a SECOND valid-looking IFD (a decoy Quality "FAKE") must emit the
+  /// real fixed-start IFD's LensType and NONE of the decoy's tags. (Only the
+  /// `MM`/`II` marker is read from the embedded header; the field is not.)
+  #[test]
+  fn type3_embedded_ifd0_field_ignored_walks_fixed_start() {
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // type-3 header (10)
+    b.extend_from_slice(b"MM"); // embedded TIFF, big-endian
+    b.extend_from_slice(&[0x00, 0x2a]); // magic
+    // IFD0-offset field = 40 (NOT 8): if followed it points the Main IFD at
+    // tiff_at(10) + 40 = blob 50 — the DECOY IFD below. ExifTool ignores it.
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x28]);
+    // REAL IFD at the FIXED start (blob 18): LensType (0x0083) int8u = 6 → "G".
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    b.extend_from_slice(&[0x00, 0x83, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01]);
+    b.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]);
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // Pad to blob 50, then the DECOY IFD: Quality (0x0004) string[4] = "FAKE".
+    while b.len() < 50 {
+      b.push(0);
+    }
+    b.extend_from_slice(&[0x00, 0x01]); // 1 entry
+    b.extend_from_slice(&[0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00, 0x04]);
+    b.extend_from_slice(b"FAKE"); // inline value
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+
+    let (typed, emissions) = parse(&b, ByteOrder::Big, Some("NIKON D70"));
+    // The real fixed-start LensType is emitted; the decoy Quality is NOT.
+    assert_eq!(
+      typed.lens_type(),
+      Some("G"),
+      "the fixed-start IFD's LensType must decode"
+    );
+    assert_eq!(
+      typed.quality(),
+      None,
+      "the decoy IFD (field-pointed) must NOT be walked"
+    );
+    assert!(
+      emissions.iter().all(|e| e.name() != "Quality"),
+      "the decoy Quality tag must be absent, got {emissions:?}"
+    );
+    assert!(emissions.iter().any(|e| e.name() == "LensType"));
+  }
+
+  /// End-to-end (type-2): an out-of-line value whose full length runs PAST the
+  /// parent EXIF buffer is DROPPED, not emitted as a truncated partial tail —
+  /// matching ExifTool (`$valuePtr + $size > $dataLen` ⇒ `$bad`, no emission;
+  /// verified: ExifTool emits only a `[minor] Bad offset` warning, no tag).
+  /// A legitimately in-bounds entry in the same MakerNote still decodes. (The
+  /// directory entry table itself is bounded to the buffer, ExifTool's
+  /// `DataLen` bound — NOT to the shorter declared MakerNote length.)
+  ///
+  /// Uses `%Nikon::Type2` tags (Quality 0x0003 in-bounds, Converter 0x000b
+  /// out-of-line) since the type-2 layout is walked against that table.
+  #[test]
+  fn nikon_type2_out_of_line_value_past_buffer_is_dropped() {
+    // Parent TIFF (little-endian, type-2 LE). MakerNote at offset 8.
+    let mut data: Vec<u8> = Vec::new();
+    data.extend_from_slice(&[b'I', b'I', 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00]);
+    let mn_offset = data.len(); // 8
+    // Type-2 header "Nikon\0\x01" + 1 pad byte; IFD begins at blob offset 8.
+    data.extend_from_slice(b"Nikon\x00\x01\x00");
+    let ifd_at = data.len(); // = mn_offset + 8
+    data.extend_from_slice(&[0x02, 0x00]); // 2 entries (LE)
+    // Entry 0 — Quality (0x0003) ASCII "F" (count 2, inline) → in-bounds.
+    data.extend_from_slice(&[0x03, 0x00, 0x02, 0x00, 0x02, 0x00, 0x00, 0x00]);
+    data.extend_from_slice(&[b'F', 0x00, 0x00, 0x00]);
+    // Entry 1 — Converter (0x000b) rational64u[4] = 32 bytes, OUT-OF-LINE at a
+    // parent-relative offset whose full 32 bytes run past the buffer end.
+    let value_off = (data.len() + 8) as u32; // points just after this IFD
+    data.extend_from_slice(&[0x0b, 0x00, 0x05, 0x00, 0x04, 0x00, 0x00, 0x00]);
+    data.extend_from_slice(&value_off.to_le_bytes()); // out-of-line offset
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    // Supply only 8 of the 32 value bytes (truncated past EOF).
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00, 0x01]);
+    let mn_len = data.len() - mn_offset;
+    let _ = ifd_at;
+
+    let (_typed, emissions) = parse_in_tiff(
+      &data,
+      mn_offset,
+      mn_len,
+      ByteOrder::Little,
+      true,
+      Some("NIKON E990"),
+    );
+    // The in-bounds Quality decodes; the truncated out-of-line Converter is
+    // dropped (NOT a partial-tail value).
+    let get = |n: &str| {
+      emissions
+        .iter()
+        .find(|e| e.name() == n)
+        .map(|e| e.value().clone())
+    };
+    assert_eq!(get("Quality"), Some(TagValue::Str(SmolStr::new("F"))));
+    assert!(
+      emissions.iter().all(|e| e.name() != "Converter"),
+      "a value running past the buffer must be dropped, not partial-decoded"
+    );
+  }
+
+  /// Build a parent little-endian TIFF wrapping a type-2 (`"Nikon\0\x01"`)
+  /// MakerNote whose IFD (at blob offset 8, little-endian) carries the given
+  /// `entries` (each a full 12-byte IFD entry). Returns `(data, mn_offset,
+  /// mn_len)` for [`parse_in_tiff`]. The MakerNote value is placed out-of-line
+  /// after IFD0 so out-of-line offsets are parent-TIFF-relative (the no-`Base`
+  /// type-2 semantics).
+  fn type2_in_tiff(entries: &[[u8; 12]]) -> (Vec<u8>, usize, usize) {
+    // Build the type-2 MakerNote blob: header (8 bytes) + LE IFD at offset 8.
+    let mut mn: Vec<u8> = Vec::new();
+    mn.extend_from_slice(b"Nikon\x00\x01"); // 7 bytes
+    mn.push(0x00); // pad → entry count at blob offset 8
+    let n = u16::try_from(entries.len()).unwrap();
+    mn.extend_from_slice(&n.to_le_bytes());
+    for e in entries {
+      mn.extend_from_slice(e);
+    }
+    mn.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+    // Container TIFF: II header, IFD0 (Make=NIKON), MakerNote out-of-line.
+    let mut data: Vec<u8> = Vec::new();
+    data.extend_from_slice(&[b'I', b'I', 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00]);
+    // IFD0: 2 entries (Make, MakerNote) + next-IFD. Size = 2 + 2*12 + 4 = 30.
+    let ifd0_start = 8usize;
+    let ifd0_size = 2 + 2 * 12 + 4;
+    let ool = ifd0_start + ifd0_size;
+    let make = b"NIKON\x00";
+    let off_make = ool as u32;
+    let off_mn = (ool + make.len()) as u32;
+    data.extend_from_slice(&[0x02, 0x00]); // 2 entries
+    // Make (0x010f) ASCII, out-of-line.
+    data.extend_from_slice(&[0x0f, 0x01, 0x02, 0x00]);
+    data.extend_from_slice(&(make.len() as u32).to_le_bytes());
+    data.extend_from_slice(&off_make.to_le_bytes());
+    // MakerNote (0x927c) UNDEFINED, out-of-line.
+    data.extend_from_slice(&[0x7c, 0x92, 0x07, 0x00]);
+    data.extend_from_slice(&(mn.len() as u32).to_le_bytes());
+    data.extend_from_slice(&off_mn.to_le_bytes());
+    data.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    debug_assert_eq!(data.len(), ool);
+    data.extend_from_slice(make);
+    let mn_offset = data.len();
+    data.extend_from_slice(&mn);
+    let mn_len = data.len() - mn_offset;
+    (data, mn_offset, mn_len)
+  }
+
+  /// One 12-byte little-endian IFD entry (tag, format, count, 4 inline value
+  /// bytes).
+  fn le_entry(tag: u16, fmt: u16, count: u32, val: [u8; 4]) -> [u8; 12] {
+    let mut e = [0u8; 12];
+    e[0..2].copy_from_slice(&tag.to_le_bytes());
+    e[2..4].copy_from_slice(&fmt.to_le_bytes());
+    e[4..8].copy_from_slice(&count.to_le_bytes());
+    e[8..12].copy_from_slice(&val);
+    e
+  }
+
+  /// REGRESSION ORACLE: a type-2 (`"Nikon\0\x01"`) MakerNote is walked
+  /// against `%Nikon::Type2`, NOT `%Nikon::Main` — so 0x0003 emits as
+  /// `Quality` (the Type2 name), NOT `ColorMode` (the Main name for the same
+  /// ID). Byte-exact to `perl exiftool 13.59` on the crafted blob: `Quality`,
+  /// `WhiteBalance`, `DigitalZoom`, `Converter` — the four Type2 tags supplied.
+  #[test]
+  fn nikon_type2_uses_type2_table() {
+    let entries = [
+      le_entry(0x0003, 2, 2, [b'F', 0x00, 0x00, 0x00]), // Quality "F"
+      le_entry(0x0007, 2, 2, [b'A', 0x00, 0x00, 0x00]), // WhiteBalance "A"
+      le_entry(0x000a, 3, 1, [0x02, 0x00, 0x00, 0x00]), // DigitalZoom int16u 2
+      le_entry(0x000b, 3, 1, [0x01, 0x00, 0x00, 0x00]), // Converter int16u 1
+    ];
+    let (data, mn_offset, mn_len) = type2_in_tiff(&entries);
+    let (_typed, emissions) = parse_in_tiff(
+      &data,
+      mn_offset,
+      mn_len,
+      ByteOrder::Little,
+      true,
+      Some("NIKON E990"),
+    );
+    let get = |n: &str| {
+      emissions
+        .iter()
+        .find(|e| e.name() == n)
+        .map(|e| e.value().clone())
+    };
+    // The Type2 names — matching the oracle exactly.
+    assert_eq!(get("Quality"), Some(TagValue::Str(SmolStr::new("F"))));
+    assert_eq!(get("WhiteBalance"), Some(TagValue::Str(SmolStr::new("A"))));
+    // A single small int16u renders to `I64` (render.rs: U64→I64 when it fits).
+    assert_eq!(get("DigitalZoom"), Some(TagValue::I64(2)));
+    assert_eq!(get("Converter"), Some(TagValue::I64(1)));
+    // 0x0003 is Quality, NEVER the Main name ColorMode (the bug).
+    assert!(
+      emissions.iter().all(|e| e.name() != "ColorMode"),
+      "type-2 0x0003 must be Quality (Type2), not ColorMode (Main): {emissions:?}"
+    );
+    // And the typed Main-semantic surface is NOT populated from a type-2 walk
+    // (0x0004/0x0007 mean different tags there).
+    assert_eq!(_typed.quality(), None);
+    assert_eq!(_typed.focus_mode(), None);
+  }
+
+  /// A type-2 value is read LITTLE-ENDIAN (the `MakerNotes.pm:544` fixed
+  /// `ByteOrder => 'LittleEndian'`), regardless of the parent TIFF order. Here
+  /// the parent is passed BIG-endian, yet DigitalZoom (0x000a) int16u with LE
+  /// bytes `02 00` reads `2` — proving the type-2 path forces LE (a big-endian
+  /// read of `02 00` would be `0x0200 = 512`).
+  #[test]
+  fn nikon_type2_little_endian() {
+    let entries = [le_entry(0x000a, 3, 1, [0x02, 0x00, 0x00, 0x00])]; // DigitalZoom
+    let (data, mn_offset, mn_len) = type2_in_tiff(&entries);
+    // Parent order BIG — the type-2 arm must IGNORE it and force LE.
+    let (_typed, emissions) = parse_in_tiff(
+      &data,
+      mn_offset,
+      mn_len,
+      ByteOrder::Big,
+      true,
+      Some("NIKON E990"),
+    );
+    let dz = emissions
+      .iter()
+      .find(|e| e.name() == "DigitalZoom")
+      .map(|e| e.value().clone());
+    assert_eq!(
+      dz,
+      Some(TagValue::I64(2)),
+      "type-2 forces LittleEndian: `02 00` is 2, not 512 (BE)"
+    );
+  }
+
+  /// The type-2 IFD is read at `Start => '$valuePtr + 8'` — the entry count
+  /// sits at blob offset 8 (after the 8-byte `"Nikon\0\x01"`+pad header). A
+  /// decoy IFD planted at blob offset 0 (a different tag) is NOT walked; only
+  /// the real IFD at +8 emits. Proves the +8 start.
+  #[test]
+  fn nikon_type2_start_plus_8() {
+    // Real IFD at +8 carries Quality (0x0003). To prove +8 (not +0), we hand-
+    // build the MakerNote so its FIRST 8 bytes ("Nikon\0\x01"+pad) would, if
+    // (wrongly) read as an IFD at offset 0, parse a bogus entry count from the
+    // ASCII header bytes — never the real IFD. The +8 walk finds Quality.
+    let entries = [le_entry(0x0003, 2, 2, [b'F', 0x00, 0x00, 0x00])];
+    let (data, mn_offset, mn_len) = type2_in_tiff(&entries);
+    // Sanity: the entry count u16 lives at blob offset 8 within the MakerNote.
+    let mn = &data[mn_offset..mn_offset + mn_len];
+    assert_eq!(&mn[0..8], b"Nikon\x00\x01\x00", "8-byte type-2 header");
+    assert_eq!(
+      u16::from_le_bytes([mn[8], mn[9]]),
+      1,
+      "the IFD entry count (1) is at blob offset 8 — the +8 Start"
+    );
+    let (_typed, emissions) = parse_in_tiff(
+      &data,
+      mn_offset,
+      mn_len,
+      ByteOrder::Little,
+      true,
+      Some("NIKON E990"),
+    );
+    assert!(
+      emissions.iter().any(|e| e.name() == "Quality"),
+      "the IFD at +8 must be walked (Quality emitted): {emissions:?}"
+    );
+  }
+}

--- a/src/exif/makernotes/vendors/nikon/printconv.rs
+++ b/src/exif/makernotes/vendors/nikon/printconv.rs
@@ -1,0 +1,1596 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Per-tag PrintConv / ValueConv for the Nikon MakerNotes tables — a small
+//! enum over the `PrintConv => { … }` hashes and inline expressions in
+//! `Image::ExifTool::Nikon` (`Nikon.pm`). The IFD walker calls
+//! [`NikonConv::apply`] at emit time with the decoded raw value.
+//!
+//! The `%Image::ExifTool::Nikon::Main` table sets a table-level
+//! `PRINT_CONV => \&FormatString` (`Nikon.pm:1784`), which title-cases the
+//! all-caps string values Nikon cameras write (e.g. `FINE` → `Fine`,
+//! `SPEEDLIGHT` → `Speedlight`). A tag with NO own `PrintConv` and a string
+//! value falls through to that table default — modelled here by
+//! [`NikonConv::FormatString`]. Tags with their own `PrintConv` (LensType,
+//! FlashMode, …) or `PrintConv => undef` (SerialNumber) bypass it.
+
+#![deny(clippy::indexing_slicing)]
+
+use super::body::ParsedValue;
+use crate::exif::ifd::ByteOrder;
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::string::String;
+
+/// One Nikon tag's conversion strategy. Enum-newtype/unit-only (D8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NikonConv {
+  /// No own PrintConv — the value falls through the table-level
+  /// `PRINT_CONV => \&FormatString` (`Nikon.pm:1784`) when it is a string
+  /// (title-cases all-caps Nikon strings); a non-string value renders via the
+  /// default `ReadValue` join. This is the dominant Nikon::Main string tag.
+  FormatString,
+  /// No PrintConv AND no table-default (the tag set `PrintConv => undef` to
+  /// disable the inherited `FormatString`, e.g. `SerialNumber` 0x001d) — emit
+  /// the raw decoded value verbatim.
+  Raw,
+  /// `MakerNoteVersion` (0x0001) — `ValueConv` converts a binary 4-byte value
+  /// to the digit string, then `PrintConv` `s/^(\d{2})/$1./;s/^0//` inserts a
+  /// dot after the first two digits and strips a leading zero
+  /// (`Nikon.pm:1786-1797`). E.g. `"0210"` → `"2.10"` (a numeric-shaped string
+  /// the JSON writer emits as the bare number `2.10`).
+  MakerNoteVersion,
+  /// `ISO` (0x0002) — `int16u[2]`, `PrintConv` `s/^0 //;s/^1 (\d+)/Hi $1/`
+  /// (`Nikon.pm:1804-1819`). The first word is `1` for the "Hi ISO" modes;
+  /// otherwise the leading `0 ` is stripped. The tag's `RawConv => '$val eq
+  /// "\0\0\0\0" ? undef : $val'` (`Nikon.pm:1806`) is effectively DEAD: by
+  /// RawConv time `$val` is the decoded `int16u[2]` string (e.g. `"0 0"`),
+  /// never the raw 4-NUL byte string, so the `eq` never matches and the
+  /// all-zero LO-ISO value IS emitted (`Nikon.jpg` → `Nikon:ISO` `0`,
+  /// oracle-confirmed). NOT a drop.
+  Iso,
+  /// The three-byte signed-fraction ValueConv `unpack("c3"); $c ? $a*($b/$c)
+  /// : 0`, then `Exif::PrintFraction` (`+N` / `+N/2` / `+N/3` / `%+.3g`).
+  /// Used by `ProgramShift` (0x000d), `ExposureTuning` (0x001c).
+  SignedFractionPrintFraction,
+  /// `ExposureDifference` (0x000e) — the same `c3` ValueConv, but the
+  /// PrintConv is `$val ? sprintf("%+.1f",$val) : 0` (`Nikon.pm:1859`), NOT
+  /// `PrintFraction`. e.g. `-4.9167` → `"-4.9"`.
+  ExposureDifference,
+  /// As [`Self::SignedFractionPrintFraction`] but the `PrintConv` is the
+  /// `PrintFraction`-as-`"+N/M"` flash-comp form (0x0012 `FlashExposureComp`,
+  /// 0x0017 `ExternalFlashExposureComp`). ExifTool shares the same
+  /// `PrintFraction` here — kept distinct only for documentation.
+  FlashExposureComp,
+  /// `FlashExposureBracketValue` (0x0018) / `ExposureBracketValue` (0x0019) —
+  /// the same `c3` ValueConv, `PrintConv => sprintf("%.1f", $val)`
+  /// (`Nikon.pm:1955`). 0x0019 is a plain `rational64s` instead.
+  BracketFloat1,
+  /// `ISOSetting` (0x0013) — `int16u[2]`, `PrintConv => s/^0 //`
+  /// (`Nikon.pm:1907`). The first word is always stripped.
+  IsoSetting,
+  /// `LensType` (0x0083) — a `DecodeBits` BITMASK with post-processing:
+  /// `0 → "AF"`, then the bit labels with comma-stripping and the E/1/FT-1
+  /// reordering (`Nikon.pm:2052-2070`).
+  LensType,
+  /// `Lens` (0x0084) — `rational64u[4]` rendered by `Exif::PrintLensInfo`
+  /// (`"18-70mm f/3.5-4.5"`, `Nikon.pm:2089`).
+  Lens,
+  /// `FlashMode` (0x0087) — `int8u` hash (`Nikon.pm:2099-2110`).
+  FlashMode,
+  /// `ShootingMode` (0x0089) — the `Single-Frame` prefix logic + a
+  /// `DecodeBits` BITMASK (`Nikon.pm:2160-2189`). Bit 5's label is
+  /// model-dependent (D70 = "Unused LE-NR Slowdown", else "Auto ISO").
+  ShootingMode,
+  /// `LensFStops` (0x008b) — `c3` `ValueConv` then `PrintConv => sprintf("%.2f",
+  /// $val)` (`Nikon.pm:2196`).
+  LensFStops,
+  /// `NEFCompression` (0x0093) — `%nefCompression` hash (`Nikon.pm:2913`).
+  NefCompression,
+  /// `ColorSpace` (0x001e) — `{1=>'sRGB',2=>'Adobe RGB',4=>'BT.2100'}`
+  /// (`Nikon.pm:2010`).
+  ColorSpace,
+  /// `ShutterCount` (0x00a7) — `$val == 4294965247 ? "n/a" : $val`
+  /// (`Nikon.pm:2980`).
+  ShutterCount,
+  /// `ExposureBracketValue` (0x0019) — `rational64s`, `PrintConv =>
+  /// PrintFraction` unless the value is `undef` → `"n/a"` (`Nikon.pm:1960`).
+  ExposureBracketRational,
+  /// `SensorPixelSize` (0x009a) — `rational64u[2]`, `PrintConv =>
+  /// '$val=~s/ / x /;"$val um"'` (`Nikon.pm:2868`) → `"7.8 x 7.8 um"`.
+  SensorPixelSize,
+  /// `ImageAuthentication` (0x0020) / `%offOn` — `{0=>'Off',1=>'On'}`.
+  OffOn,
+  /// `ActiveD-Lighting` (0x0022, `Nikon.pm:1998`).
+  ActiveDLighting,
+  /// `VignetteControl` (0x002a, `Nikon.pm:2032`).
+  VignetteControl,
+  /// `ShutterMode` (0x0034, `Nikon.pm:2042`).
+  ShutterMode,
+  /// `ImageSizeRAW` (0x003e, `Nikon.pm:2042`) — `{1=>'Large',2=>'Medium',
+  /// 3=>'Small'}`.
+  ImageSizeRaw,
+  /// `JPGCompression` (0x0044, `Nikon.pm:2168-2175`) — `{1=>'Size Priority',
+  /// 3=>'Optimal Quality'}`, with a `RawConv => '($val) ? $val : undef'`
+  /// (`:2170`) that drops `0` (raw files) ⇒ the tag is NOT emitted.
+  JpgCompression,
+  /// `DateStampMode` (0x009d, `Nikon.pm:2925`).
+  DateStampMode,
+  /// `HighISONoiseReduction` (0x00b1, `Nikon.pm:3066`).
+  HighIsoNr,
+  /// `%Nikon::AFInfo` position 0 `AFAreaMode` (`Nikon.pm:2117`).
+  AfAreaMode,
+  /// `%Nikon::AFInfo` position 1 `AFPoint` (`Nikon.pm:2128`).
+  AfPoint,
+  /// `%Nikon::AFInfo` position 2 `AFPointsInFocus` (`%afPoints11`,
+  /// `Nikon.pm:2152`) — a `0 => '(none)'` / `0x7ff => 'All 11 Points'` hash
+  /// with a `DecodeBits` BITMASK fallback.
+  AfPointsInFocus,
+  /// `CropHiSpeed` (0x001b, `%cropHiSpeed`, `Nikon.pm:1974`) — `int16u[7]`; the
+  /// `OTHER` sub maps element 0 via the crop-mode hash and formats the full
+  /// record as `"<mode> (<W>x<H> cropped to <W>x<H> at pixel <X>,<Y>)"`.
+  CropHiSpeed,
+  /// `RetouchHistory` (0x009e, `Nikon.pm:2935`) — `int16u[10]`; ValueConv
+  /// trims trailing ` 0` groups, the ARRAY PrintConv maps each element via
+  /// `%retouchValues` and joins with `"; "` (`ExifTool.pm:3696`).
+  RetouchHistory,
+  /// `PowerUpTime` (0x00b6, `Nikon.pm:3071`) — `undef`; RawConv unpacks a
+  /// 16-bit year (`v`/`n` by byte order) + 5 bytes (M/D/h/m/s) into
+  /// `"YYYY:MM:DD HH:MM:SS"`; the PrintConv `ConvertDateTime` is identity.
+  PowerUpTime,
+  /// `NEFBitDepth` (0x0e22, `Nikon.pm:3280`) — `int16u[4]`; a space-joined
+  /// PrintConv hash (`'8 8 8 0' => '8 x 3'`, …) keyed on the whole record.
+  NefBitDepth,
+}
+
+impl NikonConv {
+  /// Apply this conversion to the decoded value, returning the converted
+  /// [`TagValue`] — or `None` when a `RawConv => … : undef` drops the value
+  /// (the tag is then NOT emitted, matching ExifTool: a RawConv that returns
+  /// `undef` suppresses the tag). Of the ported Nikon::Main tags, only
+  /// `JPGCompression` (0x0044, `RawConv => '($val) ? $val : undef'`,
+  /// `Nikon.pm:2170`) has a RawConv that actually fires — it drops the
+  /// raw-file `0`, so this conv returns `None` for raw `0`. Every other conv
+  /// returns `Some(_)`. (The ISO 0x0002 `$val eq "\0\0\0\0"` RawConv looks
+  /// similar but is DEAD — see [`Self::Iso`] — so ISO never drops.) The leaf
+  /// walker SKIPS a `None` (does not push), the same way the Canon binary
+  /// tables drop their `RawConv … undef` positions.
+  ///
+  /// `print_conv = false` (`-n`) emits the post-ValueConv raw scalar;
+  /// `print_conv = true` (the `-j` default) renders the human string.
+  /// `model` threads the parent IFD0 `Model` for the few model-conditional
+  /// PrintConv branches (`ShootingMode` bit 5). `order` is the byte order in
+  /// effect for the MakerNote IFD (`GetByteOrder()`) — needed by the few
+  /// RawConvs that unpack multi-byte fields from `undef` data (`PowerUpTime`).
+  #[must_use]
+  pub fn apply(
+    self,
+    raw: &ParsedValue,
+    print_conv: bool,
+    model: Option<&str>,
+    order: ByteOrder,
+  ) -> Option<TagValue> {
+    Some(match self {
+      // `RawConv => '($val) ? $val : undef'` (`Nikon.pm:2170`): a raw `0`
+      // (the raw-file marker) is `undef` ⇒ the tag is NOT emitted.
+      NikonConv::JpgCompression => return jpg_compression_conv(raw, print_conv),
+      NikonConv::Raw => raw.to_default_tag_value(),
+      NikonConv::FormatString => {
+        // ValueConv is identity; the table-default PrintConv title-cases a
+        // string value. `-n` mode emits the un-title-cased string.
+        match raw.as_text() {
+          Some(s) if print_conv => TagValue::Str(SmolStr::new(format_string(s))),
+          Some(s) => TagValue::Str(SmolStr::new(s)),
+          None => raw.to_default_tag_value(),
+        }
+      }
+      NikonConv::MakerNoteVersion => {
+        let s = maker_note_version_value(raw);
+        if print_conv {
+          TagValue::Str(SmolStr::new(maker_note_version_print(&s)))
+        } else {
+          TagValue::Str(SmolStr::new(s))
+        }
+      }
+      NikonConv::Iso => iso_conv(raw, print_conv),
+      NikonConv::IsoSetting => iso_setting_conv(raw, print_conv),
+      NikonConv::SignedFractionPrintFraction | NikonConv::FlashExposureComp => {
+        let Some(v) = raw.signed_fraction_c3() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          TagValue::Str(SmolStr::new(print_fraction(v)))
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::ExposureDifference => {
+        let Some(v) = raw.signed_fraction_c3() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          // `$val ? sprintf("%+.1f",$val) : 0`.
+          if v == 0.0 {
+            TagValue::I64(0)
+          } else {
+            TagValue::Str(SmolStr::new(std::format!("{v:+.1}")))
+          }
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::BracketFloat1 => bracket_float1(raw, print_conv),
+      NikonConv::LensType => lens_type_conv(raw, print_conv),
+      NikonConv::Lens => lens_conv(raw, print_conv),
+      NikonConv::FlashMode => hash_conv(raw, print_conv, flash_mode_label),
+      NikonConv::ShootingMode => shooting_mode_conv(raw, print_conv, model),
+      NikonConv::LensFStops => {
+        let Some(v) = raw.signed_fraction_c3() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{v:.2}")))
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::NefCompression => hash_conv(raw, print_conv, nef_compression_label),
+      NikonConv::ColorSpace => hash_conv(raw, print_conv, color_space_label),
+      NikonConv::ShutterCount => {
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv && n == 4_294_965_247 {
+          TagValue::Str(SmolStr::new("n/a"))
+        } else {
+          TagValue::I64(n)
+        }
+      }
+      NikonConv::ExposureBracketRational => {
+        // `rational64s`; PrintConv `$val !~ /undef/ ? PrintFraction : "n/a"`.
+        // The decoded `$val` is the single rational's decimal scalar; an
+        // `undef` (0/0) rational renders the bare word `undef` → "n/a".
+        let Some(joined) = raw.rational_join_decimal() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          if joined.contains("undef") {
+            TagValue::Str(SmolStr::new("n/a"))
+          } else {
+            let v: f64 = joined.parse().unwrap_or(0.0);
+            TagValue::Str(SmolStr::new(print_fraction(v)))
+          }
+        } else {
+          TagValue::Str(SmolStr::new(joined))
+        }
+      }
+      NikonConv::SensorPixelSize => {
+        let Some(joined) = raw.rational_join_decimal() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          // s/ / x / then append " um".
+          TagValue::Str(SmolStr::new(std::format!(
+            "{} um",
+            joined.replace(' ', " x ")
+          )))
+        } else {
+          TagValue::Str(SmolStr::new(joined))
+        }
+      }
+      NikonConv::OffOn => hash_conv(raw, print_conv, off_on_label),
+      NikonConv::ActiveDLighting => hash_conv(raw, print_conv, active_d_lighting_label),
+      NikonConv::VignetteControl => hash_conv(raw, print_conv, vignette_control_label),
+      NikonConv::ShutterMode => hash_conv(raw, print_conv, shutter_mode_label),
+      NikonConv::ImageSizeRaw => hash_conv(raw, print_conv, image_size_raw_label),
+      NikonConv::DateStampMode => hash_conv(raw, print_conv, date_stamp_mode_label),
+      NikonConv::HighIsoNr => hash_conv(raw, print_conv, high_iso_nr_label),
+      NikonConv::AfAreaMode => hash_conv(raw, print_conv, af_area_mode_label),
+      NikonConv::AfPoint => hash_conv(raw, print_conv, af_point_label),
+      NikonConv::AfPointsInFocus => af_points_in_focus_conv(raw, print_conv),
+      NikonConv::CropHiSpeed => crop_hi_speed_conv(raw, print_conv),
+      NikonConv::RetouchHistory => retouch_history_conv(raw, print_conv),
+      NikonConv::PowerUpTime => power_up_time_conv(raw, print_conv, order),
+      NikonConv::NefBitDepth => nef_bit_depth_conv(raw, print_conv),
+    })
+  }
+}
+
+/// `%afPoints11` (`Nikon.pm:2152`) PrintConv: `0 => '(none)'`,
+/// `0x7ff => 'All 11 Points'`, else a `DecodeBits` BITMASK over the 11 AF
+/// points. ExifTool checks the direct hash key FIRST, then falls to BITMASK
+/// (`ExifTool.pm:3603-3624`).
+fn af_points_in_focus_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(n) = raw.first_i64() else {
+    return raw.to_default_tag_value();
+  };
+  if !print_conv {
+    return TagValue::I64(n);
+  }
+  match n {
+    0 => TagValue::Str(SmolStr::new("(none)")),
+    0x7ff => TagValue::Str(SmolStr::new("All 11 Points")),
+    _ => TagValue::Str(SmolStr::new(crate::convert::decode_bits(
+      &n.to_string(),
+      Some(AF_POINTS11_BITS),
+      32,
+    ))),
+  }
+}
+
+/// `CropHiSpeed` (0x001b, `%cropHiSpeed`, `Nikon.pm:1974`). The decoded `$val`
+/// is the space-joined `int16u[7]` string. The `OTHER` sub: with exactly 7
+/// elements, map element 0 via the crop-mode hash (else `Unknown (N)`) and
+/// format `"<mode> (<a1>x<a2> cropped to <a3>x<a4> at pixel <a5>,<a6>)"`; any
+/// other count renders `Unknown ($val)`. `-n` emits the raw joined string.
+fn crop_hi_speed_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(val) = raw.int_list_val_string() else {
+    return raw.to_default_tag_value();
+  };
+  if !print_conv {
+    return TagValue::Str(SmolStr::new(val));
+  }
+  let a: Vec<&str> = val.split(' ').collect();
+  if a.len() != 7 {
+    return TagValue::Str(SmolStr::new(std::format!("Unknown ({val})")));
+  }
+  let mode = a
+    .first()
+    .and_then(|s| s.parse::<i64>().ok())
+    .and_then(crop_hi_speed_label)
+    .map_or_else(
+      || std::format!("Unknown ({})", a.first().copied().unwrap_or("")),
+      std::string::ToString::to_string,
+    );
+  TagValue::Str(SmolStr::new(std::format!(
+    "{mode} ({}x{} cropped to {}x{} at pixel {},{})",
+    a.get(1).copied().unwrap_or(""),
+    a.get(2).copied().unwrap_or(""),
+    a.get(3).copied().unwrap_or(""),
+    a.get(4).copied().unwrap_or(""),
+    a.get(5).copied().unwrap_or(""),
+    a.get(6).copied().unwrap_or(""),
+  )))
+}
+
+/// `RetouchHistory` (0x009e, `Nikon.pm:2935`). ValueConv `$val=~s/( 0)+$//`
+/// trims trailing ` 0` groups from the space-joined `int16u[10]` string; the
+/// ARRAY PrintConv maps each remaining element via `%retouchValues` (unmapped
+/// → `Unknown (N)`) and joins with `"; "` (`ExifTool.pm:3696`). `-n` emits the
+/// post-ValueConv (trimmed) raw string.
+fn retouch_history_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(val) = raw.int_list_val_string() else {
+    return raw.to_default_tag_value();
+  };
+  // s/( 0)+$// — strip trailing " 0" groups.
+  let mut trimmed = val.as_str();
+  while let Some(head) = trimmed.strip_suffix(" 0") {
+    trimmed = head;
+  }
+  if !print_conv {
+    return TagValue::Str(SmolStr::new(trimmed));
+  }
+  let mut out = String::new();
+  for (i, tok) in trimmed.split(' ').enumerate() {
+    if i > 0 {
+      out.push_str("; ");
+    }
+    match tok.parse::<i64>().ok().and_then(retouch_value_label) {
+      Some(s) => out.push_str(s),
+      None => out.push_str(&std::format!("Unknown ({tok})")),
+    }
+  }
+  TagValue::Str(SmolStr::new(out))
+}
+
+/// `PowerUpTime` (0x00b6, `Nikon.pm:3071`). RawConv: a value shorter than 7
+/// bytes passes through verbatim; otherwise unpack a 16-bit year (`v`/`n` per
+/// byte order) + 5 bytes (month/day/hour/min/sec) → `"YYYY:MM:DD HH:MM:SS"`.
+/// The PrintConv `$self->ConvertDateTime($val)` is identity (no DateFormat).
+fn power_up_time_conv(raw: &ParsedValue, print_conv: bool, order: ByteOrder) -> TagValue {
+  let _ = print_conv; // ConvertDateTime is identity ⇒ value is the same string.
+  let bytes = raw.undef_or_text_bytes();
+  if bytes.len() < 7 {
+    return raw.to_default_tag_value();
+  }
+  let (y0, y1) = (bytes.first().copied(), bytes.get(1).copied());
+  let (Some(y0), Some(y1)) = (y0, y1) else {
+    return raw.to_default_tag_value();
+  };
+  let year = match order {
+    ByteOrder::Little => u16::from_le_bytes([y0, y1]),
+    ByteOrder::Big => u16::from_be_bytes([y0, y1]),
+  };
+  let month = bytes.get(2).copied().unwrap_or(0);
+  let day = bytes.get(3).copied().unwrap_or(0);
+  let hour = bytes.get(4).copied().unwrap_or(0);
+  let min = bytes.get(5).copied().unwrap_or(0);
+  let sec = bytes.get(6).copied().unwrap_or(0);
+  TagValue::Str(SmolStr::new(std::format!(
+    "{year:04}:{month:02}:{day:02} {hour:02}:{min:02}:{sec:02}"
+  )))
+}
+
+/// `NEFBitDepth` (0x0e22, `Nikon.pm:3280`) — `int16u[4]`, a PrintConv hash
+/// keyed on the whole space-joined record (`'8 8 8 0' => '8 x 3'`, …); an
+/// unmapped record renders `Unknown ($val)`. `-n` emits the raw joined string.
+fn nef_bit_depth_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(val) = raw.int_list_val_string() else {
+    return raw.to_default_tag_value();
+  };
+  if !print_conv {
+    return TagValue::Str(SmolStr::new(val));
+  }
+  let label = match val.as_str() {
+    "0 0 0 0" => "n/a (JPEG)",
+    "8 8 8 0" => "8 x 3",
+    "16 16 16 0" => "16 x 3",
+    "12 0 0 0" => "12",
+    "14 0 0 0" => "14",
+    other => return TagValue::Str(SmolStr::new(std::format!("Unknown ({other})"))),
+  };
+  TagValue::Str(SmolStr::new(label))
+}
+
+/// `%cropHiSpeed` (`Nikon.pm:1974`) crop-mode labels (element 0).
+fn crop_hi_speed_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Off",
+    1 => "1.3x Crop",
+    2 => "DX Crop",
+    3 => "5:4 Crop",
+    4 => "3:2 Crop",
+    6 => "16:9 Crop",
+    8 => "2.7x Crop",
+    9 => "DX Movie 16:9 Crop",
+    10 => "1.3x Movie Crop",
+    11 => "FX Uncropped",
+    12 => "DX Uncropped",
+    13 => "2.8x Movie Crop",
+    14 => "1.4x Movie Crop",
+    15 => "1.5x Movie Crop",
+    17 => "FX 1:1 Crop",
+    18 => "DX 1:1 Crop",
+    _ => return None,
+  })
+}
+
+/// `%retouchValues` (`Nikon.pm`) — the in-camera retouch-effect labels.
+fn retouch_value_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "None",
+    3 => "B & W",
+    4 => "Sepia",
+    5 => "Trim",
+    6 => "Small Picture",
+    7 => "D-Lighting",
+    8 => "Red Eye",
+    9 => "Cyanotype",
+    10 => "Sky Light",
+    11 => "Warm Tone",
+    12 => "Color Custom",
+    13 => "Image Overlay",
+    14 => "Red Intensifier",
+    15 => "Green Intensifier",
+    16 => "Blue Intensifier",
+    17 => "Cross Screen",
+    18 => "Quick Retouch",
+    19 => "NEF Processing",
+    23 => "Distortion Control",
+    25 => "Fisheye",
+    26 => "Straighten",
+    29 => "Perspective Control",
+    30 => "Color Outline",
+    31 => "Soft Filter",
+    32 => "Resize",
+    33 => "Miniature Effect",
+    34 => "Skin Softening",
+    35 => "Selected Frame",
+    37 => "Color Sketch",
+    38 => "Selective Color",
+    39 => "Glamour",
+    40 => "Drawing",
+    44 => "Pop",
+    45 => "Toy Camera Effect 1",
+    46 => "Toy Camera Effect 2",
+    47 => "Cross Process (red)",
+    48 => "Cross Process (blue)",
+    49 => "Cross Process (green)",
+    50 => "Cross Process (yellow)",
+    51 => "Super Vivid",
+    52 => "High-contrast Monochrome",
+    53 => "High Key",
+    54 => "Low Key",
+    _ => return None,
+  })
+}
+
+/// `-n`/ValueConv numeric: emit an integer if the fraction is integral, else
+/// a float (mirrors Perl's dualvar — a `0` ValueConv emits `0`, `-4.9` emits
+/// the float). The JSON writer then renders the bare number.
+fn value_conv_number(v: f64) -> TagValue {
+  if v == 0.0 {
+    TagValue::I64(0)
+  } else if v.fract() == 0.0 && v.abs() < 1e15 {
+    TagValue::I64(v as i64)
+  } else {
+    TagValue::F64(v)
+  }
+}
+
+/// `Image::ExifTool::Exif::PrintFraction($val)` (`Exif.pm`) — the faithful
+/// transliteration:
+///
+/// ```perl
+/// $val *= 1.00001;                       # avoid round-off errors
+/// if (not $val)                  { '0' }
+/// elsif (int($val)/$val > 0.999) { sprintf("%+d", int($val)) }
+/// elsif (int($val*2)/($val*2) > 0.999) { sprintf("%+d/2", int($val*2)) }
+/// elsif (int($val*3)/($val*3) > 0.999) { sprintf("%+d/3", int($val*3)) }
+/// else                           { sprintf("%+.3g", $val) }
+/// ```
+///
+/// e.g. `-5/3 ≈ -1.6667` → `"-5/3"`, `-4.9` → `"-4.9"` (the `%+.3g` arm).
+fn print_fraction(v: f64) -> String {
+  let val = v * 1.000_01;
+  // `not $val` is Perl-falsy for 0 (and the un-multiplied 0 stays 0).
+  if val == 0.0 {
+    return "0".to_string();
+  }
+  // int() truncates toward zero (Perl `int`).
+  let trunc = val.trunc();
+  if trunc / val > 0.999 {
+    return std::format!("{:+}", trunc as i64);
+  }
+  let v2 = val * 2.0;
+  if v2.trunc() / v2 > 0.999 {
+    return std::format!("{:+}/2", v2.trunc() as i64);
+  }
+  let v3 = val * 3.0;
+  if v3.trunc() / v3 > 0.999 {
+    return std::format!("{:+}/3", v3.trunc() as i64);
+  }
+  // sprintf("%+.3g", $val) — 3 significant figures with a forced sign.
+  format_g_signed(val, 3)
+}
+
+/// `sprintf("%+.{prec}g", val)` — the `%g` form with a forced leading sign.
+/// Reuses the shared `%g` renderer (`crate::value::format_g`) and prepends
+/// `+` for non-negative values (the renderer already emits `-` for negatives).
+fn format_g_signed(val: f64, prec: usize) -> String {
+  let body = crate::value::format_g(val, prec);
+  if body.starts_with('-') {
+    body
+  } else {
+    std::format!("+{body}")
+  }
+}
+
+/// `MakerNoteVersion` ValueConv (`Nikon.pm:1791`):
+/// `$_=$val; /^[\x00-\x09]/ and $_=join("",unpack("CCCC",$_)); $_`.
+/// A value whose first byte is in `0x00..=0x09` is BINARY — render each of
+/// the 4 bytes as a decimal digit string; otherwise the value is already the
+/// ASCII digit string (e.g. `"0210"`).
+fn maker_note_version_value(raw: &ParsedValue) -> String {
+  let bytes = raw.undef_or_text_bytes();
+  match bytes.first() {
+    Some(&b) if b <= 0x09 => {
+      // join("", unpack("CCCC")) — the 4 bytes as concatenated decimals.
+      let mut s = String::new();
+      for &byte in bytes.iter().take(4) {
+        s.push_str(&byte.to_string());
+      }
+      s
+    }
+    _ => String::from_utf8_lossy(&bytes).into_owned(),
+  }
+}
+
+/// `MakerNoteVersion` PrintConv (`Nikon.pm:1793`):
+/// `$_=$val;s/^(\d{2})/$1\./;s/^0//;$_` — a dot after the first two digits,
+/// then strip a leading zero.
+fn maker_note_version_print(val: &str) -> String {
+  // s/^(\d{2})/$1./  — only if the first two chars are digits.
+  let mut s = String::from(val);
+  let first_two_digits = s.as_bytes().first().is_some_and(u8::is_ascii_digit)
+    && s.as_bytes().get(1).is_some_and(u8::is_ascii_digit);
+  if first_two_digits {
+    // Insert a '.' after index 2.
+    let (head, tail) = s.split_at(2);
+    s = std::format!("{head}.{tail}");
+  }
+  // s/^0//
+  if let Some(rest) = s.strip_prefix('0') {
+    s = rest.to_string();
+  }
+  s
+}
+
+/// `ISO` (0x0002) ValueConv + PrintConv. The decoded `int16u[2]` is rendered
+/// by `ReadValue` as `"A B"`; `PrintConv` `s/^0 //;s/^1 (\d+)/Hi $1/`
+/// (`Nikon.pm:1817`).
+fn iso_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let two = raw.first_two_u64();
+  let Some((a, b)) = two else {
+    return raw.to_default_tag_value();
+  };
+  if print_conv {
+    if a == 1 {
+      TagValue::Str(SmolStr::new(std::format!("Hi {b}")))
+    } else {
+      // s/^0 // — strip a leading "0 "; the remaining value is the ISO.
+      // (For a == 0 this is just `b`; ExifTool emits the bare second word.)
+      if a == 0 {
+        TagValue::I64(b as i64)
+      } else {
+        TagValue::Str(SmolStr::new(std::format!("{a} {b}")))
+      }
+    }
+  } else {
+    // -n: the raw "A B" string.
+    TagValue::Str(SmolStr::new(std::format!("{a} {b}")))
+  }
+}
+
+/// `JPGCompression` (0x0044, `Nikon.pm:2168-2175`) — `RawConv => '($val) ?
+/// $val : undef'` (`:2170`) drops a raw `0` (the raw-file marker) ⇒ tag NOT
+/// emitted; otherwise the `{1 => 'Size Priority', 3 => 'Optimal Quality'}`
+/// PrintConv hash (an unmapped value renders `Unknown (N)`, the ExifTool
+/// default). `-n` emits the raw integer.
+fn jpg_compression_conv(raw: &ParsedValue, print_conv: bool) -> Option<TagValue> {
+  let Some(n) = raw.first_i64() else {
+    return Some(raw.to_default_tag_value());
+  };
+  if n == 0 {
+    return None;
+  }
+  Some(if print_conv {
+    match jpg_compression_label(n) {
+      Some(s) => TagValue::Str(SmolStr::new(s)),
+      None => TagValue::Str(SmolStr::new(std::format!("Unknown ({n})"))),
+    }
+  } else {
+    TagValue::I64(n)
+  })
+}
+
+/// `ISOSetting` (0x0013) — `int16u[2]`, `PrintConv => s/^0 //` (`Nikon.pm:1907`).
+fn iso_setting_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let two = raw.first_two_u64();
+  let Some((a, b)) = two else {
+    return raw.to_default_tag_value();
+  };
+  if print_conv {
+    if a == 0 {
+      TagValue::I64(b as i64)
+    } else {
+      TagValue::Str(SmolStr::new(std::format!("{a} {b}")))
+    }
+  } else {
+    TagValue::Str(SmolStr::new(std::format!("{a} {b}")))
+  }
+}
+
+/// `FlashExposureBracketValue` (0x0018) — `c3` ValueConv + `sprintf("%.1f")`.
+/// `ExposureBracketValue` (0x0019) is a `rational64s`, `PrintConv`
+/// `PrintFraction` unless undef → "n/a". This helper handles the `c3` form;
+/// the rational form is routed through [`NikonConv::Raw`]'s default render
+/// when it is a rational (0x0019 has its own arm only when needed).
+fn bracket_float1(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(v) = raw.signed_fraction_c3() else {
+    return raw.to_default_tag_value();
+  };
+  if print_conv {
+    TagValue::Str(SmolStr::new(std::format!("{v:.1}")))
+  } else {
+    value_conv_number(v)
+  }
+}
+
+/// `LensType` (0x0083) `PrintConv` (`Nikon.pm:2052-2070`).
+fn lens_type_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(n) = raw.first_i64() else {
+    return raw.to_default_tag_value();
+  };
+  if !print_conv {
+    return TagValue::I64(n);
+  }
+  if n == 0 {
+    return TagValue::Str(SmolStr::new("AF"));
+  }
+  // DecodeBits($val, { 0=>MF,1=>D,2=>G,3=>VR,4=>1,5=>FT-1,6=>E,7=>AF-P }).
+  let decoded = crate::convert::decode_bits(&n.to_string(), Some(LENS_TYPE_BITS), 32);
+  TagValue::Str(SmolStr::new(lens_type_postprocess(&decoded)))
+}
+
+/// The Perl post-processing on the `DecodeBits` output (`Nikon.pm:2061-2068`):
+///
+/// ```perl
+/// s/,//g; s/\bD G\b/G/;
+/// s/ E\b// and s/^(G )?/E /;   # put "E" at the start instead of "G"
+/// s/ 1// and $_ = "1 $_";      # put "1" at start
+/// s/FT-1 // and $_ .= ' FT-1'; # put "FT-1" at end
+/// ```
+///
+/// `DecodeBits` joins set bits with `", "`, so the input is e.g. `"D, G, E"`.
+/// A direct transliteration of each substitution (the `and` chains the next
+/// substitution only when the previous one matched, exactly like Perl).
+fn lens_type_postprocess(decoded: &str) -> String {
+  // s/,//g — remove EVERY comma (turning ", " joiners into a single space).
+  let mut s: String = decoded.replace(',', "");
+  // s/\bD G\b/G/ — the first "D G" (word-bounded) collapses to "G".
+  if let Some(pos) = find_bounded(&s, "D G") {
+    let end = pos + "D G".len();
+    s = std::format!(
+      "{}G{}",
+      s.get(..pos).unwrap_or(""),
+      s.get(end..).unwrap_or("")
+    );
+  }
+  // s/ E\b// and s/^(G )?/E / — remove the first " E" (word-bounded), and only
+  // if it matched, replace a leading "G " (optional) with "E ".
+  if let Some(e_at) = find_bounded(&s, " E") {
+    let end = e_at + " E".len();
+    s = std::format!(
+      "{}{}",
+      s.get(..e_at).unwrap_or(""),
+      s.get(end..).unwrap_or("")
+    );
+    // s/^(G )?/E /
+    if let Some(rest) = s.strip_prefix("G ") {
+      s = std::format!("E {rest}");
+    } else {
+      s = std::format!("E {s}");
+    }
+  }
+  // s/ 1// and $_ = "1 $_" — remove the first " 1", and if it matched prepend "1 ".
+  if let Some(one_at) = find_bounded(&s, " 1") {
+    let end = one_at + " 1".len();
+    s = std::format!(
+      "{}{}",
+      s.get(..one_at).unwrap_or(""),
+      s.get(end..).unwrap_or("")
+    );
+    s = std::format!("1 {s}");
+  }
+  // s/FT-1 // and $_ .= ' FT-1' — remove the first "FT-1 ", and if it matched
+  // append " FT-1".
+  if let Some(ft_at) = s.find("FT-1 ") {
+    let end = ft_at + "FT-1 ".len();
+    s = std::format!(
+      "{}{}",
+      s.get(..ft_at).unwrap_or(""),
+      s.get(end..).unwrap_or("")
+    );
+    s.push_str(" FT-1");
+  }
+  s
+}
+
+/// Find `needle` in `haystack` with a trailing `\b` word boundary — the byte
+/// AFTER the match must be a non-word char (or end). Used for the `\b`-anchored
+/// `LensType` substitutions; `needle`'s own start is space-anchored by the
+/// callers (each pattern begins with a space or a known word), so only the
+/// trailing boundary needs checking here.
+fn find_bounded(haystack: &str, needle: &str) -> Option<usize> {
+  let bytes = haystack.as_bytes();
+  let mut from = 0;
+  while let Some(rel) = haystack.get(from..).and_then(|s| s.find(needle)) {
+    let pos = from + rel;
+    let end = pos + needle.len();
+    let after_is_word = bytes
+      .get(end)
+      .is_some_and(|&b| b.is_ascii_alphanumeric() || b == b'_');
+    if !after_is_word {
+      return Some(pos);
+    }
+    from = end;
+  }
+  None
+}
+
+/// `Lens` (0x0084) `PrintConv => Exif::PrintLensInfo` (`Exif.pm`).
+fn lens_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  // The decoded value is `rational64u[4]`; `ReadValue` joins as decimal
+  // scalars (`exiftool_val_str`). For `-n` we emit that join verbatim.
+  let joined = raw.rational_join_decimal();
+  let Some(joined) = joined else {
+    return raw.to_default_tag_value();
+  };
+  if print_conv {
+    TagValue::Str(SmolStr::new(print_lens_info(&joined)))
+  } else {
+    TagValue::Str(SmolStr::new(joined))
+  }
+}
+
+/// `Image::ExifTool::Exif::PrintLensInfo($val)` (`Exif.pm`): from the
+/// space-joined 4-value `"short long apShort apLong"`, build
+/// `"short-longmm f/apShort-apLong"`, collapsing equal endpoints and
+/// rendering `inf`/`undef` as `?`.
+fn print_lens_info(val: &str) -> String {
+  let vals: Vec<&str> = val.split(' ').filter(|s| !s.is_empty()).collect();
+  let [v0, v1, v2, v3] = vals.as_slice() else {
+    return val.to_string();
+  };
+  // Each must be a float / "inf" / "undef" (→ "?").
+  let norm = |s: &str| -> Option<String> {
+    if s == "inf" || s == "undef" {
+      Some("?".to_string())
+    } else if is_float(s) {
+      Some(s.to_string())
+    } else {
+      None
+    }
+  };
+  let (Some(s0), Some(s1), Some(s2), Some(s3)) = (norm(v0), norm(v1), norm(v2), norm(v3)) else {
+    return val.to_string();
+  };
+  let mut out = s0.clone();
+  // .= "-$vals[1]" if $vals[1] and $vals[1] ne $vals[0]
+  if !is_zeroish(&s1) && s1 != s0 {
+    out.push('-');
+    out.push_str(&s1);
+  }
+  out.push_str("mm f/");
+  out.push_str(&s2);
+  if !is_zeroish(&s3) && s3 != s2 {
+    out.push('-');
+    out.push_str(&s3);
+  }
+  out
+}
+
+/// `$vals[N] and …` is falsy in Perl for `"0"`/`"0.0"`/empty — treat a
+/// zero-valued endpoint as "absent" so the dash is dropped.
+fn is_zeroish(s: &str) -> bool {
+  s.parse::<f64>().map(|v| v == 0.0).unwrap_or(false)
+}
+
+/// `ShootingMode` (0x0089) `PrintConv` (`Nikon.pm:2160-2189`).
+fn shooting_mode_conv(raw: &ParsedValue, print_conv: bool, model: Option<&str>) -> TagValue {
+  let Some(n) = raw.first_i64() else {
+    return raw.to_default_tag_value();
+  };
+  if !print_conv {
+    return TagValue::I64(n);
+  }
+  // unless ($val & 0x87) { return 'Single-Frame' unless $val; $_ = 'Single-Frame, '; }
+  let mut prefix = String::new();
+  if n & 0x87 == 0 {
+    if n == 0 {
+      return TagValue::Str(SmolStr::new("Single-Frame"));
+    }
+    prefix.push_str("Single-Frame, ");
+  }
+  // Bit 5's label is model-dependent.
+  let bit5 = if model.is_some_and(model_is_d70) {
+    "Unused LE-NR Slowdown"
+  } else {
+    "Auto ISO"
+  };
+  let bits: [(u8, &str); 10] = [
+    (0, "Continuous"),
+    (1, "Delay"),
+    (2, "PC Control"),
+    (3, "Self-timer"),
+    (4, "Exposure Bracketing"),
+    (5, bit5),
+    (6, "White-Balance Bracketing"),
+    (7, "IR Control"),
+    (8, "D-Lighting Bracketing"),
+    (11, "Pre-capture"),
+  ];
+  let decoded = crate::convert::decode_bits(&n.to_string(), Some(&bits), 32);
+  TagValue::Str(SmolStr::new(std::format!("{prefix}{decoded}")))
+}
+
+/// `$$self{Model}=~/D70\b/` (`Nikon.pm:2180`) — matches "NIKON D70" and
+/// "NIKON D70s"? No: `\b` after "D70" — "D70s" has no word boundary between
+/// "70" and "s", so `/D70\b/` matches "D70" but NOT "D70s". Mirror that.
+fn model_is_d70(model: &str) -> bool {
+  // Find "D70" occurrences and require a word boundary (non-word char or end)
+  // immediately after.
+  let bytes = model.as_bytes();
+  let mut i = 0;
+  while let Some(pos) = model.get(i..).and_then(|s| s.find("D70")) {
+    let end = i + pos + 3;
+    let after_is_word = bytes
+      .get(end)
+      .is_some_and(|&b| b.is_ascii_alphanumeric() || b == b'_');
+    if !after_is_word {
+      return true;
+    }
+    i = end;
+  }
+  false
+}
+
+/// Generic single-integer hash PrintConv: look up `n` in `label`; a miss
+/// renders `Unknown (n)` (`ExifTool.pm:3622`).
+fn hash_conv(
+  raw: &ParsedValue,
+  print_conv: bool,
+  label: fn(i64) -> Option<&'static str>,
+) -> TagValue {
+  let Some(n) = raw.first_i64() else {
+    return raw.to_default_tag_value();
+  };
+  if print_conv {
+    match label(n) {
+      Some(s) => TagValue::Str(SmolStr::new(s)),
+      None => TagValue::Str(SmolStr::new(std::format!("Unknown ({n})"))),
+    }
+  } else {
+    TagValue::I64(n)
+  }
+}
+
+fn flash_mode_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Did Not Fire",
+    1 => "Fired, Manual",
+    3 => "Not Ready",
+    7 => "Fired, External",
+    8 => "Fired, Commander Mode",
+    9 => "Fired, TTL Mode",
+    18 => "LED Light",
+    _ => return None,
+  })
+}
+
+fn nef_compression_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    1 => "Lossy (type 1)",
+    2 => "Uncompressed",
+    3 => "Lossless",
+    4 => "Lossy (type 2)",
+    5 => "Striped packed 12 bits",
+    6 => "Uncompressed (reduced to 12 bit)",
+    7 => "Unpacked 12 bits",
+    8 => "Small",
+    9 => "Packed 12 bits",
+    10 => "Packed 14 bits",
+    13 => "High Efficiency",
+    14 => "High Efficiency*",
+    _ => return None,
+  })
+}
+
+fn color_space_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    1 => "sRGB",
+    2 => "Adobe RGB",
+    4 => "BT.2100",
+    _ => return None,
+  })
+}
+
+fn off_on_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Off",
+    1 => "On",
+    _ => return None,
+  })
+}
+
+fn active_d_lighting_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Off",
+    1 => "Low",
+    3 => "Normal",
+    5 => "High",
+    7 => "Extra High",
+    8 => "Extra High 1",
+    9 => "Extra High 2",
+    10 => "Extra High 3",
+    11 => "Extra High 4",
+    0xffff => "Auto",
+    _ => return None,
+  })
+}
+
+fn vignette_control_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Off",
+    1 => "Low",
+    3 => "Normal",
+    5 => "High",
+    _ => return None,
+  })
+}
+
+fn shutter_mode_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Mechanical",
+    16 => "Electronic",
+    48 => "Electronic Front Curtain",
+    64 => "Electronic (Movie)",
+    80 => "Auto (Mechanical)",
+    81 => "Auto (Electronic Front Curtain)",
+    96 => "Electronic (High Speed)",
+    _ => return None,
+  })
+}
+
+fn image_size_raw_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    1 => "Large",
+    2 => "Medium",
+    3 => "Small",
+    _ => return None,
+  })
+}
+
+fn jpg_compression_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    1 => "Size Priority",
+    3 => "Optimal Quality",
+    _ => return None,
+  })
+}
+
+fn date_stamp_mode_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Off",
+    1 => "Date & Time",
+    2 => "Date",
+    3 => "Date Counter",
+    _ => return None,
+  })
+}
+
+fn high_iso_nr_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Off",
+    1 => "Minimal",
+    2 => "Low",
+    3 => "Medium Low",
+    4 => "Normal",
+    5 => "Medium High",
+    6 => "High",
+    _ => return None,
+  })
+}
+
+/// `%Nikon::AFInfo` position 0 `AFAreaMode` (`Nikon.pm:2117-2126`).
+fn af_area_mode_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Single Area",
+    1 => "Dynamic Area",
+    2 => "Dynamic Area (closest subject)",
+    3 => "Group Dynamic",
+    4 => "Single Area (wide)",
+    5 => "Dynamic Area (wide)",
+    _ => return None,
+  })
+}
+
+/// `%Nikon::AFInfo` position 1 `AFPoint` (`Nikon.pm:2128-2150`).
+fn af_point_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "Center",
+    1 => "Top",
+    2 => "Bottom",
+    3 => "Mid-left",
+    4 => "Mid-right",
+    5 => "Upper-left",
+    6 => "Upper-right",
+    7 => "Lower-left",
+    8 => "Lower-right",
+    9 => "Far Left",
+    10 => "Far Right",
+    _ => return None,
+  })
+}
+
+/// `%afPoints11` BITMASK labels (`Nikon.pm:2152`). Sorted by bit.
+const AF_POINTS11_BITS: &[(u8, &str)] = &[
+  (0, "Center"),
+  (1, "Top"),
+  (2, "Bottom"),
+  (3, "Mid-left"),
+  (4, "Mid-right"),
+  (5, "Upper-left"),
+  (6, "Upper-right"),
+  (7, "Lower-left"),
+  (8, "Lower-right"),
+  (9, "Far Left"),
+  (10, "Far Right"),
+];
+
+/// `Nikon::FormatString` (`Nikon.pm:14172-14199`): title-case Nikon's all-caps
+/// string values. Trailing whitespace is removed, then in WORDS CONTAINING A
+/// VOWEL all letters after the first are lower-cased; the `AF`/`RAW` words are
+/// patched back to upper-case.
+///
+/// (The `LimitLongValues` branch caps very long unknown strings; none of the
+/// Nikon::Main string tags reach that limit, so it is omitted — a string over
+/// the default `LimitLongValues` would only appear on an unported tag.)
+pub fn format_string(input: &str) -> String {
+  // s/\s+$// — strip trailing whitespace (Perl \s).
+  let trimmed = input.trim_end_matches(is_perl_space);
+  // Only change case if the string contains an upper-case vowel (Perl's
+  // /[AEIOUY]/ tests the raw string, which is all-caps for the inputs that
+  // need conversion).
+  if !trimmed
+    .bytes()
+    .any(|b| matches!(b, b'A' | b'E' | b'I' | b'O' | b'U' | b'Y'))
+  {
+    return trimmed.to_string();
+  }
+  // Two passes mirror the two Perl substitutions:
+  //   1. s/\b([AEIOUY])([A-Z]+)/$1\L$2/g  (vowel-initial words)
+  //   2. s/\b([A-Z])([A-Z]*[AEIOUY][A-Z]*)/$1\L$2/g  (any word with a vowel)
+  // Both lower-case all but the first letter of words that contain a vowel.
+  // The combined effect: for every maximal run of ASCII letters that contains
+  // a vowel, keep the first letter and lower-case the rest. Then patch
+  // "Af" → "AF" and "Raw" → "RAW".
+  let mut out = String::with_capacity(trimmed.len());
+  let bytes = trimmed.as_bytes();
+  let mut i = 0;
+  while i < bytes.len() {
+    let Some(&b) = bytes.get(i) else { break };
+    if b.is_ascii_alphabetic() {
+      // Collect the maximal letter run.
+      let start = i;
+      while bytes.get(i).is_some_and(u8::is_ascii_alphabetic) {
+        i += 1;
+      }
+      let word = trimmed.get(start..i).unwrap_or("");
+      let has_vowel = word.bytes().any(|c| {
+        matches!(
+          c.to_ascii_uppercase(),
+          b'A' | b'E' | b'I' | b'O' | b'U' | b'Y'
+        )
+      });
+      if has_vowel {
+        // Keep the first char, lower-case the rest.
+        let mut chars = word.chars();
+        if let Some(first) = chars.next() {
+          out.push(first);
+          for c in chars {
+            out.extend(c.to_lowercase());
+          }
+        }
+      } else {
+        out.push_str(word);
+      }
+    } else {
+      out.push(b as char);
+      i += 1;
+    }
+  }
+  // s/\bAf\b/AF/ and s/\bRaw\b/RAW/ — applied as whole-word patches.
+  patch_word(&mut out, "Af", "AF");
+  patch_word(&mut out, "Raw", "RAW");
+  out
+}
+
+/// Replace every `\bFROM\b` occurrence with `TO` — Perl `s/\bFROM\b/TO/`.
+/// A `\b` is a transition between a word char (`[A-Za-z0-9_]`) and a
+/// non-word char (or string edge); so `"Af-C"` matches `\bAf\b` (the hyphen
+/// is a non-word boundary) and becomes `"AF-C"`.
+fn patch_word(s: &mut String, from: &str, to: &str) {
+  if from.is_empty() || !s.contains(from) {
+    return;
+  }
+  let bytes = s.as_bytes();
+  let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+  let mut out = String::with_capacity(s.len());
+  let mut i = 0;
+  while i < s.len() {
+    if let Some(slice) = s.get(i..i + from.len())
+      && slice == from
+    {
+      let before_is_word = i
+        .checked_sub(1)
+        .and_then(|p| bytes.get(p))
+        .is_some_and(|&b| is_word(b));
+      let after_is_word = bytes.get(i + from.len()).is_some_and(|&b| is_word(b));
+      if !before_is_word && !after_is_word {
+        out.push_str(to);
+        i += from.len();
+        continue;
+      }
+    }
+    // Copy one char (UTF-8 safe).
+    let ch = s.get(i..).and_then(|t| t.chars().next());
+    if let Some(c) = ch {
+      out.push(c);
+      i += c.len_utf8();
+    } else {
+      break;
+    }
+  }
+  *s = out;
+}
+
+/// Perl `\s` whitespace test (space, tab, newline, CR, form-feed, vertical tab).
+fn is_perl_space(c: char) -> bool {
+  matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{0c}' | '\u{0b}')
+}
+
+fn is_float(s: &str) -> bool {
+  s.parse::<f64>().is_ok()
+}
+
+/// `LensType` BITMASK labels (`Nikon.pm:2053-2061`). Sorted by bit for the
+/// `DecodeBits` walk.
+const LENS_TYPE_BITS: &[(u8, &str)] = &[
+  (0, "MF"),
+  (1, "D"),
+  (2, "G"),
+  (3, "VR"),
+  (4, "1"),
+  (5, "FT-1"),
+  (6, "E"),
+  (7, "AF-P"),
+];
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+  use crate::exif::ifd::RawValue;
+
+  fn undef(bytes: &[u8]) -> ParsedValue {
+    ParsedValue::new(RawValue::Bytes(bytes.to_vec()))
+  }
+  fn u8v(n: u64) -> ParsedValue {
+    ParsedValue::new(RawValue::U64(vec![n]))
+  }
+
+  /// `Nikon::FormatString` title-casing matches the bundled oracle
+  /// (verified via `perl -e '… Image::ExifTool::Nikon::FormatString(…)'`).
+  #[test]
+  fn format_string_matches_oracle() {
+    assert_eq!(format_string("FINE"), "Fine");
+    assert_eq!(format_string("NORMAL"), "Normal");
+    assert_eq!(format_string("AUTO"), "Auto");
+    assert_eq!(format_string("RAW"), "RAW"); // patched back
+    assert_eq!(format_string("COLOR"), "Color");
+    assert_eq!(format_string("AF-C"), "AF-C"); // "AF" patched, no vowel-run change
+    assert_eq!(format_string("SPEEDLIGHT"), "Speedlight");
+    assert_eq!(format_string("CUSTOM"), "Custom");
+    assert_eq!(format_string("ENHANCED"), "Enhanced");
+    assert_eq!(format_string("Med.H"), "Med.H");
+    assert_eq!(format_string("CS"), "CS"); // no vowel ⇒ unchanged
+    assert_eq!(format_string("FPNR"), "FPNR"); // no vowel ⇒ unchanged
+    assert_eq!(format_string("Preset0"), "Preset0");
+    assert_eq!(format_string("NORMAL  "), "Normal"); // trailing ws stripped
+    assert_eq!(format_string("No= 20025585"), "No= 20025585");
+  }
+
+  /// `LensType` (0x0083) DecodeBits + post-processing — oracle-cited
+  /// (`perl … DecodeBits(...)` traced in the PR notes).
+  #[test]
+  fn lens_type_print_conv() {
+    // 0 → "AF".
+    assert_eq!(
+      lens_type_conv(&u8v(0), true),
+      TagValue::Str(SmolStr::new("AF"))
+    );
+    // 0x06 → "D, G" → "G".
+    assert_eq!(
+      lens_type_conv(&u8v(0x06), true),
+      TagValue::Str(SmolStr::new("G"))
+    );
+    // 0x02 → "D".
+    assert_eq!(
+      lens_type_conv(&u8v(0x02), true),
+      TagValue::Str(SmolStr::new("D"))
+    );
+    // 0x46 → "D, G, E" → "E G".
+    assert_eq!(
+      lens_type_conv(&u8v(0x46), true),
+      TagValue::Str(SmolStr::new("E G"))
+    );
+    // 0x86 → "D, G, AF-P" → "G AF-P".
+    assert_eq!(
+      lens_type_conv(&u8v(0x86), true),
+      TagValue::Str(SmolStr::new("G AF-P"))
+    );
+    // 0x16 → "D, G, 1" → "1 G".
+    assert_eq!(
+      lens_type_conv(&u8v(0x16), true),
+      TagValue::Str(SmolStr::new("1 G"))
+    );
+    // 0x26 → "D, G, FT-1" → "G FT-1".
+    assert_eq!(
+      lens_type_conv(&u8v(0x26), true),
+      TagValue::Str(SmolStr::new("G FT-1"))
+    );
+    // 0x08 → "VR".
+    assert_eq!(
+      lens_type_conv(&u8v(0x08), true),
+      TagValue::Str(SmolStr::new("VR"))
+    );
+    // -n: the raw integer.
+    assert_eq!(lens_type_conv(&u8v(0x06), false), TagValue::I64(6));
+  }
+
+  /// `Lens` (0x0084) → `Exif::PrintLensInfo` (`"18-70mm f/3.5-4.5"`).
+  #[test]
+  fn lens_print_lens_info() {
+    assert_eq!(print_lens_info("18 70 3.5 4.5"), "18-70mm f/3.5-4.5");
+    // Prime lens (equal endpoints collapse): "50 50 1.8 1.8" → "50mm f/1.8".
+    assert_eq!(print_lens_info("50 50 1.8 1.8"), "50mm f/1.8");
+    // A non-4-value string passes through unchanged.
+    assert_eq!(print_lens_info("18 70 3.5"), "18 70 3.5");
+  }
+
+  /// `MakerNoteVersion` (0x0001) — `"0210"` → `"2.10"`, `"0100"` → `"1.00"`.
+  #[test]
+  fn maker_note_version_print_conv() {
+    // ASCII digit string (the common DSLR form).
+    let v = ParsedValue::new(RawValue::Bytes(b"0210".to_vec()));
+    assert_eq!(
+      NikonConv::MakerNoteVersion.apply(&v, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("2.10")))
+    );
+    let v = ParsedValue::new(RawValue::Bytes(b"0100".to_vec()));
+    assert_eq!(
+      NikonConv::MakerNoteVersion.apply(&v, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("1.00")))
+    );
+    // -n: the post-ValueConv "0210".
+    let v = ParsedValue::new(RawValue::Bytes(b"0210".to_vec()));
+    assert_eq!(
+      NikonConv::MakerNoteVersion.apply(&v, false, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("0210")))
+    );
+    // Binary form (first byte ≤ 0x09): "\x00\x01\x00\x00" → "0100" → "1.00".
+    let v = undef(&[0x00, 0x01, 0x00, 0x00]);
+    assert_eq!(
+      NikonConv::MakerNoteVersion.apply(&v, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("1.00")))
+    );
+  }
+
+  /// `ShootingMode` (0x0089) — value 0 → "Single-Frame"; the DecodeBits path.
+  #[test]
+  fn shooting_mode_print_conv() {
+    // 0 → "Single-Frame".
+    assert_eq!(
+      shooting_mode_conv(&u8v(0), true, None),
+      TagValue::Str(SmolStr::new("Single-Frame"))
+    );
+    // bit 0 set (Continuous), no 0x87 bits beyond → "Continuous".
+    assert_eq!(
+      shooting_mode_conv(&u8v(0x01), true, None),
+      TagValue::Str(SmolStr::new("Continuous"))
+    );
+    // bit 1 (Delay) only: 0x02 & 0x87 = 0x02 (bit1 ∈ 0x87) so NO prefix; the
+    // DecodeBits yields "Delay".
+    assert_eq!(
+      shooting_mode_conv(&u8v(0x02), true, None),
+      TagValue::Str(SmolStr::new("Delay"))
+    );
+  }
+
+  /// `AFPointsInFocus` (`%afPoints11`) — `0 → "(none)"`, bit 0 → "Center".
+  #[test]
+  fn af_points_in_focus_conv_oracle() {
+    assert_eq!(
+      af_points_in_focus_conv(&ParsedValue::new(RawValue::U64(vec![0])), true),
+      TagValue::Str(SmolStr::new("(none)"))
+    );
+    assert_eq!(
+      af_points_in_focus_conv(&ParsedValue::new(RawValue::U64(vec![1])), true),
+      TagValue::Str(SmolStr::new("Center"))
+    );
+    assert_eq!(
+      af_points_in_focus_conv(&ParsedValue::new(RawValue::U64(vec![0x7ff])), true),
+      TagValue::Str(SmolStr::new("All 11 Points"))
+    );
+  }
+
+  /// `SensorPixelSize` (0x009a) → `"7.8 x 7.8 um"`.
+  #[test]
+  fn sensor_pixel_size_conv() {
+    use crate::value::Rational;
+    let v = ParsedValue::new(RawValue::Rational(vec![
+      Rational::rational64(78, 10),
+      Rational::rational64(78, 10),
+    ]));
+    assert_eq!(
+      NikonConv::SensorPixelSize.apply(&v, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("7.8 x 7.8 um")))
+    );
+  }
+
+  /// `JPGCompression` (0x0044) — `RawConv => '($val) ? $val : undef'`: a raw
+  /// `0` (the raw-file marker) is `undef` ⇒ `apply` returns `None` (the tag is
+  /// then NOT emitted), in BOTH `-j` and `-n` modes; a non-zero value renders
+  /// via the `{1 => 'Size Priority', 3 => 'Optimal Quality'}` hash (`-j`) /
+  /// the raw integer (`-n`). Oracle: a Nikon file with 0x0044 == 0 has no
+  /// `Nikon:JPGCompression` tag.
+  #[test]
+  fn nikon_jpgcompression_zero_suppressed() {
+    // Raw 0 ⇒ dropped (None) under both -j and -n.
+    let zero = ParsedValue::new(RawValue::U64(vec![0]));
+    assert_eq!(
+      NikonConv::JpgCompression.apply(&zero, true, None, ByteOrder::Big),
+      None
+    );
+    assert_eq!(
+      NikonConv::JpgCompression.apply(&zero, false, None, ByteOrder::Big),
+      None
+    );
+    // Raw 1 ⇒ "Size Priority" (-j) / 1 (-n).
+    let one = ParsedValue::new(RawValue::U64(vec![1]));
+    assert_eq!(
+      NikonConv::JpgCompression.apply(&one, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("Size Priority")))
+    );
+    assert_eq!(
+      NikonConv::JpgCompression.apply(&one, false, None, ByteOrder::Big),
+      Some(TagValue::I64(1))
+    );
+    // Raw 3 ⇒ "Optimal Quality" (-j) / 3 (-n).
+    let three = ParsedValue::new(RawValue::U64(vec![3]));
+    assert_eq!(
+      NikonConv::JpgCompression.apply(&three, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("Optimal Quality")))
+    );
+    assert_eq!(
+      NikonConv::JpgCompression.apply(&three, false, None, ByteOrder::Big),
+      Some(TagValue::I64(3))
+    );
+    // An unmapped non-zero value renders the ExifTool `Unknown (N)` default.
+    let five = ParsedValue::new(RawValue::U64(vec![5]));
+    assert_eq!(
+      NikonConv::JpgCompression.apply(&five, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("Unknown (5)")))
+    );
+  }
+
+  /// `ISO` (0x0002) — the `$val eq "\0\0\0\0"` RawConv is DEAD (by RawConv
+  /// time `$val` is the `int16u[2]` string `"0 0"`, never the raw NUL bytes),
+  /// so an all-zero ISO is NOT dropped: `apply` returns `Some` and the `-j`
+  /// PrintConv `s/^0 //` yields `0`. Oracle: `Nikon.jpg` emits `Nikon:ISO` 0
+  /// (`int16u[2]` value `00 00 00 00`).
+  #[test]
+  fn nikon_iso_all_zero_emitted_not_dropped() {
+    let zero2 = ParsedValue::new(RawValue::U64(vec![0, 0]));
+    assert_eq!(
+      NikonConv::Iso.apply(&zero2, true, None, ByteOrder::Big),
+      Some(TagValue::I64(0))
+    );
+    // -n: the raw "0 0" string.
+    assert_eq!(
+      NikonConv::Iso.apply(&zero2, false, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("0 0")))
+    );
+  }
+
+  /// `model_is_d70` matches "NIKON D70" but NOT "NIKON D70s" (the `/D70\b/`).
+  #[test]
+  fn model_d70_word_boundary() {
+    assert!(model_is_d70("NIKON D70"));
+    assert!(!model_is_d70("NIKON D70s"));
+    assert!(!model_is_d70("NIKON D2Hs"));
+  }
+
+  /// `CropHiSpeed` (0x001b) — the `%cropHiSpeed` `OTHER` sub maps element 0 and
+  /// formats the full 7-int16u record. Oracle (Perl `%cropHiSpeed` OTHER):
+  /// `2 6048 4032 4500 3000 774 516` →
+  /// `"DX Crop (6048x4032 cropped to 4500x3000 at pixel 774,516)"`.
+  #[test]
+  fn crop_hi_speed_other_format() {
+    let v = ParsedValue::new(RawValue::U64(vec![2, 6048, 4032, 4500, 3000, 774, 516]));
+    assert_eq!(
+      NikonConv::CropHiSpeed.apply(&v, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new(
+        "DX Crop (6048x4032 cropped to 4500x3000 at pixel 774,516)"
+      )))
+    );
+    // A non-7 count renders `Unknown ($val)`.
+    let bad = ParsedValue::new(RawValue::U64(vec![0, 0, 0]));
+    assert_eq!(
+      NikonConv::CropHiSpeed.apply(&bad, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("Unknown (0 0 0)")))
+    );
+    // `-n` emits the raw joined string.
+    assert_eq!(
+      NikonConv::CropHiSpeed.apply(&v, false, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("2 6048 4032 4500 3000 774 516")))
+    );
+  }
+
+  /// `RetouchHistory` (0x009e) — ValueConv trims trailing ` 0` groups, the
+  /// ARRAY PrintConv maps each remaining element via `%retouchValues` and joins
+  /// with `"; "`. Oracle (Perl): `7 8 0 0 0 0 0 0 0 0` ValueConv → `7 8` →
+  /// PrintConv → `"D-Lighting; Red Eye"`. A bare `0` → `"None"`.
+  #[test]
+  fn retouch_history_array_print_conv() {
+    let v = ParsedValue::new(RawValue::U64(vec![7, 8, 0, 0, 0, 0, 0, 0, 0, 0]));
+    assert_eq!(
+      NikonConv::RetouchHistory.apply(&v, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("D-Lighting; Red Eye")))
+    );
+    // `-n` emits the post-ValueConv (trimmed) raw string.
+    assert_eq!(
+      NikonConv::RetouchHistory.apply(&v, false, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("7 8")))
+    );
+    // All-zero (a single 0 remains after trimming) → "None".
+    let none = ParsedValue::new(RawValue::U64(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
+    assert_eq!(
+      NikonConv::RetouchHistory.apply(&none, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("None")))
+    );
+    // An unmapped code → `Unknown (N)`.
+    let unk = ParsedValue::new(RawValue::U64(vec![99, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
+    assert_eq!(
+      NikonConv::RetouchHistory.apply(&unk, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("Unknown (99)")))
+    );
+  }
+
+  /// `PowerUpTime` (0x00b6) — RawConv unpacks a 16-bit year (per byte order) +
+  /// 5 bytes M/D/h/m/s; the PrintConv `ConvertDateTime` is identity. Big-endian
+  /// year 2008 (`0x07d8`): `07 d8 05 1e 0c 22 38` → `"2008:05:30 12:34:56"`.
+  #[test]
+  fn power_up_time_big_endian_decode() {
+    let be = ParsedValue::new(RawValue::Bytes(vec![
+      0x07, 0xd8, 0x05, 0x1e, 0x0c, 0x22, 0x38,
+    ]));
+    assert_eq!(
+      NikonConv::PowerUpTime.apply(&be, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("2008:05:30 12:34:56")))
+    );
+    // Little-endian: the year bytes swap (`d8 07` → 2008).
+    let le = ParsedValue::new(RawValue::Bytes(vec![
+      0xd8, 0x07, 0x05, 0x1e, 0x0c, 0x22, 0x38,
+    ]));
+    assert_eq!(
+      NikonConv::PowerUpTime.apply(&le, true, None, ByteOrder::Little),
+      Some(TagValue::Str(SmolStr::new("2008:05:30 12:34:56")))
+    );
+    // A value shorter than 7 bytes passes through verbatim (the RawConv guard).
+    let short = ParsedValue::new(RawValue::Bytes(vec![0x07, 0xd8]));
+    assert!(matches!(
+      NikonConv::PowerUpTime.apply(&short, true, None, ByteOrder::Big),
+      Some(TagValue::Bytes(_))
+    ));
+  }
+
+  /// `NEFBitDepth` (0x0e22) — a space-joined PrintConv hash. Oracle: `8 8 8 0`
+  /// → `"8 x 3"`; `0 0 0 0` → `"n/a (JPEG)"`; an unmapped record → `Unknown`.
+  #[test]
+  fn nef_bit_depth_hash() {
+    let v = ParsedValue::new(RawValue::U64(vec![8, 8, 8, 0]));
+    assert_eq!(
+      NikonConv::NefBitDepth.apply(&v, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("8 x 3")))
+    );
+    let jpeg = ParsedValue::new(RawValue::U64(vec![0, 0, 0, 0]));
+    assert_eq!(
+      NikonConv::NefBitDepth.apply(&jpeg, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("n/a (JPEG)")))
+    );
+    let unk = ParsedValue::new(RawValue::U64(vec![10, 0, 0, 0]));
+    assert_eq!(
+      NikonConv::NefBitDepth.apply(&unk, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("Unknown (10 0 0 0)")))
+    );
+  }
+
+  /// `SilentPhotography` (0x00bf) — `%offOn`. `0` → `"Off"`, `1` → `"On"`.
+  #[test]
+  fn silent_photography_off_on() {
+    let off = ParsedValue::new(RawValue::U64(vec![0]));
+    let on = ParsedValue::new(RawValue::U64(vec![1]));
+    assert_eq!(
+      NikonConv::OffOn.apply(&off, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("Off")))
+    );
+    assert_eq!(
+      NikonConv::OffOn.apply(&on, true, None, ByteOrder::Big),
+      Some(TagValue::Str(SmolStr::new("On")))
+    );
+  }
+}

--- a/src/exif/makernotes/vendors/nikon/tags.rs
+++ b/src/exif/makernotes/vendors/nikon/tags.rs
@@ -1,0 +1,679 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Nikon MakerNote tag tables — `%Image::ExifTool::Nikon::Main`
+//! (`Nikon.pm:1778-3260`) plus the readable, UNENCRYPTED sub-tables the
+//! bundled fixtures exercise (`%Nikon::AFInfo`, `%Nikon::ColorBalance3`).
+//!
+//! ## Scope (first Nikon PR)
+//!
+//! Every readable scalar tag in `%Nikon::Main` is ported with its faithful
+//! `Name` + conversion ([`super::printconv::NikonConv`]). The table-level
+//! `PRINT_CONV => \&FormatString` is the default for string tags
+//! ([`NikonConv::FormatString`]).
+//!
+//! - `AFInfo` (0x0088, `Nikon.pm:2113-2158`) — a `ProcessBinaryData` table
+//!   (BigEndian for DSLRs), UNENCRYPTED → AFAreaMode / AFPoint /
+//!   AFPointsInFocus. WALKED.
+//! - `ColorBalance0103` (0x0097 `0103` variant, `Nikon.pm:2980`/
+//!   `Nikon.pm` `%ColorBalance3`) — D70/D70s, UNENCRYPTED, `Start =>
+//!   '$valuePtr + 20'`, 4×int16u → WB_RGBGLevels. WALKED.
+//!
+//! ## Deferred (encrypted — need `Nikon::Decrypt`, a follow-up issue)
+//!
+//! `LensData` (0x0098), `ShotInfo*` (0x0091), `FlashInfo*` (0x00a8), and the
+//! ENCRYPTED `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) are
+//! `ProcessNikonEncrypted` sub-tables keyed on the SerialNumber +
+//! ShutterCount XOR keystream (`Nikon.pm:13604` `Decrypt`). They carry a
+//! deferred [`SubTable`] marker so the parent is NOT emitted (the #177/#223
+//! bogus-parent rule), and their decrypted children stay unported here.
+
+#![deny(clippy::indexing_slicing)]
+
+use super::printconv::NikonConv;
+use crate::exif::makernotes::vendors::FormatOverride;
+
+/// One Nikon MakerNote leaf / SubDirectory tag.
+///
+/// D8: no public fields — accessors only.
+#[derive(Debug, Clone, Copy)]
+pub struct NikonTag {
+  /// Nikon IFD tag ID (`Nikon::Main` hash key).
+  id: u16,
+  /// `Name => '…'` from bundled.
+  name: &'static str,
+  /// Conversion strategy ([`NikonConv`]).
+  conv: NikonConv,
+  /// A `Format => '…'` directive that re-reads the value bytes with a
+  /// different TIFF format (`None` for most tags).
+  format: Option<FormatOverride>,
+  /// SubDirectory dispatch target — `Some(_)` when this tag points at a
+  /// child table (the value is NOT emitted as a leaf; the #177/#223 rule).
+  sub_table: Option<SubTable>,
+  /// `Flags => 'SubIFD'` (`$$tagInfo{SubIFD}`) — the SubDirectory value is an
+  /// IFD OFFSET (`Start => '$val'`), read with an INTEGER format to locate the
+  /// child IFD; it is EXCLUDED from the implicit-`undef` SubDirectory override
+  /// (`Exif.pm:6733` `not $$tagInfo{SubIFD}`). Only `PreviewIFD` (0x0011,
+  /// `Nikon.pm:1875`) and `NikonScanIFD` (0x0e10, `Nikon.pm:3229`) carry it in
+  /// `%Nikon::Main`; every other SubDirectory is a binary block.
+  sub_ifd: bool,
+  /// `Unknown => 1` / hidden-by-default in bundled (suppressed in `-j`).
+  unknown: bool,
+}
+
+impl NikonTag {
+  /// Nikon IFD tag ID.
+  #[must_use]
+  #[inline(always)]
+  pub const fn id(&self) -> u16 {
+    self.id
+  }
+
+  /// Tag `Name`.
+  #[must_use]
+  #[inline(always)]
+  pub const fn name(&self) -> &'static str {
+    self.name
+  }
+
+  /// Conversion strategy.
+  #[must_use]
+  #[inline(always)]
+  pub const fn conv(&self) -> NikonConv {
+    self.conv
+  }
+
+  /// The optional `Format => '…'` directive.
+  #[must_use]
+  #[inline(always)]
+  pub const fn format(&self) -> Option<FormatOverride> {
+    self.format
+  }
+
+  /// SubDirectory dispatch target, if this tag is a sub-table pointer.
+  #[must_use]
+  #[inline(always)]
+  pub const fn sub_table(&self) -> Option<SubTable> {
+    self.sub_table
+  }
+
+  /// `true` when bundled marks this SubDirectory tag `Flags => 'SubIFD'` — its
+  /// value is an IFD OFFSET (not a binary block), so the implicit-`undef`
+  /// SubDirectory format override (`Exif.pm:6733`) does NOT apply.
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_sub_ifd(&self) -> bool {
+    self.sub_ifd
+  }
+
+  /// `true` when bundled marks this tag `Unknown => 1` (suppressed in `-j`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_unknown(&self) -> bool {
+    self.unknown
+  }
+}
+
+/// Nikon `Main` SubDirectory targets — the ones the port walks plus the
+/// ENCRYPTED ones it defers (marker-only, so no bogus parent is emitted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SubTable {
+  /// `%Nikon::AFInfo` (`Nikon.pm:2113-2158`) — `ProcessBinaryData`,
+  /// BigEndian for DSLRs. AFAreaMode (0) / AFPoint (1) / AFPointsInFocus (2).
+  /// WALKED.
+  AfInfo,
+  /// `%Nikon::ColorBalance3` (`%ColorBalance3`) — D70/D70s, `Start =>
+  /// '$valuePtr + 20'`, 4×int16u → WB_RGBGLevels. UNENCRYPTED. WALKED.
+  ColorBalance0103,
+  /// `LensData00`/`01`/`02`/… (0x0098) — `ProcessNikonEncrypted`. DEFERRED.
+  LensData,
+  /// `ShotInfo*` (0x0091) — `ProcessNikonEncrypted`. DEFERRED.
+  ShotInfo,
+  /// `FlashInfo*` (0x00a8) — `ProcessNikonEncrypted`. DEFERRED.
+  FlashInfo,
+  /// The ENCRYPTED `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) —
+  /// `ProcessNikonEncrypted`. DEFERRED. (The unencrypted `0100`/`0102`/`0103`
+  /// route to [`Self::ColorBalance0103`] / are walked.)
+  ColorBalanceEncrypted,
+  /// Any OTHER `%Nikon::Main` SubDirectory (`PreviewIFD`, `VRInfo`,
+  /// `PictureControl`, `ISOInfo`, `WorldTime`, `LocationInfo`, `HDRInfo`,
+  /// `AFInfo2`, `NikonSettings`, …) — present in the table so the parent
+  /// pointer is suppressed, but the child table is not ported in this PR.
+  OtherDeferred,
+}
+
+impl SubTable {
+  /// `true` when the port walks this sub-table natively (emits its leaves);
+  /// `false` when it is deferred (the parent is suppressed, no leaves).
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_walked(self) -> bool {
+    matches!(self, SubTable::AfInfo | SubTable::ColorBalance0103)
+  }
+}
+
+/// `%Image::ExifTool::Nikon::Main` (`Nikon.pm:1778-3260`). Sorted by tag ID
+/// for binary-search lookup. Only the readable scalar tags + the
+/// fixture-exercised sub-tables are ported; encrypted/Drop'd long-tail
+/// sub-tables carry a deferred [`SubTable`] marker.
+pub const NIKON_TAGS: &[NikonTag] = &[
+  tag(0x0001, "MakerNoteVersion", NikonConv::MakerNoteVersion),
+  tag(0x0002, "ISO", NikonConv::Iso),
+  tag(0x0003, "ColorMode", NikonConv::FormatString),
+  tag(0x0004, "Quality", NikonConv::FormatString),
+  tag(0x0005, "WhiteBalance", NikonConv::FormatString),
+  tag(0x0006, "Sharpness", NikonConv::FormatString),
+  tag(0x0007, "FocusMode", NikonConv::FormatString),
+  tag(0x0008, "FlashSetting", NikonConv::FormatString),
+  tag(0x0009, "FlashType", NikonConv::FormatString),
+  tag(0x000b, "WhiteBalanceFineTune", NikonConv::Raw),
+  tag(0x000c, "WB_RBLevels", NikonConv::Raw),
+  tag(
+    0x000d,
+    "ProgramShift",
+    NikonConv::SignedFractionPrintFraction,
+  ),
+  tag(0x000e, "ExposureDifference", NikonConv::ExposureDifference),
+  tag(0x000f, "ISOSelection", NikonConv::FormatString),
+  // 0x0010 — DataDump (`Nikon.pm:1865`) — `Binary => 1`, no PrintConv.
+  // Emits the `(Binary data N bytes, …)` placeholder via `Raw` → Bytes.
+  tag(0x0010, "DataDump", NikonConv::Raw),
+  // 0x0011 PreviewIFD (`Nikon.pm:1872-1880`) — `Flags => 'SubIFD'`, `Start =>
+  // '$val'`: an IFD-pointer, NOT a binary block. EXCLUDED from the
+  // implicit-`undef` override (`Exif.pm:6733`).
+  sub_ifd(0x0011, "PreviewIFD", SubTable::OtherDeferred),
+  tag(0x0012, "FlashExposureComp", NikonConv::FlashExposureComp),
+  tag(0x0013, "ISOSetting", NikonConv::IsoSetting),
+  sub(0x0014, "ColorBalanceA", SubTable::OtherDeferred),
+  tag(0x0016, "ImageBoundary", NikonConv::Raw),
+  tag(
+    0x0017,
+    "ExternalFlashExposureComp",
+    NikonConv::FlashExposureComp,
+  ),
+  tag(
+    0x0018,
+    "FlashExposureBracketValue",
+    NikonConv::BracketFloat1,
+  ),
+  tag(
+    0x0019,
+    "ExposureBracketValue",
+    NikonConv::ExposureBracketRational,
+  ),
+  tag(0x001a, "ImageProcessing", NikonConv::FormatString),
+  // 0x001b CropHiSpeed (`Nikon.pm:1974`) — `int16u[7]`, the `%cropHiSpeed`
+  // `OTHER` sub formats the full record (crop mode + the cropped geometry).
+  tag(0x001b, "CropHiSpeed", NikonConv::CropHiSpeed),
+  tag(
+    0x001c,
+    "ExposureTuning",
+    NikonConv::SignedFractionPrintFraction,
+  ),
+  // 0x001d — SerialNumber (`Nikon.pm:1990`) — `PrintConv => undef` disables
+  // the inherited FormatString.
+  tag(0x001d, "SerialNumber", NikonConv::Raw),
+  tag(0x001e, "ColorSpace", NikonConv::ColorSpace),
+  sub(0x001f, "VRInfo", SubTable::OtherDeferred),
+  tag(0x0020, "ImageAuthentication", NikonConv::OffOn),
+  sub(0x0021, "FaceDetect", SubTable::OtherDeferred),
+  tag(0x0022, "ActiveD-Lighting", NikonConv::ActiveDLighting),
+  sub(0x0023, "PictureControlData", SubTable::OtherDeferred),
+  sub(0x0024, "WorldTime", SubTable::OtherDeferred),
+  sub(0x0025, "ISOInfo", SubTable::OtherDeferred),
+  tag(0x002a, "VignetteControl", NikonConv::VignetteControl),
+  sub(0x002b, "DistortInfo", SubTable::OtherDeferred),
+  sub(0x002c, "UnknownInfo", SubTable::OtherDeferred),
+  sub(0x0032, "UnknownInfo2", SubTable::OtherDeferred),
+  tag(0x0034, "ShutterMode", NikonConv::ShutterMode),
+  sub(0x0035, "HDRInfo", SubTable::OtherDeferred),
+  tag(0x0037, "MechanicalShutterCount", NikonConv::Raw),
+  sub(0x0039, "LocationInfo", SubTable::OtherDeferred),
+  tag(0x003d, "BlackLevel", NikonConv::Raw),
+  tag(0x003e, "ImageSizeRAW", NikonConv::ImageSizeRaw),
+  tag(0x003f, "WhiteBalanceFineTune", NikonConv::Raw),
+  tag(0x0044, "JPGCompression", NikonConv::JpgCompression),
+  tag(0x0045, "CropArea", NikonConv::Raw),
+  sub(0x004e, "NikonSettings", SubTable::OtherDeferred),
+  tag(0x004f, "ColorTemperatureAuto", NikonConv::Raw),
+  sub(0x0051, "MakerNotes0x51", SubTable::OtherDeferred),
+  sub(0x0056, "MakerNotes0x56", SubTable::OtherDeferred),
+  tag(0x0080, "ImageAdjustment", NikonConv::FormatString),
+  tag(0x0081, "ToneComp", NikonConv::FormatString),
+  tag(0x0082, "AuxiliaryLens", NikonConv::FormatString),
+  tag(0x0083, "LensType", NikonConv::LensType),
+  tag(0x0084, "Lens", NikonConv::Lens),
+  tag(0x0085, "ManualFocusDistance", NikonConv::Raw),
+  tag(0x0086, "DigitalZoom", NikonConv::Raw),
+  tag(0x0087, "FlashMode", NikonConv::FlashMode),
+  sub(0x0088, "AFInfo", SubTable::AfInfo),
+  tag(0x0089, "ShootingMode", NikonConv::ShootingMode),
+  tag(0x008b, "LensFStops", NikonConv::LensFStops),
+  // 0x008c — ContrastCurve (`Nikon.pm:2200`) — `Binary`/`Drop`, no PrintConv.
+  tag(0x008c, "ContrastCurve", NikonConv::Raw),
+  tag(0x008d, "ColorHue", NikonConv::FormatString),
+  tag(0x008f, "SceneMode", NikonConv::FormatString),
+  tag(0x0090, "LightSource", NikonConv::FormatString),
+  sub(0x0091, "ShotInfo", SubTable::ShotInfo),
+  tag(0x0092, "HueAdjustment", NikonConv::Raw),
+  tag(0x0093, "NEFCompression", NikonConv::NefCompression),
+  tag(0x0094, "SaturationAdj", NikonConv::Raw),
+  tag(0x0095, "NoiseReduction", NikonConv::FormatString),
+  // 0x0096 — NEFLinearizationTable (`Nikon.pm`) — `Binary`/`Drop`, no PrintConv.
+  tag(0x0096, "NEFLinearizationTable", NikonConv::Raw),
+  // 0x0097 — ColorBalance: the unencrypted `0103` (D70/D70s) is WALKED; the
+  // other variants (encrypted `02xx`, the early `0100`/`0102`) carry a deferred
+  // marker (the dispatcher inspects the version prefix at parse time).
+  sub(0x0097, "ColorBalance", SubTable::ColorBalance0103),
+  sub(0x0098, "LensData", SubTable::LensData),
+  tag(0x0099, "RawImageCenter", NikonConv::Raw),
+  tag(0x009a, "SensorPixelSize", NikonConv::SensorPixelSize),
+  tag(0x009c, "SceneAssist", NikonConv::FormatString),
+  tag(0x009d, "DateStampMode", NikonConv::DateStampMode),
+  // 0x009e RetouchHistory (`Nikon.pm:2935`) — `int16u[10]`; ValueConv trims
+  // trailing " 0", the ARRAY PrintConv maps each via `%retouchValues`.
+  tag(0x009e, "RetouchHistory", NikonConv::RetouchHistory),
+  tag(0x00a0, "SerialNumber", NikonConv::FormatString),
+  tag(0x00a2, "ImageDataSize", NikonConv::Raw),
+  tag(0x00a5, "ImageCount", NikonConv::Raw),
+  tag(0x00a6, "DeletedImageCount", NikonConv::Raw),
+  tag(0x00a7, "ShutterCount", NikonConv::ShutterCount),
+  sub(0x00a8, "FlashInfo", SubTable::FlashInfo),
+  tag(0x00a9, "ImageOptimization", NikonConv::FormatString),
+  tag(0x00aa, "Saturation", NikonConv::FormatString),
+  tag(0x00ab, "VariProgram", NikonConv::FormatString),
+  tag(0x00ac, "ImageStabilization", NikonConv::FormatString),
+  tag(0x00ad, "AFResponse", NikonConv::FormatString),
+  // 0x00b0 MultiExposure / MultiExposure2 (`Nikon.pm:3029`) — ProcessBinaryData
+  // SubDirectory(s); deferred (no bogus parent).
+  sub(0x00b0, "MultiExposure", SubTable::OtherDeferred),
+  tag(0x00b1, "HighISONoiseReduction", NikonConv::HighIsoNr),
+  tag(0x00b3, "ToningEffect", NikonConv::FormatString),
+  // 0x00b6 PowerUpTime (`Nikon.pm:3071`) — `undef`, RawConv → date/time string.
+  tag(0x00b6, "PowerUpTime", NikonConv::PowerUpTime),
+  // 0x00b7 AFInfo2 (`Nikon.pm:3095`) — versioned ProcessBinaryData SubDirectory.
+  sub(0x00b7, "AFInfo2", SubTable::OtherDeferred),
+  // 0x00b8 FileInfo (`Nikon.pm:3122`) — ProcessBinaryData SubDirectory.
+  sub(0x00b8, "FileInfo", SubTable::OtherDeferred),
+  // 0x00b9 AFTune (`Nikon.pm:3153`) — ProcessBinaryData SubDirectory.
+  sub(0x00b9, "AFTune", SubTable::OtherDeferred),
+  // 0x00bb RetouchInfo (`Nikon.pm:3158`) — ProcessBinaryData SubDirectory.
+  sub(0x00bb, "RetouchInfo", SubTable::OtherDeferred),
+  // 0x00bd PictureControlData (`Nikon.pm:3163`) — Binary SubDirectory.
+  sub(0x00bd, "PictureControlData", SubTable::OtherDeferred),
+  // 0x00bf SilentPhotography (`Nikon.pm:3170`) — `%offOn`.
+  tag(0x00bf, "SilentPhotography", NikonConv::OffOn),
+  // 0x00c3 BarometerInfo (`Nikon.pm:3174`) — ProcessBinaryData SubDirectory.
+  sub(0x00c3, "BarometerInfo", SubTable::OtherDeferred),
+  // 0x0e00 PrintIM (`Nikon.pm:3181`) — the PrintIM SubDirectory.
+  sub(0x0e00, "PrintIM", SubTable::OtherDeferred),
+  // 0x0e01 NikonCaptureData (`Nikon.pm:3192`) — Binary/Drop SubDirectory.
+  sub(0x0e01, "NikonCaptureData", SubTable::OtherDeferred),
+  // 0x0e09 NikonCaptureVersion (`Nikon.pm:3209`) — `string`, PrintConv => undef.
+  tag(0x0e09, "NikonCaptureVersion", NikonConv::Raw),
+  // 0x0e0e NikonCaptureOffsets (`Nikon.pm:3216`) — SubDirectory.
+  sub(0x0e0e, "NikonCaptureOffsets", SubTable::OtherDeferred),
+  // 0x0e10 NikonScanIFD (`Nikon.pm:3226-3234`) — `Flags => 'SubIFD'`, `Start =>
+  // '$val'`: an IFD-pointer, EXCLUDED from the implicit-`undef` override.
+  sub_ifd(0x0e10, "NikonScanIFD", SubTable::OtherDeferred),
+  // 0x0e13 NikonCaptureEditVersions (`Nikon.pm:3235`) — Binary/Drop SubDirectory.
+  sub(0x0e13, "NikonCaptureEditVersions", SubTable::OtherDeferred),
+  // 0x0e1d NikonICCProfile (`Nikon.pm:3257`) — Binary SubDirectory.
+  sub(0x0e1d, "NikonICCProfile", SubTable::OtherDeferred),
+  // 0x0e1e NikonCaptureOutput (`Nikon.pm:3270`) — Binary SubDirectory.
+  sub(0x0e1e, "NikonCaptureOutput", SubTable::OtherDeferred),
+  // 0x0e22 NEFBitDepth (`Nikon.pm:3280`) — `int16u[4]`, space-joined PrintConv.
+  tag(0x0e22, "NEFBitDepth", NikonConv::NefBitDepth),
+];
+
+/// `%Image::ExifTool::Nikon::Type2` (`Nikon.pm:5369-5382`) — the OLD Nikon
+/// MakerNote layout (`"Nikon\0\x01"`, `MakerNoteNikon2`, `MakerNotes.pm:537-545`),
+/// e.g. the early E-series Coolpix. EXACTLY eight tags, all PLAIN name
+/// mappings: the table has NO table-level `PRINT_CONV` (unlike `%Nikon::Main`)
+/// and not one tag carries a `PrintConv`/`ValueConv`/`Format`, so every value
+/// is emitted as the raw `ReadValue` scalar ([`NikonConv::Raw`] = identity).
+/// Sorted by tag ID for the binary-search [`lookup`].
+///
+/// CRUX: the IDs 0x0003..0x000b are SHARED with `%Nikon::Main` but name
+/// DIFFERENT tags (0x0003 = `Quality` here vs `ColorMode` in `Main`,
+/// 0x0007 = `WhiteBalance` here vs `FocusMode` in `Main`, …) — so a type-2
+/// MakerNote MUST be walked against THIS table, never `Main`, or the camera
+/// data is mislabelled.
+pub const NIKON_TYPE2_TAGS: &[NikonTag] = &[
+  tag(0x0003, "Quality", NikonConv::Raw),
+  tag(0x0004, "ColorMode", NikonConv::Raw),
+  tag(0x0005, "ImageAdjustment", NikonConv::Raw),
+  tag(0x0006, "CCDSensitivity", NikonConv::Raw),
+  tag(0x0007, "WhiteBalance", NikonConv::Raw),
+  tag(0x0008, "Focus", NikonConv::Raw),
+  tag(0x000a, "DigitalZoom", NikonConv::Raw),
+  tag(0x000b, "Converter", NikonConv::Raw),
+];
+
+/// Which Nikon tag table a MakerNote IFD is walked against — selected by the
+/// header layout (`MakerNotes.pm:48-554`):
+///
+/// - [`Self::Main`] — `%Image::ExifTool::Nikon::Main` (`Nikon.pm:1778`): the
+///   modern type-3 (`"Nikon\0\x02"`) AND headerless Nikon3 (`Make =~
+///   /^NIKON/i`) layouts.
+/// - [`Self::Type2`] — `%Image::ExifTool::Nikon::Type2` (`Nikon.pm:5369`): the
+///   OLD type-2 (`"Nikon\0\x01"`) layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NikonTable {
+  /// `%Nikon::Main` — type-3 + headerless.
+  Main,
+  /// `%Nikon::Type2` — the `"Nikon\0\x01"` layout.
+  Type2,
+}
+
+impl NikonTable {
+  /// The ID-sorted backing slice for this table.
+  #[must_use]
+  #[inline(always)]
+  const fn slice(self) -> &'static [NikonTag] {
+    match self {
+      NikonTable::Main => NIKON_TAGS,
+      NikonTable::Type2 => NIKON_TYPE2_TAGS,
+    }
+  }
+
+  /// Resolve a tag ID against this table via binary search.
+  #[must_use]
+  #[inline]
+  pub fn lookup(self, id: u16) -> Option<&'static NikonTag> {
+    let table = self.slice();
+    match table.binary_search_by_key(&id, NikonTag::id) {
+      Ok(i) => table.get(i),
+      Err(_) => None,
+    }
+  }
+}
+
+/// `%Image::ExifTool::Nikon::AFInfo` (`Nikon.pm:2113-2158`) — a
+/// `ProcessBinaryData` table. Position-keyed (byte offset). BigEndian for
+/// DSLRs (`$$self{Model} =~ /^NIKON D/i`), LittleEndian otherwise.
+pub const AF_INFO: &[AfInfoEntry] = &[
+  AfInfoEntry {
+    offset: 0,
+    name: "AFAreaMode",
+    conv: NikonConv::AfAreaMode,
+    format: crate::exif::ifd::Format::Int8u,
+  },
+  AfInfoEntry {
+    offset: 1,
+    name: "AFPoint",
+    conv: NikonConv::AfPoint,
+    format: crate::exif::ifd::Format::Int8u,
+  },
+  AfInfoEntry {
+    offset: 2,
+    name: "AFPointsInFocus",
+    conv: NikonConv::AfPointsInFocus,
+    format: crate::exif::ifd::Format::Int16u,
+  },
+];
+
+/// One `%Nikon::AFInfo` binary-data position.
+#[derive(Debug, Clone, Copy)]
+pub struct AfInfoEntry {
+  /// Byte offset within the AFInfo blob (the `ProcessBinaryData` index).
+  pub offset: usize,
+  /// Tag `Name`.
+  pub name: &'static str,
+  /// PrintConv strategy.
+  pub conv: NikonConv,
+  /// On-disk format of this position.
+  pub format: crate::exif::ifd::Format,
+}
+
+/// `const`-fn leaf-tag constructor (no sub-table, no format override).
+const fn tag(id: u16, name: &'static str, conv: NikonConv) -> NikonTag {
+  NikonTag {
+    id,
+    name,
+    conv,
+    format: None,
+    sub_table: None,
+    sub_ifd: false,
+    unknown: false,
+  }
+}
+
+/// `const`-fn SubDirectory-tag constructor (a BINARY-block sub-table: NOT a
+/// `SubIFD`, so the implicit-`undef` override `Exif.pm:6733` applies).
+const fn sub(id: u16, name: &'static str, sub_table: SubTable) -> NikonTag {
+  NikonTag {
+    id,
+    name,
+    conv: NikonConv::Raw,
+    format: None,
+    sub_table: Some(sub_table),
+    sub_ifd: false,
+    unknown: false,
+  }
+}
+
+/// `const`-fn `SubIFD`-pointer constructor (`Flags => 'SubIFD'`, `Start =>
+/// '$val'`): the value is an IFD offset read as an integer — EXCLUDED from the
+/// implicit-`undef` SubDirectory override (`Exif.pm:6733` `not
+/// $$tagInfo{SubIFD}`).
+const fn sub_ifd(id: u16, name: &'static str, sub_table: SubTable) -> NikonTag {
+  NikonTag {
+    id,
+    name,
+    conv: NikonConv::Raw,
+    format: None,
+    sub_table: Some(sub_table),
+    sub_ifd: true,
+    unknown: false,
+  }
+}
+
+/// Resolve a tag ID against `%Nikon::Main` (the ID-sorted [`NIKON_TAGS`]) via
+/// binary search. Convenience for the [`NikonTable::Main`] path; the walker
+/// dispatches on [`NikonTable`] so the type-2 layout uses [`NIKON_TYPE2_TAGS`].
+#[must_use]
+#[inline]
+pub fn lookup(id: u16) -> Option<&'static NikonTag> {
+  NikonTable::Main.lookup(id)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// `NIKON_TAGS` is sorted by tag ID — required for `binary_search`.
+  #[test]
+  fn nikon_tags_sorted_by_id() {
+    let mut prev: Option<u16> = None;
+    for t in NIKON_TAGS {
+      if let Some(p) = prev {
+        assert!(
+          t.id > p,
+          "Nikon tag table out of order: 0x{:04x} after 0x{:04x}",
+          t.id,
+          p
+        );
+      }
+      prev = Some(t.id);
+    }
+  }
+
+  /// Camera-indexing tags are present with the faithful names.
+  #[test]
+  fn lookup_finds_core_tags() {
+    assert_eq!(lookup(0x0001).unwrap().name(), "MakerNoteVersion");
+    assert_eq!(lookup(0x0004).unwrap().name(), "Quality");
+    assert_eq!(lookup(0x0005).unwrap().name(), "WhiteBalance");
+    assert_eq!(lookup(0x0007).unwrap().name(), "FocusMode");
+    assert_eq!(lookup(0x0083).unwrap().name(), "LensType");
+    assert_eq!(lookup(0x0084).unwrap().name(), "Lens");
+    assert_eq!(lookup(0x0089).unwrap().name(), "ShootingMode");
+    assert_eq!(lookup(0x001d).unwrap().name(), "SerialNumber");
+    assert_eq!(lookup(0x00a7).unwrap().name(), "ShutterCount");
+  }
+
+  /// The encrypted sub-tables carry a DEFERRED (`!is_walked`) marker so the
+  /// parent pointer is suppressed (#177/#223), while the two unencrypted ones
+  /// are walked.
+  #[test]
+  fn encrypted_subdirs_are_deferred() {
+    assert_eq!(
+      lookup(0x0091).unwrap().sub_table(),
+      Some(SubTable::ShotInfo)
+    );
+    assert!(!SubTable::ShotInfo.is_walked());
+    assert_eq!(
+      lookup(0x0098).unwrap().sub_table(),
+      Some(SubTable::LensData)
+    );
+    assert!(!SubTable::LensData.is_walked());
+    assert_eq!(
+      lookup(0x00a8).unwrap().sub_table(),
+      Some(SubTable::FlashInfo)
+    );
+    assert!(!SubTable::FlashInfo.is_walked());
+    // Walked sub-tables.
+    assert_eq!(lookup(0x0088).unwrap().sub_table(), Some(SubTable::AfInfo));
+    assert!(SubTable::AfInfo.is_walked());
+    assert_eq!(
+      lookup(0x0097).unwrap().sub_table(),
+      Some(SubTable::ColorBalance0103)
+    );
+    assert!(SubTable::ColorBalance0103.is_walked());
+  }
+
+  /// `Flags => 'SubIFD'` (`$$tagInfo{SubIFD}`) is set on EXACTLY the two
+  /// IFD-pointer SubDirectories in `%Nikon::Main` — PreviewIFD (0x0011,
+  /// `Nikon.pm:1875`) and NikonScanIFD (0x0e10, `Nikon.pm:3229`) — and on no
+  /// binary-block sub-table; it gates the implicit-`undef` override
+  /// (`Exif.pm:6733` `not $$tagInfo{SubIFD}`).
+  #[test]
+  fn sub_ifd_flag_only_on_ifd_pointers() {
+    assert!(
+      lookup(0x0011).unwrap().is_sub_ifd(),
+      "PreviewIFD is a SubIFD"
+    );
+    assert!(
+      lookup(0x0e10).unwrap().is_sub_ifd(),
+      "NikonScanIFD is a SubIFD"
+    );
+    // Binary-block sub-tables are NOT SubIFD ⇒ they GET the undef override.
+    for id in [0x0088u16, 0x0097, 0x0091, 0x0098, 0x00a8, 0x001f, 0x0e00] {
+      let t = lookup(id).unwrap_or_else(|| panic!("0x{id:04x} missing"));
+      assert!(t.sub_table().is_some(), "0x{id:04x} is a SubDirectory");
+      assert!(
+        !t.is_sub_ifd(),
+        "0x{id:04x} is a binary block, NOT a SubIFD"
+      );
+    }
+    // No leaf tag is ever a SubIFD.
+    assert!(!lookup(0x0083).unwrap().is_sub_ifd()); // LensType (leaf)
+  }
+
+  /// An unknown ID returns `None`.
+  #[test]
+  fn lookup_unknown_is_none() {
+    assert!(lookup(0xFFFF).is_none());
+    assert!(lookup(0x7777).is_none());
+  }
+
+  /// These readable scalars carry the faithful name + a leaf conv (no
+  /// sub-table) so they emit as values, not bogus parents.
+  #[test]
+  fn newly_ported_readable_scalars() {
+    for (id, name) in [
+      (0x001b, "CropHiSpeed"),
+      (0x009e, "RetouchHistory"),
+      (0x00b6, "PowerUpTime"),
+      (0x00bf, "SilentPhotography"),
+      (0x0e09, "NikonCaptureVersion"),
+      (0x0e22, "NEFBitDepth"),
+    ] {
+      let t = lookup(id).unwrap_or_else(|| panic!("0x{id:04x} missing"));
+      assert_eq!(t.name(), name);
+      assert!(
+        t.sub_table().is_none(),
+        "0x{id:04x} {name} is a readable scalar, not a SubDirectory"
+      );
+    }
+  }
+
+  /// Every long-tail `%Nikon::Main` SubDirectory is DEFERRED (`!is_walked`) so
+  /// the parent pointer is suppressed (#177/#223) — none emits a bogus parent.
+  #[test]
+  fn newly_deferred_subdirs_emit_no_parent() {
+    for id in [
+      0x00b0, 0x00b7, 0x00b8, 0x00b9, 0x00bb, 0x00bd, 0x00c3, 0x0e00, 0x0e01, 0x0e0e, 0x0e10,
+      0x0e13, 0x0e1d, 0x0e1e,
+    ] {
+      let t = lookup(id).unwrap_or_else(|| panic!("0x{id:04x} missing"));
+      let sub = t
+        .sub_table()
+        .unwrap_or_else(|| panic!("0x{id:04x} must be SubDirectory-marked"));
+      assert!(
+        !sub.is_walked(),
+        "0x{id:04x} {} must be deferred (no bogus parent)",
+        t.name()
+      );
+    }
+  }
+
+  /// `%Nikon::Type2` (`Nikon.pm:5369-5382`) is EXACTLY the eight plain
+  /// name-mapped tags, ID-sorted, every one a leaf `NikonConv::Raw` (no
+  /// PrintConv/ValueConv/Format/sub-table). Crucially the SHARED IDs name
+  /// DIFFERENT tags than `%Nikon::Main`.
+  #[test]
+  fn type2_table_is_the_eight_plain_tags() {
+    let expect = [
+      (0x0003u16, "Quality"),
+      (0x0004, "ColorMode"),
+      (0x0005, "ImageAdjustment"),
+      (0x0006, "CCDSensitivity"),
+      (0x0007, "WhiteBalance"),
+      (0x0008, "Focus"),
+      (0x000a, "DigitalZoom"),
+      (0x000b, "Converter"),
+    ];
+    assert_eq!(NIKON_TYPE2_TAGS.len(), 8);
+    let mut prev: Option<u16> = None;
+    for (id, name) in expect {
+      let t = NikonTable::Type2
+        .lookup(id)
+        .unwrap_or_else(|| panic!("Type2 0x{id:04x} missing"));
+      assert_eq!(t.name(), name);
+      assert!(t.sub_table().is_none(), "Type2 tags are leaves");
+      assert!(!t.is_sub_ifd());
+      assert!(!t.is_unknown());
+      assert!(matches!(t.conv(), NikonConv::Raw), "Type2 tags are raw");
+      assert!(t.format().is_none(), "no Format directive");
+      if let Some(p) = prev {
+        assert!(id > p, "Type2 table out of order");
+      }
+      prev = Some(id);
+    }
+    // The shared IDs diverge from %Nikon::Main — Type2 0x0003/0x0007 name
+    // Quality/WhiteBalance, where Main names ColorMode/FocusMode.
+    assert_eq!(NikonTable::Type2.lookup(0x0003).unwrap().name(), "Quality");
+    assert_eq!(NikonTable::Main.lookup(0x0003).unwrap().name(), "ColorMode");
+    assert_eq!(
+      NikonTable::Type2.lookup(0x0007).unwrap().name(),
+      "WhiteBalance"
+    );
+    assert_eq!(NikonTable::Main.lookup(0x0007).unwrap().name(), "FocusMode");
+    // An ID outside the eight is unknown in Type2 (e.g. LensType 0x0083 is a
+    // Main-only tag) — so it is dropped on the type-2 path.
+    assert!(NikonTable::Type2.lookup(0x0083).is_none());
+    assert!(NikonTable::Type2.lookup(0x0001).is_none()); // MakerNoteVersion is Main-only
+  }
+
+  /// The AFInfo binary-data positions are the faithful three.
+  #[test]
+  fn af_info_positions() {
+    assert_eq!(AF_INFO.len(), 3);
+    assert_eq!(AF_INFO.first().unwrap().name, "AFAreaMode");
+    assert_eq!(AF_INFO.get(1).unwrap().name, "AFPoint");
+    assert_eq!(AF_INFO.get(2).unwrap().name, "AFPointsInFocus");
+  }
+}

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -547,6 +547,17 @@ enum MakerNoteValueConvDecode<'a> {
     mn_len: usize,
     order: ByteOrder,
   },
+  /// Nikon — `parse_in_tiff(data, mn_offset, mn_len, order, ·, model)`.
+  /// Type-3 is self-contained (embedded TIFF), but type-2 / headerless Nikon3
+  /// resolve out-of-line offsets against the PARENT TIFF block, so the parent
+  /// `data` + the MakerNote window are retained (not just the blob).
+  Nikon {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    order: ByteOrder,
+    model: Option<smol_str::SmolStr>,
+  },
 }
 
 #[cfg(feature = "alloc")]
@@ -672,6 +683,23 @@ impl MakerNoteValueConvDecode<'_> {
         mn_len,
         order,
       } => dji::parse_in_tiff(data, *mn_offset, *mn_len, *order, false).1,
+      MakerNoteValueConvDecode::Nikon {
+        data,
+        mn_offset,
+        mn_len,
+        order,
+        model,
+      } => {
+        makernotes::vendors::nikon::parse_in_tiff(
+          data,
+          *mn_offset,
+          *mn_len,
+          *order,
+          false,
+          model.as_deref(),
+        )
+        .1
+      }
     }
   }
 }
@@ -2484,7 +2512,7 @@ impl Walker<'_, '_> {
     //     track `Model` during the IFD walk, and an ILCE camera with an
     //     empty first entry is a narrow Sony-specific case outside the
     //     standalone-TIFF camera-metadata scope (`docs/tracking.md`).
-    let recognized = matches!(format_code, 1..=13 | 129);
+    let recognized = Format::is_valid_ifd_code(format_code);
     if !recognized {
       // `if ($format or $validate) { Warn(...); ++$warnCount }` — a 0
       // code is silent padding; any other bad code warns AND counts toward the
@@ -3231,6 +3259,42 @@ impl Walker<'_, '_> {
                   mn_offset,
                   mn_len,
                   order: self.order,
+                };
+              }
+              makernotes::Vendor::Nikon => {
+                // Nikon has THREE layouts with DIFFERENT base semantics:
+                //   - type-3 (`Nikon\0\x02…`, `MakerNotes.pm:51-58`) carries a
+                //     SELF-CONTAINED embedded TIFF (`Base => '$start - 8'`
+                //     rebases its out-of-line offsets to blob offset 10), so it
+                //     decodes from the captured BLOB alone.
+                //   - type-2 (`Nikon\0\x01`, `MakerNotes.pm:539-545`) and
+                //     headerless Nikon3 (`MakerNotes.pm:546-554`) have NO `Base`
+                //     override ⇒ their out-of-line value offsets are
+                //     PARENT-TIFF-relative — they must resolve against the
+                //     parent TIFF block, NOT the captured blob.
+                // So thread the parent TIFF context (`self.data`/`value_offset`/
+                // `read_len`); `nikon::parse_in_tiff` walks the blob for type-3
+                // and the parent TIFF for type-2/Nikon3 (choosing the slice
+                // from the header). The byte order is read from the embedded
+                // marker (type-3) / explicit LE (type-2) / inherited (Nikon3),
+                // so `self.order` is only the Nikon3 fallback. `model` threads
+                // `$$self{Model}` for the AFInfo BigEndian gate
+                // (`$$self{Model} =~ /^NIKON D/i`, `Nikon.pm:2115`) + the
+                // `ShootingMode` bit-5 model branch (`Nikon.pm:2180`).
+                let mn_offset = value_offset;
+                let mn_len = read_len;
+                let model = self.captured_model.as_deref();
+                let (typed_pc, emi_pc) = makernotes::vendors::nikon::parse_in_tiff(
+                  self.data, mn_offset, mn_len, self.order, true, model,
+                );
+                meta.set_nikon(typed_pc);
+                cached_pc = emi_pc;
+                value_conv_decode = MakerNoteValueConvDecode::Nikon {
+                  data: self.data,
+                  mn_offset,
+                  mn_len,
+                  order: self.order,
+                  model: model.map(smol_str::SmolStr::new),
                 };
               }
               _ => {}

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -260,8 +260,9 @@ fn vendor_status_phase_buckets_are_observable() {
   assert!(Vendor::Sony.status().is_scheduled());
   assert!(Vendor::Panasonic.status().is_scheduled());
   assert!(Vendor::Dji.status().is_scheduled());
-  // Long-tail vendors are deferred.
-  assert!(Vendor::Nikon.status().is_deferred());
+  // Nikon is now scheduled (Phase 5 — `%Nikon::Main` + readable sub-tables).
+  assert!(Vendor::Nikon.status().is_scheduled());
+  // Long-tail vendors are still deferred.
   assert!(Vendor::Pentax.status().is_deferred());
   assert!(Vendor::Fuji.status().is_deferred());
 }
@@ -1689,6 +1690,123 @@ fn from_blob_panasonic3_dcft7_base12_reads_out_of_line_at_correct_offset() {
     Some("LUMIX-LENS-12"),
     "a base-0 (Inherit) read must NOT recover the real string from a \
      base-12-stored offset"
+  );
+}
+
+/// `MakerNotesMeta::from_blob_with_context` is a blob-ONLY constructor with no
+/// parent TIFF. Nikon's type-2 (`Nikon\0\x01`) and headerless-Nikon3 layouts
+/// have NO `Base` override ⇒ their out-of-line value offsets are
+/// PARENT-TIFF-relative; with only the blob, an absolute offset would index
+/// INTO the blob and read out-of-line values from the WRONG bytes (garbage).
+/// The constructor must therefore NOT decode those layouts (leave the Nikon
+/// slot ABSENT) — only the self-contained type-3 (`Nikon\0\x02`) embedded TIFF,
+/// whose `Base => '$start - 8'` makes the blob its own context, may decode.
+/// (The production decode never hits this path — `Exif` calls
+/// `nikon::parse_in_tiff` with the real parent TIFF — so the gate is purely
+/// defensive.)
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn nikon_blob_constructor_type2_headerless_no_garbage() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::{MakerNotesMeta, dispatch, vendors};
+
+  // ---- Type-2 (`Nikon\0\x01`): IFD at offset 8, LE, offsets TIFF-relative,
+  // walked against `%Nikon::Type2`. A single OUT-OF-LINE ColorMode (0x0004 =
+  // ColorMode in Type2, ASCII[6]) whose stored offset (26) is a
+  // parent-TIFF-absolute position. With only the blob, offset 26 lands on
+  // bytes spelling "WRONG\0" — exactly the mis-rebased garbage the gate must
+  // suppress.
+  let mut t2: Vec<u8> = Vec::new();
+  t2.extend_from_slice(b"Nikon\x00\x01\x00"); // 8-byte header, IFD @8
+  t2.extend_from_slice(&1u16.to_le_bytes()); // count = 1
+  t2.extend_from_slice(&0x0004u16.to_le_bytes()); // tag 0x0004 = ColorMode (Type2)
+  t2.extend_from_slice(&2u16.to_le_bytes()); // ASCII
+  t2.extend_from_slice(&6u32.to_le_bytes()); // count 6 (out-of-line)
+  t2.extend_from_slice(&26u32.to_le_bytes()); // TIFF-absolute offset
+  t2.extend_from_slice(&0u32.to_le_bytes()); // next IFD
+  assert_eq!(
+    t2.len(),
+    26,
+    "the out-of-line bytes must start at offset 26"
+  );
+  t2.extend_from_slice(b"WRONG\x00"); // bytes a blob-only walk would mis-read
+
+  let detected_t2 = dispatch(&t2, Some("NIKON CORPORATION"), Some("E990"), None);
+  assert!(detected_t2.vendor().is_nikon());
+
+  // The gated constructor must leave the Nikon slot ABSENT.
+  let meta_t2 = MakerNotesMeta::from_blob(detected_t2, &t2, ByteOrder::Little);
+  assert!(
+    meta_t2.nikon().is_none(),
+    "from_blob must NOT decode a type-2 Nikon blob (no parent TIFF ⇒ \
+     out-of-line offsets cannot be faithfully rebased)"
+  );
+
+  // NEGATIVE CONTROL: the ungated blob-only walk (`vendors::nikon::parse`)
+  // DOES mis-read the out-of-line value from the blob — emitting it as the
+  // Type2 name `ColorMode` = "WRONG" (raw, no PrintConv). Proves the gate is
+  // load-bearing — without it the constructor would emit this garbage. (The
+  // emission name is `ColorMode`, the `%Nikon::Type2` 0x0004 tag, confirming
+  // the type-2 walk uses Type2, not `%Nikon::Main` where 0x0004 = Quality.)
+  let (_mis, mis_emit) = vendors::nikon::parse(&t2, ByteOrder::Little, Some("E990"));
+  let mis_color_mode = mis_emit
+    .iter()
+    .find(|e| e.name() == "ColorMode")
+    .map(|e| e.value().clone());
+  assert_eq!(
+    mis_color_mode,
+    Some(exifast::value::TagValue::Str("WRONG".into())),
+    "the ungated blob-only walk reads the mis-rebased out-of-line value as \
+     the Type2 ColorMode (0x0004), proving the Type2 table is used"
+  );
+
+  // ---- Headerless Nikon3: the blob IS the IFD (offset 0), offsets
+  // TIFF-relative. Same hazard ⇒ same gate.
+  let mut t3less: Vec<u8> = Vec::new();
+  t3less.extend_from_slice(&1u16.to_le_bytes()); // count = 1 (IFD @0)
+  t3less.extend_from_slice(&0x0004u16.to_le_bytes()); // Quality
+  t3less.extend_from_slice(&2u16.to_le_bytes()); // ASCII
+  t3less.extend_from_slice(&6u32.to_le_bytes()); // count 6 (out-of-line)
+  t3less.extend_from_slice(&18u32.to_le_bytes()); // TIFF-absolute offset
+  t3less.extend_from_slice(&0u32.to_le_bytes()); // next IFD
+  assert_eq!(t3less.len(), 18, "headerless out-of-line bytes start at 18");
+  t3less.extend_from_slice(b"WRONG\x00");
+
+  // Headerless Nikon3 needs a `^NIKON` make to dispatch (`MakerNotes.pm:550`).
+  let detected_hl = dispatch(&t3less, Some("NIKON"), Some("COOLPIX"), None);
+  assert!(detected_hl.vendor().is_nikon());
+  let meta_hl = MakerNotesMeta::from_blob(detected_hl, &t3less, ByteOrder::Little);
+  assert!(
+    meta_hl.nikon().is_none(),
+    "from_blob must NOT decode a headerless Nikon3 blob (offsets are \
+     parent-TIFF-relative, no parent TIFF available)"
+  );
+
+  // ---- Type-3 (`Nikon\0\x02`) self-contained embedded TIFF (BE): the blob IS
+  // its own context, so the SAME constructor decodes it correctly. Inline
+  // LensType = 0x06 → "G" (no out-of-line offset involved).
+  let mut t3: Vec<u8> = Vec::new();
+  t3.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // 10-byte header
+  t3.extend_from_slice(b"MM"); // embedded TIFF: big-endian
+  t3.extend_from_slice(&[0x00, 0x2a]);
+  t3.extend_from_slice(&[0x00, 0x00, 0x00, 0x08]); // IFD0 @ embedded-TIFF +8
+  t3.extend_from_slice(&[0x00, 0x01]); // 1 entry
+  t3.extend_from_slice(&[0x00, 0x83]); // tag 0x0083 = LensType
+  t3.extend_from_slice(&[0x00, 0x01]); // int8u
+  t3.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]); // count 1
+  t3.extend_from_slice(&[0x06, 0x00, 0x00, 0x00]); // inline value 6 → "G"
+  t3.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next IFD
+
+  let detected_t3 = dispatch(&t3, Some("NIKON CORPORATION"), Some("NIKON D70"), None);
+  assert!(detected_t3.vendor().is_nikon());
+  let meta_t3 = MakerNotesMeta::from_blob(detected_t3, &t3, ByteOrder::Big);
+  let nikon_t3 = meta_t3
+    .nikon()
+    .expect("from_blob must still decode the self-contained type-3 layout");
+  assert_eq!(
+    nikon_t3.lens_type(),
+    Some("G"),
+    "the type-3 self-contained path through from_blob still decodes correctly"
   );
 }
 
@@ -3465,6 +3583,52 @@ fn canon_mismarked_subdir_parents_not_emitted() {
   }
 }
 
+// Phase 5 — real-input Nikon fixtures (#62/#74). NOT bundled; gated on
+// EXIFTOOL_T_IMAGES (ExifTool's t/images). Covers the three MakerNote
+// layouts: type-3 embedded-TIFF (Nikon.nef / NikonD2Hs / NikonD70) + the
+// headerless Nikon3 (Nikon.jpg, a Coolpix E775). Every PORTED `Nikon:*` tag
+// must match the bundled `exiftool -G1 -j` oracle value-semantic; the
+// oracle-only-remaining keys are the DEFERRED ENCRYPTED sub-tables
+// (LensData/ShotInfo/FlashInfo + the encrypted ColorBalance) + the
+// PreviewIFD subdir offsets — verified absent without leaking a bogus parent.
+// ===========================================================================
+
+/// Read `{dir}/{file}` from EXIFTOOL_T_IMAGES into our `-j` JSON map; `None`
+/// (skip) when the env var / file is unavailable.
+#[cfg(feature = "json")]
+fn nikon_fixture_map(file: &str) -> Option<serde_json::Map<String, serde_json::Value>> {
+  let dir = std::env::var("EXIFTOOL_T_IMAGES").ok()?;
+  let path = format!("{dir}/{file}");
+  let data = std::fs::read(&path).ok()?;
+  let json = exifast::parser::extract_info(file, &data, true);
+  let doc: serde_json::Value = serde_json::from_str(&json).expect("our json parses");
+  doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .cloned()
+}
+
+/// Assert every `(key, oracle_json)` in `oracle` matches our map
+/// value-semantic (`"2.10"`==`2.10`, `1.0`==`1`); the cited values are from
+/// `perl exiftool -G1 -j <fixture>`.
+#[cfg(feature = "json")]
+fn assert_nikon_oracle(map: &serde_json::Map<String, serde_json::Value>, oracle: &[(&str, &str)]) {
+  use exifast::jsondiff::json_equivalent;
+  for (key, want) in oracle {
+    let got = map
+      .get(*key)
+      .unwrap_or_else(|| panic!("missing {key}; keys: {:?}", map.keys().collect::<Vec<_>>()));
+    let got_doc = serde_json::to_string(got).unwrap();
+    let got_obj = format!("[{{\"v\":{got_doc}}}]");
+    let want_obj = format!("[{{\"v\":{want}}}]");
+    assert!(
+      json_equivalent(&got_obj, &want_obj).is_ok(),
+      "{key}: got {got_doc}, want {want}"
+    );
+  }
+}
+
 /// #223 — the real `Canon1DmkIII.jpg` (NOT bundled; gated on
 /// `EXIFTOOL_T_IMAGES`) carries ALL SEVEN mis-marked SubDirectory parents
 /// (`CanonCameraInfo`/`CropInfo`/`CustomFunctions2`/`AspectInfo`/
@@ -3759,6 +3923,118 @@ fn canon_0x28_count_zero_no_trailing_decode() {
   }
 }
 
+/// Nikon.nef (D70 NEF, type-3 embedded-TIFF MakerNote). The ported
+/// `%Nikon::Main` scalars + the unencrypted `ColorBalance0103`
+/// (WB_RGBGLevels) match the oracle; the deferred encrypted children
+/// (LensData/etc.) stay absent without a bogus parent. Make/Model from IFD0.
+#[cfg(feature = "json")]
+#[test]
+fn real_fixture_nikon_nef_makernotes() {
+  let Some(map) = nikon_fixture_map("Nikon.nef") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES/Nikon.nef unavailable");
+    return;
+  };
+  // PORTED Nikon::Main + the embedded-TIFF base correctness (a wrong base
+  // would decode garbage, not these exact values).
+  assert_nikon_oracle(
+    &map,
+    &[
+      ("Nikon:MakerNoteVersion", "2.10"),
+      ("Nikon:ISO", "200"),
+      ("Nikon:Quality", r#""RAW""#),
+      ("Nikon:WhiteBalance", r#""Auto""#),
+      ("Nikon:Sharpness", r#""None""#),
+      ("Nikon:FocusMode", r#""AF-S""#),
+      ("Nikon:ToneComp", r#""CS""#),
+      ("Nikon:LensType", r#""G""#),
+      ("Nikon:Lens", r#""18-70mm f/3.5-4.5""#),
+      ("Nikon:FlashMode", r#""Did Not Fire""#),
+      ("Nikon:ShootingMode", r#""Single-Frame""#),
+      ("Nikon:ColorHue", r#""Mode2""#),
+      ("Nikon:LightSource", r#""Natural""#),
+      ("Nikon:NEFCompression", r#""Lossy (type 1)""#),
+      ("Nikon:NoiseReduction", r#""Off""#),
+      // ColorBalance0103 (UNENCRYPTED, walked): WB_RGBGLevels = int16u[4].
+      ("Nikon:WB_RGBGLevels", r#""478 265 493 265""#),
+      ("Nikon:SerialNumber", "12345678"),
+      ("Nikon:ShutterCount", "3619"),
+      ("Nikon:RawImageCenter", r#""1520 1008""#),
+      ("Nikon:SensorPixelSize", r#""7.8 x 7.8 um""#),
+      ("Nikon:Saturation", r#""Normal""#),
+    ],
+  );
+  // The DEFERRED ENCRYPTED sub-tables (LensData 0x0098 / ShotInfo 0x0091 /
+  // FlashInfo 0x00a8) are oracle-only — neither the bogus parent NOR the
+  // (un-decrypted) children are emitted (#177/#223).
+  for absent in [
+    "Nikon:LensData",        // bogus parent
+    "Nikon:LensDataVersion", // encrypted child
+    "Nikon:FocusDistance",
+    "Nikon:LensIDNumber",
+    "Nikon:ShotInfo",
+    "Nikon:FlashInfo",
+  ] {
+    assert!(
+      !map.contains_key(absent),
+      "deferred/bogus key {absent} must be absent"
+    );
+  }
+  // Make/Model still come from IFD0 unchanged.
+  assert_eq!(
+    map.get("IFD0:Make").and_then(|v| v.as_str()),
+    Some("NIKON CORPORATION")
+  );
+  assert_eq!(
+    map.get("IFD0:Model").and_then(|v| v.as_str()),
+    Some("NIKON D70")
+  );
+}
+
+/// Nikon.jpg (Coolpix E775 — HEADERLESS Nikon3 MakerNote, `Make =~ /^NIKON/i`,
+/// little-endian, offsets PARENT-TIFF-relative). Verifies the headerless
+/// layout decodes the full Main scalar set (a wrong base/slice would yield
+/// garbage), incl. the `(Binary data …)` DataDump placeholder.
+#[cfg(feature = "json")]
+#[test]
+fn real_fixture_nikon_jpg_makernotes() {
+  let Some(map) = nikon_fixture_map("Nikon.jpg") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES/Nikon.jpg unavailable");
+    return;
+  };
+  assert_nikon_oracle(
+    &map,
+    &[
+      ("Nikon:MakerNoteVersion", "1.00"),
+      ("Nikon:ISO", "0"),
+      ("Nikon:ColorMode", r#""Color""#),
+      ("Nikon:Quality", r#""Fine""#),
+      ("Nikon:WhiteBalance", r#""Auto""#),
+      ("Nikon:Sharpness", r#""Auto""#),
+      ("Nikon:FocusMode", r#""AF-C""#),
+      ("Nikon:ISOSelection", r#""Auto""#),
+      ("Nikon:ImageAdjustment", r#""Normal""#),
+      ("Nikon:AuxiliaryLens", r#""Off""#),
+      ("Nikon:DigitalZoom", "1"),
+      // AFInfo (UNENCRYPTED ProcessBinaryData, walked): the Coolpix is LE.
+      ("Nikon:AFAreaMode", r#""Single Area""#),
+      ("Nikon:AFPoint", r#""Center""#),
+      ("Nikon:AFPointsInFocus", r#""(none)""#),
+      // DataDump (Binary => 1) → the (Binary data N bytes, …) placeholder.
+      (
+        "Nikon:DataDump",
+        r#""(Binary data 122 bytes, use -b option to extract)""#,
+      ),
+    ],
+  );
+  // No bogus subdir parents.
+  for absent in ["Nikon:LensData", "Nikon:ShotInfo", "Nikon:FlashInfo"] {
+    assert!(
+      !map.contains_key(absent),
+      "bogus key {absent} must be absent"
+    );
+  }
+}
+
 /// #223 R4 — a `0x28` entry declaring a HUGE element count must be bounds-safe:
 /// the checked window computation (`byte_size().checked_mul(count)` +
 /// `checked_add` + `get`) never panics and never allocates the discarded
@@ -3891,4 +4167,71 @@ fn canon_223_second_pass_subdir_parents_suppressed() {
       );
     }
   }
+}
+
+/// NikonD2Hs.jpg (type-3) — exercises the FlashType empty string, the
+/// `ColorSpace` hash, AFInfo (BigEndian DSLR path) + the deferred ENCRYPTED
+/// ColorBalance (WB_RGGBLevels) which must NOT appear.
+#[cfg(feature = "json")]
+#[test]
+fn real_fixture_nikon_d2hs_makernotes() {
+  let Some(map) = nikon_fixture_map("NikonD2Hs.jpg") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES/NikonD2Hs.jpg unavailable");
+    return;
+  };
+  assert_nikon_oracle(
+    &map,
+    &[
+      ("Nikon:Quality", r#""Fine""#),
+      ("Nikon:WhiteBalance", r#""Preset0""#),
+      ("Nikon:FocusMode", r#""AF-C""#),
+      ("Nikon:FlashSetting", r#""Normal""#),
+      ("Nikon:ColorSpace", r#""sRGB""#),
+      ("Nikon:LensType", r#""D""#),
+      ("Nikon:Lens", r#""50mm f/1.8""#),
+      ("Nikon:ShootingMode", r#""Delay""#),
+      ("Nikon:SerialNumber", "3001006"),
+      ("Nikon:ImageDataSize", "1369271"),
+      ("Nikon:ImageCount", "2"),
+      ("Nikon:DeletedImageCount", "0"),
+      ("Nikon:ShutterCount", "2"),
+      // AFInfo (BigEndian DSLR path).
+      ("Nikon:AFAreaMode", r#""Single Area""#),
+      ("Nikon:AFPointsInFocus", r#""Center""#),
+      ("Nikon:HighISONoiseReduction", r#""Normal""#),
+    ],
+  );
+  // The D2Hs ColorBalance is the ENCRYPTED 0206 variant ⇒ WB_RGGBLevels is
+  // deferred (oracle-only), and no bogus ColorBalance parent is emitted.
+  assert!(!map.contains_key("Nikon:WB_RGGBLevels"));
+  assert!(!map.contains_key("Nikon:ColorBalance"));
+}
+
+/// NikonD70.jpg (type-3) — exercises the `FlashExposureComp` PrintFraction
+/// (`-5/3`) and `ExposureDifference` (`%+.1f` → `-4.9`), plus the title-cased
+/// `FlashType` ("Built-in,TTL") + the unencrypted WB_RGBGLevels.
+#[cfg(feature = "json")]
+#[test]
+fn real_fixture_nikon_d70_makernotes() {
+  let Some(map) = nikon_fixture_map("NikonD70.jpg") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES/NikonD70.jpg unavailable");
+    return;
+  };
+  assert_nikon_oracle(
+    &map,
+    &[
+      ("Nikon:Sharpness", r#""Med.H""#),
+      ("Nikon:FlashType", r#""Built-in,TTL""#),
+      ("Nikon:ExposureDifference", "-4.9"),
+      ("Nikon:FlashExposureComp", r#""-5/3""#),
+      ("Nikon:LensType", r#""G""#),
+      ("Nikon:Lens", r#""18-70mm f/3.5-4.5""#),
+      ("Nikon:FlashMode", r#""Fired, TTL Mode""#),
+      ("Nikon:ShootingMode", r#""Continuous""#),
+      ("Nikon:WB_RGBGLevels", r#""597 256 361 256""#),
+      ("Nikon:SerialNumber", r#""No= 20025585""#),
+      ("Nikon:Saturation", r#""Enhanced""#),
+    ],
+  );
+  assert!(!map.contains_key("Nikon:LensData"));
 }


### PR DESCRIPTION
Ports the Nikon MakerNotes vendor module (issue #62): faithful type-1/2/3 + headerless header detection and a ProcessExif-faithful IFD walk emitting Nikon::Main readable sub-tables, byte-exact to ExifTool 13.59.

## Scope
- **Header/layout detection**: `Nikon\0\x02` (type-3) → Nikon::Main at a FIXED `valuePtr+18` start, `Base=start-8`, ByteOrder Unknown (MakerNotes.pm:51-57); `Nikon\0\x01` (type-2) → Nikon::Type2 at `valuePtr+8`, fixed LittleEndian, parent-relative base (MakerNotes.pm:537-545); headerless (Make ^NIKON) → Nikon::Main, ByteOrder Unknown.
- **Tables**: Nikon::Main readable scalars + LensType (BITMASK) / Lens (PrintLensInfo) / AFInfo / ColorBalance0103 sub-tables; the 8-tag Nikon::Type2 table.
- **ProcessExif-faithful gate set** (mirrors the shared Walker + Canon's `compute_canon_dir_shape`): format-code validity (1..=13|129) with entry-0-abort / later-skip, invalid-size, excessive-count, bad-offset, suspicious offset<8 / IFD-overlap, illegal-tail (1/3) directory abort, warnCount>10 abort, implicit-undef SubDirectory format override, unknown-tag allocation skip.
- Encrypted sub-tables (LensData/ShotInfo/FlashInfo/encrypted-ColorBalance) deferred to #227.

## Verify
- `fmt --check` 0 · `build --all-features --all-targets -Dwarnings` 0 · `test --all-features --all-targets --skip gen_golden` 0 (2899 lib + 416 conformance + all suites, 0 failed) · `clippy --all-features` 0.
- 4 real fixtures byte-exact vs `exiftool -G1 -j` (Nikon.jpg headerless, Nikon.nef/NikonD2Hs.jpg/NikonD70.jpg type-3).
- Codex adversarial review: **APPROVE (R12, no material findings)** — a 12-round loop, every round a real faithfulness/safety fix, real-input byte-exact throughout.

## Deferred follow-ups (engine-wide / in-scope, filed)
- #227 Nikon encrypted sub-tables (needs Nikon::Decrypt).
- #230 per-entry malformed-MakerNote warning stream (all vendor walkers).
- #231 vendor walkers materialize per-entry decoded-value Vec before last-wins dedup.