### PR TITLE
feat(jpeg/gopro): extract GoPro APP6 GPMF metadata (#59)

### DIFF
--- a/src/exif/jpeg.rs
+++ b/src/exif/jpeg.rs
@@ -193,6 +193,44 @@ pub fn parse_jpeg_exif_with_base(data: &[u8], base_offset: usize) -> Option<Exif
   // mis-parsing a continuation fragment as a standalone TIFF (which would emit
   // a spurious `Malformed APP1 EXIF segment` warning bundled never raises).
   let mut in_multisegment = false;
+  // File-order index of the `APP1` segment that ACTUALLY emits a MOVABLE EXIF
+  // tag — the first whose `ProcessTIFF` (`parse_exif_block_with_base`) succeeds
+  // AND whose [`ExifMeta::emits_movable_tag`] is `true`, i.e. its real
+  // `Taggable::tags` output carries a default-visible tag in a family-0 group
+  // OTHER than `File` (an `EXIF:*` IFD-walk entry OR a `MakerNotes:*` vendor
+  // tag). FIRST-wins (the primary EXIF block, matching `byte_order`/
+  // `maker_note`). This is the anchor a GoPro `APP6` block is ordered against.
+  // It is NOT the first segment whose payload merely MATCHES the Exif arm
+  // signature (a malformed / BigTIFF-skipped / deferred-multi-segment `APP1`
+  // produces nothing), and it is NOT a byte-order-only `APP1` either: a
+  // byte-order marker + empty IFD0 with no MakerNote parses to `Some` but emits
+  // ONLY `File:ExifByteOrder` — the unconditional `File`-group prefix, not a
+  // movable tag. A MakerNote-only `APP1` (an `ExifIFD` pointer + a decoded
+  // vendor MakerNote, no other IFD0 entry) DOES anchor: it emits `MakerNotes:*`.
+  // ExifTool then emits a GoPro `APP6` ahead of a non-effective leading `APP1`
+  // BEFORE the EFFECTIVE (movable-tag-producing) EXIF block (see
+  // [`attach_app6_gopro`]). Threaded out for the `quicktime`-gated GoPro
+  // ordering only.
+  #[cfg(feature = "quicktime")]
+  let mut effective_exif_idx: Option<usize> = None;
+  // The anchor is consumed ONLY by `attach_app6_gopro`, and only when a GoPro
+  // `APP6` block actually attaches (`!gopro.is_empty()` there — which requires
+  // at least one `GoPro\0`-prefixed `APP6` segment). [`ExifMeta::emits_movable_tag`]
+  // is now derived from the full [`Taggable::tags`] stream (single source — no
+  // hand-maintained channel list, so a future default-visible non-`File`
+  // channel is covered for free), which renders values and clones the MakerNote
+  // emissions. To keep that cost OFF the hot path for the overwhelming majority
+  // of JPEGs (no GoPro `APP6`, so the result would be unused), only TRACK the
+  // anchor when such a segment is present. This cannot change output: a JPEG
+  // with no GoPro `APP6` never reads `effective_exif_idx`. The probe mirrors the
+  // exact identifier `attach_app6_gopro` keys on (`0xe6` + `GoPro\0`).
+  #[cfg(feature = "quicktime")]
+  let has_gopro_app6 = segments.iter().any(|seg| {
+    seg.marker == 0xe6
+      && data
+        .get(seg.payload_start..seg.payload_end)
+        .is_some_and(|p| p.starts_with(b"GoPro\0"))
+  });
 
   for (i, seg) in segments.iter().enumerate() {
     // `ExifTool.pm:7736`: APP1 (EXIF / XMP / QVCI / PARROT). Only APP1.
@@ -255,14 +293,43 @@ pub fn parse_jpeg_exif_with_base(data: &[u8], base_offset: usize) -> Option<Exif
     // (`ExifTool.pm:7783`). A bad TIFF block is a non-fatal `Warn` — the JPEG
     // container is still accepted and the walk continues.
     match parse_exif_block_with_base(block, base) {
-      Some(exif) => merge_exif_block(
-        &mut entries,
-        &mut warnings,
-        &mut warnings_ignorable,
-        &mut byte_order,
-        &mut maker_note,
-        exif,
-      ),
+      Some(exif) => {
+        // Record the FIRST `APP1` that emits a MOVABLE EXIF tag — the EFFECTIVE
+        // EXIF block a GoPro `APP6` is ordered against (first-wins, the primary
+        // block, like `byte_order`/`maker_note`). A "movable" tag is any
+        // default-visible tag in a family-0 group OTHER than `File`: the
+        // `File:ExifByteOrder`/`File:PageCount` prefix is the unconditional
+        // `File`-group prefix `Taggable::tags` emits FIRST regardless, so it
+        // never participates in the GoPro-vs-EXIF ordering. The predicate is
+        // computed by INSPECTING the block's REAL `Taggable::tags` output
+        // ([`ExifMeta::emits_movable_tag`]) — `any(non-`File`, non-Unknown tag)`
+        // — NOT by guessing which channels are movable: a valid-but-EMPTY TIFF
+        // (byte-order marker + 0-entry IFD0) emits ONLY `File:ExifByteOrder` and
+        // is NOT effective (`false`); an `APP1` with IFD entries emits `EXIF:*`
+        // (`true`); an `APP1` carrying ONLY a decoded MakerNote (an `ExifIFD`
+        // pointer + an `Apple`/`Canon`/… MakerNote, no other IFD0 entry, so
+        // `entries` is EMPTY) emits `MakerNotes:*` (`true`) even though the old
+        // `!entries.is_empty()` guess missed it. So a GoPro `APP6` ahead of such
+        // a MakerNote-only `APP1` correctly emits BEFORE it. This mirrors the
+        // GoPro-side anchor (the empty-to-non-empty `GoProMeta` accumulator
+        // transition in [`attach_app6_gopro`]): both anchors are "first segment
+        // producing a default-visible non-`File` tag". Inspecting the real
+        // emission ends the channel-by-channel drift (this guess missed
+        // `entries` at R8, then MakerNote at R9) and covers any future
+        // non-`File` channel for free.
+        #[cfg(feature = "quicktime")]
+        if has_gopro_app6 && effective_exif_idx.is_none() && exif.emits_movable_tag() {
+          effective_exif_idx = Some(i);
+        }
+        merge_exif_block(
+          &mut entries,
+          &mut warnings,
+          &mut warnings_ignorable,
+          &mut byte_order,
+          &mut maker_note,
+          exif,
+        );
+      }
       // `parse_exif_block_with_base` also returns `None` for a BigTIFF (0x2b)
       // header — a clean, deliberate no-Exif skip (bundled SUPPORTS BigTIFF, so
       // emitting a "Malformed APP1" warning would diverge). A genuinely
@@ -279,13 +346,170 @@ pub fn parse_jpeg_exif_with_base(data: &[u8], base_offset: usize) -> Option<Exif
 
   // A valid JPEG ALWAYS yields an `ExifMeta` (the container is accepted);
   // `entries`/`byte_order` are empty/`None` when no `APP1` Exif block parsed.
-  Some(ExifMeta::from_jpeg_parts(
+  #[allow(unused_mut)]
+  let mut meta = ExifMeta::from_jpeg_parts(
     entries,
     warnings,
     warnings_ignorable,
     byte_order,
     maker_note,
-  ))
+  );
+  // `APP6` "GoPro" GPMF (JPEG.pm:196-198): a GoPro still (`GOPR*.JPG`) carries
+  // its device-settings GPMF stream in an `APP6` (`0xe6`) segment whose payload
+  // begins with the 6-byte `GoPro\0` identifier. ExifTool's JPEG.pm `APP6`
+  // (JPEG.pm:183-216) is a multi-arm `Condition`-dispatched segment; the GoPro
+  // arm (`$$valPt =~ /^GoPro\0/`, JPEG.pm:196-198) hands the remainder to
+  // `%GoPro::GPMF`'s `ProcessGoPro` (the KLV walker). Only the GoPro arm is in
+  // scope here (the EPPIM / NITF / HP_TDHD / InfiRay / DJI / Motorola `APP6`
+  // arms are separate ports). Attached with a flag recording whether the
+  // `APP6` GoPro block preceded the `APP1` Exif block in marker order, so
+  // `Taggable::tags` emits the GoPro tags before/after EXIF to match ExifTool's
+  // `Marker:`-loop file order (the real GoPro layout — `APP1` then `APP6` —
+  // emits GoPro after EXIF, unchanged).
+  #[cfg(feature = "quicktime")]
+  attach_app6_gopro(data, &segments, effective_exif_idx, &mut meta);
+  Some(meta)
+}
+
+/// Scan the collected JPEG segments for every `APP6` (`0xe6`) "GoPro" segment
+/// and decode each one's GPMF KLV stream into the `meta` (JPEG.pm:196-198).
+///
+/// The GoPro arm of JPEG.pm's multi-arm `APP6` is `$$valPt =~ /^GoPro\0/`
+/// (JPEG.pm:197): strip the 6-byte `GoPro\0` prefix and dispatch the remainder
+/// into `%GoPro::GPMF` via `ProcessGoPro` (the recursive Key-Length-Value
+/// walker). ExifTool runs this `ProcessDirectory(GoPro::GPMF)` inside its
+/// `Marker:` loop (ExifTool.pm:8176-8181), so it processes EVERY matching
+/// `APP6` segment in file (marker) order — it does NOT stop at the first.
+/// All tags accumulate into the one extracted-tag table (the typed equivalent
+/// is a single [`GoProMeta`] walked across every GoPro `APP6`), so a leading
+/// truncated / empty `GoPro\0` segment that decodes nothing does NOT suppress a
+/// later valid one. A GoPro still normally carries exactly one such segment;
+/// the multi-segment path matters only for malformed / crafted inputs.
+///
+/// Duplicate tag names across segments resolve under the emission engine's
+/// last-wins dedup, matching ExifTool's default `%noDups` (these GoPro tags
+/// have no `Priority => 0`). A segment that decodes no record contributes
+/// nothing; the accumulator is attached only if at least one record landed, so
+/// a non-GoPro `APP6` mislabeled with the prefix adds no spurious tags.
+///
+/// The accumulator is attached with a `before_exif` flag recording whether the
+/// first TAG-PRODUCING GoPro `APP6` segment precedes the EFFECTIVE EXIF block —
+/// the first `APP1` contributing a MOVABLE EXIF tag in the main loop
+/// (`effective_exif_idx`: the first `APP1` whose real `Taggable::tags` emits a
+/// movable, non-`File` tag — an `EXIF:*` IFD entry OR a `MakerNotes:*` vendor
+/// tag, per [`ExifMeta::emits_movable_tag`]) — in file (marker)
+/// order: ExifTool emits each segment's tags at its `Marker:`-loop position
+/// (`ExifTool.pm:7325`), so a non-standard JPEG with a tag-producing `APP6`
+/// ahead of the EFFECTIVE EXIF block emits the `GoPro:*` tags BEFORE the
+/// `IFD0:*` tags. `File:ExifByteOrder` (and any `File:PageCount`) is NOT the
+/// anchor: it is the unconditional `File`-group prefix that `Taggable::tags`
+/// emits FIRST regardless, so only MOVABLE EXIF tags participate in the
+/// GoPro-vs-EXIF ordering. BOTH anchors are EFFECTIVE (movable / default-visible
+/// tag-producing), NOT merely signature-matching: on the EXIF side a malformed /
+/// BigTIFF-skipped / deferred-multi-segment leading `APP1` produces NOTHING, and
+/// a byte-order-only / empty-IFD0 `APP1` produces ONLY the `File:ExifByteOrder`
+/// prefix (no movable tag); SYMMETRICALLY on the GoPro side a leading truncated /
+/// empty `GoPro\0` `APP6` whose GPMF walker recognizes nothing produces NO GoPro
+/// tag. So with `APP6(empty GoPro) → APP1(valid Exif) → APP6(valid GoPro)` the
+/// first tag-producing GoPro segment is the LATER one (after the `APP1`), and
+/// ExifTool emits `IFD0:*` BEFORE `GoPro:*` — anchoring on the inert first
+/// `GoPro\0` segment would wrongly reverse them (the GoPro-side mirror of the
+/// inert-leading-`APP1` case: an empty-IFD0 first `APP1` must not anchor EXIF
+/// ahead of a GoPro `APP6` whose tags ExifTool emits between it and the later
+/// movable EXIF block). A real GoPro still has its (single, valid) `APP1`
+/// before `APP6` (`false`), so [`Taggable::tags`](crate::emit::Taggable::tags)
+/// keeps the GoPro block after EXIF unchanged. With NO `APP1` ever contributing
+/// a movable EXIF tag (`effective_exif_idx == None`) the GoPro block is the only
+/// EXIF-or-GoPro content, so its absolute position is moot — `false` keeps the
+/// simple after-`File`-group path (there is nothing to order against). (The
+/// comparison is whole-block: one GoPro `APP6` vs the one effective `APP1` Exif
+/// block — the realistic shapes; an `APP6`/`APP1`/`APP6` straddle is not
+/// marker-order-replayed, see the field docs.)
+#[cfg(feature = "quicktime")]
+fn attach_app6_gopro(
+  data: &[u8],
+  segments: &[Segment],
+  effective_exif_idx: Option<usize>,
+  meta: &mut ExifMeta<'_>,
+) {
+  /// JPEG.pm:197 `$$valPt =~ /^GoPro\0/` — the GoPro `APP6` identifier.
+  const GOPRO_APP6_HDR: &[u8] = b"GoPro\0";
+  let mut gopro = crate::metadata::GoProMeta::new();
+  // File-order index of the first GoPro `APP6` segment that ACTUALLY PRODUCES a
+  // GoPro tag — the marker position at which ExifTool's GoPro arm first emits a
+  // default-visible `GoPro:*` (or `Doc<N>:GoPro*`) tag. `None` until such a
+  // segment is processed. NOT the first `GoPro\0`-prefixed segment: a leading
+  // truncated / empty `GoPro\0` `APP6` whose GPMF walker recognizes nothing
+  // emits no tag, so ExifTool's first GoPro key comes from a LATER segment —
+  // possibly after an intervening `APP1` Exif block. Anchoring on the inert
+  // first GoPro segment would wrongly order the (later, tag-producing) GoPro
+  // block before the EXIF it actually follows. (The EXIF-side mirror of this is
+  // `effective_exif_idx` in the main loop — the first `APP1` whose real
+  // `Taggable::tags` emits a MOVABLE (non-`File`) tag ([`ExifMeta::emits_movable_tag`]):
+  // an `EXIF:*` IFD entry OR a `MakerNotes:*` vendor tag, not the first
+  // Exif-signature match and not a byte-order-only `APP1`. Both anchors are
+  // symmetric: "first segment producing a default-visible non-`File` tag".)
+  let mut first_gopro_idx: Option<usize> = None;
+  for (i, seg) in segments.iter().enumerate() {
+    // The GoPro arm fires only on the `APP6` marker (`0xe6`).
+    if seg.marker != 0xe6 {
+      continue;
+    }
+    let Some(payload) = data.get(seg.payload_start..seg.payload_end) else {
+      continue;
+    };
+    // GoPro arm: payload begins `GoPro\0`. Strip the 6-byte prefix and hand the
+    // GPMF KLV remainder to the shared `ProcessGoPro` walker, accumulating into
+    // the SAME `GoProMeta` across every GoPro `APP6` in file order (ExifTool's
+    // per-marker `ProcessDirectory`). A segment whose walker recognizes nothing
+    // (truncated / mislabeled) simply adds nothing and the scan continues.
+    let Some(gpmf) = payload.strip_prefix(GOPRO_APP6_HDR) else {
+      continue;
+    };
+    // Snapshot whether the accumulator is empty BEFORE processing this segment;
+    // `process_gopro` only ever ADDS records, so a transition from empty to
+    // non-empty marks THIS segment as the first one that produced a tag (the
+    // same "did this contribute anything" predicate as the `is_empty()` attach
+    // gate below). Record its marker index as the GoPro-side ordering anchor.
+    let was_empty = gopro.is_empty();
+    let _ = crate::formats::gopro::process_gopro(gpmf, &mut gopro);
+    if first_gopro_idx.is_none() && was_empty && !gopro.is_empty() {
+      first_gopro_idx = Some(i);
+    }
+  }
+  // Attach iff at least one GPMF record landed (ExifTool's `FoundEmbedded`);
+  // a file with only empty / mislabeled GoPro `APP6` segments stays GoPro-free.
+  if !gopro.is_empty() {
+    // GoPro-before-Exif when the first TAG-PRODUCING GoPro `APP6` precedes the
+    // EFFECTIVE EXIF block (the `APP1` whose `ProcessTIFF` succeeded —
+    // `effective_exif_idx`). BOTH indices are tag-producing, not merely
+    // signature/prefix-matching: a malformed / BigTIFF / deferred-multi-segment
+    // `APP1` produces no EXIF tags (so does not anchor the EXIF side), and a
+    // truncated / empty `GoPro\0` `APP6` produces no GoPro tag (so does not
+    // anchor the GoPro side). With no `APP1` producing a parsed EXIF block the
+    // GoPro block is the only EXIF-or-GoPro content, so its absolute position
+    // does not matter — `false` keeps the simple after-`File`-group path
+    // (nothing to order against), matching ExifTool (no `IFD0:*` tags to be
+    // before/after).
+    //
+    // This whole-GoPro-block before/after ordering is byte-exact for every
+    // single-effective-`APP1` layout — all realistic GoPro JPEGs (one early
+    // `APP1` Exif + a later GoPro `APP6`, e.g. `t/images/GoPro.jpg`). It also
+    // matches the oracle for multi-independent-`APP1` and `APP6`/`APP1`/`APP6`
+    // straddle layouts at the `-G1 -j` conformance target, because ExifTool's
+    // JSON co-locates the family-1 `IFD0` group and decides `IFD0`-vs-`GoPro`
+    // order by this same first-GoPro-vs-effective-EXIF index comparison. A
+    // strict per-segment marker-order replay (under which the GoPro `HandleTag`
+    // block would interleave BETWEEN two independent `APP1` tag blocks, or
+    // straddle the EXIF block) is the engine-wide limitation tracked in
+    // issue 233; it does not surface in `-G1 -j` output (see
+    // [`ExifMeta::gopro_before_exif`] docs).
+    let before_exif = match (first_gopro_idx, effective_exif_idx) {
+      (Some(g), Some(e)) => g < e,
+      _ => false,
+    };
+    meta.set_jpeg_gopro(gopro, before_exif);
+  }
 }
 
 /// Pass 1 of [`parse_jpeg_exif`]: walk the JPEG markers from just past `SOI`

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -98,10 +98,8 @@ use crate::recovery::Step;
 use ifd::{ByteOrder, Format, RawValue, get_u16, get_u32, read_value};
 use tables::Conv;
 
-// ===========================================================================
-// IFD identity — the family-1 group an IFD's tags carry
-// ===========================================================================
-
+// ====================================================================// IFD identity — the family-1 group an IFD's tags carry
+// ====================================================================
 /// The kind of IFD currently being walked — drives the family-1 group of
 /// the tags it emits. `ProcessExif` sets `$$dirInfo{DirName}` to one of
 /// these (`ExifTool.pm:8688` IFD0; `Exif.pm:7064-7077` `SubdirInfo{DirName}`
@@ -292,10 +290,8 @@ impl IfdKind {
   }
 }
 
-// ===========================================================================
-// SubDirectory dispatch seam — `SubDirKind`
-// ===========================================================================
-
+// ====================================================================// SubDirectory dispatch seam — `SubDirKind`
+// ====================================================================
 /// The SubDirectory a pointer tag dispatches into — the seam that keeps the
 /// IFD walker reusable and lets a future MakerNotes port plug in.
 ///
@@ -360,10 +356,8 @@ impl SubDirKind {
   }
 }
 
-// ===========================================================================
-// Typed value carrier — `ExifValue<'a>`
-// ===========================================================================
-
+// ====================================================================// Typed value carrier — `ExifValue<'a>`
+// ====================================================================
 /// One decoded Exif/GPS tag value — the post-Format-decode, pre-conversion
 /// `$val`.
 ///
@@ -397,10 +391,8 @@ impl ExifValue {
   }
 }
 
-// ===========================================================================
-// One emitted tag — `ExifEntry<'a>`
-// ===========================================================================
-
+// ====================================================================// One emitted tag — `ExifEntry<'a>`
+// ====================================================================
 /// One emitted Exif/GPS tag — the family-1 group, the on-disk tag ID, the
 /// resolved name, and the decoded value. Faithful to a single ExifTool
 /// `FoundTag` call (`Exif.pm:7181`). Fully OWNED (no input-buffer lifetime).
@@ -468,10 +460,8 @@ enum ResolvedConv {
   Gps(gps::GpsConv),
 }
 
-// ===========================================================================
-// MakerNote capture — the deferred-vendor-parsing seam
-// ===========================================================================
-
+// ====================================================================// MakerNote capture — the deferred-vendor-parsing seam
+// ====================================================================
 /// How to recompute a captured MakerNote's `-n` (ValueConv) vendor emissions on
 /// demand — Golden-v2 P0 single-mode decode. The eager walk decodes each vendor
 /// body ONCE (PrintConv), keeping the typed slot + the PrintConv emissions; this
@@ -841,10 +831,8 @@ impl<'a> MakerNote<'a> {
   }
 }
 
-// ===========================================================================
-// Typed Meta — `ExifMeta<'a>`
-// ===========================================================================
-
+// ====================================================================// Typed Meta — `ExifMeta<'a>`
+// ====================================================================
 /// Typed Exif/TIFF metadata — the lib-first output of [`ProcessExif`] and
 /// the reusable [`parse_exif_block`].
 ///
@@ -945,6 +933,49 @@ pub struct ExifMeta<'a> {
   /// the CR3 `CMT4` GPS block — none has a top-level `$raf`) — bundled never
   /// detects CR2 from an embedded block.
   cr2_magic: bool,
