### PR TITLE
feat(exif/canon): decode Canon::SerialInfo sub-table (EOS 5D 0x96) (#175)

### DIFF
--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -78,6 +78,7 @@ pub mod lens_types;
 pub mod model_ids;
 pub mod printconv;
 pub mod sensor_info;
+pub mod serial_info;
 pub mod shot_info;
 pub mod tags;
 
@@ -941,20 +942,32 @@ pub fn parse_in_tiff(
       }
     } else if entry.tag_id == 0x96 && model.is_some_and(printconv::model_matches_eos_5d) {
       // `0x96` MODEL-CONDITIONAL LIST (`Canon.pm:1834-1846`): for an
-      // EOS-5D body the FIRST arm wins — `SerialInfo`, a pure SubDirectory
-      // pointer to `Canon::SerialInfo` (`Canon.pm:1836-1838`; NO `Writable`,
-      // no value emission). Like every other deferred Canon::Main
-      // SubDirectory (the `_ =>` arm above), ExifTool descends into the child
-      // table and emits its leaves but NEVER the `SerialInfo` parent value
-      // (`Exif.pm:7103-7104` `next` skips `FoundTag` for a no-value
-      // SubDirectory). The port DEFERS that child walk, so the faithful
-      // behaviour is to emit nothing here — suppress the parent (issue #177;
-      // same bogus-parent class). CRITICALLY this is the SerialInfo branch,
-      // NOT `InternalSerialNumber`, so the trailing-`0xff` `ValueConv` strip
-      // does NOT apply and `populate_typed` is (correctly) not run — the typed
-      // `internal_serial_number` stays unset. Previously this arm emitted the
-      // raw `SerialInfo` value, leaking a bogus `Canon:SerialInfo` parent that
-      // ExifTool never emits.
+      // EOS-5D body the FIRST arm wins — `SerialInfo`, the SubDirectory
+      // pointer to `%Canon::SerialInfo` (`Canon.pm:1836-1838`). ExifTool
+      // descends into that child table and emits ITS leaves
+      // (`InternalSerialNumber2` / `InternalSerialNumber`) but NEVER the
+      // `SerialInfo` parent value (`Exif.pm:7103-7104` `next` skips `FoundTag`
+      // for a no-value SubDirectory) — so the parent is correctly absent (issue
+      // #177). The walker captured the raw on-disk SerialInfo blob verbatim
+      // (`RawValue::Bytes`, un-stripped — the trailing-`0xff`/NUL `string`
+      // semantics belong only to the SECOND arm `InternalSerialNumber`), so
+      // decode it here (`serial_info::parse`). The two leaves are
+      // family-1 `Canon` like every other Canon MakerNote tag; each carries the
+      // `Camera` family-2 group of the SerialInfo table, but the JSON sink keys
+      // on family-1 (`-G1`). `populate_typed` is (correctly) not run for this
+      // arm — the typed `internal_serial_number` accessor tracks only the
+      // model-agnostic SECOND-arm leaf, which an EOS-5D body never takes.
+      let blob = match &entry.value {
+        // The faithful `$$valPt` view the body walker captured for the 5D arm.
+        RawValue::Bytes(b) => b.as_slice(),
+        // Defensive: the walker always rewrites a 5D `0x96` to `Bytes`; any
+        // other shape means no SerialInfo blob to decode — emit nothing.
+        _ => &[],
+      };
+      for (name, value) in serial_info::parse(blob, print_conv) {
+        // Explicit BinaryData positions are never `Unknown`.
+        emissions.push(VendorEmission::new(name, value, false));
+      }
     } else if entry.tag_id == 0x28 {
       // `ImageUniqueID` (`Canon.pm:1726-1735`): the table forces
       // `Format => 'undef'`, so the walker captured the ORIGINAL on-disk
@@ -1352,17 +1365,20 @@ mod tests {
   }
 
   /// `0x96` MODEL-CONDITIONAL LIST (`Canon.pm:1834-1846`), FIRST arm: an
-  /// EOS-5D body routes `0x96` to the `SerialInfo` SubDirectory pointer
-  /// (`Canon.pm:1836-1838`; no `Writable`, no value emission), NOT
-  /// `InternalSerialNumber`. ExifTool descends into `Canon::SerialInfo` and
-  /// emits its leaves but NEVER the `SerialInfo` parent value; the port
-  /// defers that child walk, so it emits NEITHER `SerialInfo` (the bogus
-  /// parent, suppressed per #177) NOR `InternalSerialNumber` (the
-  /// trailing-`0xff` strip does NOT apply on this arm). The typed
-  /// `internal_serial_number` stays unset.
+  /// EOS-5D body routes `0x96` to the `SerialInfo` SubDirectory
+  /// (`Canon.pm:1836-1838`), NOT `InternalSerialNumber`. ExifTool descends
+  /// into `%Canon::SerialInfo` and emits its leaves (`InternalSerialNumber2` /
+  /// `InternalSerialNumber`) but NEVER the `SerialInfo` parent value; the port
+  /// decodes the sub-table (#175) while still suppressing the bogus parent
+  /// (#177). The typed `internal_serial_number` accessor (the model-agnostic
+  /// SECOND-arm leaf) stays unset — an EOS-5D never takes that arm.
+  ///
+  /// Oracle (`perl exiftool -G1 -j` on a crafted EOS 5D Mark II with this
+  /// SerialInfo blob): `Canon:InternalSerialNumber2 = "ABC123XYZ"`,
+  /// `Canon:InternalSerialNumber = "DEF456"`.
   #[test]
-  fn parse_eos_5d_0x96_suppresses_serialinfo_parent() {
-    let value = b"ABC123\xff\xff\xff";
+  fn parse_eos_5d_0x96_decodes_serialinfo_subtable() {
+    let value = b"ABC123XYZDEF456\x00";
     let blob = one_main_entry_blob(0x96, 0x02, value.len() as u32, value);
     let (typed, emissions) = parse_in_tiff(
       &blob,
@@ -1373,26 +1389,64 @@ mod tests {
       Some("Canon EOS 5D Mark II"),
       None,
     );
-    // The SerialInfo SubDirectory parent is suppressed (deferred child walk),
-    // and the second-arm InternalSerialNumber is NOT selected for an EOS-5D.
+    // The bogus `SerialInfo` SubDirectory parent is NEVER emitted (#177)…
     assert!(
       !emissions.iter().any(|e| e.name() == "SerialInfo"),
       "EOS 5D must NOT emit the bogus SerialInfo SubDirectory parent (#177)"
     );
-    assert!(
-      !emissions.iter().any(|e| e.name() == "InternalSerialNumber"),
-      "EOS 5D must NOT emit InternalSerialNumber (it took the SerialInfo arm)"
-    );
-    // Typed accessor for InternalSerialNumber stays unset.
+    // …but its decoded leaves ARE (#175).
+    let isn2 = emissions
+      .iter()
+      .find(|e| e.name() == "InternalSerialNumber2")
+      .map(|e| e.value().clone());
+    assert_eq!(isn2, Some(TagValue::Str("ABC123XYZ".into())));
+    let isn = emissions
+      .iter()
+      .find(|e| e.name() == "InternalSerialNumber")
+      .map(|e| e.value().clone());
+    assert_eq!(isn, Some(TagValue::Str("DEF456".into())));
+    // The typed `internal_serial_number` tracks only the model-agnostic
+    // SECOND-arm leaf, which an EOS-5D never takes — it stays unset.
     assert_eq!(typed.internal_serial_number(), None);
+  }
+
+  /// `RawConv => '$val =~ /^\w{6}/ ? $val : undef'` (`Canon.pm:7154`/`:7159`):
+  /// a SerialInfo `InternalSerialNumber2` whose first six bytes are NOT all
+  /// word characters is dropped, exactly like the oracle returns undef. The
+  /// valid offset-9 `InternalSerialNumber` still emits.
+  #[test]
+  fn parse_eos_5d_0x96_rawconv_drops_non_word_internal_serial2() {
+    let value = b"!!ABC123ZDEF456\x00";
+    let blob = one_main_entry_blob(0x96, 0x02, value.len() as u32, value);
+    let (_typed, emissions) = parse_in_tiff(
+      &blob,
+      0,
+      blob.len(),
+      ByteOrder::Little,
+      true,
+      Some("Canon EOS 5D Mark III"),
+      None,
+    );
+    assert!(
+      !emissions
+        .iter()
+        .any(|e| e.name() == "InternalSerialNumber2"),
+      "non-/^\\w{{6}}/ InternalSerialNumber2 must be dropped (RawConv undef)"
+    );
+    let isn = emissions
+      .iter()
+      .find(|e| e.name() == "InternalSerialNumber")
+      .map(|e| e.value().clone());
+    assert_eq!(isn, Some(TagValue::Str("DEF456".into())));
   }
 
   /// `/EOS 5D/` is an UNANCHORED substring (`Canon.pm:1837`) — base
   /// "EOS 5D" matches just as "EOS 5D Mark IV" does; the SerialInfo
-  /// SubDirectory parent is suppressed (#177) for either spelling.
+  /// sub-table is decoded (and the bogus parent suppressed, #177) for either
+  /// spelling.
   #[test]
-  fn parse_eos_5d_base_model_0x96_suppresses_serialinfo_parent() {
-    let value = b"WXYZ";
+  fn parse_eos_5d_base_model_0x96_decodes_serialinfo() {
+    let value = b"WXYZ12ABCSER789\x00";
     let blob = one_main_entry_blob(0x96, 0x02, value.len() as u32, value);
     let (typed, emissions) = parse_in_tiff(
       &blob,
@@ -1404,7 +1458,12 @@ mod tests {
       None,
     );
     assert!(!emissions.iter().any(|e| e.name() == "SerialInfo"));
-    assert!(!emissions.iter().any(|e| e.name() == "InternalSerialNumber"));
+    let isn2 = emissions
+      .iter()
+      .find(|e| e.name() == "InternalSerialNumber2")
+      .map(|e| e.value().clone());
+    assert_eq!(isn2, Some(TagValue::Str("WXYZ12ABC".into())));
+    // The typed `internal_serial_number` (SECOND-arm) stays unset.
     assert_eq!(typed.internal_serial_number(), None);
   }
 

--- a/src/exif/makernotes/vendors/canon/serial_info.rs
+++ b/src/exif/makernotes/vendors/canon/serial_info.rs
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Canon::SerialInfo` (`Canon.pm:7145-7161`).
+//!
+//! Binary-data sub-table — `%binaryDataAttrs` (default `FORMAT => 'int8u'`),
+//! `FIRST_ENTRY => 0`, `GROUPS => { 0 => 'MakerNotes', 2 => 'Camera' }`.
+//! Reached via the `Canon::Main` tag `0x96` model-conditional LIST: the FIRST
+//! arm `SerialInfo` SubDirectory is selected when `$$self{Model} =~ /EOS 5D/`
+//! (`Canon.pm:1835-1838`); the SECOND arm `InternalSerialNumber` is the
+//! model-agnostic leaf (handled by the dispatcher, not this table).
+//!
+//! Two named positions (`Canon.pm:7150-7160`):
+//!
+//! - offset 0 `InternalSerialNumber2`, `Format => 'string[9]'` — nine bytes
+//!   read as a NUL-truncated string (`ReadValue`'s `s/\0.*//s`,
+//!   `ExifTool.pm:6311`), then `RawConv => '$val =~ /^\w{6}/ ? $val : undef'`
+//!   (emit only when the first six characters are word characters
+//!   `[A-Za-z0-9_]`; else drop the tag). Seen on 5DmkII/5DmkIII/5DmkIV/5DS/5DSR
+//!   (github398) — "could be the number on a barcode sticker of the main
+//!   circuit board".
+//! - offset 9 `InternalSerialNumber`, `Format => 'string'` — a `string` with no
+//!   `[count]` runs to the END of the binary block (`$count = $more`,
+//!   `ExifTool.pm:9970`), then NUL-truncated, then the SAME `/^\w{6}/` RawConv.
+//!
+//! Neither position has a `PrintConv`, so the `-j` and `-n` views are identical
+//! (the bare ASCII string).
+//!
+//! D8: this is a pure decoder (no public struct fields); it returns the
+//! `(Name, TagValue)` emission pairs the dispatch site wraps in the `Canon`
+//! family-1 group.
+
+// Golden-v2 Contract 3c (Phase C, slice w2d): panic-safety by construction —
+// every raw index/slice below is dominated by a preceding length guard and
+// converted to a checked `.get()` form (re-asserts the parent `exif` deny over
+// the makernotes subtree's slice-D/E `#![allow]` shim).
+#![deny(clippy::indexing_slicing)]
+
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Decode the `Canon::SerialInfo` binary block (`Canon.pm:7145-7161`) into the
+/// `(Name, TagValue)` emission pairs. `print_conv` is accepted for a uniform
+/// sub-table signature; there is NO `PrintConv` here, so the result is
+/// identical in `-j` and `-n` (the bare ASCII string per surviving position).
+///
+/// `data` is the raw SerialInfo blob (`$$valPt`) — the on-disk bytes captured
+/// verbatim by the body walker for the 5D `0x96` arm (no NUL-trim, no `0xff`
+/// strip applied upstream). A position whose bytes are absent / fail the
+/// `/^\w{6}/` RawConv is simply omitted (bundled's `RawConv => … : undef`).
+#[must_use]
+pub fn parse(data: &[u8], print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let _ = print_conv; // no PrintConv in this table
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // offset 0 `InternalSerialNumber2` — `Format => 'string[9]'`: read nine
+  // bytes, NUL-truncate, then `/^\w{6}/`.
+  if let Some(v) = read_word_string(data.get(0..9).unwrap_or(data)) {
+    out.push((SmolStr::new_static("InternalSerialNumber2"), v));
+  }
+  // offset 9 `InternalSerialNumber` — `Format => 'string'` with no count runs
+  // to the end of the block (`$count = $more`), NUL-truncate, then `/^\w{6}/`.
+  if let Some(v) = read_word_string(data.get(9..).unwrap_or(&[])) {
+    out.push((SmolStr::new_static("InternalSerialNumber"), v));
+  }
+  out
+}
+
+/// `ReadValue` `string` decode (`ExifTool.pm:6311`: `s/\0.*//s` — truncate at
+/// the first NUL) followed by the SerialInfo `RawConv` (`Canon.pm:7154`/`:7159`:
+/// `$val =~ /^\w{6}/ ? $val : undef` — keep the value only when its first SIX
+/// bytes are ASCII word characters `[A-Za-z0-9_]`; otherwise drop it).
+///
+/// The `/^\w{6}/` RawConv gate is applied to the RAW (NUL-truncated) Perl byte
+/// string, matching ExifTool's evaluation order (`RawConv` runs on the byte
+/// value, BEFORE JSON serialization). `\w` (no `/u` flag) matches the ASCII word
+/// class, so a non-ASCII byte in the first six positions correctly fails the
+/// test the same way it does in Perl's byte-string regex.
+///
+/// The surviving byte string is then converted to the emitted `String` via
+/// [`crate::convert::fix_utf8`] — the faithful transliteration of
+/// `Image::ExifTool::XMP::FixUTF8`, which the `exiftool` JSON emitter runs on
+/// every extracted string (`exiftool:3822`). Each MALFORMED UTF-8 byte becomes a
+/// single ASCII `?` (`0x3F`), NOT the Unicode REPLACEMENT CHARACTER U+FFFD that
+/// `String::from_utf8_lossy` would emit. A value such as `b"ABC123\xff\xff\xff"`
+/// (six word chars then three invalid bytes, no NUL in the first nine) PASSES the
+/// `/^\w{6}/` gate on its raw bytes and serializes as `"ABC123???"` (perl oracle:
+/// `Image::ExifTool::XMP::FixUTF8(\$s)` on `"ABC123\xff\xff\xff"` ⇒ `ABC123???`,
+/// bytes `41 42 43 31 32 33 3f 3f 3f`); `from_utf8_lossy` would wrongly emit
+/// `ABC123` + three U+FFFD, a byte-mismatch at the conformance `jsondiff` gate.
+fn read_word_string(window: &[u8]) -> Option<TagValue> {
+  // `s/\0.*//s` — truncate at the first NUL byte.
+  let trimmed = match window.iter().position(|&b| b == 0) {
+    // `nul < window.len()`, so `window.get(..nul)` is `Some` — the checked,
+    // byte-identical form of `&window[..nul]`.
+    Some(nul) => window.get(..nul).unwrap_or(window),
+    None => window,
+  };
+  // `/^\w{6}/` on the RAW (NUL-truncated) bytes — require at least six leading
+  // bytes, each an ASCII word char. The gate stays on the byte string (ExifTool
+  // RawConv order); only the OUTPUT conversion goes through FixUTF8.
+  let head = trimmed.get(..6)?;
+  if head.iter().all(|&b| is_word_byte(b)) {
+    Some(TagValue::Str(SmolStr::from(crate::convert::fix_utf8(
+      trimmed,
+    ))))
+  } else {
+    None
+  }
+}
+
+/// Perl `\w` (ASCII, no `/u`): `[A-Za-z0-9_]`.
+const fn is_word_byte(b: u8) -> bool {
+  b.is_ascii_alphanumeric() || b == b'_'
+}
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is a parser-panic-safety
+// contract (Phase C w2d); the test fixtures index fixed-layout buffers freely
+// (an out-of-range index is a test-assertion failure, not a shipped panic), so
+// the deny is relaxed here.
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// Both positions valid. Oracle (`perl exiftool -G1 -j` on a crafted EOS 5D
+  /// Mark III): blob `"ABC123XYZ" + "DEF456\0"` ⇒
+  /// `Canon:InternalSerialNumber2 = "ABC123XYZ"`,
+  /// `Canon:InternalSerialNumber = "DEF456"`.
+  #[test]
+  fn decodes_both_positions() {
+    let blob = b"ABC123XYZDEF456\x00";
+    let em = parse(blob, true);
+    assert_eq!(
+      find(&em, "InternalSerialNumber2"),
+      Some(TagValue::Str("ABC123XYZ".into()))
+    );
+    assert_eq!(
+      find(&em, "InternalSerialNumber"),
+      Some(TagValue::Str("DEF456".into()))
+    );
+    assert_eq!(em.len(), 2);
+    // No PrintConv ⇒ `-n` is identical.
+    assert_eq!(parse(blob, false), em);
+  }
+
+  /// `string[9]` reads exactly nine bytes from offset 0, even when no NUL
+  /// terminates them inside the field — bytes 9.. are the offset-9 string.
+  #[test]
+  fn internal_serial_number2_is_fixed_nine_bytes() {
+    // Nine-byte field, then offset-9 string `"WORD12\0"`.
+    let blob = b"ABCDEFGHIWORD12\x00";
+    let em = parse(blob, true);
+    assert_eq!(
+      find(&em, "InternalSerialNumber2"),
+      Some(TagValue::Str("ABCDEFGHI".into()))
+    );
+    assert_eq!(
+      find(&em, "InternalSerialNumber"),
+      Some(TagValue::Str("WORD12".into()))
+    );
+  }
+
+  /// `RawConv => '$val =~ /^\w{6}/ ? $val : undef'` drops a value whose first
+  /// six bytes are NOT all word characters. Oracle: a leading-`!!` offset-0
+  /// blob drops `InternalSerialNumber2` but keeps the valid offset-9
+  /// `InternalSerialNumber`.
+  #[test]
+  fn rawconv_drops_non_word_leading() {
+    let blob = b"!!ABC123ZDEF456\x00";
+    let em = parse(blob, true);
+    assert_eq!(find(&em, "InternalSerialNumber2"), None);
+    assert_eq!(
+      find(&em, "InternalSerialNumber"),
+      Some(TagValue::Str("DEF456".into()))
+    );
+    assert_eq!(em.len(), 1);
+  }
+
+  /// The `string` decode NUL-truncates BEFORE `/^\w{6}/`: exactly six word
+  /// chars then a NUL passes (oracle nul6); five word chars then a NUL fails
+  /// (oracle nul5).
+  #[test]
+  fn nul_truncation_precedes_word_test() {
+    // Six word chars then NUL in the offset-0 field.
+    let pass = b"ABCDEF\x00YZWORD12\x00";
+    assert_eq!(
+      find(&parse(pass, true), "InternalSerialNumber2"),
+      Some(TagValue::Str("ABCDEF".into()))
+    );
+    // Five word chars then NUL ⇒ `"ABCDE"` (5 chars) fails `/^\w{6}/`.
+    let fail = b"ABCDE\x00XYZWORD12\x00";
+    assert_eq!(find(&parse(fail, true), "InternalSerialNumber2"), None);
+  }
+
+  /// A value whose first six bytes are word chars but whose tail holds INVALID
+  /// UTF-8 bytes (no NUL in the first nine) PASSES the `/^\w{6}/` RawConv on its
+  /// raw byte string and must serialize through ExifTool's `FixUTF8` — each bad
+  /// byte → a single ASCII `?` (`0x3F`), NOT the U+FFFD that `from_utf8_lossy`
+  /// emits. Oracle (bundled perl, the exact function `exiftool:3822` runs):
+  ///   perl -Ilib -MImage::ExifTool::XMP -e 'my $s="ABC123\xff\xff\xff";
+  ///         Image::ExifTool::XMP::FixUTF8(\$s); print $s' ⇒ "ABC123???"
+  ///         (bytes 41 42 43 31 32 33 3f 3f 3f).
+  /// This is a genuine guard: `String::from_utf8_lossy(b"ABC123\xff\xff\xff")`
+  /// returns `"ABC123\u{FFFD}\u{FFFD}\u{FFFD}"`, so the assertion below FAILS
+  /// under the pre-fix conversion and only passes via `fix_utf8`.
+  #[test]
+  fn non_utf8_survivor_uses_fix_utf8_not_lossy() {
+    // Offset-0 `string[9]` field = "ABC123" + three 0xff bytes (no NUL): the
+    // raw bytes pass `/^\w{6}/`, then FixUTF8 maps each 0xff to '?'.
+    let blob = b"ABC123\xff\xff\xffWORD12\x00";
+    let v = find(&parse(blob, true), "InternalSerialNumber2");
+    assert_eq!(v, Some(TagValue::Str("ABC123???".into())));
+    // Sanity: confirm the expected string is plain ASCII '?' (0x3f), not U+FFFD.
+    if let Some(TagValue::Str(s)) = v {
+      assert_eq!(s.as_bytes(), b"ABC123\x3f\x3f\x3f");
+      assert!(!s.contains('\u{FFFD}'));
+    }
+    // No PrintConv ⇒ `-n` is identical.
+    assert_eq!(
+      find(&parse(blob, false), "InternalSerialNumber2"),
+      Some(TagValue::Str("ABC123???".into()))
+    );
+    // Independent regression anchor: the pre-fix `from_utf8_lossy` path would
+    // have produced U+FFFD, which is what we are guarding against.
+    assert_eq!(
+      String::from_utf8_lossy(b"ABC123\xff\xff\xff"),
+      "ABC123\u{FFFD}\u{FFFD}\u{FFFD}"
+    );
+  }
+
+  /// The underscore is a `\w` character; six leading underscores pass.
+  #[test]
+  fn underscore_is_a_word_char() {
+    let blob = b"______XYZWORD12\x00";
+    assert_eq!(
+      find(&parse(blob, true), "InternalSerialNumber2"),
+      Some(TagValue::Str("______XYZ".into()))
+    );
+  }
+
+  /// A blob too short to hold a six-char offset-0 string drops
+  /// `InternalSerialNumber2`; a blob with no offset-9 bytes (≤ 9 bytes) drops
+  /// `InternalSerialNumber` (the empty `string` cannot match `/^\w{6}/`).
+  #[test]
+  fn short_blob_drops_absent_positions() {
+    // Five bytes: offset-0 field is `"ABCDE"` (< 6 word chars) → dropped;
+    // offset 9.. is empty → dropped.
+    let em = parse(b"ABCDE", true);
+    assert!(em.is_empty());
+    // Exactly nine valid bytes: offset-0 passes, offset 9.. empty → dropped.
+    let em = parse(b"ABCDEF123", true);
+    assert_eq!(
+      find(&em, "InternalSerialNumber2"),
+      Some(TagValue::Str("ABCDEF123".into()))
+    );
+    assert_eq!(find(&em, "InternalSerialNumber"), None);
+    assert_eq!(em.len(), 1);
+  }
+}

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -431,6 +431,151 @@ fn canon_eos_real_fixture_decodes_typed_fields() {
   assert_eq!(canon.focus_distance_decoded(), None);
 }
 
+/// Build a crafted EOS-5D JPEG (no bundled 5D fixture exists — the `t/images`
+/// Canon bodies are REBEL/1D-III/350D/M50). Big-endian (MM) TIFF: IFD0 carries
+/// `Make`="Canon" / `Model` (so the `0x96` LIST evaluates `$$self{Model} =~
+/// /EOS 5D/`) / an ExifIFD pointer; ExifIFD carries the `0x927c` MakerNote; the
+/// Canon MakerNote IFD (a bare IFD) carries a single `0x96` entry whose
+/// out-of-line value is `serialinfo_blob` — the raw `%Canon::SerialInfo` bytes.
+/// Wrapped in `SOI + APP1(Exif\0\0…) + EOI`. Mirrors `/tmp/build5d.py`, which
+/// produced the oracle-cited expectations.
+fn craft_eos_5d_jpeg(model: &[u8], serialinfo_blob: &[u8]) -> Vec<u8> {
+  let make = b"Canon\x00";
+  // TIFF-relative offsets (8-byte header at the start).
+  let hdr = 8usize;
+  let ifd0_start = hdr; // 8
+  let ifd0_size = 2 + 12 * 3 + 4; // count + 3 entries + next
+  let make_off = ifd0_start + ifd0_size;
+  let model_off = make_off + make.len();
+  let exif_start = model_off + model.len();
+  let exif_size = 2 + 12 + 4; // count + 1 entry + next
+  let canon_start = exif_start + exif_size;
+  let canon_size = 2 + 12 + 4; // count + 1 entry + next
+  let serial_off = canon_start + canon_size;
+  let mn_len = (serial_off + serialinfo_blob.len()) - canon_start;
+
+  let u16 = |v: u16| v.to_be_bytes();
+  let u32 = |v: u32| v.to_be_bytes();
+  let mut t: Vec<u8> = Vec::new();
+  t.extend_from_slice(b"MM");
+  t.extend_from_slice(&u16(0x2a));
+  t.extend_from_slice(&u32(ifd0_start as u32));
+  // ---- IFD0: Make, Model, ExifIFD ----
+  t.extend_from_slice(&u16(3));
+  t.extend_from_slice(&u16(0x010f)); // Make
+  t.extend_from_slice(&u16(2)); // ASCII
+  t.extend_from_slice(&u32(make.len() as u32));
+  t.extend_from_slice(&u32(make_off as u32));
+  t.extend_from_slice(&u16(0x0110)); // Model
+  t.extend_from_slice(&u16(2)); // ASCII
+  t.extend_from_slice(&u32(model.len() as u32));
+  t.extend_from_slice(&u32(model_off as u32));
+  t.extend_from_slice(&u16(0x8769)); // ExifIFD pointer
+  t.extend_from_slice(&u16(4)); // LONG
+  t.extend_from_slice(&u32(1));
+  t.extend_from_slice(&u32(exif_start as u32));
+  t.extend_from_slice(&u32(0)); // IFD0 next = 0
+  // ---- strings ----
+  t.extend_from_slice(make);
+  t.extend_from_slice(model);
+  // ---- ExifIFD: MakerNote ----
+  t.extend_from_slice(&u16(1));
+  t.extend_from_slice(&u16(0x927c)); // MakerNote
+  t.extend_from_slice(&u16(7)); // UNDEF
+  t.extend_from_slice(&u32(mn_len as u32));
+  t.extend_from_slice(&u32(canon_start as u32));
+  t.extend_from_slice(&u32(0)); // ExifIFD next = 0
+  // ---- Canon MakerNote IFD: 0x96 SerialInfo ----
+  t.extend_from_slice(&u16(1));
+  t.extend_from_slice(&u16(0x0096)); // 0x96
+  t.extend_from_slice(&u16(2)); // ASCII (the on-disk declared format)
+  t.extend_from_slice(&u32(serialinfo_blob.len() as u32));
+  t.extend_from_slice(&u32(serial_off as u32));
+  t.extend_from_slice(&u32(0)); // Canon IFD next = 0
+  // ---- SerialInfo blob ----
+  t.extend_from_slice(serialinfo_blob);
+
+  // Wrap in a JPEG: SOI + APP1(Exif\0\0 + tiff) + EOI.
+  let mut app1: Vec<u8> = Vec::new();
+  app1.extend_from_slice(b"Exif\x00\x00");
+  app1.extend_from_slice(&t);
+  let mut jpeg: Vec<u8> = Vec::new();
+  jpeg.extend_from_slice(&[0xff, 0xd8]); // SOI
+  jpeg.extend_from_slice(&[0xff, 0xe1]); // APP1
+  jpeg.extend_from_slice(&((app1.len() + 2) as u16).to_be_bytes());
+  jpeg.extend_from_slice(&app1);
+  jpeg.extend_from_slice(&[0xff, 0xd9]); // EOI
+  jpeg
+}
+
+/// `Canon::SerialInfo` (`Canon.pm:7145-7161`) end-to-end, FIRST arm of the
+/// `0x96` LIST (`Canon.pm:1835-1838`): a crafted EOS 5D Mark III JPEG with a
+/// valid SerialInfo blob decodes into `Canon:InternalSerialNumber2` /
+/// `Canon:InternalSerialNumber`, and NEVER the bogus `SerialInfo` parent (#177).
+///
+/// Oracle (`perl exiftool -G1 -j` on the SAME crafted bytes):
+///
+/// ```text
+/// "IFD0:Model": "Canon EOS 5D Mark III",
+/// "Canon:InternalSerialNumber2": "ABC123XYZ",
+/// "Canon:InternalSerialNumber": "DEF456"
+/// ```
+#[test]
+fn canon_serialinfo_5d_decodes_internal_serial_number2() {
+  let data = craft_eos_5d_jpeg(b"Canon EOS 5D Mark III\x00", b"ABC123XYZDEF456\x00");
+  let meta = exifast::exif::jpeg::parse_jpeg_exif(&data).expect("crafted 5D JPEG parsed");
+  let mn = meta.maker_note().expect("MakerNote captured");
+  assert!(mn.vendor().is_canon(), "vendor = Canon");
+  let emissions = mn.emissions_print_conv();
+
+  // The decoded SerialInfo leaves (oracle byte-exact).
+  let isn2 = emissions
+    .iter()
+    .find(|e| e.name() == "InternalSerialNumber2")
+    .map(|e| e.value().clone());
+  assert_eq!(
+    isn2,
+    Some(exifast::TagValue::Str("ABC123XYZ".into())),
+    "InternalSerialNumber2 must decode to the oracle value"
+  );
+  let isn = emissions
+    .iter()
+    .find(|e| e.name() == "InternalSerialNumber")
+    .map(|e| e.value().clone());
+  assert_eq!(isn, Some(exifast::TagValue::Str("DEF456".into())));
+
+  // The bogus `SerialInfo` SubDirectory parent is NEVER emitted (#177).
+  assert!(
+    !emissions.iter().any(|e| e.name() == "SerialInfo"),
+    "the raw SerialInfo blob must NOT be emitted as a parent (#177)"
+  );
+}
+
+/// `RawConv => '$val =~ /^\w{6}/ ? $val : undef'` (`Canon.pm:7154`): a crafted
+/// EOS 5D SerialInfo blob whose `InternalSerialNumber2` first six bytes are NOT
+/// all word characters is DROPPED — matching the oracle's undef (the offset-9
+/// `InternalSerialNumber` still emits).
+#[test]
+fn canon_serialinfo_rawconv_drops_non_word() {
+  let data = craft_eos_5d_jpeg(b"Canon EOS 5D Mark III\x00", b"!!ABC123ZDEF456\x00");
+  let meta = exifast::exif::jpeg::parse_jpeg_exif(&data).expect("crafted 5D JPEG parsed");
+  let mn = meta.maker_note().expect("MakerNote captured");
+  let emissions = mn.emissions_print_conv();
+
+  assert!(
+    !emissions
+      .iter()
+      .any(|e| e.name() == "InternalSerialNumber2"),
+    "non-/^\\w{{6}}/ InternalSerialNumber2 must be dropped (RawConv undef)"
+  );
+  // The valid offset-9 InternalSerialNumber still emits.
+  let isn = emissions
+    .iter()
+    .find(|e| e.name() == "InternalSerialNumber")
+    .map(|e| e.value().clone());
+  assert_eq!(isn, Some(exifast::TagValue::Str("DEF456".into())));
+}
+
 // ===========================================================================
 // Phase 3 — real-input Sony/Panasonic JPEG fixtures
 // ===========================================================================

--- a/tests/quicktime_brands.rs
+++ b/tests/quicktime_brands.rs
@@ -1690,12 +1690,16 @@ fn cr3_cmt3_before_cmt1_no_model_threaded() {
   // NO Model in state; a CMT1-before-CMT3 threads the Model.
   //
   // The clean model-gated observable is Canon Main tag `0x96` (Canon.pm:1834):
-  //   - Model =~ /EOS 5D/  ⇒ FIRST arm `SerialInfo` (a SubDirectory; exifast
-  //     surfaces it as the raw blob) ⇒ `InternalSerialNumber` is ABSENT.
+  //   - Model =~ /EOS 5D/  ⇒ FIRST arm `SerialInfo` SubDirectory (decoded into
+  //     `%Canon::SerialInfo`, #175) ⇒ `Canon:InternalSerialNumber2` IS emitted
+  //     and the bare `Canon:InternalSerialNumber` is ABSENT (offset-9 string is
+  //     empty in this 9-byte blob).
   //   - no/other Model      ⇒ SECOND arm `InternalSerialNumber` (the trailing
-  //     `0xff` strip applies) ⇒ `Canon:InternalSerialNumber` IS emitted.
-  // Ground-truthed against `exiftool -G1 -j`: the reordered file emits
-  // `Canon:InternalSerialNumber":"ABC123"` while the in-order file does not.
+  //     `0xff` strip applies) ⇒ the bare `Canon:InternalSerialNumber` IS emitted
+  //     (and `InternalSerialNumber2` is ABSENT).
+  // Ground-truthed against `exiftool -G1 -j`: the in-order file emits
+  // `Canon:InternalSerialNumber2` (the SerialInfo arm); the reordered file emits
+  // the bare `Canon:InternalSerialNumber":"ABC123"`.
 
   // CMT1 IFD0 with Model (0x0110) ASCII = "Canon EOS 5D\0".
   let cmt1 = tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
@@ -1703,7 +1707,8 @@ fn cr3_cmt3_before_cmt1_no_model_threaded() {
   let cmt3 = tiff_le_one_entry(0x0096, 2, b"ABC123\xff\xff\xff");
 
   // In-order [CMT1, CMT3]: the Model is in state at the CMT3 walk ⇒ 0x96 routes
-  // to the SerialInfo arm ⇒ InternalSerialNumber is NOT emitted.
+  // to the SerialInfo arm ⇒ `InternalSerialNumber2` emitted, bare
+  // `InternalSerialNumber` absent.
   let in_order = cr3_with_cmt_order(&[(b"CMT1", cmt1.clone()), (b"CMT3", cmt3.clone())]);
   let json_in = exifast::parser::extract_info("cr3_inorder.cr3", &in_order, true);
   assert!(
@@ -1711,8 +1716,10 @@ fn cr3_cmt3_before_cmt1_no_model_threaded() {
     "in-order CMT1 Model missing: {json_in}"
   );
   assert!(
-    !json_in.contains("InternalSerialNumber"),
-    "in-order: Model in state ⇒ 0x96 is SerialInfo, InternalSerialNumber must be absent: {json_in}"
+    json_in.contains(r#""Canon:InternalSerialNumber2""#)
+      && !json_in.contains(r#""Canon:InternalSerialNumber":"#),
+    "in-order: Model in state ⇒ 0x96 is SerialInfo ⇒ InternalSerialNumber2 \
+     present and bare InternalSerialNumber absent: {json_in}"
   );
 
   // Reordered [CMT3, CMT1]: the Model is NOT yet in state at the CMT3 walk ⇒
@@ -1815,10 +1822,10 @@ fn cr3_overbudget_or_dropped_cmt1_no_stale_model_for_cmt3() {
   // never clears it. This test pins BOTH directions.
   //
   // Discriminating observable is Canon Main tag `0x96` (Canon.pm:1834):
-  //   - Model =~ /EOS 5D/ ⇒ `SerialInfo` SubDirectory arm ⇒ InternalSerialNumber
-  //     ABSENT.
+  //   - Model =~ /EOS 5D/ ⇒ `SerialInfo` SubDirectory arm (decoded, #175) ⇒
+  //     `InternalSerialNumber2` present, bare `InternalSerialNumber` ABSENT.
   //   - other / no Model  ⇒ `InternalSerialNumber` arm (trailing 0xff stripped)
-  //     ⇒ present.
+  //     ⇒ bare `InternalSerialNumber` present.
   // Ground-truthed against `exiftool -G1 -j`.
 
   let cmt1_5d = || tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
@@ -1828,7 +1835,7 @@ fn cr3_overbudget_or_dropped_cmt1_no_stale_model_for_cmt3() {
 
   // (a) The spec scenario — CMT1(5D), then a model-LESS CMT1, then CMT3. The 5D
   // Model must STILL thread (the model-less CMT1 does not clear it) ⇒ 0x96 is
-  // SerialInfo ⇒ InternalSerialNumber ABSENT.
+  // SerialInfo ⇒ InternalSerialNumber2 present, bare InternalSerialNumber ABSENT.
   let data_a = cr3_with_cmt_order(&[
     (b"CMT1", cmt1_5d()),
     (b"CMT1", cmt1_nomodel()),
@@ -1840,9 +1847,10 @@ fn cr3_overbudget_or_dropped_cmt1_no_stale_model_for_cmt3() {
     "the 5D Model is emitted (the model-less CMT1 carries no Model tag): {json_a}"
   );
   assert!(
-    !json_a.contains("InternalSerialNumber"),
+    json_a.contains(r#""Canon:InternalSerialNumber2""#)
+      && !json_a.contains(r#""Canon:InternalSerialNumber":"#),
     "model-less middle CMT1 must NOT clear the 5D Model: 0x96 stays SerialInfo \
-     ⇒ InternalSerialNumber absent: {json_a}"
+     ⇒ InternalSerialNumber2 present, bare InternalSerialNumber absent: {json_a}"
   );
 
   // (b) The supersede direction (the exact R4 drop-bug inverse) — CMT1(5D),
@@ -1877,12 +1885,13 @@ fn cr3_modelless_cmt1_does_not_clear_threaded_model() {
   // CMT1 would be wrong.
   //
   // Discriminating observable is Canon Main tag `0x96` (Canon.pm:1834): with
-  // Model =~ /EOS 5D/ ⇒ the `SerialInfo` SubDirectory arm (InternalSerialNumber
-  // ABSENT); with no Model in state ⇒ the `InternalSerialNumber` arm (present,
-  // trailing 0xff stripped). The threaded model is therefore "Canon EOS 5D" (the
-  // model the `0x96` condition actually keys on), so the assertion is meaningful:
-  // if the model-less CMT1 wrongly cleared the Model, InternalSerialNumber would
-  // appear. Ground-truthed against `exiftool -G1 -j`.
+  // Model =~ /EOS 5D/ ⇒ the `SerialInfo` SubDirectory arm (decoded, #175 ⇒
+  // `InternalSerialNumber2` present, bare `InternalSerialNumber` ABSENT); with no
+  // Model in state ⇒ the bare `InternalSerialNumber` arm (present, trailing 0xff
+  // stripped). The threaded model is therefore "Canon EOS 5D" (the model the
+  // `0x96` condition actually keys on), so the assertion is meaningful: if the
+  // model-less CMT1 wrongly cleared the Model, the bare InternalSerialNumber
+  // would appear. Ground-truthed against `exiftool -G1 -j`.
 
   // CMT1 #1: IFD0 with Model (0x0110) = "Canon EOS 5D\0".
   let cmt1_model = tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
@@ -1906,11 +1915,14 @@ fn cr3_modelless_cmt1_does_not_clear_threaded_model() {
     "CMT1 Model missing: {json}"
   );
   // The CMT3 walk saw the threaded Model (NOT cleared by the model-less CMT1) ⇒
-  // 0x96 routes to SerialInfo ⇒ InternalSerialNumber must be ABSENT.
+  // 0x96 routes to SerialInfo ⇒ InternalSerialNumber2 present, bare
+  // InternalSerialNumber ABSENT.
   assert!(
-    !json.contains("InternalSerialNumber"),
+    json.contains(r#""Canon:InternalSerialNumber2""#)
+      && !json.contains(r#""Canon:InternalSerialNumber":"#),
     "model-less CMT1 must NOT clear the threaded Model: with EOS 5D in state, \
-     0x96 is SerialInfo and InternalSerialNumber must be absent: {json}"
+     0x96 is SerialInfo ⇒ InternalSerialNumber2 present, bare \
+     InternalSerialNumber absent: {json}"
   );
 }
 
@@ -1960,10 +1972,10 @@ fn cr3_cmt1_in_earlier_uuid_threads_model_to_cmt3_in_later_uuid() {
   // `uuid` atom must see the `Model` of a CMT1 in an EARLIER Canon `uuid` atom.
   // The old per-uuid-local model reset this between atoms, silently flipping the
   // model-conditional `0x96` arm (Canon.pm:1834):
-  //   - Model =~ /EOS 5D/ ⇒ `SerialInfo` SubDirectory arm ⇒ InternalSerialNumber
-  //     ABSENT.
-  //   - no/other Model     ⇒ `InternalSerialNumber` arm (trailing 0xff stripped)
-  //     ⇒ present.
+  //   - Model =~ /EOS 5D/ ⇒ `SerialInfo` SubDirectory arm (decoded, #175) ⇒
+  //     `InternalSerialNumber2` present, bare `InternalSerialNumber` ABSENT.
+  //   - no/other Model     ⇒ bare `InternalSerialNumber` arm (trailing 0xff
+  //     stripped) ⇒ present.
   // Ground-truthed against `exiftool -G1 -j` on this multi-uuid layout.
 
   let cmt1_5d = || tiff_le_one_entry(0x0110, 2, b"Canon EOS 5D\0");
@@ -1971,7 +1983,8 @@ fn cr3_cmt1_in_earlier_uuid_threads_model_to_cmt3_in_later_uuid() {
 
   // uuid#1 { CMT1(Model="Canon EOS 5D") }, then uuid#2 { CMT3(0x96) }. The 5D
   // Model set while walking uuid#1 must STILL be in state at the uuid#2 CMT3 ⇒
-  // 0x96 routes to SerialInfo ⇒ InternalSerialNumber ABSENT.
+  // 0x96 routes to SerialInfo ⇒ InternalSerialNumber2 present, bare
+  // InternalSerialNumber ABSENT.
   let threaded = cr3_with_canon_uuids(&[&[(b"CMT1", cmt1_5d())], &[(b"CMT3", cmt3())]]);
   let json = exifast::parser::extract_info("cr3_cross_uuid.cr3", &threaded, true);
   assert!(
@@ -1979,9 +1992,11 @@ fn cr3_cmt1_in_earlier_uuid_threads_model_to_cmt3_in_later_uuid() {
     "the uuid#1 CMT1 Model is emitted: {json}"
   );
   assert!(
-    !json.contains("InternalSerialNumber"),
+    json.contains(r#""Canon:InternalSerialNumber2""#)
+      && !json.contains(r#""Canon:InternalSerialNumber":"#),
     "R5: a CMT1 Model in an EARLIER Canon uuid must thread to a CMT3 in a LATER \
-     uuid ⇒ 0x96 is SerialInfo ⇒ InternalSerialNumber absent: {json}"
+     uuid ⇒ 0x96 is SerialInfo ⇒ InternalSerialNumber2 present, bare \
+     InternalSerialNumber absent: {json}"
   );
 
   // Non-vacuousness: the SAME 0x96 bytes WITHOUT a preceding CMT1 Model take the


### PR DESCRIPTION
Decodes the Canon::SerialInfo binary sub-table (Canon.pm:7145-7161) for the EOS 5D-family 0x96 MakerNote path, replacing the deferred raw blob with the typed serial tags.

## Scope
- Canon Main tag 0x96 is model-conditional (Canon.pm:1834-1846): `Model =~ /EOS 5D/` → `SerialInfo` SubDirectory (this PR decodes it); other bodies keep `InternalSerialNumber` (unchanged).
- New `canon/serial_info.rs` (mirrors the `sensor_info.rs` decoder shape, file-level `#![deny(clippy::indexing_slicing)]`): **InternalSerialNumber2** (string[9]@0, NUL-truncate) + **InternalSerialNumber** (string@9-to-end, NUL-truncate), both gated by the `/^\w{6}/` RawConv (emit only when the first 6 post-NUL chars are ASCII word chars). Surviving values serialize through the ExifTool-faithful `convert::fix_utf8` (FixUTF8: each malformed byte → ASCII `?`, matching ExifTool's JSON path — not `from_utf8_lossy`'s U+FFFD).
- Emitted family-1 `Canon:`; the bogus `SerialInfo` parent stays suppressed (#177).

## Verify
- `fmt --check` 0 · `build --all-features --all-targets -Dwarnings` 0 · `test --all-features --all-targets --skip gen_golden` 0 (lib 2847 + conformance **416/0** + serial_info unit 7) · `clippy --all-features` 0.
- No real EOS 5D fixture exists (t/images Canon bodies are REBEL/1D-III/350D/M50), so verified via crafted 5D MakerNotes + the `perl FixUTF8` oracle: valid → `InternalSerialNumber2`/`InternalSerialNumber`; `/^\w{6}/` negative → dropped; `ABC123\xff\xff\xff` → `ABC123???`; NUL-truncate / short-blob / underscore edge cases all oracle-confirmed.
- Non-5D Canon fixtures byte-exact (they take the InternalSerialNumber path, unchanged).
- Codex adversarial review: **APPROVE (R2, no material findings)**.

Sibling of #164 (Canon deep sub-tables); refs #73/#56.