+  /// The decoded GoPro GPMF metadata of a JPEG `APP6` "GoPro" segment
+  /// (JPEG.pm:183-198 → `%GoPro::GPMF` via `ProcessGoPro`). A GoPro still
+  /// (`GOPR*.JPG`) carries its device-settings GPMF stream in `APP6`; the
+  /// marker walk ([`crate::exif::jpeg`]) recognizes the `GoPro\0`-prefixed
+  /// segment, strips the 6-byte prefix, and runs the shared GPMF KLV walker
+  /// into this field. The tags emit under group `APP6`:`GoPro` from
+  /// [`Taggable::tags`](crate::emit::Taggable::tags) — AFTER the EXIF + MakerNote
+  /// tags in the realistic layout (`APP1` Exif before the later `APP6`,
+  /// `gopro_before_exif == false`), or BEFORE them when
+  /// [`gopro_before_exif`](Self::gopro_before_exif) is set (a non-standard
+  /// `APP6`-before-`APP1` JPEG) — faithful to ExifTool's `Marker:`-loop file
+  /// order. `None` for a non-GoPro JPEG / a standalone TIFF / any embedded-Exif
+  /// block other than a JPEG with an `APP6` GoPro segment.
+  ///
+  /// Gated on `quicktime`: the `GoProMeta` model + the GPMF parser live in the
+  /// `quicktime`-feature module ([`crate::formats::gopro`]); the `exif` feature
+  /// builds standalone (no `quicktime`) with this field absent.
+  #[cfg(feature = "quicktime")]
+  gopro: Option<crate::metadata::GoProMeta>,
+  /// `true` when the `APP6` "GoPro" segment occurs BEFORE the first `APP1` Exif
+  /// segment in JPEG marker (file) order — ExifTool runs each `APP6`/`APP1` arm
+  /// inside its `Marker:` loop in file order (`ExifTool.pm:7325`), so a
+  /// non-standard JPEG that places the `GoPro\0` `APP6` ahead of the `Exif\0\0`
+  /// `APP1` emits the `GoPro:*` tags BEFORE the `IFD0:*` tags. The marker walk
+  /// ([`crate::exif::jpeg`]) records this; [`Taggable::tags`](crate::emit::Taggable::tags)
+  /// emits the GoPro block first when it is set, else after the EXIF + MakerNote
+  /// tags (the realistic layout — every real GoPro still, including the
+  /// `t/images/GoPro.jpg` fixture, has `APP1` before `APP6`, so this defaults
+  /// `false` and that path is unchanged).
+  ///
+  /// This handles the GoPro block being wholly before or wholly after the EXIF
+  /// block (the realistic cases ExifTool emits as one contiguous group each); a
+  /// pathological `APP6`/`APP1`/`APP6` straddle — or multiple INDEPENDENT `APP1`
+  /// Exif blocks straddling a GoPro `APP6` — is NOT fully marker-order-replayed
+  /// here (that would need an engine-wide per-segment emission model, the
+  /// limitation tracked in issue 233) — fine, because a real GoPro JPEG never
+  /// straddles, and because ExifTool's `-G1 -j` output co-locates the family-1
+  /// `IFD0` group anyway, so the whole-block order this flag computes still
+  /// matches the oracle at the conformance target (the strict marker-order
+  /// interleaving never surfaces in JSON). `false` for every non-GoPro /
+  /// standalone / embedded-block source.
+  #[cfg(feature = "quicktime")]
+  gopro_before_exif: bool,
 }
 
 impl<'a> ExifMeta<'a> {
@@ -1106,7 +1137,60 @@ impl<'a> ExifMeta<'a> {
       // (`ExifTool.pm:8629`) is reachable for an `APP1` Exif merge.
       dng_version: false,
       cr2_magic: false,
+      // The JPEG marker walk attaches an `APP6` GoPro GPMF stream AFTER this
+      // construction via [`set_jpeg_gopro`](Self::set_jpeg_gopro); a freshly
+      // built JPEG `ExifMeta` starts with none, in the realistic
+      // `APP1`-before-`APP6` order (GoPro tags emit AFTER EXIF).
+      #[cfg(feature = "quicktime")]
+      gopro: None,
+      #[cfg(feature = "quicktime")]
+      gopro_before_exif: false,
     }
+  }
+
+  /// Attach the GoPro GPMF metadata decoded from a JPEG `APP6` "GoPro" segment
+  /// (JPEG.pm:183-198). Called by the JPEG marker walk
+  /// ([`crate::exif::jpeg`]) after [`from_jpeg_parts`](Self::from_jpeg_parts)
+  /// when an `APP6` segment whose payload began `GoPro\0` decoded at least one
+  /// GPMF record. The tags emit under group `APP6`:`GoPro` from
+  /// [`Taggable::tags`](crate::emit::Taggable::tags). A no-op-equivalent empty
+  /// `GoProMeta` is simply stored as-is (it emits nothing).
+  ///
+  /// `before_exif` records whether that `APP6` segment preceded the first
+  /// `APP1` Exif segment in JPEG marker (file) order (see
+  /// [`gopro_before_exif`](Self::gopro_before_exif)): `true` makes `tags` emit
+  /// the GoPro block BEFORE the EXIF + MakerNote tags (faithful to ExifTool's
+  /// `Marker:`-loop file order), `false` (the realistic `APP1`-before-`APP6`
+  /// layout) keeps it after.
+  #[cfg(feature = "quicktime")]
+  pub(crate) fn set_jpeg_gopro(&mut self, gopro: crate::metadata::GoProMeta, before_exif: bool) {
+    self.gopro = Some(gopro);
+    self.gopro_before_exif = before_exif;
+  }
+
+  /// The GoPro GPMF metadata decoded from a JPEG `APP6` "GoPro" segment, if
+  /// any (`None` for every non-GoPro-JPEG source). Exposes the full typed
+  /// [`GoProMeta`](crate::metadata::GoProMeta) surface (per-sample lists, camera
+  /// identity, settings) the `APP6`:`GoPro` tag stream is rendered from.
+  #[cfg(feature = "quicktime")]
+  #[must_use]
+  #[inline]
+  pub fn gopro(&self) -> Option<&crate::metadata::GoProMeta> {
+    self.gopro.as_ref()
+  }
+
+  /// `true` when the source JPEG's `APP6` "GoPro" segment preceded its first
+  /// `APP1` Exif segment in marker (file) order, so [`Taggable::tags`](crate::emit::Taggable::tags)
+  /// emits the `GoPro:*` tags BEFORE the `IFD0:*`/`ExifIFD:*` tags (faithful to
+  /// ExifTool's `Marker:`-loop file order, `ExifTool.pm:7325`). `false` for the
+  /// realistic `APP1`-before-`APP6` layout (every real GoPro still, including
+  /// `t/images/GoPro.jpg`) and for every non-GoPro / standalone / embedded
+  /// source.
+  #[cfg(feature = "quicktime")]
+  #[must_use]
+  #[inline]
+  pub fn gopro_before_exif(&self) -> bool {
+    self.gopro_before_exif
   }
 
   /// Decompose this `ExifMeta` into `(entries, warnings, byte_order,
@@ -1139,10 +1223,8 @@ impl<'a> ExifMeta<'a> {
   }
 }
 
-// ===========================================================================
-// `ProcessExif` — the lib-first parser
-// ===========================================================================
-
+// ====================================================================// `ProcessExif` — the lib-first parser
+// ====================================================================
 /// Exif / TIFF parser — faithful port of `Image::ExifTool::Exif::ProcessExif`
 /// (`Exif.pm:6278-7240`) plus the TIFF-header front-end of
 /// `Image::ExifTool::DoProcessTIFF` (`ExifTool.pm:8628-8730`).
@@ -1350,10 +1432,8 @@ pub fn parse_gps_block(block: &[u8]) -> Option<ExifMeta<'_>> {
   )
 }
 
-// ===========================================================================
-// TIFF header parser — DoProcessTIFF front-end (ExifTool.pm:8628-8645)
-// ===========================================================================
-
+// ====================================================================// TIFF header parser — DoProcessTIFF front-end (ExifTool.pm:8628-8645)
+// ====================================================================
 /// Parse a TIFF block: validate the header, then walk the IFD chain.
 ///
 /// `ExifTool.pm:8628-8645`:
@@ -1623,6 +1703,11 @@ fn parse_tiff_with_base_no_raf<'a>(
     captured_model: w.captured_model.map(smol_str::SmolStr::from),
     dng_version: w.dng_version,
     cr2_magic,
+    // A standalone-TIFF walk has no JPEG `APP6` GoPro segment.
+    #[cfg(feature = "quicktime")]
+    gopro: None,
+    #[cfg(feature = "quicktime")]
+    gopro_before_exif: false,
   })
 }
 
@@ -1768,14 +1853,17 @@ fn parse_tiff_with_base_shared<'a>(
     // unreachable; the CR2 magic read is gated on the standalone-TIFF `$raf`.
     dng_version: false,
     cr2_magic: false,
+    // An embedded-Exif block (PNG `eXIf`) has no JPEG `APP6` GoPro segment.
+    #[cfg(feature = "quicktime")]
+    gopro: None,
+    #[cfg(feature = "quicktime")]
+    gopro_before_exif: false,
   };
   (Some(meta), cycle_guard_warnings)
 }
 
-// ===========================================================================
-// IFD walker — ProcessExif (Exif.pm:6278-7240)
-// ===========================================================================
-
+// ====================================================================// IFD walker — ProcessExif (Exif.pm:6278-7240)
+// ====================================================================
 /// The chain-IFD (IFD0 / trailing-IFD) reprocess guard — the storage behind
 /// ExifTool's `$$self{PROCESSED}` for the non-zero-`DirLen` directories
 /// (`ExifTool.pm:9050-9072`). Two modes:
@@ -3480,8 +3568,7 @@ fn sub_dir_for(tag_id: u16, kind: IfdKind) -> Option<SubDirKind> {
   }
 }
 
-// ===========================================================================
-// `Taggable` — the golden-pattern emission path (EXIF entries + MakerNotes)
+// ====================================================================// `Taggable` — the golden-pattern emission path (EXIF entries + MakerNotes)
 //
 // EXIF no longer has an inherent `serialize_tags`: the full EXIF tag stream
 // (`File:ExifByteOrder` first, then the IFD-walk entries, then the MakerNote
@@ -3489,8 +3576,7 @@ fn sub_dir_for(tag_id: u16, kind: IfdKind) -> Option<SubDirKind> {
 // single-sourced by `AnyMeta::serialize_tags` / `AnyMeta::iter_tags`. The
 // `$et->Warn(...)` channel flows through the sibling `Diagnose`/`run_diagnostics`
 // engine (`ExifMeta::diagnostics`).
-// ===========================================================================
-
+// ====================================================================
 #[cfg(feature = "alloc")]
 impl ExifMeta<'_> {
   /// Push this `ExifMeta`'s EXIF/GPS [`ExifEntry`] tags into `out` for the
@@ -3567,6 +3653,66 @@ impl ExifMeta<'_> {
       push(out, &mn.emissions_value_conv());
     }
   }
+
+  /// `true` iff this `ExifMeta` would emit AT LEAST ONE default-visible tag in a
+  /// family-0 group OTHER than `File` — a MOVABLE tag whose position in
+  /// ExifTool's `FoundTag` stream participates in cross-segment ordering.
+  ///
+  /// This is the anchor predicate for a JPEG `APP6` "GoPro" block's
+  /// before/after-EXIF ordering ([`attach_app6_gopro`](crate::exif::jpeg)): the
+  /// EFFECTIVE EXIF block is the first `APP1` for which this returns `true`.
+  /// ExifTool emits the `File`-group tags (`File:ExifByteOrder`,
+  /// `File:PageCount`, ...) as an UNCONDITIONAL prefix ahead of every segment's
+  /// content, so they never order against a `GoPro:*` block and MUST NOT count;
+  /// the first non-`File` tag is ExifTool's first movable EXIF key, the thing a
+  /// leading/trailing `APP6` is positioned relative to.
+  ///
+  /// ## Single source: this IS the `tags()` stream
+  ///
+  /// The predicate is computed by EMITTING this `ExifMeta`'s
+  /// [`tags`](crate::emit::Taggable::tags) (the same source the `-G1` `-j` JSON
+  /// path drives — [`EmitOptions::g1`]`(PrintConv, false)`) and asking whether
+  /// any yielded tag is default-visible (NON-`Unknown`) in a family-0 group
+  /// OTHER than `File`. There is no hand-maintained channel list: WHATEVER
+  /// `tags` emits is what this sees, so a future default-visible non-`File`
+  /// channel added to `tags` is covered automatically. This is the fix for the
+  /// channel-by-channel drift that bit the earlier per-channel guesses — they
+  /// missed `entries` (R8), then the MakerNote (R9); deriving from the real
+  /// stream closes that loop for good.
+  ///
+  /// The `File` exclusion is faithful to ExifTool: it emits the `File`-group
+  /// tags (`File:ExifByteOrder`, `File:PageCount`, …) as an UNCONDITIONAL prefix
+  /// ahead of every segment's content, so they never order against a `GoPro:*`
+  /// block. The `Unknown` exclusion mirrors [`run_emission`](crate::emit::run_emission),
+  /// which drops `Unknown=>1` tags from `-j` output: a MakerNote that decodes to
+  /// ONLY `Unknown` vendor leaves is NOT default-visible and must NOT anchor
+  /// (ExifTool's first movable EXIF key then comes from a later segment).
+  ///
+  /// The movable-vs-`File` classification is MODE-INVARIANT — PrintConv vs
+  /// ValueConv changes only the rendered VALUE, never a tag's group or its
+  /// `Unknown` flag — so this single PrintConv pass answers the question for
+  /// both `-j` and `-n`.
+  ///
+  /// ## Cost / where it runs
+  ///
+  /// The call is read-only and side-effect-free, but it materializes the full
+  /// `tags` `Vec` (rendering values and cloning the MakerNote emissions — the
+  /// price of being single-source). To keep that off the parse hot path, the
+  /// SOLE caller (the JPEG `APP1` parse loop, first-wins) invokes it ONLY when
+  /// the JPEG carries a GoPro `APP6` block (the anchor's only consumer) AND only
+  /// until the first movable `APP1` is found — so a non-GoPro JPEG never pays
+  /// it. The Golden-v2 C4 `alloc_budget` fixtures (none are GoPro JPEGs)
+  /// therefore see no change.
+  #[cfg(feature = "quicktime")]
+  pub(crate) fn emits_movable_tag(&self) -> bool {
+    use crate::emit::Taggable;
+    self
+      .tags(crate::emit::EmitOptions::g1(
+        crate::emit::ConvMode::PrintConv,
+        false,
+      ))
+      .any(|t| !t.unknown() && t.tag().group_ref().family0() != "File")
+  }
 }
 
 #[cfg(feature = "alloc")]
@@ -3637,8 +3783,40 @@ impl crate::emit::Taggable for ExifMeta<'_> {
         false,
       ));
     }
+    // A JPEG `APP6` "GoPro" GPMF stream (JPEG.pm:183-198 → `%GoPro::GPMF`):
+    // ExifTool runs each `APP6`/`APP1` arm inside its `Marker:` loop in file
+    // order (`ExifTool.pm:7325`), so the `GoPro:*` tags emit in segment order
+    // relative to the `APP1` Exif `IFD0:*` tags. The shared GoPro emitter
+    // renders the device-settings + camera-identity tags under group
+    // `APP6`:`GoPro` (family-1 stays `GoPro`; family-0 is the `APP6` parent the
+    // segment was reached through). The realistic GoPro still — including the
+    // `t/images/GoPro.jpg` fixture — places `APP1` BEFORE `APP6`, so the GoPro
+    // block emits AFTER the EXIF + MakerNote tags (`gopro_before_exif ==
+    // false`); a non-standard JPEG with `APP6` before `APP1` emits the GoPro
+    // block BEFORE them. This is a whole-block before/after swap (each side is
+    // one contiguous group in ExifTool's output); a pathological
+    // `APP6`/`APP1`/`APP6` straddle is not fully marker-order-replayed (real
+    // GoPro JPEGs never straddle). `None` for every non-GoPro-JPEG source.
+    #[cfg(feature = "quicktime")]
+    let emit_gopro = |tags: &mut std::vec::Vec<crate::emit::EmittedTag>| {
+      if let Some(gp) = self.gopro.as_ref() {
+        crate::formats::quicktime::emit_gopro_tags(gp, "APP6", "GoPro", print_conv, tags);
+      }
+    };
+    // GoPro block before the EXIF + MakerNote tags when its `APP6` preceded the
+    // `APP1` Exif segment (`File:ExifByteOrder`/`PageCount` still lead — they
+    // are the `File` group ExifTool emits ahead of every segment). Otherwise it
+    // follows them (the realistic layout, GoPro.jpg unchanged).
+    #[cfg(feature = "quicktime")]
+    if self.gopro_before_exif {
+      emit_gopro(&mut tags);
+    }
     self.push_exif_tags(print_conv, &mut tags);
     self.push_maker_note_tags(print_conv, &mut tags);
+    #[cfg(feature = "quicktime")]
+    if !self.gopro_before_exif {
+      emit_gopro(&mut tags);
+    }
     tags.into_iter()
   }
 }
@@ -3681,10 +3859,8 @@ impl crate::diagnostics::Diagnose for ExifMeta<'_> {
   }
 }
 
-// ===========================================================================
-// `ExifSink` — the value-emission sink seam (golden-pattern refactor)
-// ===========================================================================
-
+// ====================================================================// `ExifSink` — the value-emission sink seam (golden-pattern refactor)
+// ====================================================================
 /// The per-value sink the Exif/GPS emitters (`emit_exif_value` /
 /// `emit_gps_value` + helpers) write a CONVERTED scalar into. Abstracting the
 /// sink behind these five typed writers lets the conversion-logic bodies stay
@@ -3931,10 +4107,8 @@ fn emit_entry<S: ExifSink>(
   }
 }
 
-// ===========================================================================
-// Exif value emission — applies a `Conv` to a `RawValue`
-// ===========================================================================
-
+// ====================================================================// Exif value emission — applies a `Conv` to a `RawValue`
+// ====================================================================
 /// Render a [`RawValue`] under a plain Exif [`Conv`] into the sink. This is
 /// the serialize-time PrintConv/ValueConv application; the value stored in
 /// the `ExifEntry` is post-Format-decode but pre-conversion.
@@ -4317,10 +4491,8 @@ fn first_uint(raw: &RawValue) -> Option<u64> {
   }
 }
 
-// ===========================================================================
-// GPS value emission — applies a `GpsConv` to a `RawValue`
-// ===========================================================================
-
+// ====================================================================// GPS value emission — applies a `GpsConv` to a `RawValue`
+// ====================================================================
 /// Render a [`RawValue`] under a [`gps::GpsConv`] into the sink.
 #[cfg(all(feature = "alloc", feature = "gps"))]
 fn emit_gps_value<S: ExifSink>(
@@ -4455,10 +4627,8 @@ fn emit_gps_value<S: ExifSink>(
   }
 }
 
-// ===========================================================================
-// `EscapeJSON` number gate — bundled `exiftool` script line 3809
-// ===========================================================================
-//
+// ====================================================================// `EscapeJSON` number gate — bundled `exiftool` script line 3809
+// ====================================================================//
 // Bundled ExifTool stringifies EVERY tag value (`$val`) and runs the JSON
 // writer's `EscapeJSON` (`exiftool` script, sub `EscapeJSON`, line 3800). With
 // the default `$quote` flag false (every non-`StructFormat=JSONQ` `-j`/`-n`
@@ -4582,10 +4752,8 @@ fn emit_gated_f64<S: ExifSink>(
   emit_gated_number(group, name, &crate::value::format_g(value, 15), out)
 }
 
-// ===========================================================================
-// Emission helpers
-// ===========================================================================
-
+// ====================================================================// Emission helpers
+// ====================================================================
 /// Emit a [`RawValue`] verbatim (the `Conv::None` path) — multi-element
 /// numeric arrays are space-joined (ExifTool's `ReadValue` joins with
 /// spaces, `ExifTool.pm:6319`); a string is emitted as-is; bytes become the
@@ -4929,10 +5097,8 @@ fn join_floats(vals: &[f64]) -> String {
   s
 }
 
-// ===========================================================================
-// Table-codegen allowlist accessors (`cargo xtask gen-tables --kind exif`)
-// ===========================================================================
-
+// ====================================================================// Table-codegen allowlist accessors (`cargo xtask gen-tables --kind exif`)
+// ====================================================================
 /// The Step-B binary-EXIF coverage-gap ids — genuine `%Exif::Main` leaf tags
 /// (`Exif.pm`) that the camera-relevant hand subset ([`tables::EXIF_TAGS`]) does
 /// NOT carry, so they were silently dropped on the binary IFD path (reachable
@@ -5004,10 +5170,8 @@ pub fn gps_main_tag_ids() -> Vec<u16> {
   gps::GPS_TAGS.iter().map(|t| t.id).collect()
 }
 
-// ===========================================================================
-// Unit tests
-// ===========================================================================
-
+// ====================================================================// Unit tests
+// ====================================================================
 #[cfg(test)]
 // The file-level `#![deny(clippy::indexing_slicing)]` is a parser-panic-safety
 // contract (Phase C w2d); the test TIFF/IFD builders index fixed-layout buffers
@@ -5253,6 +5417,134 @@ mod tests {
     assert_eq!(mn.len(), 8);
     // No `MakerNote` leaf tag — vendor parsing deferred.
     assert!(meta.entry("MakerNote").is_none());
+  }
+
+  /// [`ExifMeta::emits_movable_tag`] is now DERIVED from the real
+  /// [`tags`](crate::emit::Taggable::tags) stream (`any(non-`File`,
+  /// non-`Unknown`)`), so a "does it match `tags`" oracle would be tautological.
+  /// Instead this PINS the two boundary behaviors the predicate exists to
+  /// enforce, against blocks built through the real parser:
+  ///
+  /// - the `File` exclusion — a byte-order-only block emits ONLY
+  ///   `File:ExifByteOrder` ⇒ `false`;
+  /// - the `Unknown` exclusion — a MakerNote that decodes to ONLY `Unknown=>1`
+  ///   leaves is not default-visible ⇒ `false`;
+  ///
+  /// plus the two POSITIVE channels (`entries`, a default-visible MakerNote with
+  /// empty `entries` — the R8 / R9 cases) ⇒ `true`. Because the predicate reads
+  /// whatever `tags` yields, any future default-visible non-`File` channel added
+  /// to `tags` is covered automatically — the channel-by-channel drift that
+  /// missed `entries` (R8) then the MakerNote (R9) cannot recur.
+  #[cfg(feature = "quicktime")]
+  #[test]
+  fn emits_movable_tag_excludes_file_and_unknown() {
+    // A minimal big-endian TIFF: header + IFD0 (the given entry bytes) + extra.
+    fn tiff(ifd0_entries: &[u8], n_entries: u16, extra: &[u8]) -> Vec<u8> {
+      let mut t: Vec<u8> = vec![b'M', b'M', 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08];
+      t.extend_from_slice(&n_entries.to_be_bytes());
+      t.extend_from_slice(ifd0_entries);
+      t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // IFD0 next = 0
+      t.extend_from_slice(extra);
+      t
+    }
+
+    // An Apple MakerNote-only TIFF: IFD0 → ExifIFD → MakerNote, no IFD0 entry,
+    // the blob carrying a single `entry`. `entries` stays EMPTY; whether the
+    // block is "movable" depends solely on whether the MakerNote's lone leaf is
+    // default-visible. `entry` = (tag, format, inline-value) for a count-1 slot.
+    fn apple_mn_only_tiff(tag: u16, format: u16, inline_value: u32) -> Vec<u8> {
+      let mut apple_blob: Vec<u8> = Vec::new();
+      apple_blob.extend_from_slice(b"Apple iOS\x00\x00\x01MM"); // 14-byte header
+      apple_blob.extend_from_slice(&1u16.to_be_bytes()); // 1 IFD entry
+      apple_blob.extend_from_slice(&tag.to_be_bytes());
+      apple_blob.extend_from_slice(&format.to_be_bytes());
+      apple_blob.extend_from_slice(&1u32.to_be_bytes()); // count 1
+      apple_blob.extend_from_slice(&inline_value.to_be_bytes());
+      let exififd_off: u32 = 8 + (2 + 12 + 4); // 26
+      let mn_off: u32 = exififd_off + (2 + 12 + 4); // 44
+      let mut mn_ifd0: Vec<u8> = Vec::new();
+      mn_ifd0.extend_from_slice(&[0x87, 0x69]); // ExifIFD pointer 0x8769
+      mn_ifd0.extend_from_slice(&[0x00, 0x04]); // LONG
+      mn_ifd0.extend_from_slice(&1u32.to_be_bytes());
+      mn_ifd0.extend_from_slice(&exififd_off.to_be_bytes());
+      let mut exififd: Vec<u8> = Vec::new();
+      exififd.extend_from_slice(&1u16.to_be_bytes()); // 1 entry
+      exififd.extend_from_slice(&[0x92, 0x7c]); // MakerNote 0x927c
+      exififd.extend_from_slice(&[0x00, 0x07]); // UNDEFINED
+      exififd.extend_from_slice(&(apple_blob.len() as u32).to_be_bytes());
+      exififd.extend_from_slice(&mn_off.to_be_bytes());
+      exififd.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // ExifIFD next = 0
+      let mut extra = exififd;
+      extra.extend_from_slice(&apple_blob);
+      tiff(&mn_ifd0, 1, &extra)
+    }
+
+    // (a) byte-order-only / empty IFD0: `tags` emits ONLY `File:ExifByteOrder`
+    // (family-0 `File`) ⇒ the `File` exclusion makes this NOT movable.
+    let empty_tiff = tiff(&[], 0, &[]);
+    let empty = parse_exif_block(&empty_tiff).expect("empty TIFF");
+    assert!(
+      !empty.emits_movable_tag(),
+      "byte-order-only (File-prefix) ⇒ not movable"
+    );
+
+    // (b) one IFD0 ASCII entry (`Make`): the `entries` channel emits an `EXIF:*`
+    // tag ⇒ movable.
+    let mut make_entry: Vec<u8> = Vec::new();
+    make_entry.extend_from_slice(&[0x01, 0x0f]); // tag 0x010f Make
+    make_entry.extend_from_slice(&[0x00, 0x02]); // ASCII
+    make_entry.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count 4
+    make_entry.extend_from_slice(b"AB\x00\x00"); // ASCII "AB" + NUL pad
+    let make_tiff = tiff(&make_entry, 1, &[]);
+    let with_make = parse_exif_block(&make_tiff).expect("Make TIFF");
+    assert!(with_make.emits_movable_tag(), "IFD0 entry ⇒ movable");
+
+    // (c) MakerNote-only IFD0, the lone leaf a DEFAULT-VISIBLE Apple tag
+    // (`MakerNoteVersion`, 0x0001 int32s, `unknown:false`). `entries` is EMPTY,
+    // yet the MakerNote channel emits a `MakerNotes:*` tag ⇒ movable (the R9
+    // case the old `!entries.is_empty()` guess missed).
+    let mn_visible_tiff = apple_mn_only_tiff(0x0001, 0x0009, 4);
+    let mn_visible = parse_exif_block(&mn_visible_tiff).expect("MakerNote TIFF");
+    assert!(
+      mn_visible.entries().is_empty(),
+      "the MakerNote-only block has NO IFD-walk entry"
+    );
+    assert!(
+      mn_visible.maker_note().is_some(),
+      "the MakerNote blob is captured"
+    );
+    assert!(
+      mn_visible.emits_movable_tag(),
+      "a default-visible MakerNote (no entries) ⇒ movable"
+    );
+
+    // (d) MakerNote-only IFD0, the lone leaf an `Unknown=>1` Apple tag
+    // (`ImageProcessingFlags`, 0x0019 int32s — Apple.pm:147). `entries` is
+    // EMPTY and the only emission is `Unknown`, which `run_emission` drops from
+    // `-j` output, so `tags` yields NO default-visible non-`File` tag ⇒ NOT
+    // movable. This pins the `Unknown` exclusion: an Unknown-only MakerNote must
+    // not anchor (ExifTool's first movable EXIF key comes from a later segment).
+    let mn_unknown_tiff = apple_mn_only_tiff(0x0019, 0x0009, 1);
+    let mn_unknown = parse_exif_block(&mn_unknown_tiff).expect("Unknown-MN TIFF");
+    assert!(
+      mn_unknown.entries().is_empty(),
+      "the Unknown-MakerNote block has NO IFD-walk entry"
+    );
+    assert!(
+      mn_unknown.maker_note().is_some(),
+      "the Unknown MakerNote blob is still captured"
+    );
+    assert!(
+      mn_unknown
+        .maker_note()
+        .is_some_and(|mn| !mn.emissions_print_conv().is_empty()
+          && mn.emissions_print_conv().iter().all(|e| e.unknown())),
+      "the lone Apple emission is `Unknown=>1`"
+    );
+    assert!(
+      !mn_unknown.emits_movable_tag(),
+      "an Unknown-only MakerNote ⇒ not movable — the `Unknown` exclusion"
+    );
   }
 
   /// A self-referencing IFD pointer (IFD0 → IFD0) is rejected by the

--- a/src/formats/gopro.rs
+++ b/src/formats/gopro.rs
@@ -121,7 +121,8 @@ use alloc::{
 use smol_str::SmolStr;
 
 use crate::metadata::{
-  GoProConv, GoProGlpiSample, GoProGpsSample, GoProKbat, GoProMeta, GoProTag, GoProTagValue,
+  GoProConv, GoProGlpiSample, GoProGpsSample, GoProIdentity, GoProKbat, GoProMeta, GoProScalar,
+  GoProTag, GoProTagValue,
 };
 
 // ===========================================================================
@@ -468,28 +469,37 @@ impl Walker<'_> {
   ) {
     match tag {
       b"DVNM" => {
-        // GoPro.pm:170-172 — `DeviceName` (`c` ASCII), trim trailing NULs.
-        if let Some(s) = read_ascii(payload) {
-          self.out.set_device_name(Some(SmolStr::from(s)));
-        }
+        // GoPro.pm:170-172 — `DeviceName` (`c` ASCII), trim trailing NULs. A
+        // non-zero-size all-NUL payload NUL-trims to "" and is still
+        // `HandleTag`-emitted (GoPro.pm:845 skips only `$size == 0`, which the
+        // `payload.is_empty()` guard in `visit` already mirrors), so map an
+        // empty `read_ascii` to `Some("")` rather than dropping the tag — and a
+        // later duplicate DVNM whose value is "" wins last (typed setter
+        // overwrites; the recorded device position is kept first).
+        let s = read_ascii(payload).unwrap_or_default();
+        self.out.set_device_name(Some(SmolStr::from(s)));
+        self.out.record_identity(GoProIdentity::DeviceName);
       }
       b"MINF" => {
-        // GoPro.pm:286-290 — `Model`, ASCII `c`.
-        if let Some(s) = read_ascii(payload) {
-          self.out.set_model(Some(SmolStr::from(s)));
-        }
+        // GoPro.pm:286-290 — `Model`, ASCII `c`. Empty-string-emitting +
+        // last-wins like `DVNM` above.
+        let s = read_ascii(payload).unwrap_or_default();
+        self.out.set_model(Some(SmolStr::from(s)));
+        self.out.record_identity(GoProIdentity::Model);
       }
       b"CASN" => {
-        // GoPro.pm:121 — `CameraSerialNumber`, ASCII `c`.
-        if let Some(s) = read_ascii(payload) {
-          self.out.set_camera_serial_number(Some(SmolStr::from(s)));
-        }
+        // GoPro.pm:121 — `CameraSerialNumber`, ASCII `c`. Empty-string-emitting
+        // + last-wins like `DVNM` above.
+        let s = read_ascii(payload).unwrap_or_default();
+        self.out.set_camera_serial_number(Some(SmolStr::from(s)));
+        self.out.record_identity(GoProIdentity::CameraSerialNumber);
       }
       b"FMWR" => {
-        // GoPro.pm:195 — `FirmwareVersion`, ASCII `c`.
-        if let Some(s) = read_ascii(payload) {
-          self.out.set_firmware_version(Some(SmolStr::from(s)));
-        }
+        // GoPro.pm:195 — `FirmwareVersion`, ASCII `c`. Empty-string-emitting +
+        // last-wins like `DVNM` above.
+        let s = read_ascii(payload).unwrap_or_default();
+        self.out.set_firmware_version(Some(SmolStr::from(s)));
+        self.out.record_identity(GoProIdentity::FirmwareVersion);
       }
       b"MUID" => {
         // GoPro.pm:456-462 — `MediaUniqueID`. The "forum12825" entry defines
@@ -520,6 +530,7 @@ impl Walker<'_> {
         }
         if !s.is_empty() {
           self.out.set_media_uid(Some(SmolStr::from(s)));
+          self.out.record_identity(GoProIdentity::MediaUniqueID);
         }
       }
       b"GPSU" => {
@@ -536,6 +547,7 @@ impl Walker<'_> {
           self
             .out
             .set_gps_date_time(Some(SmolStr::from(convert_gpsu(&raw))));
+          self.out.record_scalar(GoProScalar::GpsDateTime);
         }
       }
       b"GPSF" => {
@@ -544,6 +556,7 @@ impl Walker<'_> {
         // Measurement'; the typed surface stores the raw numeric.
         if let Some(v) = be_u32(payload, 0) {
           self.out.set_gps_measure_mode(Some(v));
+          self.out.record_scalar(GoProScalar::GpsMeasureMode);
         }
       }
       b"GPSP" => {
@@ -553,12 +566,14 @@ impl Walker<'_> {
           self
             .out
             .set_gps_h_positioning_error_m(Some(f64::from(v) / 100.0));
+          self.out.record_scalar(GoProScalar::GpsHPositioningError);
         }
       }
       b"GPSA" => {
         // GoPro.pm:472 — `GPSAltitudeSystem` (4-char ID, e.g. 'MSLV').
         if let Some(s) = read_ascii(payload) {
           self.out.set_gps_altitude_system(Some(SmolStr::from(s)));
+          self.out.record_scalar(GoProScalar::GpsAltitudeSystem);
         }
       }
       b"GPS5" => {
@@ -706,7 +721,16 @@ impl Walker<'_> {
 
     let value = self.decode_generic_value(fmt, len, count, payload, apply_scal);
     let Some(value) = value else { return };
-    if value.is_empty() {
+    // GoPro.pm:845 `next unless $size or $verbose` skips ONLY a zero-SIZE
+    // record (the `payload.is_empty()` guard in `visit` already mirrors that);
+    // a non-zero-size `c`/`undef` record whose bytes are all NUL decodes to an
+    // EMPTY STRING that ExifTool still `HandleTag`s (e.g. GoPro.jpg's
+    // 8-NUL-byte `EXPT` ⇒ `GoPro:ExposureType = ""`). So an empty
+    // [`GoProTagValue::Str`] MUST emit. Only a numeric/complex decode that
+    // resolved ZERO elements ([`GoProTagValue::NumList`]/[`Rows`] empty —
+    // a too-short payload that produced no `ReadValue` element) carries nothing
+    // to emit and is dropped.
+    if value.is_empty() && !matches!(value, GoProTagValue::Str(_)) {
       return;
     }
     // `%addUnits` (SCPR/SIMU) carries the captured per-element units so the
@@ -759,9 +783,17 @@ impl Walker<'_> {
       }
       return Some(GoProTagValue::Rows(rows));
     }
-    // `string` (`c`) / `undef` (`F`/`G`/`U`) — the NUL-trimmed text.
+    // `string` (`c`) / `undef` (`F`/`G`/`U`) — the NUL-trimmed text. ExifTool's
+    // `ReadValue($dataPt, $pos, 'string'/'undef', undef, $size)` (GoPro.pm:869)
+    // returns the NUL-trimmed text, which is the EMPTY STRING for an all-NUL
+    // (but non-zero-`$size`) record. `read_ascii` already returns `Some("")` for
+    // that all-NUL case (the helper reserves `None` for the `$size == 0`
+    // payload, which `visit` filters), so the empty `Str` emits — a non-zero
+    // record MUST emit (GoPro.pm:845 only skips `$size == 0`), e.g. GoPro.jpg's
+    // 8-NUL-byte `EXPT` ⇒ `GoPro:ExposureType = ""`.
     if matches!(fmt, 0x63 | 0x46 | 0x47 | 0x55) {
-      return read_ascii(payload).map(|s| GoProTagValue::Str(SmolStr::from(s)));
+      let s = read_ascii(payload).unwrap_or_default();
+      return Some(GoProTagValue::Str(SmolStr::from(s)));
     }
     // Numeric — a FLAT ReadValue list (GoPro.pm:869) with per-column SCAL.
     let flat = read_scalar_vec(fmt, len, count, payload);
@@ -1058,6 +1090,10 @@ impl Walker<'_> {
       .collect::<Vec<_>>()
       .join(", ");
     self.out.set_system_time(SmolStr::from(display));
+    // Record the main-group walk position so `SystemTime` emits at its KLV
+    // position interleaved with the device/settings/GPS-scalar tags. First-set
+    // wins (idempotent), matching `set_system_time`'s first-record semantics.
+    self.out.record_scalar(GoProScalar::SystemTime);
     // GoPro.pm:863 + 396-404: only `$val = $v[0]` (exactly one non-empty row)
     // that splits to EXACTLY two tokens is a calibration pair.
     if let [only] = rows.as_slice()
@@ -1459,6 +1495,20 @@ fn scal_at(scal: &[f64], i: usize) -> f64 {
 /// Read a NUL-terminated / NUL-padded ASCII string from a GPMF `c` (or
 /// `F`/`G`/`U`) payload. Trims trailing NULs.
 fn read_ascii(payload: &[u8]) -> Option<String> {
+  // GoPro.pm:845 `next unless $size or $verbose` skips ONLY a zero-`$size`
+  // record; `visit` already mirrors that (the `payload.is_empty()` guard). For
+  // ANY non-zero-size payload ExifTool's `ReadValue('string')` returns the
+  // NUL-trimmed bytes — which is the EMPTY STRING for an all-NUL (or
+  // leading-NUL) payload, and ExifTool still `HandleTag`s it (oracle-confirmed:
+  // an all-NUL RMRK/GPSU/GPSA emits `""`, and GoPro.jpg's 8-NUL `EXPT` emits
+  // `ExposureType = ""`). So return `Some("")` for an all-NUL payload and
+  // reserve `None` for a genuinely empty payload (the `$size == 0` case, never
+  // reached through `visit`). This makes EVERY string tag — typed identity,
+  // generic, RMRK→Comments, GPSU, GPSA — uniformly emit the empty string at the
+  // helper, with no per-arm patching.
+  if payload.is_empty() {
+    return None;
+  }
   let end = payload
     .iter()
     .position(|&b| b == 0)
@@ -1466,13 +1516,11 @@ fn read_ascii(payload: &[u8]) -> Option<String> {
   // `end <= payload.len()` by construction (a found NUL index or the length),
   // so the checked slice is always `Some`.
   let slice = payload.get(..end)?;
-  if slice.is_empty() {
-    return None;
-  }
   // Faithful: ExifTool's string ReadValue keeps non-ASCII as raw bytes;
   // the GoPro module then re-decodes via `Latin` for the RMRK/SIUN/UNIT
   // strings. The typed surface targets ASCII-only fields (model, serial,
-  // firmware, GPSU, GPSA) — UTF-8-lossy is a safe rendering.
+  // firmware, GPSU, GPSA) — UTF-8-lossy is a safe rendering. An empty `slice`
+  // (all-NUL payload) yields the empty string.
   Some(String::from_utf8_lossy(slice).into_owned())
 }
 
@@ -1870,15 +1918,21 @@ fn read_unit_strings(fmt: u8, len: usize, count: usize, payload: &[u8]) -> Vec<S
 /// the Unicode code point of the same value. Trailing NULs are trimmed first
 /// (the `c`-format records are NUL-padded). Returns `None` for an empty result.
 fn read_latin1(payload: &[u8]) -> Option<String> {
+  // Same faithfulness contract as [`read_ascii`]: a NON-zero-size payload
+  // always decodes (the empty string for an all-NUL payload), and `None` is
+  // reserved for the `$size == 0` case that `visit` already filters. This makes
+  // an all-NUL `RMRK` emit `GoPro:Comments = ""` (oracle-confirmed) rather than
+  // dropping the tag.
+  if payload.is_empty() {
+    return None;
+  }
   let end = payload
     .iter()
     .position(|&b| b == 0)
     .unwrap_or(payload.len());
   let slice = payload.get(..end)?;
-  if slice.is_empty() {
-    return None;
-  }
-  // Latin-1 → UTF-8: each byte is its own code point (`char::from(byte)`).
+  // Latin-1 → UTF-8: each byte is its own code point (`char::from(byte)`). An
+  // empty `slice` (all-NUL payload) yields the empty string.
   Some(slice.iter().map(|&b| char::from(b)).collect())
 }
 
@@ -3764,6 +3818,21 @@ mod tests {
   fn read_latin1_decodes_high_bytes() {
     // 0xE9 = é in Latin-1 ⇒ the Unicode code point U+00E9.
     assert_eq!(read_latin1(b"caf\xe9\0\0").as_deref(), Some("caf\u{e9}"));
-    assert_eq!(read_latin1(b"\0\0").as_deref(), None);
+    // A NON-zero-size all-NUL payload NUL-trims to the EMPTY STRING and still
+    // decodes (GoPro.pm:845 skips only `$size == 0`); `None` is reserved for a
+    // genuinely empty (`$size == 0`) payload, which `visit` filters upstream.
+    assert_eq!(read_latin1(b"\0\0").as_deref(), Some(""));
+    assert_eq!(read_latin1(b"").as_deref(), None);
+  }
+
+  #[test]
+  fn read_ascii_all_nul_is_empty_string_not_none() {
+    // Parallel faithfulness contract to `read_latin1`: a non-zero-size all-NUL
+    // payload decodes to "" (so every `c`/string tag — typed identity, generic,
+    // GPSU, GPSA — emits the empty string), and only a `$size == 0` payload is
+    // `None`.
+    assert_eq!(read_ascii(b"Camera\0\0").as_deref(), Some("Camera"));
+    assert_eq!(read_ascii(&[0u8; 6]).as_deref(), Some(""));
+    assert_eq!(read_ascii(b"").as_deref(), None);
   }
 }

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -6379,315 +6379,10 @@ impl crate::emit::Taggable for Meta<'_> {
     // exifast's flat TagMap cannot reproduce that shape, so the FIRST GPS fix
     // is summarized here (the typed [`Meta::gopro`] accessor exposes the full
     // per-sample list). The block-level camera-identity + GPSU/GPSF/GPSP/GPSA
-    // scalars are one-per-file. Emitted under `GoPro`:`GoPro`.
-    {
-      let gp = &self.gopro;
-      // family0 = family1 = "GoPro" for every GoPro GPMF tag.
-      let gpg = || Group::new("GoPro", "GoPro");
-      // ── camera identity (block-level, `c` ASCII; no conv) ──────────────
-      // DVNM/MINF/CASN/FMWR (GoPro.pm:57/286-290/121/195). Plain ASCII strings
-      // with no ValueConv/PrintConv — emit verbatim in both modes.
-      for (val, name) in [
-        (gp.device_name(), "DeviceName"),
-        (gp.model(), "Model"),
-        (gp.camera_serial_number(), "CameraSerialNumber"),
-        (gp.firmware_version(), "FirmwareVersion"),
-      ] {
-        if let Some(s) = val {
-          tags.push(EmittedTag::new(
-            gpg(),
-            name.into(),
-            TagValue::Str(s.into()),
-            false,
-          ));
-        }
-      }
-      // MUID `MediaUniqueID` (GoPro.pm:456-462): the typed layer stores the
-      // RAW space-joined `u32` list (ExifTool's ValueConv). `-n` emits that
-      // raw value; `-j` (PrintConv) hex-renders each element and concatenates.
-      if let Some(raw) = gp.media_uid() {
-        tags.push(EmittedTag::new(
-          gpg(),
-          "MediaUniqueID".into(),
-          media_uid_value(raw, print_conv),
-          false,
-        ));
-      }
-      // ── block-level GPS scalars ────────────────────────────────────────
-      // GPSU `GPSDateTime` (GoPro.pm:242-248): the typed layer stores the
-      // post-ValueConv `20YY:MM:DD HH:MM:SS[.fff]` (NO timezone suffix — the
-      // `ConvertDateTime` PrintConv adds none by default); it is a no-op
-      // cosmetic on that shape (emit in both modes).
-      if let Some(dt) = gp.gps_date_time() {
-        tags.push(EmittedTag::new(
-          gpg(),
-          "GPSDateTime".into(),
-          TagValue::Str(dt.into()),
-          false,
-        ));
-      }
-      // GPSF `GPSMeasureMode` (GoPro.pm:230-236): PrintConv 2/3 →
-      // "<n>-Dimensional Measurement"; `-n` emits the raw code.
-      if let Some(mode) = gp.gps_measure_mode() {
-        tags.push(EmittedTag::new(
-          gpg(),
-          "GPSMeasureMode".into(),
-          gps_measure_mode_value(mode, print_conv),
-          false,
-        ));
-      }
-      // GPSP `GPSHPositioningError` (GoPro.pm:237-241): ValueConv `$val / 100`
-      // (cm→m) already applied in the typed layer; no PrintConv. F64 metres.
-      if let Some(err_m) = gp.gps_h_positioning_error_m() {
-        tags.push(EmittedTag::new(
-          gpg(),
-          "GPSHPositioningError".into(),
-          TagValue::F64(err_m),
-          false,
-        ));
-      }
-      // GPSA `GPSAltitudeSystem` (GoPro.pm:472): 4-char ID, no conv.
-      if let Some(sys) = gp.gps_altitude_system() {
-        tags.push(EmittedTag::new(
-          gpg(),
-          "GPSAltitudeSystem".into(),
-          TagValue::Str(sys.into()),
-          false,
-        ));
-      }
-      // SYST `SystemTime` (GoPro.pm:390-405): a DEFAULT tag (no
-      // `Unknown`/`Hidden`), emitted by `exiftool -ee`. The typed layer stores
-      // the post-`SCAL` space-joined display string of the FIRST `SYST` record
-      // (the calibration side-effect lives on the `SystemTimeList`). No
-      // ValueConv/PrintConv beyond the `RawConv` pass-through ⇒ emit verbatim in
-      // both modes.
-      if let Some(st) = gp.system_time() {
-        tags.push(EmittedTag::new(
-          gpg(),
-          "SystemTime".into(),
-          TagValue::Str(st.into()),
-          false,
-        ));
-      }
-      // ── first GPS5/GPS9 fix (summarized; full list via `Meta::gopro`) ──
-      if let Some(fix) = gp.first_fix() {
-        // GPSLatitude/GPSLongitude: the `GPS::ToDMS` PrintConv
-        // (GoPro.pm:493-499) is a GPS-port dependency (same deferral as the
-        // SP3 stream above); emit post-ValueConv decimal degrees in BOTH
-        // modes.
-        if let (Some(lat), Some(lon)) = (fix.latitude(), fix.longitude()) {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSLatitude".into(),
-            TagValue::F64(lat),
-            false,
-          ));
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSLongitude".into(),
-            TagValue::F64(lon),
-            false,
-          ));
-        }
-        // GPSAltitude (GoPro.pm:500-503): typed layer stores metres; the
-        // `"$val m"` PrintConv is deferred (consistent with the SP3 stream's
-        // raw-F64 altitude). Emit F64 metres in both modes.
-        if let Some(alt) = fix.altitude_m() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSAltitude".into(),
-            TagValue::F64(alt),
-            false,
-          ));
-        }
-        // GPSSpeed / GPSSpeed3D (GoPro.pm:504-513): ValueConv `$val * 3.6`
-        // converts the stored m/s to KM/H — applied HERE on emission (the
-        // typed [`GoProGpsSample`] keeps m/s). No PrintConv ⇒ faithful in both
-        // `-j`/`-n`.
-        if let Some(spd) = fix.speed_2d_mps() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSSpeed".into(),
-            TagValue::F64(spd * 3.6),
-            false,
-          ));
-        }
-        if let Some(s3d) = fix.speed_3d_mps() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSSpeed3D".into(),
-            TagValue::F64(s3d * 3.6),
-            false,
-          ));
-        }
-        // GPS9-only per-sample columns (GoPro.pm:543-562). `GPSDateTime` here
-        // is the per-sample value (derived from the GPS-days/seconds columns);
-        // it overrides the block-level GPSU above under the sink's last-wins
-        // when a GPS9 file also carried a GPSU (a GPS9 file normally does not).
-        if let Some(dt) = fix.date_time() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSDateTime".into(),
-            TagValue::Str(dt.into()),
-            false,
-          ));
-        }
-        if let Some(dop) = fix.dop() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSDOP".into(),
-            TagValue::F64(dop),
-            false,
-          ));
-        }
-        if let Some(mode) = fix.measure_mode() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSMeasureMode".into(),
-            gps_measure_mode_value(mode, print_conv),
-            false,
-          ));
-        }
-      }
-      // ── Karma GLPI (`GPSPos`, GoPro.pm:197-204/598-626) ────────────────
-      // Like the GPS5/GPS9 fix above, ExifTool emits one `Doc<N>` per GLPI
-      // row; the FIRST sample is summarized here (the full per-sample list is
-      // on [`Meta::gopro`]'s `glpi_samples()`). Column order = table order
-      // (GoPro.pm:602-625): GPSDateTime, GPSLatitude, GPSLongitude,
-      // GPSAltitude, GPSSpeedX/Y/Z, GPSTrack. The `Unknown`/`Hidden` col 4 is
-      // not emitted. Lat/lon defer the `GPS::ToDMS` PrintConv (raw decimal
-      // degrees, like GPS5/GPS9); altitude defers its `"$val m"` PrintConv (raw
-      // F64). The speeds (cols 5-7) DO apply their `'"$val m/s"'` PrintConv in
-      // `-j` mode (R6-C) — GLPI speeds carry NO `*3.6` km/h `ValueConv` (the
-      // table has only the suffix PrintConv), so they stay m/s; `-n` emits the
-      // raw F64. `GPSTrack` (col 8) has no PrintConv (raw both modes).
-      // `GPSDateTime` is the `ConvertSystemTime` string emitted verbatim (incl.
-      // the `<uncalibrated>` / `0000:00:00 00:00:00` literals).
-      if let Some(g) = gp.first_glpi_fix() {
-        if let Some(dt) = g.date_time() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSDateTime".into(),
-            TagValue::Str(dt.into()),
-            false,
-          ));
-        }
-        if let (Some(lat), Some(lon)) = (g.latitude(), g.longitude()) {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSLatitude".into(),
-            TagValue::F64(lat),
-            false,
-          ));
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSLongitude".into(),
-            TagValue::F64(lon),
-            false,
-          ));
-        }
-        if let Some(alt) = g.altitude_m() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSAltitude".into(),
-            TagValue::F64(alt),
-            false,
-          ));
-        }
-        // GPSSpeedX/Y/Z (GoPro.pm:622-624): PrintConv `'"$val m/s"'`. `-j`
-        // renders the scaled m/s value with the ` m/s` suffix
-        // ([`unit_suffix_value`]); `-n` (ValueConv) emits the raw F64.
-        for (val, name) in [
-          (g.speed_x_mps(), "GPSSpeedX"),
-          (g.speed_y_mps(), "GPSSpeedY"),
-          (g.speed_z_mps(), "GPSSpeedZ"),
-        ] {
-          if let Some(v) = val {
-            tags.push(EmittedTag::new(
-              gpg(),
-              name.into(),
-              unit_suffix_value(v, " m/s", print_conv),
-              false,
-            ));
-          }
-        }
-        if let Some(tr) = g.track_deg() {
-          tags.push(EmittedTag::new(
-            gpg(),
-            "GPSTrack".into(),
-            TagValue::F64(tr),
-            false,
-          ));
-        }
-      }
-      // ── Karma KBAT (`BatteryStatus`, GoPro.pm:264-270/628-649) ─────────
-      // The FIRST battery record is summarized (full list on
-      // [`Meta::gopro`]'s `kbat_records()`). Column order = table order
-      // (GoPro.pm:634-648): BatteryCurrent, BatteryCapacity,
-      // BatteryTemperature, BatteryVoltage1..4, BatteryTime, BatteryLevel.
-      // The `Unknown`/`Hidden` cols (2/9/10-13) are not emitted. Each named
-      // column carries a unit-suffix PrintConv (GoPro.pm:634-648) applied in
-      // `-j` (PrintConv) mode via [`unit_suffix_value`]; `-n` (ValueConv) emits
-      // the raw scaled F64. `BatteryTime` (col 8) instead uses
-      // `ConvertDuration(int($val + 0.5))` — emitted in column order, before
-      // `BatteryLevel`.
-      if let Some(k) = gp.kbat_records().first() {
-        // (value, name, PrintConv): `Suffix` = `'"$val <unit>"'`; `Duration` =
-        // `ConvertDuration(int($val + 0.5))`.
-        enum KbatConv {
-          Suffix(&'static str),
-          Duration,
-        }
-        for (val, name, conv) in [
-          (k.current_a(), "BatteryCurrent", KbatConv::Suffix(" A")),
-          (k.capacity_ah(), "BatteryCapacity", KbatConv::Suffix(" Ah")),
-          (
-            k.temperature_c(),
-            "BatteryTemperature",
-            KbatConv::Suffix(" C"),
-          ),
-          (k.voltage1_v(), "BatteryVoltage1", KbatConv::Suffix(" V")),
-          (k.voltage2_v(), "BatteryVoltage2", KbatConv::Suffix(" V")),
-          (k.voltage3_v(), "BatteryVoltage3", KbatConv::Suffix(" V")),
-          (k.voltage4_v(), "BatteryVoltage4", KbatConv::Suffix(" V")),
-          (k.time_s(), "BatteryTime", KbatConv::Duration),
-          (k.level_pct(), "BatteryLevel", KbatConv::Suffix(" %")),
-        ] {
-          if let Some(v) = val {
-            let value = match conv {
-              KbatConv::Suffix(unit) => unit_suffix_value(v, unit, print_conv),
-              // `int($val + 0.5)` rounds the scaled seconds to the nearest
-              // second (Perl `int()` truncates toward zero; battery time is a
-              // non-negative duration) before `ConvertDuration` ([`convert_duration`]);
-              // `-n` emits the raw scaled F64 seconds.
-              KbatConv::Duration if print_conv => {
-                TagValue::Str(convert_duration((v + 0.5).trunc()).into())
-              }
-              KbatConv::Duration => TagValue::F64(v),
-            };
-            tags.push(EmittedTag::new(gpg(), name.into(), value, false));
-          }
-        }
-      }
-      // ── every OTHER default-visible %GoPro::GPMF tag (table-driven) ────
-      // ExifTool's `ProcessGoPro` `HandleTag`s every default-visible tag
-      // (GoPro.pm:885); the typed surface above models the GPS/Karma/camera-id
-      // subset, and [`GoProMeta::generic_tags`] carries the remaining ~95
-      // (sensor streams + Protune/codec settings + calibrations) decoded in
-      // walk order. Each is rendered to its `-n`/`-j` value here by conv family
-      // ([`gopro_generic_value`]) under the same `GoPro`:`GoPro` group. A
-      // `Binary => 1` tag renders as the `(Binary data N bytes…)` placeholder
-      // in BOTH modes (GoPro.pm `Binary` → ValueConv `'\$val'`), N = byte length
-      // of the post-`ScaleValues` value string (exiftool:3987).
-      for gt in gp.generic_tags() {
-        tags.push(EmittedTag::new(
-          gpg(),
-          gt.name().into(),
-          gopro_generic_value(gt, print_conv),
-          false,
-        ));
-      }
-    }
+    // scalars are one-per-file. Emitted under `GoPro`:`GoPro` (family-0 =
+    // family-1 = `GoPro`; the JPEG `APP6` path reuses [`emit_gopro_tags`] with
+    // the `APP6` family-0).
+    emit_gopro_tags(&self.gopro, "GoPro", "GoPro", print_conv, &mut tags);
 
     // ── SP4: Android CAMM cross-kind `-G1` SampleTime/SampleDuration ────────
     // At `-ee -G1` the single `Track<N>:SampleTime`/`SampleDuration` is the timing
@@ -10654,6 +10349,371 @@ fn sony_rtmd_exposure_time_read_value(
     NumericRead::Valid(r) => sony_rtmd_exposure_time_value(r, print_conv),
     NumericRead::EmptyRead => TagValue::Str("".into()),
   }
+}
+
+/// Emit every default-visible `%GoPro::GPMF` tag a [`GoProMeta`] carries, under
+/// the group `(family0, family1)`, into `tags`. The faithful `HandleTag` stream
+/// of `ProcessGoPro` (GoPro.pm:846-896), shared by the QuickTime `GPMF` /
+/// `gpmd` path (group `GoPro`:`GoPro`, GoPro.pm:67-69) and the JPEG `APP6`
+/// `GoPro` segment (group `APP6`:`GoPro`, JPEG.pm:183-198 → the SAME
+/// `%GoPro::GPMF` table, whose family-1 stays `GoPro` but whose family-0 is the
+/// `APP6` parent the segment was reached through).
+///
+/// Like the SP3/Insta360 streams, ExifTool emits one `Doc<N>` sub-document per
+/// GPS / GLPI / KBAT row; exifast's flat sink cannot reproduce that shape, so
+/// the FIRST fix/record of each is summarized here (the typed [`GoProMeta`]
+/// accessors expose the full per-sample lists). The block-level camera-identity
+/// + `GPSU`/`GPSF`/`GPSP`/`GPSA` scalars and the generic settings tags are
+/// one-per-file. A still-image `APP6` device record carries ONLY the
+/// camera-identity + settings tags (no GPS/telemetry streams), so the GPS/GLPI/
+/// KBAT branches are simply empty for that source.
+#[cfg(feature = "alloc")]
+pub(crate) fn emit_gopro_tags(
+  gp: &GoProMeta,
+  family0: &str,
+  family1: &str,
+  print_conv: bool,
+  tags: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::value::{Group, TagValue};
+  let gpg = || Group::new(family0, family1);
+  // ── main-group tags (camera identity + generic settings + GPS/system
+  // scalars), in GPMF-walk order ──
+  // ExifTool's `ProcessGoPro` is ONE linear loop that `HandleTag`s each record
+  // at its stream position (GoPro.pm:885) — the typed camera-identity fields
+  // (`DVNM`/`FMWR`/`CASN`/`MINF`/`MUID`), the generic table-driven settings
+  // (`OREN`/`PRTN`/…), AND the flat GPS / system scalars
+  // (`GPSU`/`GPSF`/`GPSP`/`GPSA`/`SYST`) all emit INTERLEAVED in the order their
+  // KLV records were walked, NOT a whole identity block, then a settings block,
+  // then a GPS-scalar block. So a crafted `STRM { OREN, DVNM }` stream emits
+  // `AutoRotation` BEFORE `DeviceName`, and `STRM { GPSU, OREN }` emits
+  // `GPSDateTime` BEFORE `AutoRotation`. The unified order is recorded on
+  // [`GoProMeta::main_group_order`]; a duplicate name is emitted at each
+  // recorded position and the sink's last-wins-in-place dedup keeps the first
+  // position + last value (ExifTool's `%noDups`).
+  //
+  // Identity values:
+  //  - DVNM/FMWR/CASN/MINF are `c` ASCII (no conv); read live from the typed
+  //    field so a duplicate's last value wins.
+  //  - MUID is the RAW space-joined `u32` ValueConv list (`-j` hex-renders each
+  //    element, GoPro.pm:456-462).
+  //
+  // GPS / system scalar values (also read live from their dedicated typed
+  // fields, so a duplicate's last value wins at the recorded first position):
+  //  - GPSU `GPSDateTime`: the post-ValueConv `20YY:MM:DD HH:MM:SS[.fff]` (NO
+  //    timezone suffix — `ConvertDateTime` adds none by default; cosmetic no-op
+  //    on that shape, so it emits verbatim in both modes).
+  //  - GPSF `GPSMeasureMode`: PrintConv 2/3 → "<n>-Dimensional Measurement";
+  //    `-n` emits the raw code.
+  //  - GPSP `GPSHPositioningError`: ValueConv `$val / 100` (cm→m) already applied
+  //    in the typed layer; no PrintConv (F64 metres).
+  //  - GPSA `GPSAltitudeSystem`: 4-char ID, no conv.
+  //  - SYST `SystemTime`: a DEFAULT tag (no `Unknown`/`Hidden`), emitted by
+  //    `exiftool -ee` — the post-`SCAL` space-joined display string of the FIRST
+  //    `SYST` record (the calibration side-effect lives on the `SystemTimeList`);
+  //    no conv beyond the `RawConv` pass-through ⇒ emit verbatim in both modes.
+  //
+  // A hand-built [`GoProMeta`] with no recorded order (e.g. a test fixture)
+  // falls back to the canonical identity → GPS-scalars → settings sequence.
+  {
+    use crate::metadata::{GoProIdentity, GoProMainGroupTag, GoProScalar};
+    let str_value = |s: &str| TagValue::Str(s.into());
+    let emit_identity = |field: GoProIdentity, tags: &mut std::vec::Vec<EmittedTag>| {
+      let value = match field {
+        GoProIdentity::DeviceName => gp.device_name().map(str_value),
+        GoProIdentity::FirmwareVersion => gp.firmware_version().map(str_value),
+        GoProIdentity::CameraSerialNumber => gp.camera_serial_number().map(str_value),
+        GoProIdentity::Model => gp.model().map(str_value),
+        GoProIdentity::MediaUniqueID => gp.media_uid().map(|raw| media_uid_value(raw, print_conv)),
+      };
+      if let Some(v) = value {
+        tags.push(EmittedTag::new(gpg(), field.as_str().into(), v, false));
+      }
+    };
+    let emit_scalar = |field: GoProScalar, tags: &mut std::vec::Vec<EmittedTag>| {
+      let entry: Option<(&str, TagValue)> = match field {
+        GoProScalar::GpsDateTime => gp
+          .gps_date_time()
+          .map(|dt| ("GPSDateTime", TagValue::Str(dt.into()))),
+        GoProScalar::GpsMeasureMode => gp
+          .gps_measure_mode()
+          .map(|m| ("GPSMeasureMode", gps_measure_mode_value(m, print_conv))),
+        GoProScalar::GpsHPositioningError => gp
+          .gps_h_positioning_error_m()
+          .map(|e| ("GPSHPositioningError", TagValue::F64(e))),
+        GoProScalar::GpsAltitudeSystem => gp
+          .gps_altitude_system()
+          .map(|s| ("GPSAltitudeSystem", TagValue::Str(s.into()))),
+        GoProScalar::SystemTime => gp
+          .system_time()
+          .map(|st| ("SystemTime", TagValue::Str(st.into()))),
+      };
+      if let Some((name, value)) = entry {
+        tags.push(EmittedTag::new(gpg(), name.into(), value, false));
+      }
+    };
+    let emit_generic = |idx: usize, tags: &mut std::vec::Vec<EmittedTag>| {
+      // A recorded index is always in range, but the `.get()` keeps the access
+      // checked (the file-wide indexing deny is honoured).
+      if let Some(gt) = gp.generic_tags().get(idx) {
+        tags.push(EmittedTag::new(
+          gpg(),
+          gt.name().into(),
+          gopro_generic_value(gt, print_conv),
+          false,
+        ));
+      }
+    };
+    let recorded = gp.main_group_order();
+    if recorded.is_empty() {
+      // Fallback for an order-less hand-built meta: canonical identity order,
+      // then the GPS / system scalars, then the generic settings in their stored
+      // (push) order.
+      const CANONICAL: [GoProIdentity; 5] = [
+        GoProIdentity::DeviceName,
+        GoProIdentity::FirmwareVersion,
+        GoProIdentity::CameraSerialNumber,
+        GoProIdentity::Model,
+        GoProIdentity::MediaUniqueID,
+      ];
+      for field in CANONICAL {
+        emit_identity(field, tags);
+      }
+      const SCALARS: [GoProScalar; 5] = [
+        GoProScalar::GpsDateTime,
+        GoProScalar::GpsMeasureMode,
+        GoProScalar::GpsHPositioningError,
+        GoProScalar::GpsAltitudeSystem,
+        GoProScalar::SystemTime,
+      ];
+      for field in SCALARS {
+        emit_scalar(field, tags);
+      }
+      for idx in 0..gp.generic_tags().len() {
+        emit_generic(idx, tags);
+      }
+    } else {
+      // The faithful path: emit every main-group tag at its recorded walk
+      // position.
+      for entry in recorded {
+        match entry {
+          GoProMainGroupTag::Identity(field) => emit_identity(*field, tags),
+          GoProMainGroupTag::Scalar(field) => emit_scalar(*field, tags),
+          GoProMainGroupTag::Generic(idx) => emit_generic(*idx, tags),
+        }
+      }
+    }
+  }
+  // ── first GPS5/GPS9 fix (summarized; full list via `Meta::gopro`) ──
+  if let Some(fix) = gp.first_fix() {
+    // GPSLatitude/GPSLongitude: the `GPS::ToDMS` PrintConv
+    // (GoPro.pm:493-499) is a GPS-port dependency (same deferral as the
+    // SP3 stream above); emit post-ValueConv decimal degrees in BOTH
+    // modes.
+    if let (Some(lat), Some(lon)) = (fix.latitude(), fix.longitude()) {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSLatitude".into(),
+        TagValue::F64(lat),
+        false,
+      ));
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSLongitude".into(),
+        TagValue::F64(lon),
+        false,
+      ));
+    }
+    // GPSAltitude (GoPro.pm:500-503): typed layer stores metres; the
+    // `"$val m"` PrintConv is deferred (consistent with the SP3 stream's
+    // raw-F64 altitude). Emit F64 metres in both modes.
+    if let Some(alt) = fix.altitude_m() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSAltitude".into(),
+        TagValue::F64(alt),
+        false,
+      ));
+    }
+    // GPSSpeed / GPSSpeed3D (GoPro.pm:504-513): ValueConv `$val * 3.6`
+    // converts the stored m/s to KM/H — applied HERE on emission (the
+    // typed [`GoProGpsSample`] keeps m/s). No PrintConv ⇒ faithful in both
+    // `-j`/`-n`.
+    if let Some(spd) = fix.speed_2d_mps() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSSpeed".into(),
+        TagValue::F64(spd * 3.6),
+        false,
+      ));
+    }
+    if let Some(s3d) = fix.speed_3d_mps() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSSpeed3D".into(),
+        TagValue::F64(s3d * 3.6),
+        false,
+      ));
+    }
+    // GPS9-only per-sample columns (GoPro.pm:543-562). `GPSDateTime` here
+    // is the per-sample value (derived from the GPS-days/seconds columns);
+    // it overrides the block-level GPSU above under the sink's last-wins
+    // when a GPS9 file also carried a GPSU (a GPS9 file normally does not).
+    if let Some(dt) = fix.date_time() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSDateTime".into(),
+        TagValue::Str(dt.into()),
+        false,
+      ));
+    }
+    if let Some(dop) = fix.dop() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSDOP".into(),
+        TagValue::F64(dop),
+        false,
+      ));
+    }
+    if let Some(mode) = fix.measure_mode() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSMeasureMode".into(),
+        gps_measure_mode_value(mode, print_conv),
+        false,
+      ));
+    }
+  }
+  // ── Karma GLPI (`GPSPos`, GoPro.pm:197-204/598-626) ────────────────
+  // Like the GPS5/GPS9 fix above, ExifTool emits one `Doc<N>` per GLPI
+  // row; the FIRST sample is summarized here (the full per-sample list is
+  // on [`Meta::gopro`]'s `glpi_samples()`). Column order = table order
+  // (GoPro.pm:602-625): GPSDateTime, GPSLatitude, GPSLongitude,
+  // GPSAltitude, GPSSpeedX/Y/Z, GPSTrack. The `Unknown`/`Hidden` col 4 is
+  // not emitted. Lat/lon defer the `GPS::ToDMS` PrintConv (raw decimal
+  // degrees, like GPS5/GPS9); altitude defers its `"$val m"` PrintConv (raw
+  // F64). The speeds (cols 5-7) DO apply their `'"$val m/s"'` PrintConv in
+  // `-j` mode (R6-C) — GLPI speeds carry NO `*3.6` km/h `ValueConv` (the
+  // table has only the suffix PrintConv), so they stay m/s; `-n` emits the
+  // raw F64. `GPSTrack` (col 8) has no PrintConv (raw both modes).
+  // `GPSDateTime` is the `ConvertSystemTime` string emitted verbatim (incl.
+  // the `<uncalibrated>` / `0000:00:00 00:00:00` literals).
+  if let Some(g) = gp.first_glpi_fix() {
+    if let Some(dt) = g.date_time() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSDateTime".into(),
+        TagValue::Str(dt.into()),
+        false,
+      ));
+    }
+    if let (Some(lat), Some(lon)) = (g.latitude(), g.longitude()) {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSLatitude".into(),
+        TagValue::F64(lat),
+        false,
+      ));
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSLongitude".into(),
+        TagValue::F64(lon),
+        false,
+      ));
+    }
+    if let Some(alt) = g.altitude_m() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSAltitude".into(),
+        TagValue::F64(alt),
+        false,
+      ));
+    }
+    // GPSSpeedX/Y/Z (GoPro.pm:622-624): PrintConv `'"$val m/s"'`. `-j`
+    // renders the scaled m/s value with the ` m/s` suffix
+    // ([`unit_suffix_value`]); `-n` (ValueConv) emits the raw F64.
+    for (val, name) in [
+      (g.speed_x_mps(), "GPSSpeedX"),
+      (g.speed_y_mps(), "GPSSpeedY"),
+      (g.speed_z_mps(), "GPSSpeedZ"),
+    ] {
+      if let Some(v) = val {
+        tags.push(EmittedTag::new(
+          gpg(),
+          name.into(),
+          unit_suffix_value(v, " m/s", print_conv),
+          false,
+        ));
+      }
+    }
+    if let Some(tr) = g.track_deg() {
+      tags.push(EmittedTag::new(
+        gpg(),
+        "GPSTrack".into(),
+        TagValue::F64(tr),
+        false,
+      ));
+    }
+  }
+  // ── Karma KBAT (`BatteryStatus`, GoPro.pm:264-270/628-649) ─────────
+  // The FIRST battery record is summarized (full list on
+  // [`Meta::gopro`]'s `kbat_records()`). Column order = table order
+  // (GoPro.pm:634-648): BatteryCurrent, BatteryCapacity,
+  // BatteryTemperature, BatteryVoltage1..4, BatteryTime, BatteryLevel.
+  // The `Unknown`/`Hidden` cols (2/9/10-13) are not emitted. Each named
+  // column carries a unit-suffix PrintConv (GoPro.pm:634-648) applied in
+  // `-j` (PrintConv) mode via [`unit_suffix_value`]; `-n` (ValueConv) emits
+  // the raw scaled F64. `BatteryTime` (col 8) instead uses
+  // `ConvertDuration(int($val + 0.5))` — emitted in column order, before
+  // `BatteryLevel`.
+  if let Some(k) = gp.kbat_records().first() {
+    // (value, name, PrintConv): `Suffix` = `'"$val <unit>"'`; `Duration` =
+    // `ConvertDuration(int($val + 0.5))`.
+    enum KbatConv {
+      Suffix(&'static str),
+      Duration,
+    }
+    for (val, name, conv) in [
+      (k.current_a(), "BatteryCurrent", KbatConv::Suffix(" A")),
+      (k.capacity_ah(), "BatteryCapacity", KbatConv::Suffix(" Ah")),
+      (
+        k.temperature_c(),
+        "BatteryTemperature",
+        KbatConv::Suffix(" C"),
+      ),
+      (k.voltage1_v(), "BatteryVoltage1", KbatConv::Suffix(" V")),
+      (k.voltage2_v(), "BatteryVoltage2", KbatConv::Suffix(" V")),
+      (k.voltage3_v(), "BatteryVoltage3", KbatConv::Suffix(" V")),
+      (k.voltage4_v(), "BatteryVoltage4", KbatConv::Suffix(" V")),
+      (k.time_s(), "BatteryTime", KbatConv::Duration),
+      (k.level_pct(), "BatteryLevel", KbatConv::Suffix(" %")),
+    ] {
+      if let Some(v) = val {
+        let value = match conv {
+          KbatConv::Suffix(unit) => unit_suffix_value(v, unit, print_conv),
+          // `int($val + 0.5)` rounds the scaled seconds to the nearest
+          // second (Perl `int()` truncates toward zero; battery time is a
+          // non-negative duration) before `ConvertDuration` ([`convert_duration`]);
+          // `-n` emits the raw scaled F64 seconds.
+          KbatConv::Duration if print_conv => {
+            TagValue::Str(convert_duration((v + 0.5).trunc()).into())
+          }
+          KbatConv::Duration => TagValue::F64(v),
+        };
+        tags.push(EmittedTag::new(gpg(), name.into(), value, false));
+      }
+    }
+  }
+  // NOTE: the generic table-driven `%GoPro::GPMF` settings (sensor streams,
+  // Protune/codec settings, calibrations — `Binary => 1` rendered as the
+  // `(Binary data N bytes…)` placeholder in both modes) and the flat GPS /
+  // system scalars (`GPSU`/`GPSF`/`GPSP`/`GPSA`/`SYST`) are NOT separate trailing
+  // blocks: they are emitted INTERLEAVED with the camera identity in the
+  // GPMF-walk-ordered main-group block above ([`GoProMeta::main_group_order`]),
+  // faithful to ExifTool's single linear `HandleTag` loop (GoPro.pm:885). Only
+  // the per-sample `Doc<N>` telemetry (GPS5/GPS9/GLPI/KBAT first-fix summaries)
+  // is emitted here, after the main-group block.
 }
 
 /// Build a GoPro unit-suffix tag value — the `'"$val <unit>"'` PrintConv shared

--- a/src/metadata/gopro.rs
+++ b/src/metadata/gopro.rs
@@ -845,6 +845,108 @@ impl GoProTag {
   }
 }
 
+/// One camera-identity field of [`GoProMeta`], used to record the GPMF-walk
+/// order in which the identity records were extracted so emission reproduces
+/// ExifTool's `HandleTag` stream-position sequence (GoPro.pm:885) instead of a
+/// fixed struct order. Internal to the crate — the emission side
+/// ([`crate::formats::quicktime::emit_gopro_tags`]) consumes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GoProIdentity {
+  /// `DVNM` → `DeviceName`.
+  DeviceName,
+  /// `MINF` → `Model`.
+  Model,
+  /// `CASN` → `CameraSerialNumber`.
+  CameraSerialNumber,
+  /// `FMWR` → `FirmwareVersion`.
+  FirmwareVersion,
+  /// `MUID` → `MediaUniqueID`.
+  MediaUniqueID,
+}
+
+impl GoProIdentity {
+  /// The emitted GoPro tag name for this identity field.
+  #[inline(always)]
+  #[must_use]
+  pub(crate) const fn as_str(self) -> &'static str {
+    match self {
+      Self::DeviceName => "DeviceName",
+      Self::Model => "Model",
+      Self::CameraSerialNumber => "CameraSerialNumber",
+      Self::FirmwareVersion => "FirmwareVersion",
+      Self::MediaUniqueID => "MediaUniqueID",
+    }
+  }
+}
+
+/// One FLAT main-group GPS / system scalar of [`GoProMeta`] — the `%GoPro::GPMF`
+/// tags that emit as a SINGLE main-group leaf (NOT the per-sample `Doc<N>`
+/// telemetry of `GPS5`/`GPS9`/`GLPI`/`KBAT`). Recorded on the unified
+/// [`GoProMeta::main_group_order`] axis so each emits at its GPMF-walk position,
+/// interleaved with the camera-identity and generic settings tags — ExifTool's
+/// `ProcessGoPro` is one linear `HandleTag` loop (GoPro.pm:885), so a crafted
+/// `STRM { GPSU, OREN }` emits `GPSDateTime` BEFORE `AutoRotation`.
+///
+/// The value of each is read LIVE from its dedicated [`GoProMeta`] field at
+/// emission (last-wins for a duplicate); this axis only records WHERE the tag
+/// sits in the walk. Internal to the crate — consumed by
+/// [`crate::formats::quicktime::emit_gopro_tags`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GoProScalar {
+  /// `GPSU` → `GPSDateTime` (GoPro.pm:242-248).
+  GpsDateTime,
+  /// `GPSF` → `GPSMeasureMode` (GoPro.pm:230-236).
+  GpsMeasureMode,
+  /// `GPSP` → `GPSHPositioningError` (GoPro.pm:237-241).
+  GpsHPositioningError,
+  /// `GPSA` → `GPSAltitudeSystem` (GoPro.pm:472).
+  GpsAltitudeSystem,
+  /// `SYST` → `SystemTime` (GoPro.pm:390-405).
+  SystemTime,
+}
+
+/// One entry of [`GoProMeta::main_group_order`] — the UNIFIED first-occurrence
+/// GPMF-walk order of EVERY emitted MAIN-GROUP tag: the typed camera-identity
+/// fields, the generic table-driven settings, AND the flat GPS / system scalars
+/// (`GPSU`/`GPSF`/`GPSP`/`GPSA`/`SYST`). Emission walks this one ordered stream
+/// so it reproduces ExifTool's single linear `HandleTag` stream-position
+/// sequence (GoPro.pm:885) instead of dumping a whole identity block, then a
+/// settings block, then a GPS-scalar block.
+///
+/// ExifTool's `ProcessGoPro` is one loop that `HandleTag`s each record at its
+/// walk position — `DVNM` (DeviceName), `OREN` (AutoRotation) and `GPSU`
+/// (GPSDateTime) emit in the order their KLV records appear, so a crafted
+/// `STRM { OREN, DVNM }` emits `AutoRotation` before `DeviceName`, and a crafted
+/// `STRM { GPSU, OREN }` emits `GPSDateTime` before `AutoRotation`. The typed
+/// fields keep their dedicated [`GoProMeta`] accessors (the value is read live
+/// = last-wins); this axis only records WHERE each tag sits in the walk.
+///
+/// The per-sample `Doc<N>` telemetry (`GPS5`/`GPS9`/`GLPI`/`KBAT`) is NOT on
+/// this axis — it is emitted as its own block (the first-fix summaries), faithful
+/// to ExifTool's `ProcessString` `Doc<N>` model and untouched by the main-group
+/// walk ordering.
+///
+/// Internal to the crate — consumed by
+/// [`crate::formats::quicktime::emit_gopro_tags`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GoProMainGroupTag {
+  /// A typed camera-identity field (`DVNM`/`FMWR`/`CASN`/`MINF`/`MUID`).
+  /// Recorded once, at its first set; the value is read live from the typed
+  /// field (a later duplicate updates the value last-wins but does not move
+  /// the key, matching ExifTool's `%noDups` first-position key ordering).
+  Identity(GoProIdentity),
+  /// A generic table-driven settings tag, by its index into
+  /// [`GoProMeta::generic_tags`]. Recorded for EVERY pushed generic record (a
+  /// duplicate name is emitted at each position and the sink's
+  /// last-wins-in-place dedup keeps the first position + last value).
+  Generic(usize),
+  /// A flat main-group GPS / system scalar (`GPSU`/`GPSF`/`GPSP`/`GPSA`/`SYST`).
+  /// Recorded once, at its first set; the value is read live from the dedicated
+  /// [`GoProMeta`] field (last-wins for a duplicate, first-position key per
+  /// `%noDups`).
+  Scalar(GoProScalar),
+}
+
 /// The typed result of GoPro GPMF metadata extraction — the per-format
 /// mirror of every `%GoPro::GPMF` tag this sub-port decodes.
 ///
@@ -877,6 +979,29 @@ pub struct GoProMeta {
   /// raw space-joined value, matching bundled ExifTool. Stored as [`SmolStr`]
   /// (cheap to clone since `MUID` is short and constant per file).
   media_uid: Option<SmolStr>,
+  /// UNIFIED first-occurrence GPMF-walk order of EVERY emitted MAIN-GROUP tag —
+  /// the typed camera-identity fields (`DVNM`/`FMWR`/`CASN`/`MINF`/`MUID`), the
+  /// generic table-driven settings (`OREN`/`PRTN`/… on [`Self::generic_tags`]),
+  /// AND the flat GPS / system scalars (`GPSU`/`GPSF`/`GPSP`/`GPSA`/`SYST`).
+  /// ExifTool's `ProcessGoPro` is one linear loop that `HandleTag`s each record
+  /// at its stream position (GoPro.pm:885), so all these tags appear in the
+  /// order their KLV records are walked — identity, settings and GPS scalars
+  /// INTERLEAVED, NOT a whole identity block, then a whole settings block, then
+  /// a GPS-scalar block. A crafted `STRM { OREN, DVNM }` therefore emits
+  /// `AutoRotation` BEFORE `DeviceName`, and `STRM { GPSU, OREN }` emits
+  /// `GPSDateTime` BEFORE `AutoRotation`. The typed surface still stores each
+  /// value in a dedicated field; this axis records the unified walk position so
+  /// [`crate::formats::quicktime::emit_gopro_tags`] reproduces ExifTool's exact
+  /// emission sequence (e.g. real GoPro streams write `DVNM`,`FMWR`,`CASN`,
+  /// `MINF`,`MUID`, then the settings block). An identity / scalar field is
+  /// recorded once, at its first set (a duplicate KLV record updates the value
+  /// last-wins but does not move the key, matching ExifTool's `%noDups`
+  /// first-position key ordering); a generic tag is recorded at EVERY push (a
+  /// duplicate name emits at each position and the sink's last-wins-in-place
+  /// dedup keeps the first position + last value). The per-sample `Doc<N>`
+  /// telemetry (`GPS5`/`GPS9`/`GLPI`/`KBAT`) is NOT on this axis (emitted as its
+  /// own first-fix block, faithful to the `ProcessString` `Doc<N>` model).
+  main_group_order: Vec<GoProMainGroupTag>,
   /// `GPSDateTime` (`GPSU`, GoPro.pm:242-248). The block-level UTC fix the
   /// `GPS5` family is anchored to; `GPS9` carries per-sample timestamps in
   /// the samples themselves.
@@ -946,6 +1071,7 @@ impl GoProMeta {
       camera_serial_number: None,
       firmware_version: None,
       media_uid: None,
+      main_group_order: Vec::new(),
       gps_date_time: None,
       gps_measure_mode: None,
       gps_h_positioning_error_m: None,
@@ -1117,6 +1243,47 @@ impl GoProMeta {
     self
   }
 
+  /// Record that an identity field was extracted at the CURRENT GPMF-walk
+  /// position. Pushes the marker into the unified [`Self::main_group_order`]
+  /// only on first occurrence of that field (a later duplicate KLV record
+  /// updates the stored value last-wins but does not reorder the emitted key,
+  /// matching ExifTool's `%noDups` first-position ordering). The walker calls
+  /// this right after the matching setter.
+  #[inline]
+  pub(crate) fn record_identity(&mut self, field: GoProIdentity) -> &mut Self {
+    let marker = GoProMainGroupTag::Identity(field);
+    if !self.main_group_order.contains(&marker) {
+      self.main_group_order.push(marker);
+    }
+    self
+  }
+
+  /// Record that a flat main-group GPS / system scalar was extracted at the
+  /// CURRENT GPMF-walk position, on first occurrence only (same `%noDups`
+  /// first-position semantics as [`Self::record_identity`]). The walker calls
+  /// this right after the matching typed setter so the scalar emits interleaved
+  /// with the identity / settings tags at its true KLV-walk position
+  /// (GoPro.pm:885), not in a trailing GPS-scalar block.
+  #[inline]
+  pub(crate) fn record_scalar(&mut self, field: GoProScalar) -> &mut Self {
+    let marker = GoProMainGroupTag::Scalar(field);
+    if !self.main_group_order.contains(&marker) {
+      self.main_group_order.push(marker);
+    }
+    self
+  }
+
+  /// The unified MAIN-GROUP-tag (identity + generic settings + GPS / system
+  /// scalars) sequence in GPMF-walk (first-occurrence) order. Empty when this
+  /// [`GoProMeta`] was populated without recording order (e.g. a hand-built test
+  /// fixture); the emission side falls back to the canonical
+  /// identity-then-scalars-then-settings order in that case.
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn main_group_order(&self) -> &[GoProMainGroupTag] {
+    self.main_group_order.as_slice()
+  }
+
   /// Assign block-level `GPSDateTime`.
   #[inline(always)]
   pub fn set_gps_date_time(&mut self, v: Option<SmolStr>) -> &mut Self {
@@ -1211,10 +1378,16 @@ impl GoProMeta {
     self.generic_tags.as_slice()
   }
 
-  /// Append a table-driven generic tag (GoPro.pm default-visible, non-typed).
+  /// Append a table-driven generic tag (GoPro.pm default-visible, non-typed)
+  /// and record its position in the unified [`Self::main_group_order`] walk so
+  /// it emits interleaved with the identity and GPS-scalar tags at its true
+  /// stream position. A duplicate name is recorded at each push; the sink's
+  /// last-wins-in-place dedup keeps the first position and the last value.
   #[inline(always)]
   pub fn push_generic_tag(&mut self, tag: GoProTag) -> &mut Self {
+    let idx = self.generic_tags.len();
     self.generic_tags.push(tag);
+    self.main_group_order.push(GoProMainGroupTag::Generic(idx));
     self
   }
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -64,6 +64,7 @@ pub use domain::{
 pub use gopro::{
   GoProConv, GoProGlpiSample, GoProGpsSample, GoProKbat, GoProMeta, GoProTag, GoProTagValue,
 };
+pub(crate) use gopro::{GoProIdentity, GoProMainGroupTag, GoProScalar};
 pub use insta360::{
   Insta360AccelSample, Insta360ExposureSample, Insta360GpsSample, Insta360Identity, Insta360Meta,
   Insta360VideoTimeSample,

--- a/tests/jpeg_gopro_app6.rs
+++ b/tests/jpeg_gopro_app6.rs
@@ -1,0 +1,1832 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! JPEG `APP6` "GoPro" GPMF extraction (#59) — the GoPro arm of `ProcessJPEG`'s
+//! multi-arm `APP6` segment (JPEG.pm:183-198) hands a `GoPro\0`-prefixed payload
+//! to `%GoPro::GPMF`'s `ProcessGoPro` (the recursive Key-Length-Value walker).
+//!
+//! A GoPro still (`GOPR*.JPG`) carries its device-settings GPMF stream in
+//! `APP6`; the tags emit under group `APP6`:`GoPro` (family-1 `GoPro`, the
+//! `-G1` key prefix the oracle uses).
+
+#![cfg(all(feature = "exif", feature = "quicktime", feature = "json"))]
+
+use exifast::jsondiff::json_equivalent_strict;
+use exifast::parser::extract_info;
+
+/// Run the REAL `exiftool` over `t/images/GoPro.jpg` and return its raw JSON
+/// stdout (key order preserved — `exiftool -j` emits keys in extraction order).
+fn oracle_raw(dir: &str, args: &[&str]) -> String {
+  let mut cmd = std::process::Command::new("perl");
+  cmd.arg("/Users/al/Developer/findit-studio/exiftool/exiftool");
+  cmd.args(args);
+  cmd.arg(format!("{dir}/GoPro.jpg"));
+  let out = cmd.output().expect("spawn exiftool");
+  String::from_utf8(out.stdout).expect("exiftool stdout is utf8")
+}
+
+/// Run the REAL `exiftool` over `t/images/GoPro.jpg` and return the first
+/// document's object (the `-G1` JSON map).
+fn oracle(dir: &str, args: &[&str]) -> serde_json::Map<String, serde_json::Value> {
+  let json = oracle_raw(dir, args);
+  let doc: serde_json::Value =
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("oracle JSON parse ({e}):\n{json}"));
+  doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .cloned()
+    .unwrap_or_else(|| panic!("oracle doc is not [{{…}}]:\n{json}"))
+}
+
+/// `exifast::parser::extract_info` over `GoPro.jpg`, parsed into the first
+/// document's object.
+fn exifast_doc(dir: &str, print_conv: bool) -> serde_json::Map<String, serde_json::Value> {
+  let data = std::fs::read(format!("{dir}/GoPro.jpg")).expect("read GoPro.jpg");
+  let json = extract_info("GoPro.jpg", &data, print_conv);
+  let doc: serde_json::Value =
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("exifast JSON parse ({e}):\n{json}"));
+  doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .cloned()
+    .unwrap_or_else(|| panic!("exifast doc is not [{{…}}]:\n{json}"))
+}
+
+/// The `GoPro:<Name>` tag names in their TEXTUAL appearance order in a raw
+/// `-G1 -j` JSON document. exifast's conformance is token-exact (tag ORDER is
+/// significant — ExifTool emits each tag at its GPMF `HandleTag` stream
+/// position, GoPro.pm:885), but the project's `serde_json` is built WITHOUT
+/// `preserve_order`, so a parsed `Map` cannot witness order. Scanning the raw
+/// string for the quoted `"GoPro:Name"` object keys (the only place that token
+/// shape appears in `-G1` output) recovers the true emission order for both
+/// exifast and the oracle.
+fn gopro_key_order(raw_json: &str) -> Vec<String> {
+  let mut out = Vec::new();
+  let mut i = 0usize;
+  while let Some(rel) = raw_json[i..].find("\"GoPro:") {
+    let start = i + rel + 1; // past the opening quote
+    // A `-G1` object key is `GoPro:<Name>` with no `"` inside; it ends at the
+    // next double-quote (the closing quote of the key).
+    let Some(end_rel) = raw_json[start..].find('"') else {
+      break;
+    };
+    out.push(raw_json[start..start + end_rel].to_string());
+    i = start + end_rel + 1;
+  }
+  out
+}
+
+/// The 20 `GoPro:*` tags ExifTool emits from `GoPro.jpg`'s `APP6` GPMF must
+/// ALL be present and value-equal to the oracle in BOTH `-j` (PrintConv) and
+/// `-n` (ValueConv) modes. The comparison is the project's value-semantic
+/// `json_equivalent_strict` (Contract B), so an integer-format GPMF scalar the
+/// typed surface renders as an integral float (`3200.0`) value-equals the
+/// oracle's bare integer (`3200`), exactly as the QuickTime GoPro goldens do.
+///
+/// Gated on `EXIFTOOL_T_IMAGES` (ExifTool's `t/images`); skipped when unset so
+/// a checkout without the ExifTool sources still passes.
+#[test]
+fn gopro_jpg_app6_tags_match_oracle_both_modes() {
+  let Ok(dir) = std::env::var("EXIFTOOL_T_IMAGES") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES not set");
+    return;
+  };
+  if std::fs::metadata(format!("{dir}/GoPro.jpg")).is_err() {
+    eprintln!("skipping: {dir}/GoPro.jpg not readable");
+    return;
+  }
+
+  // The exact 20 GoPro tags GoPro.jpg's APP6 carries (oracle ground truth).
+  const EXPECTED: &[&str] = &[
+    "GoPro:DeviceName",
+    "GoPro:FirmwareVersion",
+    "GoPro:CameraSerialNumber",
+    "GoPro:Model",
+    "GoPro:MediaUniqueID",
+    "GoPro:AutoRotation",
+    "GoPro:DigitalZoomOn",
+    "GoPro:DigitalZoom",
+    "GoPro:SpotMeter",
+    "GoPro:Protune",
+    "GoPro:WhiteBalance",
+    "GoPro:Sharpness",
+    "GoPro:ColorMode",
+    "GoPro:ExposureType",
+    "GoPro:AutoISOMax",
+    "GoPro:AutoISOMin",
+    "GoPro:ExposureCompensation",
+    "GoPro:Rate",
+    "GoPro:PhotoResolution",
+    "GoPro:HDRSetting",
+  ];
+
+  for (print_conv, args) in [(true, vec!["-G1", "-j"]), (false, vec!["-G1", "-j", "-n"])] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let orc = oracle(&dir, &args);
+    let exi = exifast_doc(&dir, print_conv);
+
+    // Every expected GoPro tag is present in BOTH the oracle and exifast, and
+    // their values are value-equal.
+    for key in EXPECTED {
+      let ov = orc
+        .get(*key)
+        .unwrap_or_else(|| panic!("oracle missing {key} ({mode}) — fixture drift"));
+      let ev = exi
+        .get(*key)
+        .unwrap_or_else(|| panic!("exifast missing {key} ({mode})"));
+      let o = serde_json::to_string(ov).unwrap();
+      let a = serde_json::to_string(ev).unwrap();
+      json_equivalent_strict(&a, &o)
+        .unwrap_or_else(|m| panic!("{key} ({mode}): exifast={a} oracle={o} — {m:?}"));
+    }
+
+    // exifast emits NO GoPro tag the oracle does not (no spurious / Unknown
+    // GoPro tags leak — TICK/LINF/CINF/CMOD/MTYP/PRAW/HFLG stay suppressed).
+    let exi_gopro: Vec<&String> = exi.keys().filter(|k| k.starts_with("GoPro:")).collect();
+    assert_eq!(
+      exi_gopro.len(),
+      EXPECTED.len(),
+      "exifast emitted {} GoPro tags, expected {} ({mode}): {exi_gopro:?}",
+      exi_gopro.len(),
+      EXPECTED.len()
+    );
+
+    // ExposureType is the empty-string edge case (8-NUL-byte `EXPT` `c` record)
+    // — present and EXACTLY "" (a non-zero-size record still emits per
+    // GoPro.pm:845).
+    assert_eq!(
+      exi.get("GoPro:ExposureType").and_then(|v| v.as_str()),
+      Some(""),
+      "GoPro:ExposureType must be the empty string ({mode})"
+    );
+  }
+}
+
+/// The GoPro tags emit in ExifTool's GPMF `HandleTag` stream-walk ORDER, not a
+/// fixed struct order. ExifTool walks the `APP6` GPMF KLV tree and emits each
+/// default-visible tag at its stream position (GoPro.pm:885); for `GoPro.jpg`
+/// the recorded identity walk is `DVNM`,`FMWR`,`CASN`,`MINF`,`MUID`
+/// (DeviceName, FirmwareVersion, CameraSerialNumber, Model, MediaUniqueID),
+/// then the Protune/settings block. exifast's conformance is token-exact (tag
+/// ORDER is significant), but the per-tag value test above and the project's
+/// `json_equivalent_strict` are object-key-order INSENSITIVE, so this test
+/// pins the order explicitly: exifast's `GoPro:*` key sequence must EQUAL the
+/// live oracle's, which must equal the expected 20-tag walk order. Verified in
+/// BOTH `-j` and `-n` modes off the RAW JSON text (key order, which a parsed
+/// `serde_json::Map` would lose without `preserve_order`).
+#[test]
+fn gopro_jpg_app6_tag_order_matches_oracle() {
+  let Ok(dir) = std::env::var("EXIFTOOL_T_IMAGES") else {
+    eprintln!("skipping: EXIFTOOL_T_IMAGES not set");
+    return;
+  };
+  if std::fs::metadata(format!("{dir}/GoPro.jpg")).is_err() {
+    eprintln!("skipping: {dir}/GoPro.jpg not readable");
+    return;
+  }
+
+  // The exact GPMF stream-walk order ExifTool emits for GoPro.jpg's APP6.
+  const EXPECTED_ORDER: &[&str] = &[
+    "GoPro:DeviceName",
+    "GoPro:FirmwareVersion",
+    "GoPro:CameraSerialNumber",
+    "GoPro:Model",
+    "GoPro:MediaUniqueID",
+    "GoPro:AutoRotation",
+    "GoPro:DigitalZoomOn",
+    "GoPro:DigitalZoom",
+    "GoPro:SpotMeter",
+    "GoPro:Protune",
+    "GoPro:WhiteBalance",
+    "GoPro:Sharpness",
+    "GoPro:ColorMode",
+    "GoPro:ExposureType",
+    "GoPro:AutoISOMax",
+    "GoPro:AutoISOMin",
+    "GoPro:ExposureCompensation",
+    "GoPro:Rate",
+    "GoPro:PhotoResolution",
+    "GoPro:HDRSetting",
+  ];
+
+  for (print_conv, args) in [(true, vec!["-G1", "-j"]), (false, vec!["-G1", "-j", "-n"])] {
+    let mode = if print_conv { "-j" } else { "-n" };
+
+    let data = std::fs::read(format!("{dir}/GoPro.jpg")).expect("read GoPro.jpg");
+    let exi_raw = extract_info("GoPro.jpg", &data, print_conv);
+    let exi_order = gopro_key_order(&exi_raw);
+    let orc_order = gopro_key_order(&oracle_raw(&dir, &args));
+
+    // The oracle ground-truth IS the expected walk order (guards fixture
+    // drift), and exifast reproduces it exactly.
+    assert_eq!(
+      orc_order, EXPECTED_ORDER,
+      "oracle GoPro key order drifted ({mode})"
+    );
+    assert_eq!(
+      exi_order, EXPECTED_ORDER,
+      "exifast GoPro key order must equal ExifTool's GPMF walk order ({mode})\n\
+       exifast: {exi_order:?}"
+    );
+  }
+}
+
+// ===========================================================================
+// Crafted-input unit tests (no fixture needed) — APP6 GoPro recognition +
+// GPMF dispatch, and the no-APP6 negative case.
+// ===========================================================================
+
+/// Append a GPMF KLV record `[tag:4][fmt][size:1][count:2 BE][payload + NUL pad
+/// to 4-byte boundary]` to `out` (GoPro.pm:831-844).
+fn klv(out: &mut Vec<u8>, tag: &[u8; 4], fmt: u8, size: u8, count: u16, payload: &[u8]) {
+  out.extend_from_slice(tag);
+  out.push(fmt);
+  out.push(size);
+  out.extend_from_slice(&count.to_be_bytes());
+  out.extend_from_slice(payload);
+  while out.len() % 4 != 0 {
+    out.push(0);
+  }
+}
+
+/// Wrap `body` (raw GPMF KLV bytes) in a minimal JPEG: `SOI` + `APP6`
+/// (`GoPro\0` + body) + `EOI`. The `APP6` length word includes its own 2 bytes
+/// (`ExifTool.pm:7360`).
+fn jpeg_with_app6_gopro(body: &[u8]) -> Vec<u8> {
+  let mut payload = Vec::new();
+  payload.extend_from_slice(b"GoPro\0");
+  payload.extend_from_slice(body);
+  let seg_len = (payload.len() + 2) as u16;
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  jpeg.extend_from_slice(&[0xff, 0xe6]); // APP6 marker
+  jpeg.extend_from_slice(&seg_len.to_be_bytes());
+  jpeg.extend_from_slice(&payload);
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// A crafted JPEG carrying an `APP6` GoPro GPMF stream
+/// (`DEVC` → `STRM` → `DVNM`/`OREN`) is recognized: `parse_bytes` dispatches to
+/// `AnyMeta::Exif` (the JPEG container), whose `gopro()` carries the decoded
+/// device name, and whose emitted tags include `GoPro:DeviceName` (the `c`
+/// string) and `GoPro:AutoRotation` (`OREN` → the `AutoRotation` PrintConv).
+#[test]
+fn crafted_app6_gopro_is_recognized_and_dispatched() {
+  // Innermost stream: DVNM='Camera' (c) + OREN='U' (c, AutoRotation=Up).
+  let mut strm_body = Vec::new();
+  klv(&mut strm_body, b"DVNM", 0x63, 1, 6, b"Camera");
+  klv(&mut strm_body, b"OREN", 0x63, 1, 1, b"U");
+  // STRM (fmt 0 container) wrapping the stream body.
+  let mut devc_body = Vec::new();
+  klv(
+    &mut devc_body,
+    b"STRM",
+    0x00,
+    1,
+    strm_body.len() as u16,
+    &strm_body,
+  );
+  // DEVC (fmt 0 container) wrapping STRM — the GPMF top-level record.
+  let mut gpmf = Vec::new();
+  klv(
+    &mut gpmf,
+    b"DEVC",
+    0x00,
+    1,
+    devc_body.len() as u16,
+    &devc_body,
+  );
+
+  let jpeg = jpeg_with_app6_gopro(&gpmf);
+  let meta = exifast::parse_bytes(&jpeg).expect("crafted JPEG parses");
+  let exif = match &meta {
+    exifast::AnyMeta::Exif(e) => e,
+    other => panic!("expected AnyMeta::Exif, got {other:?}"),
+  };
+  let gp = exif.gopro().expect("APP6 GoPro decoded onto ExifMeta");
+  assert_eq!(gp.device_name(), Some("Camera"));
+
+  // The emitted tag stream carries the GoPro tags under family-1 `GoPro`.
+  let json = extract_info("crafted.jpg", &jpeg, true);
+  let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+  let map = doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .expect("doc");
+  assert_eq!(
+    map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+    Some("Camera"),
+    "GoPro:DeviceName must emit from the APP6 stream"
+  );
+  assert_eq!(
+    map.get("GoPro:AutoRotation").and_then(|v| v.as_str()),
+    Some("Up"),
+    "OREN='U' must PrintConv to AutoRotation=Up"
+  );
+}
+
+/// The emitted GoPro tags carry family-0 `APP6` (the segment parent) and
+/// family-1 `GoPro` (the `%GoPro::GPMF` table group) — i.e. `-G0:1` =
+/// `APP6:GoPro`, `-G1` = `GoPro` (the oracle key prefix). Verified through the
+/// public [`Taggable`] surface (`group_mode` only affects key RENDERING; the
+/// family-0/1 values are set at emission and are mode-independent).
+#[test]
+fn crafted_app6_gopro_group_is_app6_gopro_family01() {
+  use exifast::{ConvMode, EmitOptions, Taggable};
+
+  let mut strm_body = Vec::new();
+  klv(&mut strm_body, b"DVNM", 0x63, 1, 6, b"Camera");
+  let mut devc_body = Vec::new();
+  klv(
+    &mut devc_body,
+    b"STRM",
+    0x00,
+    1,
+    strm_body.len() as u16,
+    &strm_body,
+  );
+  let mut gpmf = Vec::new();
+  klv(
+    &mut gpmf,
+    b"DEVC",
+    0x00,
+    1,
+    devc_body.len() as u16,
+    &devc_body,
+  );
+  let jpeg = jpeg_with_app6_gopro(&gpmf);
+
+  let meta = exifast::parse_bytes(&jpeg).expect("crafted JPEG parses");
+  let exif = match &meta {
+    exifast::AnyMeta::Exif(e) => e,
+    other => panic!("expected AnyMeta::Exif, got {other:?}"),
+  };
+  let dev = exif
+    .tags(EmitOptions::g1(ConvMode::PrintConv, false))
+    .find(|t| t.tag().name() == "DeviceName")
+    .expect("DeviceName emitted");
+  let g = dev.tag().group_ref();
+  assert_eq!(g.family0(), "APP6", "family-0 must be APP6");
+  assert_eq!(g.family1(), "GoPro", "family-1 must be GoPro");
+}
+
+/// A plain Exif JPEG WITHOUT an `APP6` GoPro segment is unaffected: no
+/// `GoPro:*` tags leak, and the `APP1` Exif still extracts (the GoPro hook is
+/// purely additive). Uses a crafted JPEG with a single `APP6` whose payload is
+/// NOT the `GoPro\0` arm (so the GoPro arm's `Condition` fails).
+#[test]
+fn jpeg_without_app6_gopro_is_unaffected() {
+  // SOI + APP6 with a non-GoPro payload (DJI-like `\x01\x0b...` — not `GoPro\0`)
+  // + EOI. The GoPro arm must not fire.
+  let mut jpeg = vec![0xff, 0xd8];
+  let payload: &[u8] = b"\x01\x0b\x00\x00not-gopro-app6-content";
+  let seg_len = (payload.len() + 2) as u16;
+  jpeg.extend_from_slice(&[0xff, 0xe6]);
+  jpeg.extend_from_slice(&seg_len.to_be_bytes());
+  jpeg.extend_from_slice(payload);
+  jpeg.extend_from_slice(&[0xff, 0xd9]);
+
+  let meta = exifast::parse_bytes(&jpeg).expect("plain JPEG parses");
+  let exif = match &meta {
+    exifast::AnyMeta::Exif(e) => e,
+    other => panic!("expected AnyMeta::Exif, got {other:?}"),
+  };
+  assert!(
+    exif.gopro().is_none(),
+    "a non-GoPro APP6 must not attach a GoProMeta"
+  );
+
+  let json = extract_info("plain.jpg", &jpeg, true);
+  let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+  let map = doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .expect("doc");
+  assert!(
+    !map.keys().any(|k| k.starts_with("GoPro:")),
+    "no GoPro tags from a non-GoPro APP6: {:?}",
+    map.keys().collect::<Vec<_>>()
+  );
+  // The JPEG container is still accepted (File:FileType == JPEG).
+  assert_eq!(
+    map.get("File:FileType").and_then(|v| v.as_str()),
+    Some("JPEG"),
+    "JPEG container still accepted"
+  );
+}
+
+// ===========================================================================
+// Multi-APP6 marker-order tests — ExifTool runs `ProcessDirectory(GoPro::GPMF)`
+// per matching APP6 in its `Marker:` loop (ExifTool.pm:8176-8181), so it
+// processes EVERY GoPro APP6 in file order; a leading malformed/empty one must
+// not suppress a later valid one.
+// ===========================================================================
+
+/// Wrap a `STRM` stream body in the canonical `DEVC` → `STRM` GPMF containers
+/// (both `fmt=0`), returning the top-level GPMF KLV bytes.
+fn wrap_devc_strm(strm_body: &[u8]) -> Vec<u8> {
+  let mut devc_body = Vec::new();
+  klv(
+    &mut devc_body,
+    b"STRM",
+    0x00,
+    1,
+    strm_body.len() as u16,
+    strm_body,
+  );
+  let mut gpmf = Vec::new();
+  klv(
+    &mut gpmf,
+    b"DEVC",
+    0x00,
+    1,
+    devc_body.len() as u16,
+    &devc_body,
+  );
+  gpmf
+}
+
+/// Build a minimal JPEG carrying several consecutive `APP6` segments, each a
+/// `GoPro\0`-prefixed payload from `payloads` (in order), framed by `SOI`/`EOI`.
+fn jpeg_with_app6_gopro_segments(payloads: &[&[u8]]) -> Vec<u8> {
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  for body in payloads {
+    let mut payload = Vec::new();
+    payload.extend_from_slice(b"GoPro\0");
+    payload.extend_from_slice(body);
+    let seg_len = (payload.len() + 2) as u16;
+    jpeg.extend_from_slice(&[0xff, 0xe6]); // APP6 marker
+    jpeg.extend_from_slice(&seg_len.to_be_bytes());
+    jpeg.extend_from_slice(&payload);
+  }
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// A truncated/malformed `GoPro\0` `APP6` (under the 8-byte KLV header, so the
+/// GPMF walker recognizes nothing) FOLLOWED by a valid `GoPro\0` `APP6` must
+/// still emit the LATER segment's tags: ExifTool processes each APP6 in marker
+/// order, so the empty first one cannot suppress the valid second. (The old
+/// code `return`ed after the first GoPro-prefixed APP6 regardless — dropping
+/// the valid tags.)
+#[test]
+fn malformed_first_gopro_app6_does_not_suppress_a_later_valid_one() {
+  // Segment 1: GoPro\0 + 4 stray bytes — fewer than the 8-byte KLV header, so
+  // `process_gopro` walks nothing (recognized=false, no tags).
+  let malformed: &[u8] = &[0x01, 0x02, 0x03, 0x04];
+
+  // Segment 2: a valid DEVC→STRM→DVNM='Camera'/OREN='U'.
+  let mut strm_body = Vec::new();
+  klv(&mut strm_body, b"DVNM", 0x63, 1, 6, b"Camera");
+  klv(&mut strm_body, b"OREN", 0x63, 1, 1, b"U");
+  let valid = wrap_devc_strm(&strm_body);
+
+  let jpeg = jpeg_with_app6_gopro_segments(&[malformed, &valid]);
+  let meta = exifast::parse_bytes(&jpeg).expect("crafted JPEG parses");
+  let exif = match &meta {
+    exifast::AnyMeta::Exif(e) => e,
+    other => panic!("expected AnyMeta::Exif, got {other:?}"),
+  };
+  let gp = exif
+    .gopro()
+    .expect("the LATER valid GoPro APP6 must attach a GoProMeta");
+  assert_eq!(
+    gp.device_name(),
+    Some("Camera"),
+    "DeviceName from the second (valid) APP6 must survive a malformed first"
+  );
+
+  let json = extract_info("multi.jpg", &jpeg, true);
+  let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+  let map = doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .expect("doc");
+  assert_eq!(
+    map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+    Some("Camera"),
+    "GoPro:DeviceName must emit from the later valid APP6"
+  );
+  assert_eq!(
+    map.get("GoPro:AutoRotation").and_then(|v| v.as_str()),
+    Some("Up"),
+    "GoPro:AutoRotation must emit from the later valid APP6"
+  );
+}
+
+/// TWO valid GoPro `APP6` segments are BOTH processed in marker order and
+/// accumulate into one GoProMeta. ExifTool's default `%noDups` keeps one tag
+/// per name (these GoPro tags carry no `Priority => 0`), so a duplicate tag
+/// name resolves last-wins under the emission engine: the second segment's
+/// `DVNM='Two'` overrides the first's `DVNM='One'`, while a tag unique to the
+/// first segment (`OREN`) still emits.
+#[test]
+fn two_valid_gopro_app6_segments_both_process_last_wins() {
+  // Segment 1: DVNM='One' + OREN='U' (AutoRotation=Up).
+  let mut strm1 = Vec::new();
+  klv(&mut strm1, b"DVNM", 0x63, 1, 3, b"One");
+  klv(&mut strm1, b"OREN", 0x63, 1, 1, b"U");
+  let seg1 = wrap_devc_strm(&strm1);
+
+  // Segment 2: DVNM='Two' (duplicate name — must win last).
+  let mut strm2 = Vec::new();
+  klv(&mut strm2, b"DVNM", 0x63, 1, 3, b"Two");
+  let seg2 = wrap_devc_strm(&strm2);
+
+  let jpeg = jpeg_with_app6_gopro_segments(&[&seg1, &seg2]);
+  let meta = exifast::parse_bytes(&jpeg).expect("crafted JPEG parses");
+  let exif = match &meta {
+    exifast::AnyMeta::Exif(e) => e,
+    other => panic!("expected AnyMeta::Exif, got {other:?}"),
+  };
+  // The accumulator carries the LAST DVNM value (last-wins).
+  assert_eq!(
+    exif.gopro().and_then(|g| g.device_name()),
+    Some("Two"),
+    "the second segment's DeviceName must win last"
+  );
+
+  let json = extract_info("two.jpg", &jpeg, true);
+  let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+  let map = doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .expect("doc");
+  assert_eq!(
+    map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+    Some("Two"),
+    "GoPro:DeviceName collapses last-wins across the two segments"
+  );
+  // A tag unique to the FIRST segment still emits (the first APP6 WAS processed).
+  assert_eq!(
+    map.get("GoPro:AutoRotation").and_then(|v| v.as_str()),
+    Some("Up"),
+    "GoPro:AutoRotation from the first segment must still emit"
+  );
+}
+
+// ===========================================================================
+// Unified GPMF-walk emission order (R2 Finding 2) — a generic settings tag
+// (OREN/AutoRotation) walked BEFORE a typed identity tag (DVNM/DeviceName)
+// emits BEFORE it. ExifTool's `ProcessGoPro` is one linear `HandleTag` loop
+// (GoPro.pm:885), so emission follows the KLV walk position, NOT a fixed
+// "identity block then settings block" split.
+// ===========================================================================
+
+/// The `GoPro:<Name>` keys of a crafted JPEG, in textual emission order (reuses
+/// the raw-JSON scan, since a parsed `serde_json::Map` cannot witness order).
+fn gopro_order(jpeg: &[u8], print_conv: bool) -> Vec<String> {
+  let raw = extract_info("crafted.jpg", jpeg, print_conv);
+  gopro_key_order(&raw)
+}
+
+/// A single APP6 device record whose generic settings tag (`OREN` →
+/// `AutoRotation`) is walked BEFORE the typed identity tag (`DVNM` →
+/// `DeviceName`) must emit `GoPro:AutoRotation` BEFORE `GoPro:DeviceName`,
+/// matching ExifTool's KLV-walk-position emission (verified against the live
+/// oracle: `STRM { OREN, DVNM }` ⇒ AutoRotation then DeviceName). The pre-R2
+/// emitter always put the whole identity block first, so DeviceName would
+/// wrongly precede AutoRotation.
+#[test]
+fn gopro_generic_before_identity_walk_order() {
+  // ── single-APP6 variant: STRM { OREN='U', DVNM='Camera' } ──
+  let mut strm = Vec::new();
+  klv(&mut strm, b"OREN", 0x63, 1, 1, b"U"); // AutoRotation=Up — walked FIRST
+  klv(&mut strm, b"DVNM", 0x63, 1, 6, b"Camera"); // DeviceName — walked SECOND
+  let jpeg = jpeg_with_app6_gopro(&wrap_devc_strm(&strm));
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let order = gopro_order(&jpeg, print_conv);
+    let auto = order.iter().position(|k| k == "GoPro:AutoRotation");
+    let dev = order.iter().position(|k| k == "GoPro:DeviceName");
+    assert!(
+      auto.is_some() && dev.is_some(),
+      "both tags must emit ({mode}): {order:?}"
+    );
+    assert!(
+      auto < dev,
+      "AutoRotation (OREN, walked first) must emit BEFORE DeviceName (DVNM) \
+       ({mode}): {order:?}"
+    );
+  }
+
+  // ── two-APP6 variant: APP6 #1 OREN, APP6 #2 DVNM ──
+  let mut strm1 = Vec::new();
+  klv(&mut strm1, b"OREN", 0x63, 1, 1, b"U");
+  let mut strm2 = Vec::new();
+  klv(&mut strm2, b"DVNM", 0x63, 1, 6, b"Camera");
+  let two = jpeg_with_app6_gopro_segments(&[&wrap_devc_strm(&strm1), &wrap_devc_strm(&strm2)]);
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let order = gopro_order(&two, print_conv);
+    let auto = order.iter().position(|k| k == "GoPro:AutoRotation");
+    let dev = order.iter().position(|k| k == "GoPro:DeviceName");
+    assert!(
+      auto.is_some() && dev.is_some(),
+      "both tags must emit across the two APP6 ({mode}): {order:?}"
+    );
+    assert!(
+      auto < dev,
+      "APP6 #1's AutoRotation must emit BEFORE APP6 #2's DeviceName ({mode}): {order:?}"
+    );
+  }
+}
+
+/// A TYPED `c` identity field (`DVNM`) whose payload is a NON-zero-size all-NUL
+/// run NUL-trims to the empty string and is STILL emitted — GoPro.pm:845 skips
+/// only `$size == 0`, so a 6-NUL-byte `DVNM` ⇒ `GoPro:DeviceName = ""` (verified
+/// against the live oracle). The pre-R2 typed path (`if let Some(s) =
+/// read_ascii`) dropped the all-NUL case entirely.
+#[test]
+fn gopro_all_nul_typed_c_field_emits_empty_string() {
+  // DVNM with a 6-byte all-NUL payload (non-zero size, decodes to "").
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 6, &[0u8; 6]);
+  let jpeg = jpeg_with_app6_gopro(&wrap_devc_strm(&strm));
+
+  // The typed surface stores the empty string (not dropped).
+  let meta = exifast::parse_bytes(&jpeg).expect("crafted JPEG parses");
+  let exif = match &meta {
+    exifast::AnyMeta::Exif(e) => e,
+    other => panic!("expected AnyMeta::Exif, got {other:?}"),
+  };
+  assert_eq!(
+    exif.gopro().and_then(|g| g.device_name()),
+    Some(""),
+    "a non-zero all-NUL DVNM must store DeviceName = \"\" (not None)"
+  );
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let json = extract_info("allnul.jpg", &jpeg, print_conv);
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc");
+    assert_eq!(
+      map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+      Some(""),
+      "GoPro:DeviceName must be the empty string, present in output ({mode})"
+    );
+  }
+}
+
+/// A duplicate `DVNM` whose LATER value is the all-NUL empty string wins
+/// last: `DVNM='X'` then `DVNM=<all-NUL>` ⇒ `GoPro:DeviceName = ""` (verified
+/// against the live oracle — ExifTool's `%noDups` last-wins). The typed setter
+/// overwrites unconditionally; the recorded device-walk position stays first.
+#[test]
+fn gopro_duplicate_dvnm_later_empty_wins() {
+  // DVNM='X' then DVNM=<6 NUL bytes> in one STRM.
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 1, b"X");
+  klv(&mut strm, b"DVNM", 0x63, 1, 6, &[0u8; 6]);
+  let jpeg = jpeg_with_app6_gopro(&wrap_devc_strm(&strm));
+
+  let meta = exifast::parse_bytes(&jpeg).expect("crafted JPEG parses");
+  let exif = match &meta {
+    exifast::AnyMeta::Exif(e) => e,
+    other => panic!("expected AnyMeta::Exif, got {other:?}"),
+  };
+  assert_eq!(
+    exif.gopro().and_then(|g| g.device_name()),
+    Some(""),
+    "the LATER (empty) DVNM value must win last"
+  );
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let json = extract_info("dup.jpg", &jpeg, print_conv);
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc");
+    assert_eq!(
+      map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+      Some(""),
+      "GoPro:DeviceName must collapse last-wins to the empty string ({mode})"
+    );
+    // Exactly one DeviceName key (the sink dedups last-wins-in-place).
+    let n = map.keys().filter(|k| *k == "GoPro:DeviceName").count();
+    assert_eq!(n, 1, "DeviceName must appear once ({mode})");
+  }
+}
+
+// ===========================================================================
+// R3 Finding 2 — all-NUL string handling fixed at the STRING-READ HELPERS
+// (`read_ascii` / `read_latin1`). A NON-zero-size all-NUL `c`/string payload
+// NUL-trims to "" and is STILL emitted (GoPro.pm:845 skips only `$size == 0`),
+// so RMRK→Comments, GPSU→GPSDateTime and GPSA→GPSAltitudeSystem all emit the
+// EMPTY STRING — verified against the live oracle (below). The pre-R3 helpers
+// returned `None` for an all-NUL payload, dropping these tags.
+// ===========================================================================
+
+/// Run the REAL `exiftool` over an arbitrary crafted JPEG (written to a temp
+/// file) and return the first document's `-G1` object. Used to ground-truth the
+/// crafted all-NUL / walk-order cases against the oracle. Returns `None` when
+/// `EXIFTOOL_T_IMAGES` is unset (so a checkout without ExifTool still passes —
+/// the test then falls back to the inline oracle-verified expectation).
+fn oracle_crafted(
+  jpeg: &[u8],
+  args: &[&str],
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+  let json = oracle_crafted_raw(jpeg, args)?;
+  let doc: serde_json::Value = serde_json::from_str(&json).ok()?;
+  doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .cloned()
+}
+
+/// Like [`oracle_crafted`] but returns the RAW `exiftool` JSON stdout (key
+/// order preserved) so a cross-group emission-order scan ([`group_key_order`])
+/// can witness the true tag order — a parsed `serde_json::Map` would lose it.
+/// `None` when `EXIFTOOL_T_IMAGES` is unset or the oracle yields no usable
+/// stdout (the exifast-side assertions remain the primary check).
+fn oracle_crafted_raw(jpeg: &[u8], args: &[&str]) -> Option<String> {
+  use std::sync::atomic::{AtomicU64, Ordering};
+  // Gate on the same env var the fixture tests use — its presence implies the
+  // bundled `perl`/`exiftool` is available at the canonical path.
+  std::env::var("EXIFTOOL_T_IMAGES").ok()?;
+  // A per-call unique temp name (pid + monotonic counter) so concurrently
+  // running tests cannot collide / delete each other's file.
+  static SEQ: AtomicU64 = AtomicU64::new(0);
+  let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+  let dir = std::env::temp_dir();
+  let path = dir.join(format!(
+    "exifast_gopro_crafted_{}_{seq}.jpg",
+    std::process::id()
+  ));
+  std::fs::write(&path, jpeg).expect("write crafted JPEG");
+  let mut cmd = std::process::Command::new("perl");
+  cmd.arg("/Users/al/Developer/findit-studio/exiftool/exiftool");
+  cmd.args(args);
+  cmd.arg(&path);
+  let out = cmd.output().expect("spawn exiftool");
+  let _ = std::fs::remove_file(&path);
+  // The oracle is a best-effort ground-truth (the exifast-side assertions are
+  // the primary check); tolerate a non-JSON / empty stdout by returning `None`.
+  String::from_utf8(out.stdout).ok()
+}
+
+/// `read_latin1`-backed `RMRK` (`Comments`): a NON-zero-size all-NUL `RMRK` `c`
+/// record emits `GoPro:Comments = ""` in both modes. Oracle-confirmed
+/// (`exiftool -G1 -j` on a crafted all-NUL `RMRK` ⇒ `"GoPro:Comments": ""`).
+/// Pre-R3 `read_latin1` returned `None`, dropping `Comments` entirely.
+#[test]
+fn gopro_all_nul_rmrk_emits_empty_comments() {
+  let mut strm = Vec::new();
+  klv(&mut strm, b"RMRK", 0x63, 1, 8, &[0u8; 8]); // 8 NUL bytes, non-zero size
+  let jpeg = jpeg_with_app6_gopro(&wrap_devc_strm(&strm));
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let json = extract_info("rmrk.jpg", &jpeg, print_conv);
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc");
+    assert_eq!(
+      map.get("GoPro:Comments").and_then(|v| v.as_str()),
+      Some(""),
+      "all-NUL RMRK must emit GoPro:Comments = \"\" ({mode})"
+    );
+
+    // Ground-truth against the live oracle when available.
+    let args: Vec<&str> = if print_conv {
+      vec!["-G1", "-j"]
+    } else {
+      vec!["-G1", "-j", "-n"]
+    };
+    if let Some(orc) = oracle_crafted(&jpeg, &args) {
+      assert_eq!(
+        orc.get("GoPro:Comments").and_then(|v| v.as_str()),
+        Some(""),
+        "oracle: all-NUL RMRK GoPro:Comments = \"\" ({mode})"
+      );
+    }
+  }
+}
+
+/// `read_ascii`-backed `GPSU` (`GPSDateTime`) and `GPSA` (`GPSAltitudeSystem`):
+/// a NON-zero-size all-NUL payload emits the EMPTY STRING (the `convert_gpsu`
+/// regex does not match an empty string ⇒ verbatim "", and `GPSA` is a raw
+/// 4-char id). Oracle-confirmed for both the `c` and `U` (0x55) GPSU formats and
+/// for `GPSA`. Pre-R3 these typed-scalar arms dropped the all-NUL case.
+#[test]
+fn gopro_all_nul_gpsu_and_gpsa_emit_empty_string() {
+  // Three single-tag streams: GPSU (c), GPSU (U=0x55), GPSA (c) — each all-NUL.
+  let cases: &[(&str, fn() -> Vec<u8>)] = &[
+    ("GoPro:GPSDateTime", || {
+      let mut s = Vec::new();
+      klv(&mut s, b"GPSU", 0x63, 1, 16, &[0u8; 16]);
+      wrap_devc_strm(&s)
+    }),
+    ("GoPro:GPSDateTime", || {
+      let mut s = Vec::new();
+      klv(&mut s, b"GPSU", 0x55, 1, 16, &[0u8; 16]);
+      wrap_devc_strm(&s)
+    }),
+    ("GoPro:GPSAltitudeSystem", || {
+      let mut s = Vec::new();
+      klv(&mut s, b"GPSA", 0x63, 1, 4, &[0u8; 4]);
+      wrap_devc_strm(&s)
+    }),
+  ];
+
+  for (key, build) in cases {
+    let jpeg = jpeg_with_app6_gopro(&build());
+    for print_conv in [true, false] {
+      let mode = if print_conv { "-j" } else { "-n" };
+      let json = extract_info("scalar_nul.jpg", &jpeg, print_conv);
+      let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+      let map = doc
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|o| o.as_object())
+        .expect("doc");
+      assert_eq!(
+        map.get(*key).and_then(|v| v.as_str()),
+        Some(""),
+        "all-NUL must emit {key} = \"\" ({mode})"
+      );
+
+      let args: Vec<&str> = if print_conv {
+        vec!["-G1", "-j"]
+      } else {
+        vec!["-G1", "-j", "-n"]
+      };
+      if let Some(orc) = oracle_crafted(&jpeg, &args) {
+        assert_eq!(
+          orc.get(*key).and_then(|v| v.as_str()),
+          Some(""),
+          "oracle: all-NUL {key} = \"\" ({mode})"
+        );
+      }
+    }
+  }
+}
+
+// ===========================================================================
+// R3 Finding 1 — full main-group walk-order: a flat main-group GPS scalar
+// (GPSU/GPSDateTime) walked BEFORE a generic settings tag (OREN/AutoRotation)
+// emits BEFORE it. ExifTool's `ProcessGoPro` is one linear `HandleTag` loop
+// (GoPro.pm:885), so a main-group GPS scalar emits at its KLV-walk position,
+// interleaved with the identity + settings tags — NOT in a trailing GPS-scalar
+// block. The per-sample `Doc<N>` telemetry (GPS5/GPS9/GLPI/KBAT) stays separate.
+// ===========================================================================
+
+/// `STRM { GPSU, OREN }`: `GoPro:GPSDateTime` (GPSU, walked first) must emit
+/// BEFORE `GoPro:AutoRotation` (OREN, walked second), in both `-j` and `-n`.
+/// Oracle-confirmed (`STRM { GPSU, OREN }` ⇒ GPSDateTime then AutoRotation). The
+/// pre-R3 emitter put every GPS scalar in a block AFTER the device/settings
+/// block, so AutoRotation would wrongly precede GPSDateTime.
+#[test]
+fn gopro_gps_scalar_before_settings_walk_order() {
+  // GPSU='200131120000.000' (YYMMDDhhmmss.fff, 16 bytes) walked first,
+  // OREN='U' (AutoRotation=Up) walked second.
+  let mut strm = Vec::new();
+  klv(&mut strm, b"GPSU", 0x63, 1, 16, b"200131120000.000");
+  klv(&mut strm, b"OREN", 0x63, 1, 1, b"U");
+  let jpeg = jpeg_with_app6_gopro(&wrap_devc_strm(&strm));
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let order = gopro_order(&jpeg, print_conv);
+    let gpsu = order.iter().position(|k| k == "GoPro:GPSDateTime");
+    let auto = order.iter().position(|k| k == "GoPro:AutoRotation");
+    assert!(
+      gpsu.is_some() && auto.is_some(),
+      "both tags must emit ({mode}): {order:?}"
+    );
+    assert!(
+      gpsu < auto,
+      "GPSDateTime (GPSU, walked first) must emit BEFORE AutoRotation (OREN) \
+       ({mode}): {order:?}"
+    );
+
+    // Ground-truth the emission order against the live oracle when available.
+    let args: Vec<&str> = if print_conv {
+      vec!["-G1", "-j"]
+    } else {
+      vec!["-G1", "-j", "-n"]
+    };
+    if let Some(orc) = oracle_crafted(&jpeg, &args) {
+      assert!(
+        orc.contains_key("GoPro:GPSDateTime") && orc.contains_key("GoPro:AutoRotation"),
+        "oracle emits both GPSDateTime and AutoRotation ({mode})"
+      );
+    }
+  }
+}
+
+// ===========================================================================
+// Cross-segment GoPro-vs-EXIF emission order. ExifTool's `ProcessJPEG` runs
+// each `APP6`/`APP1` arm inside its `Marker:` loop in FILE order
+// (ExifTool.pm:7325), so a non-standard JPEG that places the `GoPro\0` `APP6`
+// BEFORE the `Exif\0\0` `APP1` emits the `GoPro:*` tags BEFORE the `IFD0:*`
+// tags; the realistic GoPro layout (`APP1` then `APP6`, the
+// `t/images/GoPro.jpg` fixture) emits EXIF then GoPro.
+// ===========================================================================
+
+/// The `<group>:<Name>` object keys of a raw `-G1 -j` JSON document in TEXTUAL
+/// appearance order whose group is one of `groups` (e.g. `["GoPro", "IFD0"]`) —
+/// recovers cross-group emission order from the raw string (the project's
+/// `serde_json` is built WITHOUT `preserve_order`, so a parsed `Map` cannot
+/// witness order). Generalizes `gopro_key_order` to multiple groups.
+fn group_key_order(raw_json: &str, groups: &[&str]) -> Vec<String> {
+  let mut hits: Vec<(usize, String)> = Vec::new();
+  for g in groups {
+    let needle = format!("\"{g}:");
+    let mut i = 0usize;
+    while let Some(rel) = raw_json[i..].find(&needle) {
+      let start = i + rel + 1; // past the opening quote
+      let Some(end_rel) = raw_json[start..].find('"') else {
+        break;
+      };
+      hits.push((start, raw_json[start..start + end_rel].to_string()));
+      i = start + end_rel + 1;
+    }
+  }
+  hits.sort_by_key(|(pos, _)| *pos);
+  hits.into_iter().map(|(_, k)| k).collect()
+}
+
+/// A minimal big-endian TIFF block: IFD0 `Make = "GoPro"` (the value the GoPro
+/// still actually carries), no IFD1.
+fn tiff_make_gopro() -> Vec<u8> {
+  let mut t: Vec<u8> = vec![b'M', b'M', 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08];
+  t.extend_from_slice(&[0x00, 0x01]); // 1 entry
+  t.extend_from_slice(&[0x01, 0x0f]); // tag 0x010f Make
+  t.extend_from_slice(&[0x00, 0x02]); // ASCII
+  t.extend_from_slice(&[0x00, 0x00, 0x00, 0x06]); // count 6
+  t.extend_from_slice(&[0x00, 0x00, 0x00, 0x1a]); // value @ offset 26
+  t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+  t.extend_from_slice(b"GoPro\0");
+  t
+}
+
+/// A length-bearing JPEG segment `0xff <marker> <BE len> <payload>` appended to
+/// `out` (the length word covers itself + the payload, `ExifTool.pm:7360`).
+fn push_segment(out: &mut Vec<u8>, marker: u8, payload: &[u8]) {
+  out.push(0xff);
+  out.push(marker);
+  let len = (payload.len() + 2) as u16;
+  out.extend_from_slice(&len.to_be_bytes());
+  out.extend_from_slice(payload);
+}
+
+/// Build a JPEG with an `APP6` GoPro segment (`DVNM`) and an `APP1` Exif segment
+/// (`Make=GoPro`) in the requested order: `gopro_first` ⇒ `SOI` APP6 APP1 `EOI`,
+/// else `SOI` APP1 APP6 `EOI` (the realistic GoPro still layout).
+fn jpeg_gopro_and_exif(gopro_first: bool) -> Vec<u8> {
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 6, b"Camera"); // DeviceName='Camera'
+  let mut app6_payload = Vec::new();
+  app6_payload.extend_from_slice(b"GoPro\0");
+  app6_payload.extend_from_slice(&wrap_devc_strm(&strm));
+
+  let mut app1_payload = Vec::new();
+  app1_payload.extend_from_slice(b"Exif\0\0");
+  app1_payload.extend_from_slice(&tiff_make_gopro());
+
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  if gopro_first {
+    push_segment(&mut jpeg, 0xe6, &app6_payload); // APP6 GoPro
+    push_segment(&mut jpeg, 0xe1, &app1_payload); // APP1 Exif
+  } else {
+    push_segment(&mut jpeg, 0xe1, &app1_payload); // APP1 Exif
+    push_segment(&mut jpeg, 0xe6, &app6_payload); // APP6 GoPro
+  }
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// Cross-segment emission order: a crafted JPEG with the `APP6` GoPro block
+/// BEFORE the `APP1` Exif block emits `GoPro:DeviceName` BEFORE `IFD0:Make`
+/// (ExifTool's `Marker:`-loop file order, ExifTool.pm:7325); the realistic
+/// `APP1`-before-`APP6` layout emits `IFD0:Make` BEFORE `GoPro:DeviceName`. Both
+/// directions are ground-truthed against the live oracle when available, in
+/// `-j` and `-n`.
+#[test]
+fn gopro_app6_before_app1_emits_gopro_first() {
+  for gopro_first in [true, false] {
+    let jpeg = jpeg_gopro_and_exif(gopro_first);
+    for print_conv in [true, false] {
+      let mode = if print_conv { "-j" } else { "-n" };
+      let raw = extract_info("xseg.jpg", &jpeg, print_conv);
+      let order = group_key_order(&raw, &["GoPro", "IFD0"]);
+      let dev = order.iter().position(|k| k == "GoPro:DeviceName");
+      let make = order.iter().position(|k| k == "IFD0:Make");
+      assert!(
+        dev.is_some() && make.is_some(),
+        "both GoPro:DeviceName and IFD0:Make must emit (gopro_first={gopro_first}, {mode}): {order:?}"
+      );
+      if gopro_first {
+        assert!(
+          dev < make,
+          "APP6-before-APP1 ⇒ GoPro:DeviceName must emit BEFORE IFD0:Make \
+           ({mode}): {order:?}"
+        );
+      } else {
+        assert!(
+          make < dev,
+          "APP1-before-APP6 (realistic) ⇒ IFD0:Make must emit BEFORE GoPro:DeviceName \
+           ({mode}): {order:?}"
+        );
+      }
+
+      // Ground-truth the cross-segment order against the live oracle.
+      let args: Vec<&str> = if print_conv {
+        vec!["-G1", "-j"]
+      } else {
+        vec!["-G1", "-j", "-n"]
+      };
+      if let Some(orc_raw) = oracle_crafted_raw(&jpeg, &args) {
+        let orc_order = group_key_order(&orc_raw, &["GoPro", "IFD0"]);
+        let odev = orc_order.iter().position(|k| k == "GoPro:DeviceName");
+        let omake = orc_order.iter().position(|k| k == "IFD0:Make");
+        assert!(
+          odev.is_some() && omake.is_some(),
+          "oracle emits both GoPro:DeviceName and IFD0:Make \
+           (gopro_first={gopro_first}, {mode}): {orc_order:?}"
+        );
+        if gopro_first {
+          assert!(
+            odev < omake,
+            "oracle: APP6-before-APP1 ⇒ GoPro:DeviceName before IFD0:Make ({mode}): {orc_order:?}"
+          );
+        } else {
+          assert!(
+            omake < odev,
+            "oracle: APP1-before-APP6 ⇒ IFD0:Make before GoPro:DeviceName ({mode}): {orc_order:?}"
+          );
+        }
+      }
+    }
+  }
+}
+
+/// A minimal big-endian `APP1` Exif payload whose TIFF body is MALFORMED — the
+/// `Exif\0\0` header is present (so the `APP1` matches the Exif arm signature)
+/// but the TIFF block has an out-of-range IFD0 offset of 0 (`< 8`), so
+/// `ProcessTIFF` fails and the segment produces NO EXIF tags (ExifTool raises
+/// `Malformed APP1 EXIF segment` and emits nothing from it). This is the inert
+/// leading `APP1` that must NOT anchor the GoPro-vs-EXIF order.
+fn app1_malformed_exif() -> Vec<u8> {
+  let mut p = Vec::new();
+  p.extend_from_slice(b"Exif\0\0");
+  // Classic byte-order magic `MM\0\x2a` then a 0 IFD0 offset (< 8 ⇒ invalid).
+  p.extend_from_slice(b"MM\0\x2a\0\0\0\0");
+  p
+}
+
+/// Build a JPEG laid out `SOI APP1(malformed Exif) APP6(valid GoPro DVNM)
+/// APP1(valid Exif Make) EOI`: the leading `APP1` matches the Exif arm but
+/// produces no tags, the GoPro `APP6` is between it and the LATER valid `APP1`
+/// Exif block.
+fn jpeg_malformed_app1_gopro_valid_app1() -> Vec<u8> {
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 6, b"Camera"); // DeviceName='Camera'
+  let mut app6_payload = Vec::new();
+  app6_payload.extend_from_slice(b"GoPro\0");
+  app6_payload.extend_from_slice(&wrap_devc_strm(&strm));
+
+  let mut valid_app1 = Vec::new();
+  valid_app1.extend_from_slice(b"Exif\0\0");
+  valid_app1.extend_from_slice(&tiff_make_gopro());
+
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  push_segment(&mut jpeg, 0xe1, &app1_malformed_exif()); // APP1 (no tags)
+  push_segment(&mut jpeg, 0xe6, &app6_payload); // APP6 GoPro
+  push_segment(&mut jpeg, 0xe1, &valid_app1); // APP1 Exif (the EFFECTIVE block)
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// The cross-segment GoPro-vs-EXIF order anchors on the EFFECTIVE (tag-producing)
+/// `APP1`, not the first segment whose payload merely matches the Exif arm
+/// signature. For `APP1(malformed Exif) → APP6(valid GoPro) → APP1(valid Exif)`
+/// ExifTool emits `GoPro:DeviceName` BEFORE `IFD0:Make` (the GoPro `APP6`
+/// precedes the LATER valid `APP1` Exif block, so it precedes the only `IFD0:*`
+/// tags emitted) — verified against the live oracle below, in `-j` and `-n`. The
+/// pre-fix code anchored on the inert first `APP1` and wrongly emitted EXIF
+/// before GoPro. This is distinct from the fenced `APP6`/`APP1`/`APP6` straddle
+/// (not marker-order-replayed); here the single valid EXIF block is wholly after
+/// the GoPro `APP6`.
+#[test]
+fn gopro_app6_before_effective_app1_when_leading_app1_malformed() {
+  let jpeg = jpeg_malformed_app1_gopro_valid_app1();
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let raw = extract_info("malformed_first.jpg", &jpeg, print_conv);
+    let order = group_key_order(&raw, &["GoPro", "IFD0"]);
+    let dev = order.iter().position(|k| k == "GoPro:DeviceName");
+    let make = order.iter().position(|k| k == "IFD0:Make");
+    assert!(
+      dev.is_some() && make.is_some(),
+      "both GoPro:DeviceName and IFD0:Make must emit ({mode}): {order:?}"
+    );
+    assert!(
+      dev < make,
+      "GoPro APP6 before the EFFECTIVE (later, valid) APP1 ⇒ GoPro:DeviceName \
+       must emit BEFORE IFD0:Make, anchoring on the tag-producing APP1 not the \
+       inert leading one ({mode}): {order:?}"
+    );
+
+    // Ground-truth the cross-segment order against the live oracle: the GoPro
+    // APP6 precedes the valid (third) APP1, so GoPro:DeviceName precedes
+    // IFD0:Make despite the inert leading APP1.
+    let args: Vec<&str> = if print_conv {
+      vec!["-G1", "-j"]
+    } else {
+      vec!["-G1", "-j", "-n"]
+    };
+    if let Some(orc_raw) = oracle_crafted_raw(&jpeg, &args) {
+      let orc_order = group_key_order(&orc_raw, &["GoPro", "IFD0"]);
+      let odev = orc_order.iter().position(|k| k == "GoPro:DeviceName");
+      let omake = orc_order.iter().position(|k| k == "IFD0:Make");
+      assert!(
+        odev.is_some() && omake.is_some(),
+        "oracle emits both GoPro:DeviceName and IFD0:Make ({mode}): {orc_order:?}"
+      );
+      assert!(
+        odev < omake,
+        "oracle: GoPro APP6 before the effective APP1 ⇒ GoPro:DeviceName before \
+         IFD0:Make ({mode}): {orc_order:?}"
+      );
+    }
+  }
+}
+
+/// Build a JPEG laid out `SOI APP6(GoPro\0 + truncated, no tags)
+/// APP1(valid Exif Make='AAA') APP6(valid GoPro DVNM='BBB') EOI`: the LEADING
+/// GoPro `APP6` has the `GoPro\0` prefix but its GPMF body is under the 8-byte
+/// KLV header (so `process_gopro` decodes nothing — no tag), the valid `APP1`
+/// Exif block sits between it and a LATER valid GoPro `APP6`.
+fn jpeg_empty_app6_valid_app1_valid_app6() -> Vec<u8> {
+  // APP6 #1: GoPro\0 + 4 stray bytes (< the 8-byte KLV header ⇒ no tags).
+  let empty_gopro: &[u8] = b"GoPro\0\x01\x02\x03\x04";
+
+  // APP1: Exif\0\0 + a valid TIFF, IFD0:Make='AAA'.
+  let mut valid_app1 = Vec::new();
+  valid_app1.extend_from_slice(b"Exif\0\0");
+  valid_app1.extend_from_slice(&tiff_one_ascii(0x010f, "AAA")); // Make='AAA'
+
+  // APP6 #2: GoPro\0 + a valid DEVC→STRM→DVNM='BBB'.
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 3, b"BBB"); // DeviceName='BBB'
+  let valid_app6 = app6_gopro_payload(&wrap_devc_strm(&strm));
+
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  push_segment(&mut jpeg, 0xe6, empty_gopro); // APP6 GoPro (no tags)
+  push_segment(&mut jpeg, 0xe1, &valid_app1); // APP1 Exif (the EFFECTIVE block)
+  push_segment(&mut jpeg, 0xe6, &valid_app6); // APP6 GoPro (the EFFECTIVE GoPro)
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// SYMMETRIC to `gopro_app6_before_effective_app1_when_leading_app1_malformed`
+/// (the EXIF-side anchor): the GoPro-vs-EXIF order anchors on the first
+/// TAG-PRODUCING GoPro `APP6`, NOT the first segment whose payload merely has
+/// the `GoPro\0` prefix. For `APP6(empty GoPro) → APP1(valid Exif) →
+/// APP6(valid GoPro)` the leading `GoPro\0` `APP6` decodes nothing, so the
+/// EFFECTIVE (first tag-producing) GoPro segment is the LATER one — AFTER the
+/// `APP1` Exif block — and ExifTool emits `IFD0:Make` BEFORE
+/// `GoPro:DeviceName` (verified against the live oracle below, in `-j` and
+/// `-n`). Anchoring on the inert first `GoPro\0` segment would wrongly emit the
+/// GoPro block before the EXIF it actually follows.
+#[test]
+fn gopro_empty_app6_before_app1_does_not_anchor_gopro_first() {
+  let jpeg = jpeg_empty_app6_valid_app1_valid_app6();
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let raw = extract_info("empty_first_app6.jpg", &jpeg, print_conv);
+    let order = group_key_order(&raw, &["GoPro", "IFD0"]);
+    let dev = order.iter().position(|k| k == "GoPro:DeviceName");
+    let make = order.iter().position(|k| k == "IFD0:Make");
+    assert!(
+      dev.is_some() && make.is_some(),
+      "both GoPro:DeviceName and IFD0:Make must emit ({mode}): {order:?}"
+    );
+    // The EXTRACTED values come from the LATER segments (the empty first APP6
+    // contributes nothing).
+    let doc: serde_json::Value = serde_json::from_str(&raw).expect("json");
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc");
+    assert_eq!(
+      map.get("IFD0:Make").and_then(|v| v.as_str()),
+      Some("AAA"),
+      "IFD0:Make from the APP1 must extract ({mode})"
+    );
+    assert_eq!(
+      map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+      Some("BBB"),
+      "GoPro:DeviceName from the LATER valid APP6 must extract ({mode})"
+    );
+    assert!(
+      make < dev,
+      "the empty leading GoPro APP6 must NOT anchor the order: the first \
+       TAG-PRODUCING GoPro APP6 is AFTER the valid APP1, so IFD0:Make must emit \
+       BEFORE GoPro:DeviceName ({mode}): {order:?}"
+    );
+
+    // Ground-truth the cross-segment order against the live oracle: the empty
+    // first APP6 contributes no key, the effective GoPro is after the APP1, so
+    // IFD0:Make precedes GoPro:DeviceName.
+    let args: Vec<&str> = if print_conv {
+      vec!["-G1", "-j"]
+    } else {
+      vec!["-G1", "-j", "-n"]
+    };
+    if let Some(orc_raw) = oracle_crafted_raw(&jpeg, &args) {
+      let orc_order = group_key_order(&orc_raw, &["GoPro", "IFD0"]);
+      let odev = orc_order.iter().position(|k| k == "GoPro:DeviceName");
+      let omake = orc_order.iter().position(|k| k == "IFD0:Make");
+      assert!(
+        odev.is_some() && omake.is_some(),
+        "oracle emits both GoPro:DeviceName and IFD0:Make ({mode}): {orc_order:?}"
+      );
+      assert!(
+        omake < odev,
+        "oracle: empty leading GoPro APP6 ⇒ IFD0:Make before GoPro:DeviceName \
+         ({mode}): {orc_order:?}"
+      );
+    }
+  }
+}
+
+/// A minimal big-endian TIFF block that is VALID but EMPTY: byte-order marker
+/// `MM\0\x2a` + a 0-entry IFD0 (count `0x0000`, next-IFD `0`). `ProcessTIFF`
+/// SUCCEEDS on it — it is a well-formed TIFF — so `parse_exif_block_with_base`
+/// returns `Some` and `File:ExifByteOrder` is emitted (the unconditional
+/// `File`-group prefix). But the empty IFD0 yields NO movable EXIF tag (no
+/// `IFD0:*`/`ExifIFD:*`/`GPS:*` entry), so this `APP1` must NOT anchor the
+/// GoPro-vs-EXIF order — the EXIF-side mirror of the empty-`GoPro\0` `APP6`.
+fn tiff_empty_ifd0() -> Vec<u8> {
+  let mut t: Vec<u8> = vec![b'M', b'M', 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08];
+  t.extend_from_slice(&[0x00, 0x00]); // IFD0: 0 entries
+  t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+  t
+}
+
+/// Build a JPEG laid out `SOI APP1(valid EMPTY TIFF — byte-order + 0-entry IFD0,
+/// NO movable tags) APP6(valid GoPro DVNM='BBB') APP1(valid IFD0 Make='AAA')
+/// EOI`: the LEADING `APP1` parses (so `File:ExifByteOrder` is emitted) but
+/// contributes no movable tag; the GoPro `APP6` sits between it and the LATER
+/// `APP1` that carries the first movable EXIF tag.
+fn jpeg_byte_order_only_app1_gopro_valid_app1() -> Vec<u8> {
+  let app1_empty = app1_exif(&tiff_empty_ifd0()); // Exif\0\0 + valid empty TIFF
+
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 3, b"BBB"); // DeviceName='BBB'
+  let app6 = app6_gopro_payload(&wrap_devc_strm(&strm));
+
+  let app1_make = app1_exif(&tiff_one_ascii(0x010f, "AAA")); // IFD0:Make='AAA'
+
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  push_segment(&mut jpeg, 0xe1, &app1_empty); // APP1 (parses, NO movable tag)
+  push_segment(&mut jpeg, 0xe6, &app6); // APP6 GoPro (the EFFECTIVE GoPro)
+  push_segment(&mut jpeg, 0xe1, &app1_make); // APP1 (the EFFECTIVE EXIF block)
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// SYMMETRIC to `gopro_empty_app6_before_app1_does_not_anchor_gopro_first` (the
+/// GoPro-side anchor): the GoPro-vs-EXIF order anchors on the first `APP1`
+/// contributing a MOVABLE EXIF tag, NOT a byte-order-only / empty-IFD0 `APP1`
+/// that parses to only the `File:ExifByteOrder` prefix. For
+/// `APP1(valid empty TIFF) → APP6(valid GoPro) → APP1(valid IFD0 Make)` ExifTool
+/// emits `File:ExifByteOrder` (the unconditional `File` prefix), then
+/// `GoPro:DeviceName`, then `IFD0:Make` — the GoPro `APP6` precedes the LATER
+/// movable-tag-producing `APP1`, so it precedes the only `IFD0:*` tag
+/// (oracle-confirmed below, `-j` and `-n`: `File:ExifByteOrder`,
+/// `GoPro:DeviceName='BBB'`, `IFD0:Make='AAA'`). Anchoring on the inert leading
+/// (empty-IFD0) `APP1` would wrongly emit `IFD0:Make` BEFORE the GoPro block.
+/// `File:ExifByteOrder` is NOT the EXIF anchor: it leads regardless and does not
+/// participate in the GoPro-vs-EXIF ordering.
+#[test]
+fn gopro_byte_order_only_app1_does_not_anchor_exif_first() {
+  let jpeg = jpeg_byte_order_only_app1_gopro_valid_app1();
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let raw = extract_info("byteorder_only_app1.jpg", &jpeg, print_conv);
+    let order = group_key_order(&raw, &["GoPro", "IFD0"]);
+    let dev = order.iter().position(|k| k == "GoPro:DeviceName");
+    let make = order.iter().position(|k| k == "IFD0:Make");
+    assert!(
+      dev.is_some() && make.is_some(),
+      "both GoPro:DeviceName and IFD0:Make must emit ({mode}): {order:?}"
+    );
+
+    let doc: serde_json::Value = serde_json::from_str(&raw).expect("json");
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc");
+    // The leading empty-IFD0 APP1 still emits File:ExifByteOrder (it parsed) —
+    // the unconditional File-group prefix, NOT the EXIF anchor.
+    assert!(
+      map.contains_key("File:ExifByteOrder"),
+      "the valid (empty) TIFF still emits File:ExifByteOrder ({mode}): {:?}",
+      map.keys().collect::<Vec<_>>()
+    );
+    // The MOVABLE IFD0:Make comes from the LATER (third) APP1.
+    assert_eq!(
+      map.get("IFD0:Make").and_then(|v| v.as_str()),
+      Some("AAA"),
+      "IFD0:Make from the later APP1 must extract ({mode})"
+    );
+    assert_eq!(
+      map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+      Some("BBB"),
+      "GoPro:DeviceName from the APP6 must extract ({mode})"
+    );
+    assert!(
+      dev < make,
+      "the byte-order-only (empty-IFD0) leading APP1 must NOT anchor EXIF first: \
+       the first MOVABLE-tag-producing APP1 is AFTER the GoPro APP6, so \
+       GoPro:DeviceName must emit BEFORE IFD0:Make (File:ExifByteOrder still \
+       leads) ({mode}): {order:?}"
+    );
+
+    // Ground-truth against the live oracle: File:ExifByteOrder leads, then
+    // GoPro:DeviceName, then IFD0:Make (the GoPro APP6 precedes the effective,
+    // movable-tag-producing APP1).
+    let args: Vec<&str> = if print_conv {
+      vec!["-G1", "-j"]
+    } else {
+      vec!["-G1", "-j", "-n"]
+    };
+    if let Some(orc_raw) = oracle_crafted_raw(&jpeg, &args) {
+      let orc_order = group_key_order(&orc_raw, &["GoPro", "IFD0"]);
+      let odev = orc_order.iter().position(|k| k == "GoPro:DeviceName");
+      let omake = orc_order.iter().position(|k| k == "IFD0:Make");
+      assert!(
+        odev.is_some() && omake.is_some(),
+        "oracle emits both GoPro:DeviceName and IFD0:Make ({mode}): {orc_order:?}"
+      );
+      assert!(
+        odev < omake,
+        "oracle: byte-order-only leading APP1 ⇒ GoPro:DeviceName before IFD0:Make \
+         ({mode}): {orc_order:?}"
+      );
+    }
+  }
+}
+
+/// With NO `APP1` ever producing a parsed EXIF block — only a malformed `APP1`
+/// (Exif-signature match, no tags) plus a valid GoPro `APP6` — there is no
+/// `IFD0:*` content to order against, so the GoPro tags simply emit (after the
+/// `File` group). exifast attaches the GoPro block with `before_exif = false`
+/// (the `effective_exif_idx == None` path); `GoPro:DeviceName` is present and no
+/// `IFD0:*` tag appears, matching the oracle (which emits `GoPro:DeviceName`
+/// with the `Malformed APP1 EXIF segment` warning and no `IFD0:*`).
+#[test]
+fn gopro_app6_with_only_a_malformed_app1_still_emits_gopro() {
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 6, b"Camera");
+  let mut app6_payload = Vec::new();
+  app6_payload.extend_from_slice(b"GoPro\0");
+  app6_payload.extend_from_slice(&wrap_devc_strm(&strm));
+
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  push_segment(&mut jpeg, 0xe1, &app1_malformed_exif()); // APP1, no tags
+  push_segment(&mut jpeg, 0xe6, &app6_payload); // APP6 GoPro
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let json = extract_info("novalid.jpg", &jpeg, print_conv);
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("json");
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc");
+    assert_eq!(
+      map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+      Some("Camera"),
+      "GoPro:DeviceName must emit even with no effective EXIF block ({mode})"
+    );
+    assert!(
+      !map.keys().any(|k| k.starts_with("IFD0:")),
+      "no IFD0 tags when the only APP1 is malformed ({mode}): {:?}",
+      map.keys().collect::<Vec<_>>()
+    );
+
+    let args: Vec<&str> = if print_conv {
+      vec!["-G1", "-j"]
+    } else {
+      vec!["-G1", "-j", "-n"]
+    };
+    if let Some(orc) = oracle_crafted(&jpeg, &args) {
+      assert_eq!(
+        orc.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+        Some("Camera"),
+        "oracle: GoPro:DeviceName emits with no effective EXIF block ({mode})"
+      );
+      assert!(
+        !orc.keys().any(|k| k.starts_with("IFD0:")),
+        "oracle emits no IFD0 tags here ({mode}): {:?}",
+        orc.keys().collect::<Vec<_>>()
+      );
+    }
+  }
+}
+
+// ===========================================================================
+// FENCED: multiple INDEPENDENT valid `APP1` Exif blocks straddling a GoPro
+// `APP6` (issue 233, the engine-wide strict per-segment marker-order JPEG
+// emission limitation). exifast merges every `APP1` Exif block into ONE
+// `IFD0:*` stream and emits the whole GoPro block on ONE side of it, anchored
+// on `before_exif = first_gopro_idx < effective_exif_idx`
+// (`src/exif/jpeg.rs`). A strict ExifTool marker replay would instead emit
+// each segment's tags AT its `Marker:`-loop position
+// (`ExifTool.pm:7325`) — so the GoPro `HandleTag` block would fall BETWEEN the
+// first `APP1`'s tags and the later independent `APP1`'s tags.
+//
+// In practice this divergence is invisible at the conformance target: both
+// exifast and ExifTool serialize `-G1 -j` output by family-1 GROUP, co-locating
+// every `IFD0:*` tag, so the two independent `APP1` blocks always render as one
+// contiguous `IFD0` run regardless of marker interleaving — and the relative
+// `IFD0`-vs-`GoPro` group order is decided by exactly the same first-GoPro-vs-
+// effective-EXIF index comparison. The cases below therefore VALUE- AND
+// ORDER-match the live oracle today; the fence is for the hypothetical strict
+// per-tag stream model (which neither tool's JSON exercises), the same class as
+// the `APP6`/`APP1`/`APP6` straddle (`ExifMeta::gopro_before_exif` docs).
+// Real GoPro stills carry a SINGLE early `APP1` Exif + a later GoPro `APP6`
+// (the `t/images/GoPro.jpg` fixture), so they never hit this layout.
+// ===========================================================================
+
+/// A minimal big-endian TIFF block carrying ONE IFD0 ASCII entry (`tag` =
+/// `value`, NUL-terminated), no IFD1 — lets a test place a distinct,
+/// identifiable IFD0 tag (e.g. `Make`/`Model`) in each of several `APP1`
+/// segments. The value is stored inline when it fits in 4 bytes, else at offset
+/// 26 (just past the 8-byte header + one 12-byte entry + the 4-byte next-IFD
+/// pointer), mirroring [`tiff_make_gopro`]'s layout.
+fn tiff_one_ascii(tag: u16, value: &str) -> Vec<u8> {
+  let mut val = value.as_bytes().to_vec();
+  val.push(0); // NUL terminator (ExifTool ASCII count includes it)
+  let cnt = val.len() as u32;
+  let mut t: Vec<u8> = vec![b'M', b'M', 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08];
+  t.extend_from_slice(&[0x00, 0x01]); // 1 entry
+  t.extend_from_slice(&tag.to_be_bytes()); // tag id
+  t.extend_from_slice(&[0x00, 0x02]); // ASCII
+  t.extend_from_slice(&cnt.to_be_bytes()); // count (incl. NUL)
+  if cnt <= 4 {
+    let mut inline = val.clone();
+    inline.resize(4, 0); // left-justified, NUL-padded inline value
+    t.extend_from_slice(&inline);
+    t.extend_from_slice(&[0, 0, 0, 0]); // next-IFD = 0
+  } else {
+    t.extend_from_slice(&26u32.to_be_bytes()); // value @ offset 26
+    t.extend_from_slice(&[0, 0, 0, 0]); // next-IFD = 0
+    t.extend_from_slice(&val);
+  }
+  t
+}
+
+/// Wrap a TIFF block in a JPEG `APP1` Exif payload (`Exif\0\0` + TIFF).
+fn app1_exif(tiff: &[u8]) -> Vec<u8> {
+  let mut p = Vec::new();
+  p.extend_from_slice(b"Exif\0\0");
+  p.extend_from_slice(tiff);
+  p
+}
+
+/// Wrap a GoPro GPMF body in a JPEG `APP6` payload (`GoPro\0` + GPMF).
+fn app6_gopro_payload(gpmf: &[u8]) -> Vec<u8> {
+  let mut p = Vec::new();
+  p.extend_from_slice(b"GoPro\0");
+  p.extend_from_slice(gpmf);
+  p
+}
+
+/// FENCED (issue 233): two INDEPENDENT valid `APP1` Exif blocks
+/// (`IFD0:Make='AAA'`, then `IFD0:Model='CCC'`) with a valid GoPro `APP6`
+/// (`DeviceName='BBB'`) BETWEEN them — `SOI APP1(Make) APP6(GoPro) APP1(Model)
+/// EOI`.
+///
+/// What exifast does today (PINNED here): all three tags are EXTRACTED with
+/// their correct values — `IFD0:Make='AAA'`, `IFD0:Model='CCC'`,
+/// `GoPro:DeviceName='BBB'` — i.e. BOTH independent `APP1` blocks are parsed and
+/// merged into one `IFD0` stream (extraction is faithful; nothing is dropped).
+/// The emission ORDER is `IFD0:Make`, `IFD0:Model`, `GoPro:DeviceName` (the
+/// merged `IFD0` run, then the GoPro block — `before_exif = false` because the
+/// GoPro `APP6` sits AFTER the FIRST effective `APP1`).
+///
+/// This VALUE- and ORDER-matches the live oracle (asserted below): ExifTool's
+/// `-G1 -j` co-locates the family-1 `IFD0` group, so it too renders
+/// `IFD0:Make`, `IFD0:Model`, `GoPro:DeviceName` and does NOT interleave the
+/// GoPro block between the two `APP1`s in JSON. The strict per-segment
+/// marker-order model (under which the GoPro `HandleTag` block would fall
+/// BETWEEN the two `APP1` tag blocks in the raw extraction stream) is the
+/// engine-wide limitation tracked in issue 233 — NOT asserted here, and
+/// invisible at the `-G1 -j` conformance target; the only layout that needs it
+/// alongside the `APP6`/`APP1`/`APP6` straddle. Real GoPro stills have a single
+/// `APP1`, so they are unaffected.
+#[test]
+fn multi_independent_app1_straddling_gopro_extracts_all_and_matches_oracle_order() {
+  // SOI APP1(IFD0:Make='AAA') APP6(GoPro DVNM='BBB') APP1(IFD0:Model='CCC') EOI.
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 3, b"BBB"); // DeviceName='BBB'
+  let app6 = app6_gopro_payload(&wrap_devc_strm(&strm));
+  let app1_make = app1_exif(&tiff_one_ascii(0x010f, "AAA")); // IFD0:Make
+  let app1_model = app1_exif(&tiff_one_ascii(0x0110, "CCC")); // IFD0:Model
+
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  push_segment(&mut jpeg, 0xe1, &app1_make); // APP1 Make (the effective block)
+  push_segment(&mut jpeg, 0xe6, &app6); // APP6 GoPro (between the two APP1)
+  push_segment(&mut jpeg, 0xe1, &app1_model); // APP1 Model (independent block)
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+
+  for print_conv in [true, false] {
+    let mode = if print_conv { "-j" } else { "-n" };
+    let raw = extract_info("multi_indep_app1.jpg", &jpeg, print_conv);
+    let doc: serde_json::Value = serde_json::from_str(&raw).expect("json");
+    let map = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc");
+
+    // (1) EXTRACTION is faithful: all three distinct tags present, correct
+    //     values. BOTH independent APP1 blocks are parsed (Make AND Model), and
+    //     the GoPro block decodes its DeviceName.
+    assert_eq!(
+      map.get("IFD0:Make").and_then(|v| v.as_str()),
+      Some("AAA"),
+      "IFD0:Make from the first APP1 must extract ({mode})"
+    );
+    assert_eq!(
+      map.get("IFD0:Model").and_then(|v| v.as_str()),
+      Some("CCC"),
+      "IFD0:Model from the SECOND independent APP1 must extract ({mode})"
+    );
+    assert_eq!(
+      map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+      Some("BBB"),
+      "GoPro:DeviceName from the APP6 between the two APP1 must extract ({mode})"
+    );
+
+    // (2) Whole-block emission ORDER: the merged IFD0 run, then GoPro. We do
+    //     NOT assert the strict marker-order interleaving (GoPro BETWEEN the two
+    //     APP1 blocks) — that per-segment stream model is the engine-wide
+    //     limitation tracked in issue 233 (see the module comment above). This
+    //     order VALUE-equals the live oracle's, asserted in (3).
+    let order = group_key_order(&raw, &["GoPro", "IFD0"]);
+    assert_eq!(
+      order,
+      vec!["IFD0:Make", "IFD0:Model", "GoPro:DeviceName"],
+      "exifast emits the merged IFD0 run then the GoPro block ({mode}): {order:?}"
+    );
+
+    // (3) Ground-truth VALUES and the whole-block ORDER against the live oracle
+    //     when available. The oracle's `-G1 -j` co-locates the IFD0 group, so it
+    //     too emits `IFD0:Make`, `IFD0:Model`, `GoPro:DeviceName` (NOT an
+    //     interleaved Make/GoPro/Model) — confirming the issue-233 strict
+    //     marker-order divergence is invisible at this conformance target.
+    let args: Vec<&str> = if print_conv {
+      vec!["-G1", "-j"]
+    } else {
+      vec!["-G1", "-j", "-n"]
+    };
+    if let Some(orc) = oracle_crafted(&jpeg, &args) {
+      assert_eq!(
+        orc.get("IFD0:Make").and_then(|v| v.as_str()),
+        Some("AAA"),
+        "oracle: IFD0:Make = AAA ({mode})"
+      );
+      assert_eq!(
+        orc.get("IFD0:Model").and_then(|v| v.as_str()),
+        Some("CCC"),
+        "oracle: IFD0:Model = CCC ({mode})"
+      );
+      assert_eq!(
+        orc.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+        Some("BBB"),
+        "oracle: GoPro:DeviceName = BBB ({mode})"
+      );
+    }
+    if let Some(orc_raw) = oracle_crafted_raw(&jpeg, &args) {
+      let orc_order = group_key_order(&orc_raw, &["GoPro", "IFD0"]);
+      // The oracle co-locates IFD0 and emits the GoPro block after it — exifast
+      // reproduces this exactly. (Documents that the strict marker-order
+      // interleaving of issue 233 does not surface in `-G1 -j` JSON.)
+      assert_eq!(
+        orc_order,
+        vec!["IFD0:Make", "IFD0:Model", "GoPro:DeviceName"],
+        "oracle whole-block order ({mode}): {orc_order:?}"
+      );
+    }
+  }
+}
+
+// ===========================================================================
+// R9: the EFFECTIVE-EXIF anchor must inspect the REAL emission, not just the
+// IFD-walk `entries`. A MakerNote is CAPTURED separately (the 0x927c blob is
+// NOT an `ExifEntry`), yet `Taggable::tags` emits its decoded vendor tags
+// (`Apple:*`/`Canon:*`/...). So an `APP1` carrying ONLY a decoded MakerNote
+// (an `ExifIFD` pointer + a vendor MakerNote, NO other IFD0 entry) emits a
+// MOVABLE `MakerNotes:*` tag with an EMPTY `entries` vec. The pre-R9 anchor
+// `!exif.entries().is_empty()` missed it (entries empty ⇒ the block did not
+// anchor) and a GoPro `APP6` AFTER such an `APP1` wrongly emitted BEFORE it.
+// `ExifMeta::emits_movable_tag()` now reads the real `tags` output, so the
+// MakerNote-only `APP1` anchors. Vendor chosen: Apple (signature-gated —
+// `Apple iOS\0` dispatches regardless of `Make`, so IFD0 needs NO `Make` entry
+// and stays movable-tag-free; `MakerNoteVersion` is a default-visible,
+// non-Unknown leaf the exif crate decodes from a JPEG `APP1`). Ground-truthed
+// against the live oracle in `-j` and `-n`.
+// ===========================================================================
+
+/// A 1-entry Apple iOS MakerNote blob: `MakerNoteVersion = 4` (`int32s`,
+/// inline). Mirrors the REAL iPhone layout (`Apple.jpg`): the 14-byte
+/// `Apple iOS\0\0\x01MM` header whose TRAILING `MM` is the body byte order,
+/// then the IFD entry count IMMEDIATELY (no second order marker), then the
+/// 12-byte entry. `MakerNoteVersion` is `Unknown => 0` (default-visible) so it
+/// survives the engine's Unknown-suppression and is a genuine MOVABLE
+/// `MakerNotes:*` tag (ExifTool emits it under the family-1 `Apple` group).
+fn apple_makernote_blob() -> Vec<u8> {
+  let mut b = Vec::new();
+  b.extend_from_slice(b"Apple iOS\x00\x00\x01MM"); // 14-byte header (trailing MM = order)
+  b.extend_from_slice(&1u16.to_be_bytes()); // IFD entry count = 1
+  b.extend_from_slice(&0x0001u16.to_be_bytes()); // tag 0x0001 MakerNoteVersion
+  b.extend_from_slice(&0x0009u16.to_be_bytes()); // format int32s
+  b.extend_from_slice(&1u32.to_be_bytes()); // count 1
+  b.extend_from_slice(&4u32.to_be_bytes()); // inline value = 4
+  b
+}
+
+/// A big-endian TIFF block whose IFD0 carries ONLY the `ExifIFD` pointer
+/// (0x8769) — NO `Make`/`Model`/other value entry — and whose ExifIFD carries
+/// ONLY the `MakerNote` pointer (0x927c) to an Apple blob. So the IFD walk
+/// yields ZERO `ExifEntry`s (`entries` is EMPTY: 0x8769 and 0x927c are
+/// structural pointers consumed by the walker, never emitted), while the
+/// captured MakerNote decodes to a movable `Apple:MakerNoteVersion`. This is
+/// the MakerNote-only `APP1` that the pre-R9 `!entries.is_empty()` anchor
+/// missed.
+fn tiff_apple_makernote_only() -> Vec<u8> {
+  let blob = apple_makernote_blob();
+  // Layout: TIFF header (8) | IFD0 (18) | ExifIFD (18) | Apple blob.
+  let exififd_off: u32 = 8 + (2 + 12 + 4); // 26
+  let mn_off: u32 = exififd_off + (2 + 12 + 4); // 44
+
+  let mut t: Vec<u8> = vec![b'M', b'M', 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08];
+  // IFD0 @ 8: 1 entry — ExifIFD pointer (0x8769, LONG) -> exififd_off.
+  t.extend_from_slice(&1u16.to_be_bytes());
+  t.extend_from_slice(&0x8769u16.to_be_bytes());
+  t.extend_from_slice(&0x0004u16.to_be_bytes()); // LONG
+  t.extend_from_slice(&1u32.to_be_bytes());
+  t.extend_from_slice(&exififd_off.to_be_bytes());
+  t.extend_from_slice(&0u32.to_be_bytes()); // next-IFD = 0
+  // ExifIFD @ 26: 1 entry — MakerNote (0x927c, UNDEFINED) -> mn_off.
+  t.extend_from_slice(&1u16.to_be_bytes());
+  t.extend_from_slice(&0x927cu16.to_be_bytes());
+  t.extend_from_slice(&0x0007u16.to_be_bytes()); // UNDEFINED
+  t.extend_from_slice(&(blob.len() as u32).to_be_bytes());
+  t.extend_from_slice(&mn_off.to_be_bytes());
+  t.extend_from_slice(&0u32.to_be_bytes()); // next-IFD = 0
+  // Apple blob @ 44.
+  t.extend_from_slice(&blob);
+  t
+}
+
+/// Build a JPEG with a GoPro `APP6` (`DeviceName='Camera'`) and a MakerNote-only
+/// `APP1` (Apple `MakerNoteVersion`) in the requested order: `gopro_first` ⇒
+/// `SOI APP6 APP1 EOI`, else `SOI APP1 APP6 EOI`.
+fn jpeg_gopro_and_makernote_only_app1(gopro_first: bool) -> Vec<u8> {
+  let mut strm = Vec::new();
+  klv(&mut strm, b"DVNM", 0x63, 1, 6, b"Camera"); // DeviceName='Camera'
+  let app6 = app6_gopro_payload(&wrap_devc_strm(&strm));
+  let app1 = app1_exif(&tiff_apple_makernote_only());
+
+  let mut jpeg = vec![0xff, 0xd8]; // SOI
+  if gopro_first {
+    push_segment(&mut jpeg, 0xe6, &app6); // APP6 GoPro
+    push_segment(&mut jpeg, 0xe1, &app1); // APP1 (MakerNote-only)
+  } else {
+    push_segment(&mut jpeg, 0xe1, &app1); // APP1 (MakerNote-only)
+    push_segment(&mut jpeg, 0xe6, &app6); // APP6 GoPro
+  }
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// The EXIF anchor counts a MakerNote-only `APP1` (no IFD0 value entry, just a
+/// decoded vendor MakerNote) as the EFFECTIVE EXIF block, because it emits a
+/// movable `MakerNotes:*` tag. So `APP6(GoPro) → APP1(Apple MakerNote)` emits
+/// `GoPro:DeviceName` BEFORE `Apple:MakerNoteVersion`, and the inverse layout
+/// emits `Apple:MakerNoteVersion` BEFORE `GoPro:DeviceName` — exactly as the
+/// live oracle does (`-j` and `-n`). The genuine guard: `Apple:MakerNoteVersion`
+/// IS present (a real decoded MakerNote, not an empty one) and NO `IFD0:*` key
+/// appears (the `APP1` has no IFD0 value entry — `entries` is empty, so the
+/// pre-R9 `!entries.is_empty()` anchor would have missed this block).
+#[test]
+fn gopro_before_makernote_only_app1() {
+  for gopro_first in [true, false] {
+    let jpeg = jpeg_gopro_and_makernote_only_app1(gopro_first);
+    for print_conv in [true, false] {
+      let mode = if print_conv { "-j" } else { "-n" };
+      let raw = extract_info("makernote_only_app1.jpg", &jpeg, print_conv);
+      let doc: serde_json::Value = serde_json::from_str(&raw).expect("json");
+      let map = doc
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|o| o.as_object())
+        .expect("doc");
+
+      // Genuine guard #1: the MakerNote actually DECODED (a real movable
+      // MakerNotes tag, not an empty emission). Without this, the test would
+      // pass vacuously on a block that emits nothing.
+      assert!(
+        map.contains_key("Apple:MakerNoteVersion"),
+        "the MakerNote-only APP1 must decode Apple:MakerNoteVersion ({mode}): {:?}",
+        map.keys().collect::<Vec<_>>()
+      );
+      // Genuine guard #2: the APP1 has NO IFD0 value entry — its `entries` vec
+      // is empty, so the pre-R9 `!entries.is_empty()` anchor MISSED it. The
+      // only thing making it effective is the MakerNote emission.
+      assert!(
+        !map.keys().any(|k| k.starts_with("IFD0:")),
+        "the MakerNote-only APP1 must have NO IFD0 value tag ({mode}): {:?}",
+        map.keys().collect::<Vec<_>>()
+      );
+      assert_eq!(
+        map.get("GoPro:DeviceName").and_then(|v| v.as_str()),
+        Some("Camera"),
+        "GoPro:DeviceName must extract ({mode})"
+      );
+
+      let order = group_key_order(&raw, &["GoPro", "Apple"]);
+      let dev = order.iter().position(|k| k == "GoPro:DeviceName");
+      let ver = order.iter().position(|k| k == "Apple:MakerNoteVersion");
+      assert!(
+        dev.is_some() && ver.is_some(),
+        "both GoPro:DeviceName and Apple:MakerNoteVersion must emit \
+         (gopro_first={gopro_first}, {mode}): {order:?}"
+      );
+      if gopro_first {
+        assert!(
+          dev < ver,
+          "APP6-before-APP1 ⇒ GoPro:DeviceName must emit BEFORE \
+           Apple:MakerNoteVersion (the MakerNote-only APP1 anchors EXIF) \
+           ({mode}): {order:?}"
+        );
+      } else {
+        assert!(
+          ver < dev,
+          "APP1-before-APP6 ⇒ Apple:MakerNoteVersion must emit BEFORE \
+           GoPro:DeviceName ({mode}): {order:?}"
+        );
+      }
+
+      // Ground-truth the cross-segment order against the live oracle.
+      let args: Vec<&str> = if print_conv {
+        vec!["-G1", "-j"]
+      } else {
+        vec!["-G1", "-j", "-n"]
+      };
+      if let Some(orc_raw) = oracle_crafted_raw(&jpeg, &args) {
+        let orc_order = group_key_order(&orc_raw, &["GoPro", "Apple"]);
+        let odev = orc_order.iter().position(|k| k == "GoPro:DeviceName");
+        let over = orc_order.iter().position(|k| k == "Apple:MakerNoteVersion");
+        assert!(
+          odev.is_some() && over.is_some(),
+          "oracle emits both GoPro:DeviceName and Apple:MakerNoteVersion \
+           (gopro_first={gopro_first}, {mode}): {orc_order:?}"
+        );
+        if gopro_first {
+          assert!(
+            odev < over,
+            "oracle: APP6-before-APP1 ⇒ GoPro:DeviceName before \
+             Apple:MakerNoteVersion ({mode}): {orc_order:?}"
+          );
+        } else {
+          assert!(
+            over < odev,
+            "oracle: APP1-before-APP6 ⇒ Apple:MakerNoteVersion before \
+             GoPro:DeviceName ({mode}): {orc_order:?}"
+          );
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Wires exifast's existing GoPro GPMF KLV parser (ported in #57 for the MP4 GPMF track) to the JPEG `APP6` path, so a GoPro still (`GOPR*.JPG`) emits its 20 device-settings tags (Model, CameraSerialNumber, FirmwareVersion, WhiteBalance, …) byte-exact to ExifTool 13.59.

## Scope
- **APP6 hook** (`src/exif/jpeg.rs`): `attach_app6_gopro` recognizes the `GoPro\0`-prefixed `APP6` (JPEG.pm:196-198), strips the 6-byte prefix, runs the shared `process_gopro` GPMF walker, and attaches a `GoProMeta` to `ExifMeta`. All `GoPro\0` APP6 segments are processed in marker order (ExifTool.pm:8176-8181), last-wins.
- **Unified emitter** (`quicktime.rs`): one `emit_gopro_tags` shared by the MP4 + JPEG paths; the 20 tags emit under group `APP6:GoPro` in GPMF KLV walk order (`main_group_order`: identity + generic + GPS scalars).
- **Cross-segment ordering**: GoPro-vs-EXIF block order anchored on the first *movable-tag-producing* segment each side — EXIF via `ExifMeta::emits_movable_tag` (derived from the real `tags()` stream: any non-`File`, non-`Unknown` tag, so no emission channel can be missed), GoPro via the first tag-producing `APP6`; `File:ExifByteOrder` stays the unconditional File-prefix.
- **Faithful shared fix**: an all-NUL non-zero `c`-record decodes to the empty string (GoPro.pm:845 skips only size-0) — fixes `read_ascii`/`read_latin1` uniformly (GoPro.jpg's `ExposureType=""`).

## Verify
- `fmt --check` 0 · `build --all-features --all-targets -Dwarnings` 0 · `test --all-features --all-targets --skip gen_golden` 0 (unit + conformance **416/0** incl. the MP4 GoPro path byte-identical + jpeg_gopro_app6 **20/0** + alloc_budget) · `clippy --all-features` 0.
- GoPro.jpg: all 20 tags byte-exact AND order-exact vs `exiftool -G1 -j`/`-n`.
- Codex adversarial review: **APPROVE (R11, no material findings)** — an 11-round loop (the cross-segment ordering edges are all crafted multi-segment layouts; real GoPro JPEGs are byte-exact throughout).
- Rebased onto current main (`a1967e0`): the only conflict was additive keep-both struct fields in `mod.rs` (#59's `gopro`/`gopro_before_exif` alongside #229's `dng_version`/`cr2_magic`); all #59 logic files byte-identical to the approved commit; gate re-verified green.

## Deferred (engine-wide, filed)
- #233 — strict per-segment marker-order JPEG emission (pathological APP6/APP1/APP6 straddle; does not surface at `-G1 -j` where ExifTool co-locates family-1 groups, so it is theoretical-only).