### PR TITLE
feat(exif/nikon): decrypt + decode LensData sub-table (#227 phase 1)

### DIFF
--- a/src/exif/makernotes/vendors/nikon/body.rs
+++ b/src/exif/makernotes/vendors/nikon/body.rs
@@ -72,6 +72,44 @@ impl ParsedValue {
     }
   }
 
+  /// The post-`ReadValue` `$val` as a SINGLE all-digit count key — the faithful,
+  /// FORMAT-AGNOSTIC port of ExifTool's `$count =~ /^\d+$/` test applied to the
+  /// prescan-captured `$val` (`ProcessNikonEncrypted`, `Nikon.pm:13948`; the
+  /// `$val` is `PrescanExif`'s `ReadValue` result, `Nikon.pm:14122`).
+  ///
+  /// `/^\d+$/` matches the WHOLE rendered scalar against one-or-more ASCII
+  /// digits, so it is independent of the TIFF storage format: an `int32u 100`
+  /// renders `"100"` (matches), an ASCII `"100"` (`string`/`undef` `0x00a7`)
+  /// also renders `"100"` (matches), while a multi-element value renders
+  /// space-joined (`int32u[2]` ⇒ `"100 0"`, the space fails), a negative
+  /// renders with a leading `-` (fails), and a non-digit string fails. The
+  /// rendering is [`RawValue::val_bytes`] — ExifTool's exact `$val` bytes for
+  /// every shape. Used for the `ShutterCount` (0x00a7) count key, so a malformed
+  /// `int32u[2]`/`int32s` 0x00a7 must NOT unlock decryption, while an integer OR
+  /// ASCII-digit 0x00a7 does.
+  ///
+  /// The returned value is the count's LOW 32 BITS: ExifTool keeps the count as a
+  /// numeric scalar and the cipher consumes only its four low bytes
+  /// (`$key ^= ($count >> $i*8) & 0xff foreach 0..3`, `Nikon.pm:13620-13621`), so
+  /// an all-digit string exceeding `u32` — which ExifTool still accepts via
+  /// `/^\d+$/` and decrypts — is KEYED (not REJECTED for not fitting `u32`). The
+  /// coercion uses the shared 64-bit-saturating [`super::decrypt::digit_key_u64`],
+  /// faithfully modeling Perl's 64-bit numeric model: exact across the whole
+  /// `u64` range, saturating beyond it (a `> u64` decimal is a crafted value Perl
+  /// itself resolves via platform-defined NV→UV — no portable oracle).
+  #[must_use]
+  pub fn single_digit_count(&self) -> Option<u32> {
+    let rendered = self.raw.val_bytes();
+    // `/^\d+$/`: non-empty AND every byte an ASCII digit (no sign, space, NUL,
+    // or non-digit). A space-joined multi-element render fails here.
+    if rendered.is_empty() || !rendered.iter().all(u8::is_ascii_digit) {
+      return None;
+    }
+    // The cipher's four-byte XOR fold consumes the count's low 32 bits; coerce via
+    // the shared 64-bit-saturating helper and keep the low 32 bits.
+    Some(super::decrypt::digit_key_u64(&rendered) as u32)
+  }
+
   /// The first two unsigned integers (for `int16u[2]` ISO/ISOSetting).
   #[must_use]
   pub fn first_two_u64(&self) -> Option<(u64, u64)> {
@@ -599,26 +637,155 @@ pub fn walk_nikon_ifd(
     if tag_def.is_none() {
       continue; // Unknown tag — emits nothing (no `-u`); skip the value decode.
     }
-    let Some(raw) = read_value(
-      blob,
-      value_data_offset,
-      read_format,
-      read_count,
-      total_size,
-      order,
-    ) else {
-      continue;
+    // For a binary-block SubDirectory (the implicit-`undef` path that feeds the
+    // AFInfo / ColorBalance / LensData sub-decoders), the materialized `value`
+    // is DEAD — those decoders re-read the block from `walk_data` at
+    // `value_offset..value_offset + value_size`, never from this entry — so
+    // store a ZERO-COPY empty `RawValue::Bytes` instead of cloning ANY of the
+    // (possibly crafted-huge, in-bounds) value. The full value range is already
+    // proven in-bounds (the `value_end > blob.len()` Bad-offset drop above), so
+    // a `read_value` here could only ever return `Some` — skipping the read
+    // changes NO walk decision. The recorded `count`/`value_size` below keep
+    // ExifTool's faithful full `undef[N]` extent (the child walker reads the
+    // real bytes from `walk_data`; the `undef[400004]` contract holds). This
+    // CLOSES a memory-amplification vector independent of entry count: a u16's
+    // worth of binary-subdir entries (e.g. a duplicated 0x0098 LensData) all
+    // pointing at ONE in-bounds value now retains NOTHING, whereas a per-entry
+    // clone — even a bounded window — drove `N * window` heap growth from a
+    // sub-MB MakerNote. Leaf values and IFD-pointer SubDirectories (PreviewIFD
+    // 0x0011, NikonScanIFD 0x0e10, `is_sub_ifd`) keep their real decoded value
+    // (they are excluded from `implicit_undef`).
+    let value = if implicit_undef {
+      RawValue::Bytes(Vec::new())
+    } else {
+      let Some(raw) = read_value(
+        blob,
+        value_data_offset,
+        read_format,
+        read_count,
+        total_size,
+        order,
+      ) else {
+        continue;
+      };
+      raw
     };
     out.push(NikonEntry {
       tag_id,
       format,
       count: read_count,
-      value: raw,
+      value,
       value_offset: value_data_offset,
       value_size: total_size,
     });
   }
   out
+}
+
+/// Faithful port of the Nikon `PrescanExif` decryption-key pre-scan
+/// (`Nikon.pm:14067-14125`, invoked at `:14199-14203`): a SEPARATE pass over the
+/// raw MakerNote IFD that captures ONLY the `SerialNumber` (0x001d) and
+/// `ShutterCount` (0x00a7) DataMembers used to key the encrypted sub-tables,
+/// BEFORE — and INDEPENDENT of — the main [`walk_nikon_ifd`] extraction.
+///
+/// ## Why a separate scan and not the walked entries
+///
+/// ExifTool runs `PrescanExif` with DIFFERENT, simpler entry gates than the main
+/// `ProcessExif` walk: a `needTags` filter (only 0x001d / 0x00a7,
+/// `Nikon.pm:14102`), a `format 1..=13` check (`:14104` — note this DROPS code
+/// 129, which the main walk accepts), a 16 MB out-of-line size cap (`:14110`),
+/// and an in-bounds check (`:14115`). It has NO suspicious-offset gate, NO
+/// excessive-count (`> 100000`) skip, NO invalid-size (`> 0x7fffffff`) gate, and
+/// NO `warnCount > 10` directory abort. So a 0x001d / 0x00a7 that the main walk
+/// would DROP — at a suspicious offset, with an over-100000 count, or sitting
+/// after ten earlier malformed entries tripped the abort — is STILL captured
+/// here for the key, exactly as ExifTool. Sourcing the keys from the walked
+/// entries (which have already passed the stricter gates) would suppress
+/// decryption on those crafted layouts where ExifTool still decrypts.
+///
+/// Offsets resolve EXACTLY as the walk (inline at `entry + 8` for size ≤ 4, else
+/// `offset + value_base`), so the captured value bytes are identical for any
+/// well-formed file — the 0x001d / 0x00a7 of every real Nikon body passes both
+/// scans, keeping decryption byte-identical. Returns the decoded 0x001d / 0x00a7
+/// `ReadValue` results (`None` when absent, unreadable, or gated out); the caller
+/// derives the serial/count keys ([`super::scan_decrypt_keys`]). Duplicate tags
+/// keep the LAST occurrence (`$$tagHash{$tagID} = …` overwrites).
+#[must_use]
+pub fn prescan_decrypt_keys(
+  blob: &[u8],
+  ifd_offset: usize,
+  order: ByteOrder,
+  value_base: usize,
+) -> (Option<RawValue>, Option<RawValue>) {
+  let mut serial = None;
+  let mut count = None;
+  // numEntries (`Nikon.pm:14079-14082`): the 2-byte count plus the full 12-byte
+  // entry table must fit the buffer; ExifTool otherwise falls back to the RAF,
+  // and with no RAF (the in-memory MakerNote) captures nothing.
+  let Some(num_entries) = read_u16(blob, ifd_offset, order) else {
+    return (serial, count);
+  };
+  let num_entries = num_entries as usize;
+  let Some(table_end) = ifd_offset.checked_add(2).and_then(|n| {
+    12usize
+      .checked_mul(num_entries)
+      .and_then(|m| n.checked_add(m))
+  }) else {
+    return (serial, count);
+  };
+  if table_end > blob.len() {
+    return (serial, count);
+  }
+  for index in 0..num_entries {
+    let entry_off = ifd_offset + 2 + 12 * index; // < table_end ≤ blob.len()
+    let Some(tag_id) = read_u16(blob, entry_off, order) else {
+      continue;
+    };
+    // `next unless exists $$tagHash{$tagID}` (`:14102`) — only the two needTags.
+    let slot = match tag_id {
+      0x001d => &mut serial,
+      0x00a7 => &mut count,
+      _ => continue,
+    };
+    let Some(format_code) = read_u16(blob, entry_off + 2, order) else {
+      continue;
+    };
+    // `next if $format < 1 or $format > 13` (`:14104`) — drops code 129, which
+    // the main walk accepts; the prescan is format 1..=13 only.
+    if !(1..=13).contains(&format_code) {
+      continue;
+    }
+    let format = Format::from_code(format_code);
+    let Some(count_n) = read_u32(blob, entry_off + 4, order) else {
+      continue;
+    };
+    let count_n = count_n as usize;
+    let size = format.byte_size().saturating_mul(count_n);
+    let value_off = if size <= 4 {
+      entry_off + 8 // inline value (`$valuePtr = $entry + 8`)
+    } else {
+      if size > 0x0100_0000 {
+        continue; // `next if $size > 0x1000000` — the 16 MB cap (`:14110`).
+      }
+      let Some(off) = read_u32(blob, entry_off + 8, order) else {
+        continue;
+      };
+      let Some(abs) = (off as usize).checked_add(value_base) else {
+        continue;
+      };
+      // `next … if $valuePtr+$size > $dataLen` with no RAF (`:14115`) — the same
+      // in-bounds rule the walk applies (`value_end > blob.len()`).
+      match abs.checked_add(size) {
+        Some(end) if end <= blob.len() => abs,
+        _ => continue,
+      }
+    };
+    // `ReadValue($dataPt, $valuePtr, $formatStr, $count, $size)` (`:14122`).
+    if let Some(raw) = read_value(blob, value_off, format, count_n, size, order) {
+      *slot = Some(raw);
+    }
+  }
+  (serial, count)
 }
 
 /// Resolve the embedded-TIFF header for the type-3 layout. `blob` is the whole
@@ -1218,13 +1385,19 @@ mod tests {
       .iter()
       .find(|e| e.tag_id == 0x0088)
       .expect("AFInfo entry must be produced (read as undef, not skipped)");
-    // Read as `undef`: count recomputed to the on-disk byte size (400004) and
-    // the value is the raw block (`Bytes`), exactly ExifTool's `undef[400004]`.
+    // Read as `undef`: the recorded `count` keeps the on-disk byte size (400004),
+    // exactly ExifTool's `undef[400004]`, while the materialized `value` is a
+    // ZERO-COPY empty block (the clone is dead for AFInfo/ColorBalance/LensData,
+    // which re-read from `value_offset`/`value_size` in `walk_data`).
     assert_eq!(af_entry.count, count as usize * 4);
-    assert!(
-      matches!(af_entry.value, RawValue::Bytes(_)),
-      "an undef-read SubDirectory value is the raw byte block"
-    );
+    match &af_entry.value {
+      RawValue::Bytes(b) => assert_eq!(
+        b.len(),
+        0,
+        "the binary-SubDirectory value is zero-copy empty, not the full 400004 bytes"
+      ),
+      other => panic!("an undef-read SubDirectory value is the raw byte block, got {other:?}"),
+    }
     assert!(entries.iter().any(|e| e.tag_id == 0x0083));
 
     // CONTRAST: the SAME huge count on a NON-SubDirectory numeric tag
@@ -1241,6 +1414,163 @@ mod tests {
       "a non-SubDirectory numeric entry of huge count is still excessive-count-skipped"
     );
     assert_eq!(zentries[0].tag_id, 0x0083);
+  }
+
+  /// A crafted LARGE in-bounds `0x0098` LensData value (declared
+  /// `undef[200000]`) must NOT clone ANY of the declared block into the entry's
+  /// `RawValue::Bytes`: the binary-SubDirectory value is ZERO-COPY empty (the
+  /// sub-decoders re-read from `value_offset`/`value_size` in `walk_data`, so the
+  /// clone is dead). The recorded `count` / `value_size` keep ExifTool's faithful
+  /// full extent (it reads the in-bounds value too — the empty materialized value
+  /// is OUTPUT-EQUIVALENT). A later valid `LensType` sentinel still decodes (the
+  /// walk is not disturbed).
+  #[test]
+  fn nikon_subdir_large_value_zero_copy() {
+    let big: u32 = 200_000; // declared `undef` byte count, < 0x7fffffff
+    // 0x0098 LensData (binary SubDirectory, no explicit Format ⇒ implicit-undef),
+    // OUT-OF-LINE; a valid inline LensType sentinel after it.
+    let lens_data = entry_offset(0x0098, 7, big, 2 + 12 * 2 + 4); // undef, out-of-line
+    let lens_type = entry_inline(0x0083, 1, 1, [0x06, 0x00, 0x00, 0x00]); // int8u = 6
+    let mut b = headerless_ifd(&[lens_data, lens_type]);
+    // Lay the full 200000-byte value region in-bounds so ExifTool reads it.
+    b.resize(b.len() + big as usize, 0);
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    let ld = entries
+      .iter()
+      .find(|e| e.tag_id == 0x0098)
+      .expect("LensData entry must be produced (read as undef)");
+    // The recorded extent is faithful (the full declared `undef[200000]`)…
+    assert_eq!(ld.count, big as usize);
+    assert_eq!(ld.value_size, big as usize);
+    // …but the materialized value is ZERO-COPY empty, NOT 200000 bytes.
+    match &ld.value {
+      RawValue::Bytes(v) => assert_eq!(
+        v.len(),
+        0,
+        "0x0098 LensData value must be zero-copy empty (got {} bytes)",
+        v.len()
+      ),
+      other => panic!("LensData value is the raw byte block, got {other:?}"),
+    }
+    // The sentinel after the huge entry still decodes.
+    let lt = entries
+      .iter()
+      .find(|e| e.tag_id == 0x0083)
+      .expect("the LensType sentinel after the huge LensData still walks");
+    assert_eq!(lt.value, RawValue::U64(vec![6]));
+  }
+
+  /// REPEAT-ENTRY AMPLIFICATION regression (the R8 finding): a crafted IFD can
+  /// repeat a binary-SubDirectory tag (here `0x0098` LensData) MANY times, every
+  /// entry pointing at the SAME in-bounds value. Because each implicit-`undef`
+  /// entry stores a ZERO-COPY empty `RawValue::Bytes`, retained heap is bounded
+  /// INDEPENDENT of entry count — a per-entry clone (even a bounded window) would
+  /// instead drive `N * window` growth (a u16's worth of entries ⇒ hundreds of MB
+  /// from a sub-MB MakerNote). Every repeated entry is still produced with the
+  /// faithful full `value_size`, and all share one value region.
+  #[test]
+  fn nikon_repeated_subdir_value_is_bounded() {
+    let big: u32 = 100_000; // shared in-bounds `undef` value, < 0x7fffffff
+    const N: usize = 64; // many repeats of the SAME 0x0098 LensData subdir
+    // All N entries point OUT-OF-LINE at the same value region just past the IFD.
+    let value_at: u32 = 2 + 12 * N as u32 + 4;
+    let dirs: Vec<_> = (0..N)
+      .map(|_| entry_offset(0x0098, 7, big, value_at)) // undef, out-of-line, shared
+      .collect();
+    let mut b = headerless_ifd(&dirs);
+    b.resize(b.len() + big as usize, 0); // lay the shared value in-bounds
+    let entries = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    // Every repeated subdir entry is produced with the faithful full extent…
+    let lens = entries.iter().filter(|e| e.tag_id == 0x0098).count();
+    assert_eq!(lens, N, "every repeated LensData subdir entry is walked");
+    // …yet NONE retains the value bytes — total retained value heap is 0 across
+    // all N, so retained memory is independent of entry count.
+    let total_value_bytes: usize = entries
+      .iter()
+      .map(|e| match &e.value {
+        RawValue::Bytes(v) => v.len(),
+        _ => 0,
+      })
+      .sum();
+    assert_eq!(
+      total_value_bytes, 0,
+      "repeated binary-subdir entries retain zero value bytes (got {total_value_bytes})"
+    );
+    for e in entries.iter().filter(|e| e.tag_id == 0x0098) {
+      assert_eq!(
+        e.value_size, big as usize,
+        "each keeps the faithful full extent"
+      );
+    }
+  }
+
+  /// `single_digit_count` keys the count's LOW 32 BITS via the shared
+  /// 64-bit-saturating coercion (the cipher's four-byte XOR fold), so an all-digit
+  /// `ShutterCount` EXCEEDING `u32` — which ExifTool still accepts via `/^\d+$/`
+  /// and decrypts — is keyed, NOT rejected for not fitting `u32`. Exact across the
+  /// whole `u64` range; a `> u64` decimal saturates (Perl's NV→UV is platform
+  /// UB — no portable oracle). (R9/R10 finding: the prior `parse::<u32>()`
+  /// suppressed decryption, then an arbitrary-precision fold diverged from Perl's
+  /// 64-bit model above `u64`.)
+  #[test]
+  fn single_digit_count_keys_low_32_bits() {
+    let c = |s: &[u8]| ParsedValue::new(RawValue::Bytes(s.to_vec())).single_digit_count();
+    assert_eq!(c(b"100"), Some(100)); // in range
+    assert_eq!(c(b"4294967296"), Some(0)); // 2^32 ⇒ low 32 bits 0 (was rejected)
+    assert_eq!(c(b"4294967297"), Some(1)); // 2^32 + 1 ⇒ low 32 bits 1
+    // u64 boundary: u64::MAX = 0xffff_ffff_ffff_ffff ⇒ low 32 bits 0xffff_ffff;
+    // u64::MAX + 1 / + 2 SATURATE to u64::MAX ⇒ same low 32 bits (Perl 64-bit
+    // model; the cipher's XOR fold of 0xffff_ffff is key 0, matching 64-bit Perl).
+    assert_eq!(c(b"18446744073709551615"), Some(0xffff_ffff)); // u64::MAX
+    assert_eq!(c(b"18446744073709551616"), Some(0xffff_ffff)); // u64::MAX + 1
+    assert_eq!(c(b"18446744073709551617"), Some(0xffff_ffff)); // u64::MAX + 2
+    assert_eq!(c(b"100 0"), None); // space-joined multi-element render fails
+    assert_eq!(c(b"-5"), None); // a sign fails
+    assert_eq!(c(b""), None); // empty fails
+  }
+
+  /// `prescan_decrypt_keys` (ExifTool's `PrescanExif`) captures the decryption
+  /// key with LOOSER gates than the main walk: it has NO `warnCount > 10` abort,
+  /// so a trailing `ShutterCount` (0x00a7) the walk never reaches — because 11
+  /// earlier bad-offset entries tripped the abort — is STILL keyed, exactly as
+  /// ExifTool. (R9 finding: sourcing keys from the post-walk entries suppressed
+  /// decryption on such crafted layouts.)
+  #[test]
+  fn prescan_captures_key_past_walk_warn_abort() {
+    // 11 out-of-line entries whose value runs past EOF (each `++warnCount`).
+    let mut entries: Vec<Vec<u8>> = (0..11u16)
+      .map(|i| entry_offset(0x9000 + i, 2, 8, 0xffff)) // ascii[8] past EOF
+      .collect();
+    // A trailing ShutterCount (int32u 100, inline) after the 11 bad entries.
+    entries.push(entry_inline(0x00a7, 4, 1, [0x00, 0x00, 0x00, 0x64])); // big-endian 100
+    let b = headerless_ifd(&entries);
+    // The main walk ABORTS (warnCount > 10) before 0x00a7 — it is never produced.
+    let walked = walk_nikon_ifd(&b, 0, ByteOrder::Big, 0, NikonTable::Main);
+    assert!(
+      walked.iter().all(|e| e.tag_id != 0x00a7),
+      "the walk aborts before reaching the trailing 0x00a7"
+    );
+    // The prescan has no abort, so it still captures the ShutterCount key (100).
+    let (_serial, count) = prescan_decrypt_keys(&b, 0, ByteOrder::Big, 0);
+    let count = count.expect("PrescanExif captures the count key past the walk abort");
+    assert_eq!(ParsedValue::new(count).single_digit_count(), Some(100));
+  }
+
+  /// `prescan_decrypt_keys` captures ONLY the two needTags (0x001d / 0x00a7) and
+  /// reads them format-agnostically, matching `PrescanExif`'s `needTags` filter +
+  /// `ReadValue`. An unrelated tag is ignored; a present SerialNumber + a present
+  /// ShutterCount are both returned.
+  #[test]
+  fn prescan_captures_only_needtags() {
+    let serial = entry_inline(0x001d, 2, 4, [b'9', b'9', b'9', 0]); // ascii "999"
+    let other = entry_inline(0x0005, 4, 1, [0x00, 0x00, 0x00, 0x07]); // ignored
+    let shutter = entry_inline(0x00a7, 4, 1, [0x00, 0x00, 0x00, 0x2a]); // int32u 42
+    let b = headerless_ifd(&[serial, other, shutter]);
+    let (serial_val, count_val) = prescan_decrypt_keys(&b, 0, ByteOrder::Big, 0);
+    let s = serial_val.expect("0x001d captured");
+    assert_eq!(std::string::String::from_utf8_lossy(&s.val_bytes()), "999");
+    let count = count_val.expect("0x00a7 captured");
+    assert_eq!(ParsedValue::new(count).single_digit_count(), Some(42));
   }
 
   /// A `SubIFD` pointer (PreviewIFD 0x0011, NikonScanIFD 0x0e10 —

--- a/src/exif/makernotes/vendors/nikon/decrypt.rs
+++ b/src/exif/makernotes/vendors/nikon/decrypt.rs
@@ -1,0 +1,193 @@
+//! Nikon's symmetric data-block cipher (`Image::ExifTool::Nikon::Decrypt`,
+//! `Nikon.pm:13604-13638`) and the two 256-byte translation tables `@xlat`
+//! (`Nikon.pm:13555-13603`).
+//!
+//! The encrypted Nikon sub-tables (`LensData02xx`, `ShotInfo`, `FlashInfo`,
+//! encrypted `ColorBalance`) are scrambled with a stream cipher keyed by the
+//! body `SerialNumber` (0x001d) and `ShutterCount` (0x00a7). The decryption
+//! algorithm is published, so the data is recoverable.
+//!
+//! Phase 1 ports the cipher + the `SerialKey` derivation for `LensData`
+//! decoding (`super::lens_data`); the `ShotInfo`/`FlashInfo` tables stay
+//! deferred to a follow-up.
+
+/// `@xlat` (`Nikon.pm:13555-13603`) — the two 256-byte translation tables that
+/// seed the cipher state from the serial/count keys. `xlat[0]` is indexed by
+/// `serial & 0xff`, `xlat[1]` by the XOR-folded `count` key.
+const XLAT: [[u8; 256]; 2] = [
+  [
+    0xc1, 0xbf, 0x6d, 0x0d, 0x59, 0xc5, 0x13, 0x9d, 0x83, 0x61, 0x6b, 0x4f, 0xc7, 0x7f, 0x3d, 0x3d,
+    0x53, 0x59, 0xe3, 0xc7, 0xe9, 0x2f, 0x95, 0xa7, 0x95, 0x1f, 0xdf, 0x7f, 0x2b, 0x29, 0xc7, 0x0d,
+    0xdf, 0x07, 0xef, 0x71, 0x89, 0x3d, 0x13, 0x3d, 0x3b, 0x13, 0xfb, 0x0d, 0x89, 0xc1, 0x65, 0x1f,
+    0xb3, 0x0d, 0x6b, 0x29, 0xe3, 0xfb, 0xef, 0xa3, 0x6b, 0x47, 0x7f, 0x95, 0x35, 0xa7, 0x47, 0x4f,
+    0xc7, 0xf1, 0x59, 0x95, 0x35, 0x11, 0x29, 0x61, 0xf1, 0x3d, 0xb3, 0x2b, 0x0d, 0x43, 0x89, 0xc1,
+    0x9d, 0x9d, 0x89, 0x65, 0xf1, 0xe9, 0xdf, 0xbf, 0x3d, 0x7f, 0x53, 0x97, 0xe5, 0xe9, 0x95, 0x17,
+    0x1d, 0x3d, 0x8b, 0xfb, 0xc7, 0xe3, 0x67, 0xa7, 0x07, 0xf1, 0x71, 0xa7, 0x53, 0xb5, 0x29, 0x89,
+    0xe5, 0x2b, 0xa7, 0x17, 0x29, 0xe9, 0x4f, 0xc5, 0x65, 0x6d, 0x6b, 0xef, 0x0d, 0x89, 0x49, 0x2f,
+    0xb3, 0x43, 0x53, 0x65, 0x1d, 0x49, 0xa3, 0x13, 0x89, 0x59, 0xef, 0x6b, 0xef, 0x65, 0x1d, 0x0b,
+    0x59, 0x13, 0xe3, 0x4f, 0x9d, 0xb3, 0x29, 0x43, 0x2b, 0x07, 0x1d, 0x95, 0x59, 0x59, 0x47, 0xfb,
+    0xe5, 0xe9, 0x61, 0x47, 0x2f, 0x35, 0x7f, 0x17, 0x7f, 0xef, 0x7f, 0x95, 0x95, 0x71, 0xd3, 0xa3,
+    0x0b, 0x71, 0xa3, 0xad, 0x0b, 0x3b, 0xb5, 0xfb, 0xa3, 0xbf, 0x4f, 0x83, 0x1d, 0xad, 0xe9, 0x2f,
+    0x71, 0x65, 0xa3, 0xe5, 0x07, 0x35, 0x3d, 0x0d, 0xb5, 0xe9, 0xe5, 0x47, 0x3b, 0x9d, 0xef, 0x35,
+    0xa3, 0xbf, 0xb3, 0xdf, 0x53, 0xd3, 0x97, 0x53, 0x49, 0x71, 0x07, 0x35, 0x61, 0x71, 0x2f, 0x43,
+    0x2f, 0x11, 0xdf, 0x17, 0x97, 0xfb, 0x95, 0x3b, 0x7f, 0x6b, 0xd3, 0x25, 0xbf, 0xad, 0xc7, 0xc5,
+    0xc5, 0xb5, 0x8b, 0xef, 0x2f, 0xd3, 0x07, 0x6b, 0x25, 0x49, 0x95, 0x25, 0x49, 0x6d, 0x71, 0xc7,
+  ],
+  [
+    0xa7, 0xbc, 0xc9, 0xad, 0x91, 0xdf, 0x85, 0xe5, 0xd4, 0x78, 0xd5, 0x17, 0x46, 0x7c, 0x29, 0x4c,
+    0x4d, 0x03, 0xe9, 0x25, 0x68, 0x11, 0x86, 0xb3, 0xbd, 0xf7, 0x6f, 0x61, 0x22, 0xa2, 0x26, 0x34,
+    0x2a, 0xbe, 0x1e, 0x46, 0x14, 0x68, 0x9d, 0x44, 0x18, 0xc2, 0x40, 0xf4, 0x7e, 0x5f, 0x1b, 0xad,
+    0x0b, 0x94, 0xb6, 0x67, 0xb4, 0x0b, 0xe1, 0xea, 0x95, 0x9c, 0x66, 0xdc, 0xe7, 0x5d, 0x6c, 0x05,
+    0xda, 0xd5, 0xdf, 0x7a, 0xef, 0xf6, 0xdb, 0x1f, 0x82, 0x4c, 0xc0, 0x68, 0x47, 0xa1, 0xbd, 0xee,
+    0x39, 0x50, 0x56, 0x4a, 0xdd, 0xdf, 0xa5, 0xf8, 0xc6, 0xda, 0xca, 0x90, 0xca, 0x01, 0x42, 0x9d,
+    0x8b, 0x0c, 0x73, 0x43, 0x75, 0x05, 0x94, 0xde, 0x24, 0xb3, 0x80, 0x34, 0xe5, 0x2c, 0xdc, 0x9b,
+    0x3f, 0xca, 0x33, 0x45, 0xd0, 0xdb, 0x5f, 0xf5, 0x52, 0xc3, 0x21, 0xda, 0xe2, 0x22, 0x72, 0x6b,
+    0x3e, 0xd0, 0x5b, 0xa8, 0x87, 0x8c, 0x06, 0x5d, 0x0f, 0xdd, 0x09, 0x19, 0x93, 0xd0, 0xb9, 0xfc,
+    0x8b, 0x0f, 0x84, 0x60, 0x33, 0x1c, 0x9b, 0x45, 0xf1, 0xf0, 0xa3, 0x94, 0x3a, 0x12, 0x77, 0x33,
+    0x4d, 0x44, 0x78, 0x28, 0x3c, 0x9e, 0xfd, 0x65, 0x57, 0x16, 0x94, 0x6b, 0xfb, 0x59, 0xd0, 0xc8,
+    0x22, 0x36, 0xdb, 0xd2, 0x63, 0x98, 0x43, 0xa1, 0x04, 0x87, 0x86, 0xf7, 0xa6, 0x26, 0xbb, 0xd6,
+    0x59, 0x4d, 0xbf, 0x6a, 0x2e, 0xaa, 0x2b, 0xef, 0xe6, 0x78, 0xb6, 0x4e, 0xe0, 0x2f, 0xdc, 0x7c,
+    0xbe, 0x57, 0x19, 0x32, 0x7e, 0x2a, 0xd0, 0xb8, 0xba, 0x29, 0x00, 0x3c, 0x52, 0x7d, 0xa8, 0x49,
+    0x3b, 0x2d, 0xeb, 0x25, 0x49, 0xfa, 0xa3, 0xaa, 0x39, 0xa7, 0xc5, 0xa7, 0x50, 0x11, 0x36, 0xfb,
+    0xc6, 0x67, 0x4a, 0xf5, 0xa5, 0x12, 0x65, 0x7e, 0xb0, 0xdf, 0xaf, 0x4e, 0xb3, 0x61, 0x7f, 0x2f,
+  ],
+];
+
+/// Decrypt the Nikon data block `data` in place over `[start, start + len)`,
+/// keyed by `serial` and `count` — the faithful single-shot transliteration of
+/// `Image::ExifTool::Nikon::Decrypt` (`Nikon.pm:13604-13638`) for the
+/// first-call (`defined $serial and defined $count`) initialization path.
+///
+/// The cipher seeds `ci0 = xlat[0][serial & 0xff]`, `cj0 = xlat[1][key]` (where
+/// `key` is the XOR fold of the four bytes of `count`), `ck0 = 0x60`, then for
+/// each byte from `start` runs `cj = cj + ci0*ck`, `ck += 1`, `byte ^= cj` (all
+/// `u8` wrapping). It is symmetric (decrypt == encrypt), but only the read path
+/// (decrypt) is needed here.
+///
+/// `start`/`len` are clamped to `data` (the Perl `$maxLen = length - $start;
+/// $len = $maxLen if … > $maxLen`), so a short or malformed block never reads
+/// out of bounds: a `start` past the end (or `len == 0`) decrypts nothing.
+pub fn decrypt(data: &mut [u8], start: usize, len: usize, serial: u32, count: u32) {
+  if start >= data.len() {
+    return;
+  }
+  // `$maxLen = length($$dataPt) - $start; $len = $maxLen if … > $maxLen`
+  // (`Nikon.pm:13615-13616`).
+  let max_len = data.len() - start;
+  let len = len.min(max_len);
+  if len == 0 {
+    return; // `return $$dataPt if $len <= 0` (`Nikon.pm:13634`).
+  }
+  // `my $key = 0; $key ^= ($count >> ($_*8)) & 0xff foreach 0..3;`
+  // (`Nikon.pm:13620-13621`) — XOR-fold the four bytes of `count`.
+  let key =
+    (count & 0xff) ^ ((count >> 8) & 0xff) ^ ((count >> 16) & 0xff) ^ ((count >> 24) & 0xff);
+  // `$ci0 = $xlat[0][$serial & 0xff]; $cj0 = $xlat[1][$key]; $ck0 = 0x60;`
+  // (`Nikon.pm:13622-13624`). The `& 0xff` indices are always in `0..256`.
+  // `& 0xff` indices are always in `0..256`; the checked accessors satisfy the
+  // module's `deny(indexing_slicing)` (the `unwrap_or(0)` is unreachable).
+  let ci0 = XLAT
+    .first()
+    .and_then(|row| row.get((serial & 0xff) as usize))
+    .copied()
+    .unwrap_or(0);
+  let cj0 = XLAT
+    .get(1)
+    .and_then(|row| row.get((key & 0xff) as usize))
+    .copied()
+    .unwrap_or(0);
+  // First-call path (`$decryptStart` undef): `($cj, $ck) = ($cj0, $ck0)`
+  // (`Nikon.pm:13631`). The non-zero-start continuation branch is not used —
+  // every Nikon encrypted sub-table this port decodes calls `Decrypt` once
+  // with the keys and the directory's `DecryptStart`, so the parameters always
+  // initialize here.
+  let mut cj = cj0;
+  let mut ck: u8 = 0x60;
+  // `foreach $ch (@data) { $cj = ($cj + $ci0 * $ck) & 0xff; $ck = ($ck + 1) &
+  // 0xff; $ch ^= $cj; }` (`Nikon.pm:13636-13638`) — all `u8` wrapping.
+  // `len` is clamped to `data.len() - start` above, so the slice is always
+  // `Some`; `get_mut` satisfies `deny(indexing_slicing)`.
+  if let Some(slice) = data.get_mut(start..start + len) {
+    for byte in slice {
+      cj = cj.wrapping_add(ci0.wrapping_mul(ck));
+      ck = ck.wrapping_add(1);
+      *byte ^= cj;
+    }
+  }
+}
+
+/// Coerce an all-digit decimal string to the numeric key value, faithfully
+/// modeling the 64-bit Perl numeric (IV/UV) coercion the Nikon cipher keys rely
+/// on (`Nikon.pm:13620-13622`, `$count`/`$serial` used in bitwise expressions):
+/// the value as a `u64`, SATURATING at `u64::MAX` for a decimal that overflows
+/// the 64-bit range.
+///
+/// The keys consume only the LOW bits — `serial & 0xff` and `count`'s four-byte
+/// XOR fold — so the caller truncates (`as u32` → low 32 bits); this returns the
+/// full saturated `u64`. For every value a 64-bit Perl holds as an EXACT integer
+/// (`<= u64::MAX` — which covers every real `ShutterCount`/`SerialNumber` and the
+/// whole `int32u` range) the low bits are EXACT. A decimal EXCEEDING `u64::MAX`
+/// is a crafted value with NO portable oracle — Perl coerces it to an NV (double)
+/// and the NV→UV cast is platform-defined C behavior — so saturation is the
+/// chosen deterministic, panic-free approximation (and `u64::MAX as u32 =
+/// 0xffff_ffff` ⇒ count XOR-fold key 0, matching a 64-bit Perl on `2^64`-class
+/// inputs). The caller's `/^\d+$/` digit check runs BEFORE this.
+pub(super) fn digit_key_u64(digits: &[u8]) -> u64 {
+  digits.iter().fold(0u64, |acc, &b| {
+    acc.saturating_mul(10).saturating_add(u64::from(b - b'0'))
+  })
+}
+
+/// `Image::ExifTool::Nikon::SerialKey($et, $serial)` (`Nikon.pm:13644-13651`) —
+/// derive the cipher's serial-number key from the raw `SerialNumber` value.
+///
+/// - A purely-numeric serial (`/^\d+$/`, e.g. the D2Hs `3001006`) is used
+///   verbatim as the key.
+/// - A non-numeric / model-coded string serial (e.g. the D70 `"No= 20025585"`)
+///   has no usable integer, so a fixed per-model key is substituted: `0x22`
+///   for a `D50`, else `0x60` (D200, D40X, etc.).
+///
+/// Only `serial & 0xff` is consumed by [`decrypt`], so the key is returned as a
+/// `u32`. `model` is the parent IFD0 `Model` (the `D50` discriminator).
+///
+/// `serial` is the post-`ReadValue` `$val` string for the prescan `0x001d` slot
+/// (`PrescanExif`, `Nikon.pm:14122`), so it is format-agnostic: an ASCII serial
+/// is its string, while an INTEGER-format `0x001d` arrives as the rendered
+/// decimal (e.g. `int32u 12345678` ⇒ `"12345678"`) and still matches `/^\d+$/`.
+#[must_use]
+pub fn serial_key(serial: &str, model: Option<&str>) -> Option<u32> {
+  // `return $serial if … $serial =~ /^\d+$/` (`Nikon.pm:13647`) — a serial of
+  // one-or-more ASCII digits is the key itself. ExifTool uses the numeric value;
+  // only its low byte is consumed (`serial & 0xff` in [`decrypt`]), so coerce via
+  // the shared 64-bit-saturating [`digit_key_u64`] (exact low byte for every real
+  // serial; saturating beyond `u64::MAX`) and keep the low 32 bits.
+  if !serial.is_empty() && serial.bytes().all(|b| b.is_ascii_digit()) {
+    return Some(digit_key_u64(serial.as_bytes()) as u32);
+  }
+  // `return 0x22 if $$et{Model} =~ /\bD50$/` (`Nikon.pm:13649`) — the D50 uses
+  // 0x22 for its string serial; a word boundary before `D50` at end-of-string.
+  if model.is_some_and(model_ends_in_d50) {
+    return Some(0x22);
+  }
+  // `return 0x60` (`Nikon.pm:13650`) — D200, D40X, D70, etc.
+  Some(0x60)
+}
+
+/// `$$et{Model} =~ /\bD50$/` — the model name ends in the word `D50` (a `\b`
+/// word boundary precedes the `D`, i.e. the preceding char is not a word
+/// character). Real D50 models are `"NIKON D50"`.
+fn model_ends_in_d50(model: &str) -> bool {
+  let Some(prefix) = model.strip_suffix("D50") else {
+    return false;
+  };
+  // `\b` before `D`: a boundary exists when the char before `D50` is NOT a
+  // word character (`[A-Za-z0-9_]`). An empty prefix (the whole string is
+  // `D50`) is also a boundary.
+  match prefix.as_bytes().last() {
+    None => true,
+    Some(&c) => !(c.is_ascii_alphanumeric() || c == b'_'),
+  }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/exif/makernotes/vendors/nikon/decrypt/tests.rs
+++ b/src/exif/makernotes/vendors/nikon/decrypt/tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+/// The exact NikonD2Hs.jpg `LensData0201` block: the 31 raw encrypted bytes and
+/// the 31 decrypted bytes ExifTool's `-v3` dump shows after
+/// `Decrypt(start=4, serial=3001006, count=2)`. Validates the cipher byte-exact
+/// against the reference implementation, including the `DecryptStart => 4`
+/// (the 4-byte `"0201"` version prefix stays in the clear).
+#[test]
+fn d2hs_lensdata0201_decrypts_byte_exact() {
+  let mut block = [
+    0x30, 0x32, 0x30, 0x31, 0xcb, 0xca, 0xb0, 0x32, 0xb6, 0xac, 0xa8, 0xab, 0xcd, 0x70, 0x2e, 0xbb,
+    0xa7, 0xf0, 0x20, 0xa7, 0x42, 0x0a, 0x5d, 0xed, 0x7f, 0xee, 0x30, 0x45, 0x2d, 0xe8, 0x76,
+  ];
+  let expected = [
+    0x30, 0x32, 0x30, 0x31, 0x22, 0x16, 0x12, 0x09, 0x11, 0x4a, 0x50, 0x76, 0x58, 0x50, 0x50, 0x14,
+    0x14, 0x7a, 0x14, 0x16, 0x43, 0x2e, 0x47, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ];
+  let len = block.len() - 4;
+  decrypt(&mut block, 4, len, 3001006, 2);
+  assert_eq!(
+    block, expected,
+    "D2Hs LensData0201 decrypt must be byte-exact"
+  );
+  // The decoded LensIDNumber lives at offset 0x0b → 0x76 == 118; MCUVersion at
+  // 0x11 → 0x7a == 122 (the oracle values).
+  assert_eq!(block[0x0b], 118);
+  assert_eq!(block[0x11], 122);
+}
+
+/// The cipher is symmetric: decrypting twice with the same keys restores the
+/// ciphertext (`Decrypt` re-encrypts on write the same way it decrypts).
+#[test]
+fn cipher_is_symmetric() {
+  let original = [
+    0x30u8, 0x32, 0x30, 0x31, 0xcb, 0xca, 0xb0, 0x32, 0xb6, 0xac, 0xa8, 0xab,
+  ];
+  let mut buf = original;
+  let len = buf.len() - 4;
+  decrypt(&mut buf, 4, len, 3001006, 2);
+  decrypt(&mut buf, 4, len, 3001006, 2);
+  assert_eq!(buf, original, "decrypt∘decrypt restores the input");
+}
+
+/// `start` at or past the buffer end decrypts nothing (the `$start >= length`
+/// clamp) — bounds-safe on a short/empty block.
+#[test]
+fn start_past_end_is_noop() {
+  let mut buf = [0x01u8, 0x02, 0x03];
+  let before = buf;
+  decrypt(&mut buf, 3, 10, 100, 5); // start == len
+  assert_eq!(buf, before);
+  decrypt(&mut buf, 99, 10, 100, 5); // start ≫ len
+  assert_eq!(buf, before);
+  let mut empty: [u8; 0] = [];
+  decrypt(&mut empty, 0, 0, 100, 5); // empty block
+  assert!(empty.is_empty());
+}
+
+/// `len` is clamped to `length - start`, so a `len` longer than the remaining
+/// buffer never reads out of bounds — it decrypts only to the end.
+#[test]
+fn len_clamped_to_buffer() {
+  let mut a = [0x10u8, 0x20, 0x30, 0x40, 0x50, 0x60];
+  let mut b = a;
+  let alen = a.len();
+  decrypt(&mut a, 2, alen - 2, 12345, 7); // exact remaining length
+  decrypt(&mut b, 2, 1000, 12345, 7); // over-long len, same clamp
+  assert_eq!(
+    a, b,
+    "an over-long len decrypts the same bytes as the clamped len"
+  );
+  // The bytes before `start` are untouched.
+  assert_eq!(&a[..2], &[0x10, 0x20]);
+}
+
+/// The `count` key is the XOR fold of its four bytes: a `count` whose bytes XOR
+/// to the same value produces the same `cj0` seed, so the same plaintext.
+#[test]
+fn count_key_is_xor_fold_of_bytes() {
+  // 0x00000002 folds to 0x02; 0x00020000 also folds to 0x02.
+  let plain = [0xaau8; 8];
+  let mut x = plain;
+  let mut y = plain;
+  let n = plain.len();
+  decrypt(&mut x, 0, n, 555, 0x0000_0002);
+  decrypt(&mut y, 0, n, 555, 0x0002_0000);
+  assert_eq!(x, y, "counts with equal XOR folds decrypt identically");
+}
+
+/// [`serial_key`] for the D2Hs numeric serial `"3001006"` is the integer
+/// `3_001_006` (used verbatim).
+#[test]
+fn serial_key_numeric_is_verbatim() {
+  assert_eq!(serial_key("3001006", Some("NIKON D2Hs")), Some(3_001_006));
+  assert_eq!(serial_key("12345678", Some("NIKON D70")), Some(12_345_678));
+}
+
+/// A numeric serial is coerced via the shared 64-bit-saturating helper: exact
+/// across the whole `u64` range, and a digit string EXCEEDING `u64` SATURATES
+/// (Perl's 64-bit numeric model) rather than wrapping with arbitrary precision
+/// (R10). Only `serial & 0xff` is consumed by the cipher; the low 32 bits are
+/// returned. A `> u64` numeric serial is crafted (no real Nikon serial is 20+
+/// digits) and has no portable Perl oracle.
+#[test]
+fn serial_key_numeric_saturates_over_u64() {
+  // u64::MAX ⇒ low 32 bits 0xffff_ffff.
+  assert_eq!(serial_key("18446744073709551615", None), Some(0xffff_ffff));
+  // u64::MAX + 1 / + 2 saturate to u64::MAX ⇒ the same low bits.
+  assert_eq!(serial_key("18446744073709551616", None), Some(0xffff_ffff));
+  assert_eq!(serial_key("18446744073709551617", None), Some(0xffff_ffff));
+}
+
+/// [`serial_key`] for the D70 STRING serial `"No= 20025585"` is `0x60` (it is
+/// not `/^\d+$/`, and the model is not a D50) — `Nikon.pm:13650`.
+#[test]
+fn serial_key_string_d70_is_0x60() {
+  assert_eq!(serial_key("No= 20025585", Some("NIKON D70")), Some(0x60));
+  // A non-numeric serial with no model still falls through to 0x60.
+  assert_eq!(serial_key("No= 20025585", None), Some(0x60));
+}
+
+/// [`serial_key`] for a D50's string serial is `0x22` (`Nikon.pm:13649`,
+/// `/\bD50$/`).
+#[test]
+fn serial_key_string_d50_is_0x22() {
+  assert_eq!(serial_key("anything", Some("NIKON D50")), Some(0x22));
+  assert_eq!(serial_key("No= 5", Some("D50")), Some(0x22));
+  // `\b` boundary: a model merely ending in `...D50` glued to a word char is
+  // still a boundary because `D` follows a non-word region only at the start;
+  // here the char before `D50` is a space → boundary → 0x22.
+  assert_eq!(serial_key("x", Some("NIKON FOO D50")), Some(0x22));
+  // No `\bD50$` boundary when `D50` is glued to a preceding alphanumeric.
+  assert_eq!(serial_key("x", Some("NIKOND50")), Some(0x60));
+  // A numeric-looking serial wins over the D50 model branch (the `/^\d+$/`
+  // test comes first).
+  assert_eq!(serial_key("42", Some("NIKON D50")), Some(42));
+}

--- a/src/exif/makernotes/vendors/nikon/mod.rs
+++ b/src/exif/makernotes/vendors/nikon/mod.rs
@@ -37,10 +37,11 @@
 #![deny(clippy::indexing_slicing)]
 
 pub mod body;
+pub mod decrypt;
 pub mod printconv;
 pub mod tags;
 
-use crate::exif::ifd::{ByteOrder, Format, read_value};
+use crate::exif::ifd::{ByteOrder, Format, RawValue, read_value};
 use crate::exif::makernotes::VendorEmission;
 use crate::value::{Group, Metadata, TagValue};
 use smol_str::SmolStr;
@@ -308,7 +309,51 @@ pub fn parse_in_tiff(
     layout.value_base,
     layout.table,
   );
+  // PRE-SCAN for the decryption keys (`Nikon.pm:14199-14203`
+  // `PrescanExif(... 0x001d, 0x00a7 ...)`): ExifTool reads SerialNumber
+  // (0x001d) and ShutterCount (0x00a7) from the IFD BEFORE processing it, so
+  // the keys are available to ANY encrypted sub-table regardless of its IFD
+  // position. The MakerNote IFD is tag-ID-ordered (0x001d < 0x00a7 < 0x0098),
+  // so they precede LensData in walk order anyway, but a separate pass makes
+  // the capture order-independent (and only ever runs on the Main table — the
+  // Type2 layout has no encrypted sub-tables / 0x001d/0x00a7 semantics).
+  let decrypt_keys = if layout.table == NikonTable::Main {
+    scan_decrypt_keys(
+      walk_data,
+      ifd_offset,
+      layout.order,
+      layout.value_base,
+      model,
+    )
+  } else {
+    None
+  };
+  // The RAW `FocusMode` (`$$self{FocusMode}`) from tag 0x0007 (`Nikon.pm:1816`,
+  // RawConv `$$self{FocusMode} = $val`) — gates the LensData0800 Z telemetry's
+  // `FocusMode ne "Manual"` members (0x4c/0x56). UNLIKE the decrypt keys (which
+  // ExifTool genuinely pre-scans, `Nikon.pm:14199-14203`), 0x0007 is a NORMAL
+  // RawConv DataMember set DURING the IFD walk: `$$self{FocusMode}` holds
+  // whatever the LAST-walked 0x0007 entry stored AT the moment the 0x0098
+  // LensData SubDirectory is processed. So the gate must see the value
+  // POSITIONALLY — the last 0x0007 BEFORE this 0x0098 in walk order (`None` /
+  // `undef ne "Manual"` = open when no 0x0007 precedes it). The IFD is normally
+  // tag-ID-ordered (0x0007 < 0x0098), so this matches the pre-scan for a
+  // well-formed MakerNote; it differs only for an unsorted/duplicate IFD where a
+  // `FocusMode = Manual` follows the LensData. The type-2 layout reuses 0x0007
+  // for a different tag, so only the Main table tracks it.
+  let track_focus_mode = layout.table == NikonTable::Main;
+  let mut focus_mode: Option<SmolStr> = None;
   for entry in &entries {
+    // Capture the running `$$self{FocusMode}` the instant tag 0x0007 is walked,
+    // BEFORE any later 0x0098 reaches `emit_lens_data` (the RawConv stores the
+    // raw on-disk string; a non-`Text` 0x0007 leaves the member unchanged, as
+    // `as_text` returns `None` and we keep the prior value).
+    if track_focus_mode
+      && entry.tag_id == 0x0007
+      && let Some(s) = ParsedValue::new(entry.value.clone()).as_text()
+    {
+      focus_mode = Some(SmolStr::new(s));
+    }
     let Some(def) = layout.table.lookup(entry.tag_id) else {
       continue; // Unknown tag — verbose-only in ExifTool; omit.
     };
@@ -325,9 +370,19 @@ pub fn parse_in_tiff(
         SubTable::ColorBalance0103 => {
           emit_color_balance(walk_data, entry, layout, print_conv, &mut emissions);
         }
+        SubTable::LensData => {
+          emit_lens_data(
+            walk_data,
+            entry,
+            layout,
+            print_conv,
+            decrypt_keys,
+            focus_mode.as_deref(),
+            &mut emissions,
+          );
+        }
         // Deferred (encrypted / unported child table): emit nothing.
-        SubTable::LensData
-        | SubTable::ShotInfo
+        SubTable::ShotInfo
         | SubTable::FlashInfo
         | SubTable::ColorBalanceEncrypted
         | SubTable::OtherDeferred => {}
@@ -453,6 +508,698 @@ fn emit_color_balance(
     return;
   };
   emissions.push(VendorEmission::new("WB_RGBGLevels".into(), value, false));
+}
+
+/// The decryption keys captured for the encrypted Nikon sub-tables —
+/// ExifTool's `$$et{NikonSerialKey}` (the derived serial key) and
+/// `$$et{NikonCountKey}` (the raw ShutterCount).
+#[derive(Debug, Clone, Copy)]
+struct DecryptKeys {
+  /// `SerialKey($et, SerialNumber)` (`Nikon.pm:14202`) — the serial key, after
+  /// the numeric/string derivation ([`decrypt::serial_key`]).
+  serial: u32,
+  /// `ShutterCount` (0x00a7) raw value (`Nikon.pm:14203`) — the count key.
+  count: u32,
+}
+
+/// Capture the decryption keys via ExifTool's `PrescanExif` pre-scan
+/// (`Nikon.pm:14199-14203`): the `SerialNumber` (0x001d) `ReadValue` `$val` →
+/// the `SerialKey` derivation, and the `ShutterCount` (0x00a7) `$val` → the
+/// count key. Returns `None` only when no usable `ShutterCount` (0x00a7) is
+/// present; an ABSENT `SerialNumber` defaults to serial key 0 (ExifTool seeds
+/// its prescan with `0x001d => 0`), so encrypted LensData still decrypts
+/// without `0x001d`.
+///
+/// The capture runs over the RAW IFD via [`body::prescan_decrypt_keys`], NOT the
+/// post-`walk_nikon_ifd` entries: ExifTool's prescan uses LOOSER entry gates than
+/// the main walk (no suspicious-offset / excessive-count / warn-abort), so a
+/// 0x001d / 0x00a7 the walk would drop is still keyed here (see that function).
+/// Both keys derive from the post-`ReadValue` `$val` STRING (`Nikon.pm:14122`),
+/// FORMAT-AGNOSTIC: an integer-format `0x001d`/`0x00a7` renders to its decimal,
+/// an ASCII one to its string, so a present-but-integer serial and an ASCII-digit
+/// count feed `SerialKey` and the `/^\d+$/` count test just like the native
+/// format (see [`decrypt::serial_key`] and [`ParsedValue::single_digit_count`]).
+///
+/// `model` threads IFD0 `Model` for the `SerialKey` `D50` discriminator.
+fn scan_decrypt_keys(
+  blob: &[u8],
+  ifd_offset: usize,
+  order: ByteOrder,
+  value_base: usize,
+  model: Option<&str>,
+) -> Option<DecryptKeys> {
+  // ExifTool captures the keys with a SEPARATE PrescanExif pass over the raw IFD
+  // (NOT the main extraction walk) — see [`body::prescan_decrypt_keys`].
+  let (serial_val, count_val) = body::prescan_decrypt_keys(blob, ifd_offset, order, value_base);
+  // `%needTags = (0x001d => 0, …)` (`Nikon.pm:14200`): the prescan seeds
+  // `0x001d => 0`, so a TRULY ABSENT — or gated-out — `SerialNumber` decrypts
+  // with serial key 0 (`SerialKey($et, 0)` ⇒ 0). A PRESENT 0x001d feeds
+  // `SerialKey` its format-agnostic `ReadValue` `$val` (ASCII string or rendered
+  // integer), yielding the digit value or the D50/0x60 string fallback;
+  // `serial_key` is always `Some`, so `unwrap_or(0x60)` never fires.
+  let serial = match serial_val {
+    Some(raw) => {
+      let rendered = raw.val_bytes();
+      let s = std::string::String::from_utf8_lossy(&rendered);
+      decrypt::serial_key(&s, model).unwrap_or(0x60)
+    }
+    None => 0,
+  };
+  // `$$et{NikonCountKey} = $needTags{0x00a7}` (`:14203`), gated by
+  // `$count =~ /^\d+$/` in `ProcessNikonEncrypted` (`:13948`): only a SINGLE
+  // all-digit `ShutterCount` unlocks decryption (a multi-element `int32u[2]` ⇒
+  // `"100 0"`, a negative, or a non-digit value fails and leaves it undefined).
+  let count = count_val.and_then(|raw| ParsedValue::new(raw).single_digit_count())?;
+  Some(DecryptKeys { serial, count })
+}
+
+/// The `%Nikon::LensData*` layout the 4-byte `LensDataVersion` prefix selects
+/// — the faithful port of the `0x0098` conditional SubDirectory list
+/// (`Nikon.pm:2814-2899`). Each arm carries its member table, whether the body
+/// after the version is encrypted (`ProcessProc => \&ProcessNikonEncrypted` +
+/// `DecryptStart => 4`), and the table's `ByteOrder` (only `0800` overrides it
+/// to LittleEndian — but every PORTED `0800` member is a single byte, so the
+/// override is recorded for fidelity and is a no-op on those reads).
+struct LensDataLayout {
+  /// The member positions to read off the (decrypted) block.
+  table: &'static [tags::LensDataEntry],
+  /// `true` when the body after the 4-byte version is encrypted
+  /// (`DecryptStart => 4`); decrypt with the captured serial/count keys first.
+  encrypted: bool,
+  /// `Some` when this `0800` layout gates its members on the forward-looking
+  /// `$$self{OldLensData}` flag (`Nikon.pm:5726-5731`): the `undef[17]` at this
+  /// offset sets the flag UNLESS it is `/^.\0+$/s` (first byte anything, the
+  /// other 16 all NUL). When the flag is clear the gated members are skipped.
+  old_lens_data_gate: Option<usize>,
+  /// `true` for the `0800` (Z6/Z7/Z9) layout, which ALSO carries the NEW Z-lens
+  /// telemetry block (offsets 0x2f onward — `NewLensData`, `LensID` int16u + the
+  /// `FocusMode`-gated focus telemetry, `Nikon.pm:5809-5961`). Decoded by
+  /// [`emit_lens_data_0800_new`] after the legacy block.
+  has_z_block: bool,
+  /// The SubDirectory's `ByteOrder` (`MakerNotes.pm`/`Nikon.pm:2887` —
+  /// `0800` overrides it to `LittleEndian`; every other LensData table inherits
+  /// the parent MakerNote IFD's order). Drives the MULTI-BYTE Z-block reads
+  /// (int16u/int32s); the legacy block's int8u members are order-agnostic.
+  order: Option<ByteOrder>,
+}
+
+/// Resolve the `LensDataVersion` prefix to its [`LensDataLayout`]
+/// (`Nikon.pm:2814-2899`). NEVER returns `None` for a readable 4-byte version —
+/// an unrecognized version falls through to the `LensDataUnknown` arm
+/// (`Nikon.pm:2890-2898`), which emits ONLY `LensDataVersion` (its table has no
+/// other member), so no `0x0098` SubDirectory is ever silently dropped.
+fn lens_data_layout(version: &[u8; 4]) -> LensDataLayout {
+  match version {
+    b"0100" => LensDataLayout {
+      table: tags::LENS_DATA_00,
+      encrypted: false,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+    b"0101" => LensDataLayout {
+      table: tags::LENS_DATA_01,
+      encrypted: false,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+    // `$$valPt =~ /^020[1-3]/` — encrypted, read against `%LensData01`.
+    [b'0', b'2', b'0', b'1' | b'2' | b'3'] => LensDataLayout {
+      table: tags::LENS_DATA_01,
+      encrypted: true,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+    // `$$valPt =~ /^0204/` (D90, D7000) — `%LensData0204`.
+    b"0204" => LensDataLayout {
+      table: tags::LENS_DATA_0204,
+      encrypted: true,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+    // `$$valPt =~ /^040[01]/` (Nikon 1 J1/V1/J2) — `%LensData0400`.
+    [b'0', b'4', b'0', b'0' | b'1'] => LensDataLayout {
+      table: tags::LENS_DATA_0400,
+      encrypted: true,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+    // `$$valPt =~ /^0402/` (Nikon 1 J3/S1/V2) — `%LensData0402`.
+    b"0402" => LensDataLayout {
+      table: tags::LENS_DATA_0402,
+      encrypted: true,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+    // `$$valPt =~ /^0403/` (Nikon 1 J4/J5) — `%LensData0403`.
+    b"0403" => LensDataLayout {
+      table: tags::LENS_DATA_0403,
+      encrypted: true,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+    // `$$valPt =~ /^080[012]/` (Z6/Z7/Z9) — `%LensData0800` (LittleEndian, the
+    // `ByteOrder => 'LittleEndian'` SubDirectory override, `Nikon.pm:2887`). The
+    // legacy OldLensData block is gated on the `undef[17]` at 0x03; the NEW Z
+    // telemetry block (0x2f onward) is decoded by [`emit_lens_data_0800_new`].
+    [b'0', b'8', b'0', b'0' | b'1' | b'2'] => LensDataLayout {
+      table: tags::LENS_DATA_0800_OLD,
+      encrypted: true,
+      old_lens_data_gate: Some(0x03),
+      has_z_block: true,
+      order: Some(ByteOrder::Little),
+    },
+    // `LensDataUnknown` fallback (`Nikon.pm:2890-2898`) — emit ONLY the version.
+    _ => LensDataLayout {
+      table: &[],
+      encrypted: true,
+      old_lens_data_gate: None,
+      has_z_block: false,
+      order: None,
+    },
+  }
+}
+
+/// `$$self{OldLensData}` (`Nikon.pm:5726-5731`): the forward-looking `undef[17]`
+/// RawConv sets the flag UNLESS the 17 bytes are `/^.\0+$/s` — i.e. the first
+/// byte is anything and bytes 1..17 are ALL NUL. A block too short to hold the
+/// 17 bytes leaves the flag unset (the `Format => 'undef[17]'` read fails),
+/// matching ExifTool's `last`-on-short-read in `ProcessBinaryData`.
+fn old_lens_data_present(body: &[u8], gate_offset: usize) -> bool {
+  let end = gate_offset.saturating_add(17);
+  let Some(window) = body.get(gate_offset..end) else {
+    return false;
+  };
+  // `/^.\0+$/s`: at least the lead byte + one NUL, and every byte after the
+  // first is NUL. `OldLensData` is set when this does NOT match — i.e. some
+  // byte from index 1 onward is non-zero.
+  match window.split_first() {
+    Some((_lead, rest)) => rest.iter().any(|&b| b != 0),
+    None => false,
+  }
+}
+
+/// Emit the `%Nikon::LensData*` leaves (0x0098). The `LensDataVersion` (first 4
+/// ASCII bytes, `Format => 'string[4]'`) version-dispatches the layout exactly
+/// as `Nikon.pm:2814-2899` does:
+///
+/// - `0100` → [`tags::LENS_DATA_00`], UNENCRYPTED.
+/// - `0101` → [`tags::LENS_DATA_01`], UNENCRYPTED.
+/// - `020[1-3]` → [`tags::LENS_DATA_01`], `040[01]`/`0402`/`0403`/`0204`/
+///   `080[012]` → their own tables — all ENCRYPTED: the bytes AFTER the 4-byte
+///   version are DECRYPTED first ([`decrypt::decrypt`] with `DecryptStart => 4`,
+///   `Nikon.pm:2836`) using the captured serial/count keys.
+/// - ANY other version → the `LensDataUnknown` arm (`Nikon.pm:2890`), an empty
+///   member table — ENCRYPTED (`ProcessProc => \&ProcessNikonEncrypted`,
+///   `DecryptStart => 4`), so ONLY `LensDataVersion` is emitted, and only when
+///   the decryption keys are valid.
+///
+/// `LensDataVersion` is emitted for a readable 4-byte version of an UNENCRYPTED
+/// layout (`0100`/`0101`) unconditionally, and of an ENCRYPTED layout ONLY once
+/// the serial/count key gate has passed. An encrypted layout without valid keys
+/// emits NOTHING — not even `LensDataVersion`: ExifTool's `ProcessNikonEncrypted`
+/// returns 0 before its callback reads the cleartext `string[4]` at offset 0
+/// (`Nikon.pm:13948-13961`), so the whole `0x0098` SubDirectory yields no tags.
+/// The maximum byte offset a [`LensDataLayout`] actually reads — the largest
+/// member `offset + size` in its table, plus the `0800` Z telemetry's
+/// `0x60`-byte window (it reads up to `LensMountType` at `0x5f`). Used to cap
+/// the encrypted-blob clone + decrypt to ONLY the bytes the decode consumes, so
+/// a crafted in-bounds LensData value near the size ceiling cannot force a large
+/// heap copy + linear decrypt of bytes that are never read. The stream cipher is
+/// causal (each byte's keystream depends only on earlier bytes), so decrypting
+/// the needed prefix is byte-identical to decrypting the whole block.
+fn lens_data_read_extent(plan: &LensDataLayout) -> usize {
+  let table_max = plan
+    .table
+    .iter()
+    .map(|e| {
+      e.offset
+        + match &e.read {
+          tags::LensRead::Byte => 1,
+          tags::LensRead::Str(len) => *len,
+        }
+    })
+    .max()
+    .unwrap_or(0);
+  // The `0800` Z telemetry ([`emit_lens_data_0800_new`]) reads up to
+  // `LensMountType` at `0x5f` (one byte ⇒ `0x60`).
+  let z_max = if plan.has_z_block { 0x60 } else { 0 };
+  table_max.max(z_max)
+}
+
+fn emit_lens_data(
+  walk_data: &[u8],
+  entry: &NikonEntry,
+  layout: Layout,
+  print_conv: bool,
+  keys: Option<DecryptKeys>,
+  focus_mode: Option<&str>,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  let Some(sub) = walk_data.get(entry.value_offset..entry.value_offset + entry.value_size) else {
+    return;
+  };
+  // `LensDataVersion` = the first 4 ASCII bytes (`Format => 'string[4]'`).
+  let Some(version) = sub.get(0..4).and_then(|v| <&[u8; 4]>::try_from(v).ok()) else {
+    return;
+  };
+  let plan = lens_data_layout(version);
+  // An ENCRYPTED layout (every `02xx`/`04xx`/`08xx` arm AND the LensDataUnknown
+  // fallback — all `ProcessProc => \&ProcessNikonEncrypted`, `Nikon.pm:2834-
+  // 2897`) is processed by `ProcessNikonEncrypted`, which RETURNS 0 (extracting
+  // NOTHING — not even the cleartext `LensDataVersion` at offset 0) when the
+  // serial/count keys are missing/invalid (`Nikon.pm:13948-13961`). The keys
+  // are valid IFF `scan_decrypt_keys` returned `Some` (the serial defaults to 0
+  // and the count is a single `/^\d+$/` scalar), so gate the WHOLE emission on
+  // it BEFORE pushing `LensDataVersion`. An UNENCRYPTED layout (`0100`/`0101`)
+  // uses plain `ProcessBinaryData` with no key check, so it always emits.
+  let valid_keys = if plan.encrypted {
+    let Some(keys) = keys else {
+      return; // ProcessNikonEncrypted returned 0 — emit nothing at all.
+    };
+    Some(keys)
+  } else {
+    None
+  };
+  // `LensDataVersion` itself is emitted as the 4-char ASCII string (it is never
+  // encrypted, so read from the original cleartext `version` bytes). This is
+  // emitted for EVERY readable 4-byte version once the key gate (encrypted
+  // layouts) has passed — incl. the LensDataUnknown fallback, so no decryptable
+  // `0x0098` SubDirectory is silently dropped.
+  let version_str = SmolStr::new(String::from_utf8_lossy(version));
+  emissions.push(VendorEmission::new(
+    "LensDataVersion".into(),
+    TagValue::Str(version_str),
+    false,
+  ));
+  if plan.table.is_empty() {
+    return; // LensDataUnknown — only the version, no members.
+  }
+  // The decoded body buffer: the raw bytes for an unencrypted layout, or a
+  // decrypted copy for the `02xx`+ layouts. The 4-byte version prefix is NEVER
+  // encrypted (`DecryptStart => 4`).
+  let decoded: std::borrow::Cow<'_, [u8]> = if let Some(keys) = valid_keys {
+    // Cap the clone+decrypt to the byte range this layout actually reads
+    // (R2: a crafted in-bounds LensData value near the size ceiling otherwise
+    // forces a large heap copy + linear decrypt of bytes never read).
+    let cap = lens_data_read_extent(&plan).min(sub.len());
+    let mut buf = sub.get(..cap).unwrap_or(sub).to_vec();
+    let len = buf.len().saturating_sub(4);
+    decrypt::decrypt(&mut buf, 4, len, keys.serial, keys.count);
+    std::borrow::Cow::Owned(buf)
+  } else {
+    std::borrow::Cow::Borrowed(sub)
+  };
+  let body = decoded.as_ref();
+  // The byte order for MULTI-BYTE members: the SubDirectory's `ByteOrder` when
+  // the layout overrides it (`0800` ⇒ LittleEndian, `Nikon.pm:2887`), else the
+  // parent MakerNote IFD's order. The legacy block's int8u members are
+  // order-agnostic, but the Z block's int16u/int32s reads need it.
+  let sub_order = plan.order.unwrap_or(layout.order);
+  // The `0800` OldLensData members are gated on the forward-looking flag; when
+  // it is clear (the `undef[17]` is `/^.\0+$/`), skip the LEGACY block (no member
+  // emits) — but the NEW Z telemetry below is INDEPENDENTLY gated on
+  // `NewLensData`, so it is still decoded. (`ProcessBinaryData` walks every
+  // table key; only the per-member `Condition` decides emission.)
+  let legacy_gate_open = plan
+    .old_lens_data_gate
+    .is_none_or(|gate| old_lens_data_present(body, gate));
+  if legacy_gate_open {
+    for pos in plan.table {
+      match pos.read {
+        // The default `int8u` member: a single byte at its offset. The sub-table
+        // byte order does not affect a one-byte read. Read from `body`
+        // (post-decrypt for the encrypted layouts).
+        tags::LensRead::Byte => {
+          let Some(&byte) = body.get(pos.offset) else {
+            continue; // member past the (short) block — emit nothing for it.
+          };
+          let raw = RawValue::U64(std::vec![u64::from(byte)]);
+          let parsed = ParsedValue::new(raw);
+          let Some(value) = pos.conv.apply(&parsed, print_conv, None, layout.order) else {
+            continue;
+          };
+          emissions.push(VendorEmission::new(pos.name.into(), value, false));
+        }
+        // `LensModel`, `Format => 'string[len]'`: `len` ASCII bytes, NUL-truncated
+        // (`ReadValue`'s `s/\0.*//s`). An entirely-empty (all-NUL) field yields the
+        // empty string, which ExifTool still emits (the `040x`/`0402`/`0403`
+        // tables have no RawConv suppressing it).
+        tags::LensRead::Str(len) => {
+          let end = pos.offset.saturating_add(len);
+          let Some(window) = body.get(pos.offset..end) else {
+            continue; // field runs past the (short) block — drop it.
+          };
+          let trimmed = match window.iter().position(|&b| b == 0) {
+            Some(nul) => window.get(..nul).unwrap_or(window),
+            None => window,
+          };
+          let value = TagValue::Str(SmolStr::from(crate::convert::fix_utf8(trimmed)));
+          emissions.push(VendorEmission::new(pos.name.into(), value, false));
+        }
+      }
+    }
+  }
+  // The NEW Z-lens telemetry block (`Nikon.pm:5809-5961`) — only the `0800`
+  // layout carries it; gated internally on `NewLensData`/`LensID`/`FocusMode`.
+  if plan.has_z_block {
+    emit_lens_data_0800_new(body, sub_order, print_conv, focus_mode, emissions);
+  }
+}
+
+/// Decode the NEW Z-lens telemetry of `%Nikon::LensData0800` (`Nikon.pm:5809-
+/// 5961`) off the DECRYPTED block `body`, in the SubDirectory's `order`
+/// (LittleEndian for `0800`). This is the faithful port of `ProcessBinaryData`
+/// over the table keys `0x2f..=0x5f`, honouring the DATAMEMBER state machine and
+/// each member's `Condition`/`Format`/`ValueConv`/`PrintConv`/`Mask`:
+///
+/// - `0x2f` `NewLensData` (`undef[17]`, RawConv `$$self{NewLensData} = 1 unless
+///   $val =~ /^.\0+$/s`) — the forward-looking flag that gates the rest. Hidden.
+/// - `0x30` `LensID` (`int16u`, `Condition => $$self{NewLensData}`, RawConv
+///   `$$self{LensID} = $val`) — the ~80-entry Z-lens PrintConv
+///   ([`NikonConv::LensId`]). A non-zero LensID ⇒ a native Z lens.
+/// - `0x34` `LensFirmwareVersion` (`int16u`, `Condition => $$self{LensID} and
+///   $$self{LensID} != 0`) — the V.R.M PrintConv ([`NikonConv::LensFirmwareZ`]).
+/// - `0x36` `MaxAperture` / `0x38` `FNumber` (`int16u`, `Condition =>
+///   $$self{NewLensData}`, `2**($val/384-1)`, [`NikonConv::LensApertureZ`]).
+/// - `0x3c` `FocalLength` (`int16u`, `Condition => $$self{NewLensData}`,
+///   PrintConv `"$val mm"`, [`NikonConv::FocalLengthZ`]).
+/// - `0x4c` `FocusDistanceRangeWidth` (`int8u`, `Unknown => 1`, `Condition =>
+///   $$self{LensID} … and $$self{FocusMode} ne "Manual"`).
+/// - `0x4e` `FocusDistance` (`int16u`, `Condition => $$self{LensID} …`, RawConv
+///   `$val/256` then `2**(($val-80)/12)`, [`NikonConv::FocusDistanceZ`]).
+/// - `0x56` `LensDriveEnd` (`int8u`, `Unknown => 1`, `Condition => … FocusMode
+///   ne "Manual"`) — the `No`/`CFD`/`Inf` RawConv label.
+/// - `0x58` `FocusStepsFromInfinity` (`int8u`, `Unknown => 1`, `Condition =>
+///   $$self{LensID} …`).
+/// - `0x5a` `LensPositionAbsolute` (`int32s`, `Condition => $$self{LensID} …`).
+/// - `0x5f` `LensMountType` (`int8u`, `Mask => 0x01`, `{0=>'Z-mount',
+///   1=>'F-mount'}`).
+///
+/// The three `Unknown => 1` members (0x4c/0x56/0x58) are emitted with the
+/// `unknown` flag so the engine suppresses them from default output but keeps
+/// them under `-u` — byte-exact with ExifTool's default `-j` (`ProcessBinaryData`
+/// `next if $$tagInfo{Unknown}` at `ExifTool.pm:9945` for `Unknown=0`).
+fn emit_lens_data_0800_new(
+  body: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+  focus_mode: Option<&str>,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  // `0x2f` NewLensData (`undef[17]`): set the flag UNLESS `/^.\0+$/s` (the lead
+  // byte is anything and bytes 1..17 are all NUL) — the same forward-look test
+  // as OldLensData. A block too short to hold the 17 bytes leaves it clear
+  // (the `Format => 'undef[17]'` read fails ⇒ no DataMember set).
+  let new_lens_data = old_lens_data_present(body, 0x2f);
+  // `0x30` LensID (`int16u`, `Condition => $$self{NewLensData}`, RawConv
+  // `$$self{LensID} = $val`). Read only when NewLensData is set; an absent /
+  // short-block / NewLensData-clear LensID leaves it `None`, which suppresses
+  // every LensID-gated member below. NOTE: we do NOT early-return on a clear
+  // NewLensData — `LensMountType` (0x5f) has NO `Condition` in ExifTool, so it
+  // must still be emitted when byte 0x5f is present (R3 fix).
+  let lens_id: Option<u16> = if new_lens_data {
+    read_z_int16u(body, 0x30, order)
+  } else {
+    None
+  };
+  if let Some(id) = lens_id {
+    let raw = RawValue::U64(std::vec![u64::from(id)]);
+    let parsed = ParsedValue::new(raw);
+    if let Some(value) = NikonConv::LensId.apply(&parsed, print_conv, None, order) {
+      emissions.push(VendorEmission::new("LensID".into(), value, false));
+    }
+  }
+  // `$$self{LensID} and $$self{LensID} != 0` — the native-Z-lens gate shared by
+  // 0x34/0x4c/0x4e/0x56/0x58/0x5a.
+  let z_lens = lens_id.is_some_and(|id| id != 0);
+  // `$$self{FocusMode} ne "Manual"` — an ABSENT FocusMode is `undef ne
+  // "Manual"` = TRUE in Perl, so the gate is open unless FocusMode is exactly
+  // "Manual" (the RAW on-disk string).
+  let not_manual = focus_mode != Some("Manual");
+
+  // `0x34` LensFirmwareVersion (`int16u`, `Condition => $$self{LensID} and
+  // $$self{LensID} != 0`).
+  if z_lens {
+    emit_z_int16u(
+      body,
+      0x34,
+      order,
+      print_conv,
+      NikonConv::LensFirmwareZ,
+      false,
+      "LensFirmwareVersion",
+      emissions,
+    );
+  }
+  // `0x36` MaxAperture / `0x38` FNumber / `0x3c` FocalLength — gated on
+  // `$$self{NewLensData}`.
+  if new_lens_data {
+    emit_z_int16u(
+      body,
+      0x36,
+      order,
+      print_conv,
+      NikonConv::LensApertureZ,
+      false,
+      "MaxAperture",
+      emissions,
+    );
+    emit_z_int16u(
+      body,
+      0x38,
+      order,
+      print_conv,
+      NikonConv::LensApertureZ,
+      false,
+      "FNumber",
+      emissions,
+    );
+    emit_z_int16u(
+      body,
+      0x3c,
+      order,
+      print_conv,
+      NikonConv::FocalLengthZ,
+      false,
+      "FocalLength",
+      emissions,
+    );
+  }
+  // `0x4c` FocusDistanceRangeWidth (`int8u`, `Unknown => 1`, gated on z_lens AND
+  // FocusMode ne "Manual"). Its RawConv sets `$$self{FocusDistanceRangeWidth}`,
+  // but that DataMember is consumed only by LensDriveEnd's RawConv (handled
+  // there); the Unknown flag suppresses it from default output.
+  if z_lens && not_manual {
+    emit_z_int8u(
+      body,
+      0x4c,
+      print_conv,
+      NikonConv::Raw,
+      true,
+      "FocusDistanceRangeWidth",
+      emissions,
+    );
+  }
+  // `0x4e` FocusDistance (`int16u`, gated on z_lens). The PrintConv references
+  // `$$self{FocusStepsFromInfinity}`, which is `Unknown => 1` and therefore NEVER
+  // set in default mode (`next if Unknown` at `ExifTool.pm:9945`), so the "Inf"
+  // branch is unreachable — [`NikonConv::FocusDistanceZ`] formats accordingly.
+  if z_lens {
+    emit_z_int16u(
+      body,
+      0x4e,
+      order,
+      print_conv,
+      NikonConv::FocusDistanceZ,
+      false,
+      "FocusDistance",
+      emissions,
+    );
+  }
+  // `0x56` LensDriveEnd (`int8u`, `Unknown => 1`, gated on z_lens AND not
+  // Manual). STATEFUL RawConv (`Nikon.pm:5933-5939`):
+  //   unless (defined $$self{FocusDistanceRangeWidth}
+  //           and not $$self{FocusDistanceRangeWidth}) {
+  //     if ($val == 0) { $$self{LensDriveEnd} = "No" }
+  //     else           { $$self{LensDriveEnd} = "CFD" }
+  //   } else           { $$self{LensDriveEnd} = "Inf" }
+  // The RawConv's RETURN value (a Perl assignment yields its RHS) is the emitted
+  // `$val` — the STRING "No"/"CFD"/"Inf", NOT the raw int8u. It reads the 0x4c
+  // `FocusDistanceRangeWidth` DataMember, set by 0x4c's RawConv `$$self{...} =
+  // $val`. That DataMember is set ONLY when 0x4c is EXTRACTED; 0x4c is `Unknown
+  // => 1`, so it is set IFF the member survives the binary-table Unknown gate
+  // (`ExifTool.pm:9945` `next if Unknown and Unknown > $unknown`). LensDriveEnd
+  // is ITSELF `Unknown => 1` ⇒ observable only under `-u`, and in `-u` the
+  // lower-index 0x4c is ALSO extracted and runs FIRST, so whenever LensDriveEnd
+  // is visible its DataMember IS defined = the raw byte at 0x4c (byte 0x56 sits
+  // above 0x4c, so reaching 0x56 guarantees 0x4c is in-block). Thus the faithful
+  // mapping reads BOTH bytes off the same decrypted `body`:
+  //   FocusDistanceRangeWidth(0x4c) == 0 → "Inf";
+  //   else LensDriveEnd(0x56) == 0      → "No"; else → "CFD".
+  // exifast has NO `-u` mode — the engine ALWAYS drops `Unknown => 1` tags
+  // (`run_emission`'s `if e.unknown() { continue }`), so LensDriveEnd NEVER
+  // reaches output; it is emitted (unknown-flagged) and converted faithfully for
+  // correctness, exercised directly via [`lens_drive_end`].
+  if z_lens
+    && not_manual
+    && let Some(&byte) = body.get(0x56)
+  {
+    let focus_distance_range_width = body.get(0x4c).copied();
+    let label = lens_drive_end(byte, focus_distance_range_width);
+    emissions.push(VendorEmission::new(
+      "LensDriveEnd".into(),
+      TagValue::Str(SmolStr::new(label)),
+      true,
+    ));
+  }
+  // `0x58` FocusStepsFromInfinity (`int8u`, `Unknown => 1`, gated on z_lens).
+  if z_lens {
+    emit_z_int8u(
+      body,
+      0x58,
+      print_conv,
+      NikonConv::Raw,
+      true,
+      "FocusStepsFromInfinity",
+      emissions,
+    );
+  }
+  // `0x5a` LensPositionAbsolute (`int32s`, gated on z_lens). NOT Unknown.
+  if z_lens {
+    emit_z_int32s(
+      body,
+      0x5a,
+      order,
+      print_conv,
+      "LensPositionAbsolute",
+      emissions,
+    );
+  }
+  // `0x5f` LensMountType (`int8u`, `Mask => 0x01`, `{0=>'Z-mount',1=>'F-mount'}`).
+  // NO Condition — always emitted when the byte is present. The Mask is applied
+  // BEFORE the PrintConv (`ExifTool.pm:10079` `$val = ($val & $mask) >> 0`).
+  if let Some(&byte) = body.get(0x5f) {
+    let masked = i64::from(byte & 0x01);
+    let raw = RawValue::I64(std::vec![masked]);
+    let parsed = ParsedValue::new(raw);
+    if let Some(value) = NikonConv::LensMountType.apply(&parsed, print_conv, None, order) {
+      emissions.push(VendorEmission::new("LensMountType".into(), value, false));
+    }
+  }
+}
+
+/// Read an `int16u` member at `offset` off the decrypted Z block in `order`
+/// (the faithful `ReadValue($dataPt, $entry, 'int16u', 1, $more)`). `None` when
+/// the 2 bytes do not fit (a short block — `ProcessBinaryData` `last if $more <=
+/// 0`), so the member emits nothing.
+fn read_z_int16u(body: &[u8], offset: usize, order: ByteOrder) -> Option<u16> {
+  let avail = body.len().checked_sub(offset)?;
+  let raw = read_value(body, offset, Format::Int16u, 1, avail, order)?;
+  match raw {
+    RawValue::U64(v) => v.first().and_then(|&n| u16::try_from(n).ok()),
+    _ => None,
+  }
+}
+
+/// Emit one `int16u` Z member: read it in `order`, apply `conv`, push under
+/// `name` with the `unknown` flag. A short block (member past the end) emits
+/// nothing.
+fn emit_z_int16u(
+  body: &[u8],
+  offset: usize,
+  order: ByteOrder,
+  print_conv: bool,
+  conv: NikonConv,
+  unknown: bool,
+  name: &'static str,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  let Some(n) = read_z_int16u(body, offset, order) else {
+    return;
+  };
+  let raw = RawValue::U64(std::vec![u64::from(n)]);
+  let parsed = ParsedValue::new(raw);
+  if let Some(value) = conv.apply(&parsed, print_conv, None, order) {
+    emissions.push(VendorEmission::new(name.into(), value, unknown));
+  }
+}
+
+/// Emit one `int8u` Z member at `offset` (the default `FORMAT => 'int8u'`): a
+/// single byte, order-agnostic. A short block emits nothing.
+fn emit_z_int8u(
+  body: &[u8],
+  offset: usize,
+  print_conv: bool,
+  conv: NikonConv,
+  unknown: bool,
+  name: &'static str,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  let Some(&byte) = body.get(offset) else {
+    return;
+  };
+  let raw = RawValue::U64(std::vec![u64::from(byte)]);
+  let parsed = ParsedValue::new(raw);
+  if let Some(value) = conv.apply(&parsed, print_conv, None, ByteOrder::Little) {
+    emissions.push(VendorEmission::new(name.into(), value, unknown));
+  }
+}
+
+/// The `0x56` `LensDriveEnd` RawConv (`Nikon.pm:5933-5939`) — the STATEFUL
+/// label derived from the `LensDriveEnd` byte (`val`) and the `0x4c`
+/// `FocusDistanceRangeWidth` DataMember (`fdrw`, the raw byte at 0x4c, `None`
+/// when undefined — but see [`emit_lens_data_0800_new`]: when LensDriveEnd is
+/// reached, 0x4c is always in-block, so `fdrw` is `Some`):
+///
+/// ```text
+/// unless (defined $fdrw and not $fdrw) {       # !(fdrw defined && fdrw == 0)
+///     if ($val == 0) { "No" } else { "CFD" }
+/// } else { "Inf" }                              #   fdrw defined && fdrw == 0
+/// ```
+///
+/// i.e. `Inf` iff `FocusDistanceRangeWidth` is defined and `0`; otherwise `No`
+/// for `val == 0` and `CFD` for `val != 0`. Returns the `&'static str` the
+/// RawConv's terminal assignment yields (the emitted `$val`).
+#[must_use]
+const fn lens_drive_end(val: u8, fdrw: Option<u8>) -> &'static str {
+  match fdrw {
+    Some(0) => "Inf",
+    _ if val == 0 => "No",
+    _ => "CFD",
+  }
+}
+
+/// Emit `LensPositionAbsolute` (`0x5a`, `int32s`): read 4 bytes in `order` as a
+/// signed int, no ValueConv/PrintConv (rendered as the bare integer). A short
+/// block emits nothing.
+fn emit_z_int32s(
+  body: &[u8],
+  offset: usize,
+  order: ByteOrder,
+  print_conv: bool,
+  name: &'static str,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  let avail = match body.len().checked_sub(offset) {
+    Some(a) => a,
+    None => return,
+  };
+  let Some(raw) = read_value(body, offset, Format::Int32s, 1, avail, order) else {
+    return;
+  };
+  let parsed = ParsedValue::new(raw);
+  // No ValueConv/PrintConv on LensPositionAbsolute ⇒ the default `ReadValue`
+  // render (the signed integer).
+  if let Some(value) = NikonConv::Raw.apply(&parsed, print_conv, None, order) {
+    emissions.push(VendorEmission::new(name.into(), value, false));
+  }
 }
 
 /// `$$self{Model} =~ /^NIKON D/i` (`Nikon.pm:2115`) — the AFInfo BigEndian
@@ -1008,5 +1755,975 @@ mod tests {
       emissions.iter().any(|e| e.name() == "Quality"),
       "the IFD at +8 must be walked (Quality emitted): {emissions:?}"
     );
+  }
+
+  // ---- LensData version-dispatch (0x0098) ---------------------------------
+  //
+  // Each test crafts a self-contained type-3 Nikon blob carrying SerialNumber
+  // (0x001d), ShutterCount (0x00a7) and a LensData (0x0098) block whose
+  // encrypted body was produced by ENCRYPTING a known plaintext with this
+  // module's own symmetric `decrypt` (the `cipher_is_symmetric` property), so
+  // the decode round-trips a KNOWN field set. The expected rendered values are
+  // the `perl exiftool 13.59` oracle (verified out-of-band on the identical
+  // crafted bytes — see the issue-#227 verification notes).
+
+  /// The crafted-blob serial/count keys (numeric serial `12345678` ⇒ the key is
+  /// the integer itself; ShutterCount `100`).
+  const KEY_SERIAL: u32 = 12_345_678;
+  const KEY_COUNT: u32 = 100;
+
+  /// Build a self-contained type-3 Nikon blob (the `parse()` standalone path)
+  /// with SerialNumber=`12345678`, ShutterCount=`100`, and a `0x0098` LensData
+  /// value of `lens_block` (the version prefix + already-encrypted body, or a
+  /// cleartext body for the unencrypted `0100`/`0101`).
+  fn type3_with_lens_data(lens_block: &[u8]) -> Vec<u8> {
+    // Embedded TIFF (big-endian) at blob offset 10; IFD0 at embedded+8 (blob
+    // 18). Out-of-line value offsets are embedded-relative (value_base 10).
+    let serial = b"12345678\x00"; // 9 bytes (out-of-line)
+    let n_entries: u16 = 3;
+    // value area begins after count(2) + 3*12 + next(4) = 42 ⇒ embedded 8+42=50.
+    let val_emb: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4;
+    let off_serial = val_emb;
+    let off_lens = off_serial + serial.len() as u32;
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // 10-byte type-3 header
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes()); // IFD0 at embedded+8
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    // 0x001d SerialNumber — ASCII, out-of-line.
+    b.extend_from_slice(&0x001du16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x02]); // string
+    b.extend_from_slice(&(serial.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_serial.to_be_bytes());
+    // 0x0098 LensData — undef, out-of-line.
+    b.extend_from_slice(&0x0098u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x07]); // undef
+    b.extend_from_slice(&(lens_block.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_lens.to_be_bytes());
+    // 0x00a7 ShutterCount — int32u, inline = 100.
+    b.extend_from_slice(&0x00a7u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x04]); // int32u
+    b.extend_from_slice(&1u32.to_be_bytes());
+    b.extend_from_slice(&KEY_COUNT.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    debug_assert_eq!(b.len() as u32, 10 + off_serial);
+    b.extend_from_slice(serial);
+    b.extend_from_slice(lens_block);
+    b
+  }
+
+  /// Like [`type3_with_lens_data`] but ALSO carries a `FocusMode` (tag 0x0007)
+  /// string so the LensData0800 Z `FocusMode ne "Manual"` gate can be exercised.
+  /// `focus_mode` is the RAW on-disk bytes (NUL-terminated as the camera writes
+  /// it). Four out-of-line entries in tag-ID order: 0x0007, 0x001d, 0x0098, plus
+  /// the inline 0x00a7.
+  fn type3_with_focus_mode_and_lens_data(focus_mode: &[u8], lens_block: &[u8]) -> Vec<u8> {
+    let serial = b"12345678\x00"; // 9 bytes (out-of-line)
+    let n_entries: u16 = 4;
+    // value area begins after count(2) + 4*12 + next(4) = 54 ⇒ embedded 8+54=62.
+    let val_emb: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4;
+    let off_focus = val_emb;
+    let off_serial = off_focus + focus_mode.len() as u32;
+    let off_lens = off_serial + serial.len() as u32;
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // 10-byte type-3 header
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes()); // IFD0 at embedded+8
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    // 0x0007 FocusMode — ASCII, out-of-line.
+    b.extend_from_slice(&0x0007u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x02]); // string
+    b.extend_from_slice(&(focus_mode.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_focus.to_be_bytes());
+    // 0x001d SerialNumber — ASCII, out-of-line.
+    b.extend_from_slice(&0x001du16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x02]); // string
+    b.extend_from_slice(&(serial.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_serial.to_be_bytes());
+    // 0x0098 LensData — undef, out-of-line.
+    b.extend_from_slice(&0x0098u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x07]); // undef
+    b.extend_from_slice(&(lens_block.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_lens.to_be_bytes());
+    // 0x00a7 ShutterCount — int32u, inline = 100.
+    b.extend_from_slice(&0x00a7u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x04]); // int32u
+    b.extend_from_slice(&1u32.to_be_bytes());
+    b.extend_from_slice(&KEY_COUNT.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    debug_assert_eq!(b.len() as u32, 10 + off_focus);
+    b.extend_from_slice(focus_mode);
+    b.extend_from_slice(serial);
+    b.extend_from_slice(lens_block);
+    b
+  }
+
+  /// Like [`type3_with_focus_mode_and_lens_data`] but with the IFD entry RECORDS
+  /// in the UNSORTED order `0x001d, 0x0098, 0x00a7, 0x0007` — so the `0x0098`
+  /// LensData is WALKED BEFORE the `0x0007` `FocusMode` entry. This exercises the
+  /// positional `$$self{FocusMode}` gate: at the LensData position no `0x0007`
+  /// has run yet, so the member is `undef` (`undef ne "Manual"` = TRUE ⇒ open),
+  /// even though a later `0x0007 = "Manual"` exists. The value AREA layout is
+  /// unchanged (offsets are record-order-independent); only the 4 entry records
+  /// are reordered.
+  fn type3_lens_data_before_focus_mode(focus_mode: &[u8], lens_block: &[u8]) -> Vec<u8> {
+    let serial = b"12345678\x00"; // 9 bytes (out-of-line)
+    let n_entries: u16 = 4;
+    let val_emb: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4;
+    let off_focus = val_emb;
+    let off_serial = off_focus + focus_mode.len() as u32;
+    let off_lens = off_serial + serial.len() as u32;
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00"); // 10-byte type-3 header
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes()); // IFD0 at embedded+8
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    // 0x001d SerialNumber — ASCII, out-of-line (a prescan key; order-independent).
+    b.extend_from_slice(&0x001du16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x02]); // string
+    b.extend_from_slice(&(serial.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_serial.to_be_bytes());
+    // 0x0098 LensData — undef, out-of-line. WALKED BEFORE 0x0007 below.
+    b.extend_from_slice(&0x0098u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x07]); // undef
+    b.extend_from_slice(&(lens_block.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_lens.to_be_bytes());
+    // 0x00a7 ShutterCount — int32u, inline = 100 (a prescan key).
+    b.extend_from_slice(&0x00a7u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x04]); // int32u
+    b.extend_from_slice(&1u32.to_be_bytes());
+    b.extend_from_slice(&KEY_COUNT.to_be_bytes());
+    // 0x0007 FocusMode — ASCII, out-of-line. AFTER 0x0098 in walk order.
+    b.extend_from_slice(&0x0007u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x02]); // string
+    b.extend_from_slice(&(focus_mode.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_focus.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    debug_assert_eq!(b.len() as u32, 10 + off_focus);
+    b.extend_from_slice(focus_mode);
+    b.extend_from_slice(serial);
+    b.extend_from_slice(lens_block);
+    b
+  }
+
+  /// Encrypt `plain` (the cleartext version+body) with this module's symmetric
+  /// cipher (`DecryptStart => 4`, the crafted keys) — the inverse of the read
+  /// path, used to forge an encrypted LensData block from a known plaintext.
+  fn encrypt_lens(plain: &[u8]) -> Vec<u8> {
+    let mut buf = plain.to_vec();
+    let len = buf.len().saturating_sub(4);
+    decrypt::decrypt(&mut buf, 4, len, KEY_SERIAL, KEY_COUNT);
+    buf
+  }
+
+  fn lens_get(emissions: &[VendorEmission], name: &str) -> Option<TagValue> {
+    emissions
+      .iter()
+      .find(|e| e.name() == name)
+      .map(|e| e.value().clone())
+  }
+
+  fn str_val(s: &str) -> TagValue {
+    TagValue::Str(SmolStr::new(s))
+  }
+
+  /// `LensDataVersion 0204` (D90/D7000) DISPATCHES to `%LensData0204` (NOT the
+  /// Unknown fallback) and decodes its 13 shifted-offset members byte-exact to
+  /// the `perl exiftool` oracle (the offsets differ from 0101 by the +1 shift at
+  /// 0x09). This is the OLD-BUG-FIXED case: pre-fix a `0204` block emitted
+  /// NOTHING (not even `LensDataVersion`); now the full member set emits.
+  #[test]
+  fn lens_data_0204_dispatches_and_decodes() {
+    // Known plaintext: "0204" + body bytes at the 0204 offsets (see the table).
+    let mut plain = [0u8; 20];
+    plain[0..4].copy_from_slice(b"0204");
+    plain[0x04] = 0x40; // ExitPupilPosition raw 64 → 2048/64 = "32.0 mm"
+    plain[0x05] = 0x18; // AFAperture raw 24 → 2**(24/24) = "2.0"
+    plain[0x08] = 0x2a; // FocusPosition raw 0x2a → "0x2a"
+    plain[0x0a] = 0x14; // FocusDistance raw 20 → "0.03 m"
+    plain[0x0b] = 0x76; // FocalLength raw 118 → "151.0 mm"
+    plain[0x0c] = 0x18; // LensIDNumber 24
+    plain[0x0d] = 0x18; // LensFStops raw 24 → 24/12 = "2.00"
+    plain[0x0e] = 0x18; // MinFocalLength raw 24 → "10.0 mm"
+    plain[0x0f] = 0x18; // MaxFocalLength raw 24 → "10.0 mm"
+    plain[0x10] = 0x30; // MaxApertureAtMinFocal raw 48 → "4.0"
+    plain[0x11] = 0x30; // MaxApertureAtMaxFocal raw 48 → "4.0"
+    plain[0x12] = 0x07; // MCUVersion 7
+    plain[0x13] = 0x42; // EffectiveMaxAperture raw 66 → "6.7"
+    let blob = type3_with_lens_data(&encrypt_lens(&plain));
+
+    let (_t, em) = parse(&blob, ByteOrder::Big, Some("NIKON D7000"));
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0204")));
+    assert_eq!(lens_get(&em, "ExitPupilPosition"), Some(str_val("32.0 mm")));
+    assert_eq!(lens_get(&em, "AFAperture"), Some(str_val("2.0")));
+    assert_eq!(lens_get(&em, "FocusPosition"), Some(str_val("0x2a")));
+    assert_eq!(lens_get(&em, "FocusDistance"), Some(str_val("0.03 m")));
+    assert_eq!(lens_get(&em, "FocalLength"), Some(str_val("151.0 mm")));
+    assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
+    assert_eq!(lens_get(&em, "LensFStops"), Some(str_val("2.00")));
+    assert_eq!(lens_get(&em, "MinFocalLength"), Some(str_val("10.0 mm")));
+    assert_eq!(lens_get(&em, "MaxFocalLength"), Some(str_val("10.0 mm")));
+    assert_eq!(lens_get(&em, "MaxApertureAtMinFocal"), Some(str_val("4.0")));
+    assert_eq!(lens_get(&em, "MaxApertureAtMaxFocal"), Some(str_val("4.0")));
+    assert_eq!(lens_get(&em, "MCUVersion"), Some(TagValue::I64(7)));
+    assert_eq!(lens_get(&em, "EffectiveMaxAperture"), Some(str_val("6.7")));
+  }
+
+  #[test]
+  fn lens_data_read_extent_is_bounded_per_layout() {
+    // The decrypt cap is the layout's largest member offset+size — small and
+    // FIXED per version, NEVER the (attacker-controlled) declared blob length.
+    assert_eq!(lens_data_read_extent(&lens_data_layout(b"0204")), 0x14);
+    assert_eq!(
+      lens_data_read_extent(&lens_data_layout(b"0403")),
+      0x2ac + 64
+    );
+    // 0800: the Z telemetry reads up to LensMountType 0x5f ⇒ 0x60.
+    let e0800 = lens_data_read_extent(&lens_data_layout(b"0800"));
+    assert!((0x60..0x100).contains(&e0800), "0800 extent {e0800:#x}");
+  }
+
+  #[test]
+  fn lens_data_large_in_bounds_value_caps_decrypt() {
+    // R2: a crafted encrypted LensData declaring a huge in-bounds value must NOT
+    // clone+decrypt the whole blob — only the layout's read window (0x14 for
+    // 0204). The first bytes carry the real members; the 60 KB tail is padding
+    // the cap never decrypts. Decoding still succeeds (the cipher is causal).
+    let mut plain = vec![0u8; 60_000];
+    plain[0..4].copy_from_slice(b"0204");
+    plain[0x04] = 0x40; // ExitPupilPosition → "32.0 mm"
+    plain[0x0c] = 0x18; // LensIDNumber 24
+    plain[0x13] = 0x42; // EffectiveMaxAperture → "6.7"
+    let blob = type3_with_lens_data(&encrypt_lens(&plain));
+    let (_t, em) = parse(&blob, ByteOrder::Big, Some("NIKON D7000"));
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0204")));
+    assert_eq!(lens_get(&em, "ExitPupilPosition"), Some(str_val("32.0 mm")));
+    assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
+    assert_eq!(lens_get(&em, "EffectiveMaxAperture"), Some(str_val("6.7")));
+    // The decrypt window is the 0204 layout (0x14), not the 60 KB value.
+    assert_eq!(lens_data_read_extent(&lens_data_layout(b"0204")), 0x14);
+  }
+
+  #[test]
+  fn encrypted_lens_data_decrypts_without_serial_number() {
+    // R4: ExifTool seeds its prescan with `0x001d => 0`, so encrypted LensData
+    // with ShutterCount (0x00a7) but NO SerialNumber (0x001d) still decrypts
+    // with serial key 0. The 0204 block is encrypted with serial key 0 + the
+    // count, embedded in a type-3 MakerNote carrying 0x00a7 but no 0x001d.
+    let mut plain = [0u8; 20];
+    plain[0..4].copy_from_slice(b"0204");
+    plain[0x04] = 0x40; // ExitPupilPosition → "32.0 mm"
+    plain[0x0c] = 0x18; // LensIDNumber 24
+    plain[0x13] = 0x42; // EffectiveMaxAperture → "6.7"
+    let mut enc = plain.to_vec();
+    let len = enc.len() - 4;
+    decrypt::decrypt(&mut enc, 4, len, 0, KEY_COUNT); // serial key 0
+    // Type-3 MakerNote: 2 out-of-line/inline entries (0x0098 LensData, 0x00a7
+    // ShutterCount) — tag-ID-ordered, NO 0x001d SerialNumber.
+    let n_entries: u16 = 2;
+    let off_lens: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4; // embedded-relative
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes());
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    b.extend_from_slice(&0x0098u16.to_be_bytes()); // LensData, undef, out-of-line
+    b.extend_from_slice(&[0x00, 0x07]);
+    b.extend_from_slice(&(enc.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_lens.to_be_bytes());
+    b.extend_from_slice(&0x00a7u16.to_be_bytes()); // ShutterCount, int32u, inline
+    b.extend_from_slice(&[0x00, 0x04]);
+    b.extend_from_slice(&1u32.to_be_bytes());
+    b.extend_from_slice(&KEY_COUNT.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    b.extend_from_slice(&enc);
+    let (_t, em) = parse(&b, ByteOrder::Big, Some("NIKON D7000"));
+    // Decryption succeeded with the default serial key 0 (no 0x001d present).
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0204")));
+    assert_eq!(lens_get(&em, "ExitPupilPosition"), Some(str_val("32.0 mm")));
+    assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
+    assert_eq!(lens_get(&em, "EffectiveMaxAperture"), Some(str_val("6.7")));
+  }
+
+  /// `LensDataVersion 0400` (Nikon 1 J1/V1/J2) dispatches to `%LensData0400` and
+  /// decodes the `LensModel` `string[64]` at offset 0x18a (the only readable
+  /// member). Byte-exact to the `perl exiftool` oracle. Proves the
+  /// large-offset string read + the `040[01]` alternation arm.
+  #[test]
+  fn lens_data_0400_decodes_lens_model() {
+    let model = b"1 NIKKOR VR 10-30mm f/3.5-5.6";
+    let mut plain = std::vec![0u8; 0x18a + 64];
+    plain[0..4].copy_from_slice(b"0400");
+    plain
+      .get_mut(0x18a..0x18a + model.len())
+      .unwrap()
+      .copy_from_slice(model);
+    let blob = type3_with_lens_data(&encrypt_lens(&plain));
+
+    let (_t, em) = parse(&blob, ByteOrder::Big, Some("NIKON 1 J1"));
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0400")));
+    assert_eq!(
+      lens_get(&em, "LensModel"),
+      Some(str_val("1 NIKKOR VR 10-30mm f/3.5-5.6"))
+    );
+    // The `0401` sibling shares the same table/arm.
+    let mut plain2 = plain.clone();
+    plain2[0..4].copy_from_slice(b"0401");
+    let blob2 = type3_with_lens_data(&encrypt_lens(&plain2));
+    let (_t2, em2) = parse(&blob2, ByteOrder::Big, Some("NIKON 1 J2"));
+    assert_eq!(lens_get(&em2, "LensDataVersion"), Some(str_val("0401")));
+    assert_eq!(
+      lens_get(&em2, "LensModel"),
+      Some(str_val("1 NIKKOR VR 10-30mm f/3.5-5.6"))
+    );
+  }
+
+  /// `LensDataVersion 0402` decodes `LensModel` (`string[64]`) at offset 0x18b,
+  /// and `0403` at offset 0x2ac — the per-version offsets matter. Byte-exact to
+  /// the `perl exiftool` oracle.
+  #[test]
+  fn lens_data_0402_0403_decode_lens_model() {
+    let model402 = b"1 NIKKOR 11-27.5mm f/3.5-5.6";
+    let mut p402 = std::vec![0u8; 0x18b + 64];
+    p402[0..4].copy_from_slice(b"0402");
+    p402
+      .get_mut(0x18b..0x18b + model402.len())
+      .unwrap()
+      .copy_from_slice(model402);
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(&p402)),
+      ByteOrder::Big,
+      Some("NIKON 1 J3"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0402")));
+    assert_eq!(
+      lens_get(&em, "LensModel"),
+      Some(str_val("1 NIKKOR 11-27.5mm f/3.5-5.6"))
+    );
+
+    let model403 = b"1 NIKKOR VR 10-100mm f/4-5.6";
+    let mut p403 = std::vec![0u8; 0x2ac + 64];
+    p403[0..4].copy_from_slice(b"0403");
+    p403
+      .get_mut(0x2ac..0x2ac + model403.len())
+      .unwrap()
+      .copy_from_slice(model403);
+    let (_t2, em2) = parse(
+      &type3_with_lens_data(&encrypt_lens(&p403)),
+      ByteOrder::Big,
+      Some("NIKON 1 J4"),
+    );
+    assert_eq!(lens_get(&em2, "LensDataVersion"), Some(str_val("0403")));
+    assert_eq!(
+      lens_get(&em2, "LensModel"),
+      Some(str_val("1 NIKKOR VR 10-100mm f/4-5.6"))
+    );
+  }
+
+  /// `LensDataVersion 080[012]` (Z6/Z7/Z9) dispatches to `%LensData0800` and,
+  /// when the forward-looking `OldLensData` flag is SET (the `undef[17]` at 0x03
+  /// is NOT `/^.\0+$/`), decodes the LEGACY block (offsets 0x04-0x14, a second
+  /// +1 shift). Byte-exact to the `perl exiftool` oracle.
+  #[test]
+  fn lens_data_0800_old_block_decodes() {
+    let mut plain = [0u8; 0x15];
+    plain[0..4].copy_from_slice(b"0800");
+    plain[0x04] = 0x40; // ExitPupilPosition → "32.0 mm"
+    plain[0x05] = 0x18; // AFAperture → "2.0"
+    plain[0x0b] = 0x14; // FocusDistance → "0.03 m"
+    plain[0x0c] = 0x76; // FocalLength → "151.0 mm"
+    plain[0x0d] = 0x18; // LensIDNumber 24
+    plain[0x0e] = 0x18; // LensFStops → "2.00"
+    plain[0x0f] = 0x18; // MinFocalLength → "10.0 mm"
+    plain[0x10] = 0x18; // MaxFocalLength → "10.0 mm"
+    plain[0x11] = 0x30; // MaxApertureAtMinFocal → "4.0"
+    plain[0x12] = 0x30; // MaxApertureAtMaxFocal → "4.0"
+    plain[0x13] = 0x07; // MCUVersion 7
+    plain[0x14] = 0x42; // EffectiveMaxAperture → "6.7"
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(&plain)),
+      ByteOrder::Big,
+      Some("NIKON Z 6"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0800")));
+    assert_eq!(lens_get(&em, "ExitPupilPosition"), Some(str_val("32.0 mm")));
+    assert_eq!(lens_get(&em, "AFAperture"), Some(str_val("2.0")));
+    assert_eq!(lens_get(&em, "FocusDistance"), Some(str_val("0.03 m")));
+    assert_eq!(lens_get(&em, "FocalLength"), Some(str_val("151.0 mm")));
+    assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
+    assert_eq!(lens_get(&em, "LensFStops"), Some(str_val("2.00")));
+    assert_eq!(lens_get(&em, "MCUVersion"), Some(TagValue::I64(7)));
+    assert_eq!(lens_get(&em, "EffectiveMaxAperture"), Some(str_val("6.7")));
+  }
+
+  /// `LensDataVersion 0800` with the `OldLensData` flag CLEAR (the `undef[17]`
+  /// at 0x03 IS `/^.\0+$/` — all bytes after the lead are NUL) emits ONLY
+  /// `LensDataVersion`, NO legacy members (the `Condition => '$$self{OldLensData}'`
+  /// gate). Matches the `perl exiftool` oracle on the gate-off crafted bytes.
+  #[test]
+  fn lens_data_0800_gate_off_emits_only_version() {
+    let mut plain = [0u8; 0x15];
+    plain[0..4].copy_from_slice(b"0800");
+    // bytes 0x04.. all zero ⇒ undef[17] at 0x03 = lead + 16 NULs ⇒ flag clear.
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(&plain)),
+      ByteOrder::Big,
+      Some("NIKON Z 6"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0800")));
+    for name in [
+      "ExitPupilPosition",
+      "AFAperture",
+      "FocusDistance",
+      "FocalLength",
+      "LensIDNumber",
+      "MCUVersion",
+      "EffectiveMaxAperture",
+    ] {
+      assert!(
+        lens_get(&em, name).is_none(),
+        "0800 gate-off must suppress {name}, got {em:?}"
+      );
+    }
+  }
+
+  /// `LensDataVersion 0800` NEW Z-lens telemetry (`Nikon.pm:5809-5961`): with
+  /// the legacy `OldLensData` gate CLEAR (so the legacy block is silent) but the
+  /// forward-looking `NewLensData` flag SET, the Z block (0x2f onward) decodes.
+  /// All multi-byte members are read LittleEndian (the `0800` `ByteOrder`
+  /// override). The expected rendered values were cross-checked against the
+  /// actual `Nikon.pm` PrintConv/ValueConv expressions evaluated in Perl.
+  #[test]
+  fn lens_data_0800_z_telemetry_decodes() {
+    // 0x60 bytes so the block reaches LensMountType (0x5f). 0x03..0x14 left NUL
+    // ⇒ OldLensData gate CLEAR. The Z block is filled from 0x30.
+    let mut plain = [0u8; 0x60];
+    plain[0..4].copy_from_slice(b"0800");
+    // 0x30 LensID int16u LE = 13 → "Nikkor Z 24-70mm f/2.8 S" (also makes the
+    // NewLensData undef[17] at 0x2f non-`/^.\0+$/` ⇒ flag SET, z_lens TRUE).
+    plain[0x30..0x32].copy_from_slice(&13u16.to_le_bytes());
+    // 0x34 LensFirmwareVersion int16u LE = 0x0123 (291) → "1.2.3".
+    plain[0x34..0x36].copy_from_slice(&0x0123u16.to_le_bytes());
+    // 0x36 MaxAperture int16u LE = 768 → 2**(768/384-1)=2.0 → "2.0".
+    plain[0x36..0x38].copy_from_slice(&768u16.to_le_bytes());
+    // 0x38 FNumber int16u LE = 1152 → 2**(1152/384-1)=4.0 → "4.0".
+    plain[0x38..0x3a].copy_from_slice(&1152u16.to_le_bytes());
+    // 0x3c FocalLength int16u LE = 50 → "50 mm".
+    plain[0x3c..0x3e].copy_from_slice(&50u16.to_le_bytes());
+    // 0x4c FocusDistanceRangeWidth int8u (Unknown=1) — emitted but unknown-flagged.
+    plain[0x4c] = 0x05;
+    // 0x4e FocusDistance int16u LE = 24576 → raw/256=96 → 2**((96-80)/12)=2.52 → "2.52 m".
+    plain[0x4e..0x50].copy_from_slice(&24576u16.to_le_bytes());
+    // 0x56 LensDriveEnd int8u (Unknown=1) / 0x58 FocusStepsFromInfinity (Unknown=1).
+    plain[0x56] = 0x02;
+    plain[0x58] = 0x07;
+    // 0x5a LensPositionAbsolute int32s LE = 58000 → I64(58000). NOT Unknown.
+    plain[0x5a..0x5e].copy_from_slice(&58000i32.to_le_bytes());
+    // 0x5f LensMountType int8u, Mask 0x01 = 0xf1 → masked 1 → "F-mount".
+    plain[0x5f] = 0xf1;
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(&plain)),
+      ByteOrder::Big,
+      Some("NIKON Z 6"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0800")));
+    // The legacy block is gated OFF — no OldLensData members.
+    assert!(lens_get(&em, "ExitPupilPosition").is_none());
+    // Z telemetry (camera-identity, NOT unknown-flagged).
+    assert_eq!(
+      lens_get(&em, "LensID"),
+      Some(str_val("Nikkor Z 24-70mm f/2.8 S"))
+    );
+    assert_eq!(lens_get(&em, "LensFirmwareVersion"), Some(str_val("1.2.3")));
+    assert_eq!(lens_get(&em, "MaxAperture"), Some(str_val("2.0")));
+    assert_eq!(lens_get(&em, "FNumber"), Some(str_val("4.0")));
+    assert_eq!(lens_get(&em, "FocalLength"), Some(str_val("50 mm")));
+    assert_eq!(lens_get(&em, "FocusDistance"), Some(str_val("2.52 m")));
+    assert_eq!(
+      lens_get(&em, "LensPositionAbsolute"),
+      Some(TagValue::I64(58000))
+    );
+    assert_eq!(lens_get(&em, "LensMountType"), Some(str_val("F-mount")));
+    // The three `Unknown => 1` members ARE emitted (the raw `parse()` Vec keeps
+    // them) but carry the unknown flag, so default `-j` output suppresses them.
+    for name in [
+      "FocusDistanceRangeWidth",
+      "LensDriveEnd",
+      "FocusStepsFromInfinity",
+    ] {
+      let e = em.iter().find(|e| e.name() == name);
+      assert!(
+        e.is_some_and(VendorEmission::unknown),
+        "{name} must be present and unknown-flagged: {em:?}"
+      );
+    }
+    // LensDriveEnd's STATEFUL RawConv renders the string label, not the raw byte
+    // — here 0x4c FocusDistanceRangeWidth=0x05 (non-zero) and 0x56=0x02
+    // (non-zero) ⇒ "CFD" (still unknown-flagged, so output-suppressed).
+    assert_eq!(lens_get(&em, "LensDriveEnd"), Some(str_val("CFD")));
+  }
+
+  /// The `0x56` `LensDriveEnd` stateful RawConv (`Nikon.pm:5933-5939`): `Inf`
+  /// iff `FocusDistanceRangeWidth` (0x4c) is defined and `0`;
+  /// otherwise `No` for byte `0` and `CFD` for a non-zero byte. (LensDriveEnd is
+  /// `Unknown => 1` and thus never surfaces in exifast output — `run_emission`
+  /// always drops Unknown tags — so the conversion is verified directly here.)
+  #[test]
+  fn lens_drive_end_stateful_rawconv() {
+    // FocusDistanceRangeWidth defined and 0 ⇒ "Inf", regardless of the 0x56 byte.
+    assert_eq!(lens_drive_end(0, Some(0)), "Inf");
+    assert_eq!(lens_drive_end(2, Some(0)), "Inf");
+    // FocusDistanceRangeWidth defined and non-zero ⇒ byte 0 → "No", else "CFD".
+    assert_eq!(lens_drive_end(0, Some(5)), "No");
+    assert_eq!(lens_drive_end(2, Some(5)), "CFD");
+    // FocusDistanceRangeWidth undefined (`unless defined …` ⇒ first branch) ⇒
+    // byte 0 → "No", else "CFD" (never "Inf").
+    assert_eq!(lens_drive_end(0, None), "No");
+    assert_eq!(lens_drive_end(2, None), "CFD");
+  }
+
+  /// `LensDataVersion 0800` with `NewLensData` CLEAR (the `undef[17]` at 0x2f is
+  /// `/^.\0+$/` — all bytes after the lead are NUL) suppresses the ENTIRE Z
+  /// block: no `LensID`/`MaxAperture`/`LensMountType`. Only `LensDataVersion`
+  /// (and any gated-on legacy members, here also off) survives.
+  #[test]
+  fn lens_data_0800_z_gate_off_suppresses_z_block() {
+    let mut plain = [0u8; 0x60];
+    plain[0..4].copy_from_slice(b"0800");
+    // 0x2f..0x40 all NUL ⇒ NewLensData undef[17] = lead + NULs ⇒ flag CLEAR.
+    // Put data at 0x5f to prove even the unconditional LensMountType is gated:
+    // it is NOT — LensMountType has no Condition — but with the block all-NUL it
+    // renders Z-mount (masked 0). Assert the CONDITIONAL Z members are absent.
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(&plain)),
+      ByteOrder::Big,
+      Some("NIKON Z 6"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0800")));
+    for name in [
+      "LensID",
+      "LensFirmwareVersion",
+      "MaxAperture",
+      "FNumber",
+      "FocalLength",
+      "FocusDistance",
+      "LensPositionAbsolute",
+    ] {
+      assert!(
+        lens_get(&em, name).is_none(),
+        "NewLensData-clear must suppress Z member {name}, got {em:?}"
+      );
+    }
+    // LensMountType (0x5f) has NO `Condition` ⇒ it emits even with NewLensData
+    // clear (R3); the all-NUL block masks to 0 ⇒ "Z-mount".
+    assert_eq!(lens_get(&em, "LensMountType"), Some(str_val("Z-mount")));
+  }
+
+  #[test]
+  fn lens_data_0800_lens_mount_type_emits_when_new_lens_data_clear() {
+    // R3 regression: NewLensData clear (0x2f window all-NUL) but byte 0x5f set ⇒
+    // LensMountType still emits (no `Condition` in ExifTool), while the
+    // NewLensData-gated members stay suppressed.
+    let mut plain = [0u8; 0x60];
+    plain[0..4].copy_from_slice(b"0800");
+    plain[0x5f] = 0x01; // masked 0x01 ⇒ "F-mount"
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(&plain)),
+      ByteOrder::Big,
+      Some("NIKON Z 6"),
+    );
+    assert_eq!(lens_get(&em, "LensID"), None); // NewLensData-gated ⇒ suppressed
+    assert_eq!(lens_get(&em, "LensMountType"), Some(str_val("F-mount")));
+  }
+
+  /// `FocusMode` gating (`Nikon.pm:5918`/`5935`): the two `FocusMode ne
+  /// "Manual"` members (0x4c `FocusDistanceRangeWidth`, 0x56 `LensDriveEnd`) key
+  /// on the RAW on-disk `$$self{FocusMode}` string (set by tag 0x0007's
+  /// RawConv). With FocusMode exactly "Manual" their `Condition` is FALSE ⇒ they
+  /// are SUPPRESSED (not even unknown-flagged present), while the LensID-only
+  /// member 0x4e `FocusDistance` still emits.
+  #[test]
+  fn lens_data_0800_z_focus_mode_manual_gate() {
+    let mut plain = [0u8; 0x60];
+    plain[0..4].copy_from_slice(b"0800");
+    plain[0x30..0x32].copy_from_slice(&13u16.to_le_bytes()); // LensID 13 (z_lens)
+    plain[0x4c] = 0x05; // FocusDistanceRangeWidth (FocusMode-gated)
+    plain[0x4e..0x50].copy_from_slice(&24576u16.to_le_bytes()); // FocusDistance (LensID-only)
+    plain[0x56] = 0x02; // LensDriveEnd (FocusMode-gated)
+    // The crafted RAW 0x0007 string is exactly "Manual" ⇒ the gate closes.
+    let blob = type3_with_focus_mode_and_lens_data(b"Manual\x00", &encrypt_lens(&plain));
+    let (_t, em) = parse(&blob, ByteOrder::Big, Some("NIKON Z 6"));
+    // LensID-only member still emits.
+    assert_eq!(lens_get(&em, "FocusDistance"), Some(str_val("2.52 m")));
+    // FocusMode-ne-Manual members suppressed entirely (Condition false ⇒ not
+    // emitted at all, not merely unknown-flagged).
+    assert!(
+      em.iter().all(|e| e.name() != "FocusDistanceRangeWidth"),
+      "FocusMode==Manual must drop FocusDistanceRangeWidth: {em:?}"
+    );
+    assert!(
+      em.iter().all(|e| e.name() != "LensDriveEnd"),
+      "FocusMode==Manual must drop LensDriveEnd: {em:?}"
+    );
+  }
+
+  /// `$$self{FocusMode}` is POSITIONAL, not pre-scanned (`Nikon.pm:1816`: a
+  /// normal RawConv set during the IFD walk, NOT a `PrescanExif` tag). When the
+  /// `0x0098` LensData0800 is WALKED BEFORE the `0x0007 = "Manual"` entry (an
+  /// unsorted/duplicate MakerNote), the member is still `undef` at the LensData
+  /// position, so `undef ne "Manual"` is TRUE ⇒ the `FocusMode ne "Manual"` Z
+  /// members (0x4c `FocusDistanceRangeWidth`, 0x56 `LensDriveEnd`) DO emit —
+  /// matching ExifTool (a pre-scan would have WRONGLY suppressed them with the
+  /// later value). The same plaintext in tag-ID order (0x0007 first) keeps them
+  /// suppressed, proving the well-formed case is unchanged.
+  #[test]
+  fn lens_data_0800_focus_mode_after_lensdata_uses_undef() {
+    let mut plain = [0u8; 0x60];
+    plain[0..4].copy_from_slice(b"0800");
+    plain[0x30..0x32].copy_from_slice(&13u16.to_le_bytes()); // LensID 13 (native Z ⇒ NewLensData set)
+    plain[0x4c] = 0x05; // FocusDistanceRangeWidth (FocusMode-gated)
+    plain[0x4e..0x50].copy_from_slice(&24576u16.to_le_bytes()); // FocusDistance (LensID-only)
+    plain[0x56] = 0x02; // LensDriveEnd (FocusMode-gated)
+    let enc = encrypt_lens(&plain);
+
+    // LensData walked BEFORE the (later) 0x0007 = "Manual" ⇒ FocusMode is `undef`
+    // at the LensData position ⇒ the gate is OPEN ⇒ the two members emit
+    // (Unknown => 1, so present-and-unknown-flagged like the Z telemetry test).
+    let before = type3_lens_data_before_focus_mode(b"Manual\x00", &enc);
+    let (_t, em) = parse(&before, ByteOrder::Big, Some("NIKON Z 6"));
+    assert_eq!(
+      lens_get(&em, "LensID"),
+      Some(str_val("Nikkor Z 24-70mm f/2.8 S"))
+    );
+    assert_eq!(lens_get(&em, "FocusDistance"), Some(str_val("2.52 m")));
+    for name in ["FocusDistanceRangeWidth", "LensDriveEnd"] {
+      let e = em.iter().find(|e| e.name() == name);
+      assert!(
+        e.is_some_and(VendorEmission::unknown),
+        "0x0098-before-0x0007: {name} must emit (gate open via undef): {em:?}"
+      );
+    }
+
+    // The SAME plaintext in well-formed tag-ID order (0x0007 = "Manual" FIRST)
+    // closes the gate ⇒ the two members are suppressed (the existing-behavior
+    // guard for a normally-ordered MakerNote).
+    let after = type3_with_focus_mode_and_lens_data(b"Manual\x00", &enc);
+    let (_t2, em2) = parse(&after, ByteOrder::Big, Some("NIKON Z 6"));
+    assert_eq!(lens_get(&em2, "FocusDistance"), Some(str_val("2.52 m")));
+    for name in ["FocusDistanceRangeWidth", "LensDriveEnd"] {
+      assert!(
+        em2.iter().all(|e| e.name() != name),
+        "tag-ID order with FocusMode==Manual must drop {name}: {em2:?}"
+      );
+    }
+  }
+
+  /// An UNRECOGNIZED `LensDataVersion` (e.g. `9999`) falls through to the
+  /// `LensDataUnknown` arm (`Nikon.pm:2890`) — it emits ONLY `LensDataVersion`
+  /// (no members, no panic), matching the `perl exiftool` oracle. This is the
+  /// "no version silently dropped" guarantee for future/unknown versions.
+  #[test]
+  fn lens_data_unknown_version_emits_only_version() {
+    let plain = b"9999\xaa\xbb\xcc\xdd\xee\xff";
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(plain)),
+      ByteOrder::Big,
+      Some("NIKON D9999"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("9999")));
+    // No `LensData*` member tags beyond the version.
+    let member_names = [
+      "ExitPupilPosition",
+      "AFAperture",
+      "FocusPosition",
+      "FocusDistance",
+      "FocalLength",
+      "LensIDNumber",
+      "LensFStops",
+      "MCUVersion",
+      "EffectiveMaxAperture",
+      "LensModel",
+    ];
+    for name in member_names {
+      assert!(
+        lens_get(&em, name).is_none(),
+        "LensDataUnknown must emit no {name}"
+      );
+    }
+  }
+
+  /// THE OLD BUG, FIXED: before the version-dispatch completion, ANY
+  /// `LensDataVersion` above `0203` (here `0204`) returned from `emit_lens_data`
+  /// WITHOUT EMITTING ANYTHING — not even `LensDataVersion`. Now every readable
+  /// `0x0098` block emits at least `LensDataVersion`. This asserts the
+  /// regression directly: a `>0203` version is NEVER silent.
+  #[test]
+  fn lens_data_above_0203_is_never_silent() {
+    for ver in [b"0204", b"0400", b"0402", b"0403", b"0800", b"9999"] {
+      // A minimal block: just the version + a few body bytes (enough to be a
+      // readable 4-byte version; members may or may not decode, but the version
+      // MUST always appear).
+      let mut plain = [0u8; 8];
+      plain[0..4].copy_from_slice(ver);
+      let (_t, em) = parse(
+        &type3_with_lens_data(&encrypt_lens(&plain)),
+        ByteOrder::Big,
+        Some("NIKON D7000"),
+      );
+      let v = String::from_utf8_lossy(ver).into_owned();
+      assert_eq!(
+        lens_get(&em, "LensDataVersion"),
+        Some(str_val(&v)),
+        "version {v} must emit LensDataVersion (the old-bug-fixed guarantee)"
+      );
+    }
+  }
+
+  /// Bounds-safety: a TRUNCATED encrypted block (version present, body cut
+  /// short before a version's member offsets) emits `LensDataVersion` and never
+  /// panics — the per-member `get`/`get(..len)` reads simply skip absent
+  /// members. Covers the `string[64]` member running past a short block too.
+  #[test]
+  fn lens_data_truncated_block_no_panic() {
+    // 0204 with only 6 bytes (version + 2 body bytes): most members are absent.
+    let plain = b"0204\x40\x18";
+    let (_t, em) = parse(
+      &type3_with_lens_data(&encrypt_lens(plain)),
+      ByteOrder::Big,
+      Some("NIKON D7000"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0204")));
+    // ExitPupilPosition (0x04) is present; the later members are not — no panic.
+    assert_eq!(lens_get(&em, "ExitPupilPosition"), Some(str_val("32.0 mm")));
+    assert!(lens_get(&em, "EffectiveMaxAperture").is_none());
+
+    // 0400 whose block is far shorter than the 0x18a LensModel offset: the
+    // string read is skipped, only LensDataVersion emits, no panic.
+    let short0400 = b"0400\x00\x00\x00\x00";
+    let (_t2, em2) = parse(
+      &type3_with_lens_data(&encrypt_lens(short0400)),
+      ByteOrder::Big,
+      Some("NIKON 1 J1"),
+    );
+    assert_eq!(lens_get(&em2, "LensDataVersion"), Some(str_val("0400")));
+    assert!(lens_get(&em2, "LensModel").is_none());
+  }
+
+  /// REGRESSION GUARD: the unencrypted `0101` (D70/D70s) path is unchanged by
+  /// the version-dispatch refactor — it still decodes `%LensData01` members from
+  /// the CLEARTEXT block (no keys needed). A representative member decodes to
+  /// the oracle value.
+  #[test]
+  fn lens_data_0101_unencrypted_unchanged() {
+    // Cleartext 0101 block (unencrypted): a value at FocalLength (0x0a).
+    let mut plain = [0u8; 0x13];
+    plain[0..4].copy_from_slice(b"0101");
+    plain[0x0a] = 0x76; // FocalLength raw 118 → "151.0 mm"
+    plain[0x0b] = 0x18; // LensIDNumber 24
+    // NOTE: 0101 is UNENCRYPTED — feed the cleartext block directly.
+    let (_t, em) = parse(
+      &type3_with_lens_data(&plain),
+      ByteOrder::Big,
+      Some("NIKON D70"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0101")));
+    assert_eq!(lens_get(&em, "FocalLength"), Some(str_val("151.0 mm")));
+    assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
+  }
+
+  /// The set of `LensData*` member tag names — used by the encrypted-no-decode
+  /// regression tests to assert that NOTHING (not even `LensDataVersion`) is
+  /// emitted when `ProcessNikonEncrypted` would return 0.
+  const LENS_MEMBER_NAMES: [&str; 11] = [
+    "LensDataVersion",
+    "ExitPupilPosition",
+    "AFAperture",
+    "FocusPosition",
+    "FocusDistance",
+    "FocalLength",
+    "LensIDNumber",
+    "LensFStops",
+    "MCUVersion",
+    "EffectiveMaxAperture",
+    "LensModel",
+  ];
+
+  /// Build a type-3 Nikon blob with a `0x0098` LensData value but NO 0x001d /
+  /// 0x00a7 — so `scan_decrypt_keys` finds no ShutterCount and returns `None`.
+  /// A single out-of-line `0x0098` entry; no SerialNumber, no ShutterCount.
+  fn type3_lens_data_only(lens_block: &[u8]) -> Vec<u8> {
+    let n_entries: u16 = 1;
+    let off_lens: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4; // embedded-relative
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes());
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    b.extend_from_slice(&0x0098u16.to_be_bytes()); // LensData, undef, out-of-line
+    b.extend_from_slice(&[0x00, 0x07]);
+    b.extend_from_slice(&(lens_block.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_lens.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    b.extend_from_slice(lens_block);
+    b
+  }
+
+  /// An ENCRYPTED `0204` LensData with NO ShutterCount (0x00a7) — and hence no
+  /// count key — mirrors `ProcessNikonEncrypted` returning 0
+  /// (`Nikon.pm:13948-13961`): the SubDirectory yields NO tags AT ALL, including
+  /// no `LensDataVersion`. The cleartext `string[4]` at offset 0 is read only
+  /// AFTER the key gate inside the encrypted ProcessProc, so a missing count key
+  /// suppresses the version too.
+  #[test]
+  fn encrypted_lens_data_no_shutter_count_emits_nothing() {
+    let mut plain = [0u8; 20];
+    plain[0..4].copy_from_slice(b"0204");
+    plain[0x04] = 0x40; // a would-be ExitPupilPosition, must NOT surface
+    let blob = type3_lens_data_only(&encrypt_lens(&plain));
+    let (_t, em) = parse(&blob, ByteOrder::Big, Some("NIKON D7000"));
+    for name in LENS_MEMBER_NAMES {
+      assert!(
+        lens_get(&em, name).is_none(),
+        "encrypted LensData without ShutterCount must emit no {name}"
+      );
+    }
+  }
+
+  /// A MULTI-ELEMENT ShutterCount (`int32u[2]`, prescan-rendered `"100 0"`)
+  /// fails ExifTool's `$count =~ /^\d+$/` (`Nikon.pm:13948`), so the count key
+  /// stays undefined and the encrypted `0204` LensData decrypts to nothing — no
+  /// members AND no `LensDataVersion` (the encrypted key gate fails). Taking
+  /// only the first element (`100`) would have wrongly unlocked decryption.
+  #[test]
+  fn encrypted_lens_data_multielement_shutter_count_rejected() {
+    let mut plain = [0u8; 20];
+    plain[0..4].copy_from_slice(b"0204");
+    plain[0x04] = 0x40;
+    let enc = encrypt_lens(&plain);
+    // Type-3 MakerNote: 0x0098 LensData (out-of-line) + 0x00a7 as int32u[2]
+    // (out-of-line, value `[100, 0]`). Tag-ID-ordered; NO 0x001d.
+    let n_entries: u16 = 2;
+    let val_emb: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4;
+    let off_lens = val_emb;
+    let off_count = off_lens + enc.len() as u32;
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes());
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    b.extend_from_slice(&0x0098u16.to_be_bytes()); // LensData, undef, out-of-line
+    b.extend_from_slice(&[0x00, 0x07]);
+    b.extend_from_slice(&(enc.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_lens.to_be_bytes());
+    b.extend_from_slice(&0x00a7u16.to_be_bytes()); // ShutterCount, int32u[2], out-of-line
+    b.extend_from_slice(&[0x00, 0x04]); // int32u
+    b.extend_from_slice(&2u32.to_be_bytes()); // count = 2 ⇒ out-of-line
+    b.extend_from_slice(&off_count.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    b.extend_from_slice(&enc);
+    b.extend_from_slice(&100u32.to_be_bytes()); // count[0] = 100
+    b.extend_from_slice(&0u32.to_be_bytes()); // count[1] = 0
+    let (_t, em) = parse(&b, ByteOrder::Big, Some("NIKON D7000"));
+    for name in LENS_MEMBER_NAMES {
+      assert!(
+        lens_get(&em, name).is_none(),
+        "int32u[2] ShutterCount must reject decryption — no {name}"
+      );
+    }
+  }
+
+  /// FORMAT-AGNOSTIC key derivation: the prescan keys come from the `ReadValue`
+  /// `$val` STRING (`Nikon.pm:14122`), so an INTEGER-format `0x001d`
+  /// (`int32u 12345678` ⇒ `SerialKey("12345678") = 12345678`) and an ASCII
+  /// `0x00a7` (`string "100"` ⇒ `"100" =~ /^\d+$/` ⇒ count 100) derive the SAME
+  /// keys as the native `string 0x001d` + `int32u 0x00a7` layout. The block is
+  /// encrypted with `KEY_SERIAL`/`KEY_COUNT`, so a correct decode proves the
+  /// derivation reached exactly those keys despite the swapped storage formats.
+  #[test]
+  fn decrypt_keys_integer_serial_and_ascii_count() {
+    // Known 0204 plaintext (a subset of the dispatch test's field set).
+    let mut plain = [0u8; 20];
+    plain[0..4].copy_from_slice(b"0204");
+    plain[0x04] = 0x40; // ExitPupilPosition → "32.0 mm"
+    plain[0x0c] = 0x18; // LensIDNumber 24
+    plain[0x13] = 0x42; // EffectiveMaxAperture → "6.7"
+    let enc = encrypt_lens(&plain); // keys: KEY_SERIAL=12345678, KEY_COUNT=100
+
+    // Type-3 IFD, tag-ID order: 0x001d as int32u (inline = 12345678), 0x0098
+    // LensData (out-of-line), 0x00a7 as ASCII "100\0" (string, inline).
+    let n_entries: u16 = 3;
+    let off_lens: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4; // embedded-relative
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes());
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    // 0x001d SerialNumber — int32u (NOT a string), inline = 12345678. ReadValue
+    // renders "12345678", which SerialKey uses verbatim as the key.
+    b.extend_from_slice(&0x001du16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x04]); // int32u
+    b.extend_from_slice(&1u32.to_be_bytes());
+    b.extend_from_slice(&KEY_SERIAL.to_be_bytes());
+    // 0x0098 LensData — undef, out-of-line.
+    b.extend_from_slice(&0x0098u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x07]); // undef
+    b.extend_from_slice(&(enc.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_lens.to_be_bytes());
+    // 0x00a7 ShutterCount — string "100\0" (ASCII digits, NOT int32u), inline.
+    // ReadValue NUL-trims to "100", which matches /^\d+$/ ⇒ count 100.
+    b.extend_from_slice(&0x00a7u16.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x02]); // string
+    b.extend_from_slice(&4u32.to_be_bytes()); // 4 bytes ⇒ inline
+    b.extend_from_slice(b"100\x00");
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    b.extend_from_slice(&enc);
+    let (_t, em) = parse(&b, ByteOrder::Big, Some("NIKON D7000"));
+    // Decoded ⇒ the integer serial + ASCII count derived KEY_SERIAL/KEY_COUNT.
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0204")));
+    assert_eq!(lens_get(&em, "ExitPupilPosition"), Some(str_val("32.0 mm")));
+    assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
+    assert_eq!(lens_get(&em, "EffectiveMaxAperture"), Some(str_val("6.7")));
+
+    // Cross-check the helpers in isolation: the integer 0x001d renders the digit
+    // string SerialKey keys on, and the ASCII "100" passes the count /^\d+$/.
+    assert_eq!(
+      decrypt::serial_key("12345678", Some("NIKON D7000")),
+      Some(KEY_SERIAL)
+    );
+    let ascii_count = ParsedValue::new(RawValue::Text {
+      text: "100".into(),
+      raw: Box::from(&b"100"[..]),
+    });
+    assert_eq!(ascii_count.single_digit_count(), Some(KEY_COUNT));
+  }
+
+  /// REGRESSION GUARD (the key gate is ENCRYPTED-ONLY): an UNENCRYPTED `0101`
+  /// LensData with NO SerialNumber (0x001d) and NO ShutterCount (0x00a7) STILL
+  /// emits `LensDataVersion` + its members — `0100`/`0101` use plain
+  /// `ProcessBinaryData` (`Nikon.pm:2818`/`2823`, no `ProcessProc`), which has no
+  /// key check. Proves Finding 1's gate does not over-suppress the unencrypted
+  /// layouts.
+  #[test]
+  fn unencrypted_lens_data_0101_emits_without_keys() {
+    let mut plain = [0u8; 0x13];
+    plain[0..4].copy_from_slice(b"0101");
+    plain[0x0a] = 0x76; // FocalLength raw 118 → "151.0 mm"
+    plain[0x0b] = 0x18; // LensIDNumber 24
+    // UNENCRYPTED — cleartext block, NO 0x001d / 0x00a7 in the IFD.
+    let (_t, em) = parse(
+      &type3_lens_data_only(&plain),
+      ByteOrder::Big,
+      Some("NIKON D70"),
+    );
+    assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0101")));
+    assert_eq!(lens_get(&em, "FocalLength"), Some(str_val("151.0 mm")));
+    assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
   }
 }

--- a/src/exif/makernotes/vendors/nikon/printconv.rs
+++ b/src/exif/makernotes/vendors/nikon/printconv.rs
@@ -142,6 +142,62 @@ pub enum NikonConv {
   /// `NEFBitDepth` (0x0e22, `Nikon.pm:3280`) — `int16u[4]`; a space-joined
   /// PrintConv hash (`'8 8 8 0' => '8 x 3'`, …) keyed on the whole record.
   NefBitDepth,
+  /// `%Nikon::LensData00/01` aperture members (`AFAperture`,
+  /// `MaxApertureAtMinFocal`, `MaxApertureAtMaxFocal`, `EffectiveMaxAperture`)
+  /// — `%nikonApertureConversions` (`Nikon.pm:5441`): `ValueConv =>
+  /// '2**($val/24)'`, `PrintConv => sprintf("%.1f",$val)`.
+  LensDataAperture,
+  /// `%Nikon::LensData00/01` focal-length members (`FocalLength`,
+  /// `MinFocalLength`, `MaxFocalLength`) — `%nikonFocalConversions`
+  /// (`Nikon.pm:5448`): `ValueConv => '5 * 2**($val/24)'`, `PrintConv =>
+  /// sprintf("%.1f mm",$val)`.
+  LensDataFocal,
+  /// `%Nikon::LensData01` `LensFStops` (0x0c) — `ValueConv => '$val / 12'`,
+  /// `PrintConv => sprintf("%.2f", $val)` (`Nikon.pm:5552`). DISTINCT from the
+  /// 0x008b `LensFStops` ([`Self::LensFStops`], a `c3` ValueConv).
+  LensDataFStops,
+  /// `%Nikon::LensData01` `ExitPupilPosition` (0x04) — `ValueConv => '$val ?
+  /// 2048 / $val : $val'`, `PrintConv => sprintf("%.1f mm",$val)`
+  /// (`Nikon.pm:5512`).
+  ExitPupilPosition,
+  /// `%Nikon::LensData01` `FocusPosition` (0x08) — `PrintConv =>
+  /// sprintf("0x%02x", $val)` (`Nikon.pm:5524`), no ValueConv.
+  FocusPosition,
+  /// `%Nikon::LensData01` `FocusDistance` (0x09) — `ValueConv => '0.01 *
+  /// 10**($val/40)'` (metres), `PrintConv => '$val ? sprintf("%.2f m",$val) :
+  /// "inf"'` (`Nikon.pm:5538`).
+  FocusDistance,
+  /// `%Nikon::LensData0800` `LensID` (0x30, `int16u`, `Nikon.pm:5819-5875`) —
+  /// the Nikkor-Z lens-name PrintConv hash. The raw value is the LensID
+  /// integer; an unmapped value renders `Unknown (N)`. `-n` emits the integer.
+  LensId,
+  /// `%Nikon::LensData0800` `LensFirmwareVersion` (0x34, `int16u`,
+  /// `Nikon.pm:5876-5886`) — the V.R.M PrintConv: `version=int($val/256)`,
+  /// `release=int(($val-256*version)/16)`, `modification=$val-(256*version+
+  /// 16*release)`, then `sprintf("%.0f.%.0f.%.0f", version, release,
+  /// modification)`. No ValueConv (`-n` emits the raw integer).
+  LensFirmwareZ,
+  /// `%Nikon::LensData0800` `MaxAperture` (0x36) / `FNumber` (0x38) (`int16u`,
+  /// `Nikon.pm:5887-5906`) — `ValueConv => '2**($val/384-1)'`, `PrintConv =>
+  /// sprintf("%.1f",$val)`. `-n` emits the post-ValueConv float.
+  LensApertureZ,
+  /// `%Nikon::LensData0800` `FocalLength` (0x3c, `int16u`, `Nikon.pm:5907-
+  /// 5914`) — NO ValueConv; `PrintConv => '"$val mm"'`. `-n` emits the raw
+  /// integer.
+  FocalLengthZ,
+  /// `%Nikon::LensData0800` `FocusDistance` (0x4e, `int16u`, `Nikon.pm:5922-
+  /// 5932`) — `RawConv => '$val = $val/256'` (the 1st byte is the fractional
+  /// component), `ValueConv => '2**(($val-80)/12)'` (metres), then a nested
+  /// PrintConv that picks the decimal precision from the magnitude. The "Inf"
+  /// branch keys on `$$self{FocusStepsFromInfinity}`, which is `Unknown => 1`
+  /// and therefore NEVER set in default mode (`next if Unknown`), so it is
+  /// unreachable here. `-n` emits the post-ValueConv metres float.
+  FocusDistanceZ,
+  /// `%Nikon::LensData0800` `LensMountType` (0x5f, `int8u`, `Mask => 0x01`,
+  /// `Nikon.pm:5953-5961`) — `{0=>'Z-mount',1=>'F-mount'}`. The Mask is applied
+  /// by the caller BEFORE this PrintConv; the raw value here is already masked
+  /// to 0/1. `-n` emits the masked integer.
+  LensMountType,
 }
 
 impl NikonConv {
@@ -293,8 +349,269 @@ impl NikonConv {
       NikonConv::RetouchHistory => retouch_history_conv(raw, print_conv),
       NikonConv::PowerUpTime => power_up_time_conv(raw, print_conv, order),
       NikonConv::NefBitDepth => nef_bit_depth_conv(raw, print_conv),
+      NikonConv::LensDataAperture => {
+        // `2**($val/24)`; PrintConv `sprintf("%.1f",$val)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = 2f64.powf(n as f64 / 24.0);
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{v:.1}")))
+        } else {
+          TagValue::F64(v)
+        }
+      }
+      NikonConv::LensDataFocal => {
+        // `5 * 2**($val/24)`; PrintConv `sprintf("%.1f mm",$val)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = 5.0 * 2f64.powf(n as f64 / 24.0);
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{v:.1} mm")))
+        } else {
+          TagValue::F64(v)
+        }
+      }
+      NikonConv::LensDataFStops => {
+        // `$val / 12`; PrintConv `sprintf("%.2f", $val)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = n as f64 / 12.0;
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{v:.2}")))
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::ExitPupilPosition => {
+        // `$val ? 2048 / $val : $val`; PrintConv `sprintf("%.1f mm",$val)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = if n != 0 { 2048.0 / n as f64 } else { 0.0 };
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{v:.1} mm")))
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::FocusPosition => {
+        // No ValueConv; PrintConv `sprintf("0x%02x", $val)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("0x{n:02x}")))
+        } else {
+          TagValue::I64(n)
+        }
+      }
+      NikonConv::FocusDistance => {
+        // `0.01 * 10**($val/40)` (metres); PrintConv `$val ? sprintf("%.2f
+        // m",$val) : "inf"`. The ValueConv-then-PrintConv `$val` is the
+        // post-ValueConv metres; a raw `0` ⇒ ValueConv `0.01` (non-zero) ⇒ NOT
+        // "inf" — "inf" only when the ValueConv result is zero, which never
+        // happens (`0.01 * 10**x > 0`). Faithful: a zero ValueConv would print
+        // "inf", but it is unreachable on this conversion.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = 0.01 * 10f64.powf(n as f64 / 40.0);
+        if print_conv {
+          if v == 0.0 {
+            TagValue::Str(SmolStr::new("inf"))
+          } else {
+            TagValue::Str(SmolStr::new(std::format!("{v:.2} m")))
+          }
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::LensId => {
+        // `int16u` hash (`Nikon.pm:5825-5874`); unmapped → `Unknown (N)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          match lens_id_z_label(n) {
+            Some(s) => TagValue::Str(SmolStr::new(s)),
+            None => TagValue::Str(SmolStr::new(std::format!("Unknown ({n})"))),
+          }
+        } else {
+          TagValue::I64(n)
+        }
+      }
+      NikonConv::LensFirmwareZ => {
+        // No ValueConv; PrintConv decomposes the int16u into V.R.M
+        // (`Nikon.pm:5880-5885`). `-n` emits the raw integer.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          // int() truncates toward zero (the values are non-negative int16u).
+          let version = n / 256;
+          let release = (n - 256 * version) / 16;
+          let modification = n - (256 * version + 16 * release);
+          TagValue::Str(SmolStr::new(std::format!(
+            "{version}.{release}.{modification}"
+          )))
+        } else {
+          TagValue::I64(n)
+        }
+      }
+      NikonConv::LensApertureZ => {
+        // `2**($val/384-1)`; PrintConv `sprintf("%.1f",$val)`
+        // (`Nikon.pm:5892-5894`).
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = 2f64.powf(n as f64 / 384.0 - 1.0);
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{v:.1}")))
+        } else {
+          TagValue::F64(v)
+        }
+      }
+      NikonConv::FocalLengthZ => {
+        // No ValueConv; PrintConv `"$val mm"` (`Nikon.pm:5912`). `-n` emits the
+        // raw integer.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{n} mm")))
+        } else {
+          TagValue::I64(n)
+        }
+      }
+      NikonConv::FocusDistanceZ => return Some(focus_distance_z_conv(raw, print_conv)),
+      NikonConv::LensMountType => {
+        // `{0=>'Z-mount',1=>'F-mount'}` (`Nikon.pm:5957-5960`); the Mask 0x01 is
+        // applied by the caller, so `$val` here is already 0/1. An unmapped
+        // value (impossible after the mask) renders `Unknown (N)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if print_conv {
+          match n {
+            0 => TagValue::Str(SmolStr::new("Z-mount")),
+            1 => TagValue::Str(SmolStr::new("F-mount")),
+            _ => TagValue::Str(SmolStr::new(std::format!("Unknown ({n})"))),
+          }
+        } else {
+          TagValue::I64(n)
+        }
+      }
     })
   }
+}
+
+/// `%Nikon::LensData0800` `FocusDistance` (0x4e) ValueConv + PrintConv
+/// (`Nikon.pm:5922-5932`). The decoded `$val` is the raw `int16u`; RawConv
+/// `$val = $val/256` (the 1st byte is the fractional part), ValueConv
+/// `2**(($val-80)/12)` (metres). The PrintConv selects the decimal precision by
+/// magnitude:
+///
+/// ```text
+/// $val < 100 ? $val < 10 ? $val < 1 ? $val < 0.35 ? "%.4f m" : "%.3f m"
+///                                                  : "%.2f m"
+///                                   : "%.1f m"
+///                        : "%.0f m"
+/// ```
+///
+/// The leading `(defined $$self{FocusStepsFromInfinity} and … eq 0) ? "Inf"`
+/// branch keys on a `Unknown => 1` DataMember, which is never set in default
+/// mode (`next if $$tagInfo{Unknown}`), so it is unreachable and omitted.
+/// `-n` emits the post-ValueConv metres float.
+fn focus_distance_z_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(n) = raw.first_i64() else {
+    return raw.to_default_tag_value();
+  };
+  // RawConv `$val = $val/256` then ValueConv `2**(($val-80)/12)`.
+  let raw_div = n as f64 / 256.0;
+  let v = 2f64.powf((raw_div - 80.0) / 12.0);
+  if !print_conv {
+    return value_conv_number(v);
+  }
+  let s = if v < 100.0 {
+    if v < 10.0 {
+      if v < 1.0 {
+        if v < 0.35 {
+          std::format!("{v:.4} m")
+        } else {
+          std::format!("{v:.3} m")
+        }
+      } else {
+        std::format!("{v:.2} m")
+      }
+    } else {
+      std::format!("{v:.1} m")
+    }
+  } else {
+    std::format!("{v:.0} m")
+  };
+  TagValue::Str(SmolStr::new(s))
+}
+
+/// `%Nikon::LensData0800` `LensID` (0x30) PrintConv hash (`Nikon.pm:5825-5874`)
+/// — the Nikkor-Z lens-name table. A non-zero LensID denotes a native Z lens;
+/// `0` / an unlisted value falls through to `Unknown (N)` at the call site. The
+/// keys are NOT contiguous (the two 327xx entries are the TC-1.4x teleconverter
+/// combinations).
+fn lens_id_z_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    1 => "Nikkor Z 24-70mm f/4 S",
+    2 => "Nikkor Z 14-30mm f/4 S",
+    4 => "Nikkor Z 35mm f/1.8 S",
+    8 => "Nikkor Z 58mm f/0.95 S Noct",
+    9 => "Nikkor Z 50mm f/1.8 S",
+    11 => "Nikkor Z DX 16-50mm f/3.5-6.3 VR",
+    12 => "Nikkor Z DX 50-250mm f/4.5-6.3 VR",
+    13 => "Nikkor Z 24-70mm f/2.8 S",
+    14 => "Nikkor Z 85mm f/1.8 S",
+    15 => "Nikkor Z 24mm f/1.8 S",
+    16 => "Nikkor Z 70-200mm f/2.8 VR S",
+    17 => "Nikkor Z 20mm f/1.8 S",
+    18 => "Nikkor Z 24-200mm f/4-6.3 VR",
+    21 => "Nikkor Z 50mm f/1.2 S",
+    22 => "Nikkor Z 24-50mm f/4-6.3",
+    23 => "Nikkor Z 14-24mm f/2.8 S",
+    24 => "Nikkor Z MC 105mm f/2.8 VR S",
+    25 => "Nikkor Z 40mm f/2",
+    26 => "Nikkor Z DX 18-140mm f/3.5-6.3 VR",
+    27 => "Nikkor Z MC 50mm f/2.8",
+    28 => "Nikkor Z 100-400mm f/4.5-5.6 VR S",
+    29 => "Nikkor Z 28mm f/2.8",
+    30 => "Nikkor Z 400mm f/2.8 TC VR S",
+    31 => "Nikkor Z 24-120mm f/4 S",
+    32 => "Nikkor Z 800mm f/6.3 VR S",
+    35 => "Nikkor Z 28-75mm f/2.8",
+    36 => "Nikkor Z 400mm f/4.5 VR S",
+    37 => "Nikkor Z 600mm f/4 TC VR S",
+    38 => "Nikkor Z 85mm f/1.2 S",
+    39 => "Nikkor Z 17-28mm f/2.8",
+    40 => "Nikkor Z 26mm f/2.8",
+    41 => "Nikkor Z DX 12-28mm f/3.5-5.6 PZ VR",
+    42 => "Nikkor Z 180-600mm f/5.6-6.3 VR",
+    43 => "Nikkor Z DX 24mm f/1.7",
+    44 => "Nikkor Z 70-180mm f/2.8",
+    45 => "Nikkor Z 600mm f/6.3 VR S",
+    46 => "Nikkor Z 135mm f/1.8 S Plena",
+    47 => "Nikkor Z 35mm f/1.2 S",
+    48 => "Nikkor Z 28-400mm f/4-8 VR",
+    49 => "Nikkor Z 28-135mm f/4 PZ",
+    50 => "Nikkor Z 24-70mm f/2.8 S II",
+    51 => "Nikkor Z 35mm f/1.4",
+    52 => "Nikkor Z 50mm f/1.4",
+    54 => "Nikkor Z 70-200mm f/2.8 VR S II",
+    57 => "Nikkor Z 24-105mm f/4-7.1",
+    2305 => "Laowa FFII 10mm F2.8 C&D Dreamer",
+    32768 => "Nikkor Z 400mm f/2.8 TC VR S TC-1.4x",
+    32769 => "Nikkor Z 600mm f/4 TC VR S TC-1.4x",
+    _ => return None,
+  })
 }
 
 /// `%afPoints11` (`Nikon.pm:2152`) PrintConv: `0 => '(none)'`,

--- a/src/exif/makernotes/vendors/nikon/tags.rs
+++ b/src/exif/makernotes/vendors/nikon/tags.rs
@@ -18,15 +18,29 @@
 //! - `ColorBalance0103` (0x0097 `0103` variant, `Nikon.pm:2980`/
 //!   `Nikon.pm` `%ColorBalance3`) — D70/D70s, UNENCRYPTED, `Start =>
 //!   '$valuePtr + 20'`, 4×int16u → WB_RGBGLevels. WALKED.
+//! - `LensData` (0x0098, `%Nikon::LensData00`/`LensData01`/…,
+//!   `Nikon.pm:5456`/`5497`/`5582`+) — a `ProcessBinaryData` table
+//!   version-dispatched on the 4-byte `LensDataVersion` prefix
+//!   (`Nikon.pm:2814-2899`). `0100`/`0101` are UNENCRYPTED; `020[1-3]`/`0204`/
+//!   `040[01]`/`0402`/`0403`/`080[012]` are decrypted ([`super::decrypt`]) then
+//!   read against their version table with `DecryptStart => 4`. Any other
+//!   version falls through to `LensDataUnknown` (version-only). WALKED →
+//!   LensIDNumber, LensFStops, MaxAperture*, FocalLength*, LensModel, etc.
+//!   ([`LENS_DATA_00`]/[`LENS_DATA_01`]/[`LENS_DATA_0204`]/[`LENS_DATA_0400`]/
+//!   [`LENS_DATA_0402`]/[`LENS_DATA_0403`]/[`LENS_DATA_0800_OLD`]).
 //!
-//! ## Deferred (encrypted — need `Nikon::Decrypt`, a follow-up issue)
+//! ## Deferred (encrypted — need the remaining `ProcessNikonEncrypted` tables)
 //!
-//! `LensData` (0x0098), `ShotInfo*` (0x0091), `FlashInfo*` (0x00a8), and the
-//! ENCRYPTED `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) are
+//! `ShotInfo*` (0x0091), `FlashInfo*` (0x00a8), and the ENCRYPTED
+//! `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) are
 //! `ProcessNikonEncrypted` sub-tables keyed on the SerialNumber +
 //! ShutterCount XOR keystream (`Nikon.pm:13604` `Decrypt`). They carry a
 //! deferred [`SubTable`] marker so the parent is NOT emitted (the #177/#223
-//! bogus-parent rule), and their decrypted children stay unported here.
+//! bogus-parent rule), and their decrypted children stay unported here (a
+//! committed Phase 2 follow-up). The `%LensData0800` NEW Z-lens block (offsets
+//! 0x2f onward — int16u `LensID`/`MaxAperture`/`FNumber` + the
+//! `FocusMode`-gated focus telemetry) likewise stays a follow-up; its
+//! `LensDataVersion` + legacy OldLensData fields ARE emitted.
 
 #![deny(clippy::indexing_slicing)]
 
@@ -427,6 +441,167 @@ pub struct AfInfoEntry {
   pub format: crate::exif::ifd::Format,
 }
 
+/// How a `%Nikon::LensData*` member's bytes are read off the (decrypted) block.
+/// The vast majority are the table default `FORMAT => 'int8u'` (a single byte),
+/// but the newer `040x`/`0402`/`0403` tables carry a `LensModel`
+/// `Format => 'string[64]'` at a large offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LensRead {
+  /// A single `int8u` at the member's byte offset (the table default
+  /// `FORMAT => 'int8u'`).
+  Byte,
+  /// `Format => 'string[N]'` — `N` bytes read as an ASCII string (NUL-truncated
+  /// per `ReadValue`'s `s/\0.*//s`). Only `LensModel` uses it (`N = 64`).
+  Str(usize),
+}
+
+/// One `%Nikon::LensData*` binary-data position. Most members are a single
+/// `int8u` ([`LensRead::Byte`], the table's default `FORMAT => 'int8u'`), so the
+/// offset is the byte index; the `040x`/`0402`/`0403` `LensModel` member is a
+/// `string[64]` ([`LensRead::Str`]).
+#[derive(Debug, Clone, Copy)]
+pub struct LensDataEntry {
+  /// Byte offset within the LensData blob (the `ProcessBinaryData` index,
+  /// relative to the start of the block including the version prefix).
+  pub offset: usize,
+  /// Tag `Name`.
+  pub name: &'static str,
+  /// Conversion ([`NikonConv`]) for this member.
+  pub conv: NikonConv,
+  /// How the member's bytes are read ([`LensRead::Byte`] for the int8u default).
+  pub read: LensRead,
+}
+
+/// `const`-fn `int8u` LensData member (the table-default `FORMAT => 'int8u'`).
+const fn lens(offset: usize, name: &'static str, conv: NikonConv) -> LensDataEntry {
+  LensDataEntry {
+    offset,
+    name,
+    conv,
+    read: LensRead::Byte,
+  }
+}
+
+/// `const`-fn `string[len]` LensData member (`LensModel`, `Format =>
+/// 'string[64]'`). Read as a NUL-truncated ASCII string ([`LensRead::Str`]).
+const fn lens_str(offset: usize, name: &'static str, len: usize) -> LensDataEntry {
+  LensDataEntry {
+    offset,
+    name,
+    conv: NikonConv::Raw,
+    read: LensRead::Str(len),
+  }
+}
+
+/// `%Image::ExifTool::Nikon::LensData00` (`Nikon.pm:5456-5494`) — the
+/// `LensDataVersion 0100` layout (D100, D1X firmware 1.1). UNENCRYPTED. All
+/// members `int8u`; `LensDataVersion` (offset 0) is read separately as the
+/// 4-byte version string. Big-endian (no table `ByteOrder` override ⇒ the
+/// in-effect `GetByteOrder` of the parent MakerNote IFD, which is the embedded
+/// TIFF's order; single-byte members are order-agnostic anyway).
+pub const LENS_DATA_00: &[LensDataEntry] = &[
+  lens(0x06, "LensIDNumber", NikonConv::Raw),
+  lens(0x07, "LensFStops", NikonConv::LensDataFStops),
+  lens(0x08, "MinFocalLength", NikonConv::LensDataFocal),
+  lens(0x09, "MaxFocalLength", NikonConv::LensDataFocal),
+  lens(0x0a, "MaxApertureAtMinFocal", NikonConv::LensDataAperture),
+  lens(0x0b, "MaxApertureAtMaxFocal", NikonConv::LensDataAperture),
+  lens(0x0c, "MCUVersion", NikonConv::Raw),
+];
+
+/// `%Image::ExifTool::Nikon::LensData01` (`Nikon.pm:5497-5580`) — the
+/// `LensDataVersion 0101` (D70/D70s, UNENCRYPTED) AND `020[1-3]` (D200, D2Hs,
+/// D2X, D40/D40X/D80, D300 — ENCRYPTED, decrypted before this walk) layout.
+/// All members `int8u`; `LensDataVersion` (offset 0) is read separately as the
+/// 4-byte version string. The `LensFStops` here (offset 0x0c) is `$val / 12`
+/// ([`NikonConv::LensDataFStops`]), DISTINCT from the 0x008b `LensFStops`.
+pub const LENS_DATA_01: &[LensDataEntry] = &[
+  lens(0x04, "ExitPupilPosition", NikonConv::ExitPupilPosition),
+  lens(0x05, "AFAperture", NikonConv::LensDataAperture),
+  lens(0x08, "FocusPosition", NikonConv::FocusPosition),
+  lens(0x09, "FocusDistance", NikonConv::FocusDistance),
+  lens(0x0a, "FocalLength", NikonConv::LensDataFocal),
+  lens(0x0b, "LensIDNumber", NikonConv::Raw),
+  lens(0x0c, "LensFStops", NikonConv::LensDataFStops),
+  lens(0x0d, "MinFocalLength", NikonConv::LensDataFocal),
+  lens(0x0e, "MaxFocalLength", NikonConv::LensDataFocal),
+  lens(0x0f, "MaxApertureAtMinFocal", NikonConv::LensDataAperture),
+  lens(0x10, "MaxApertureAtMaxFocal", NikonConv::LensDataAperture),
+  lens(0x11, "MCUVersion", NikonConv::Raw),
+  lens(0x12, "EffectiveMaxAperture", NikonConv::LensDataAperture),
+];
+
+/// `%Image::ExifTool::Nikon::LensData0204` (`Nikon.pm:5582-5665`) — the
+/// `LensDataVersion 0204` layout (D90, D7000). ENCRYPTED (`DecryptStart => 4`,
+/// `Nikon.pm:2846`); decrypted before this walk. Same members as
+/// [`LENS_DATA_01`] but with an EXTRA byte inserted at offset 0x09
+/// (`Nikon.pm:5616`), so every member from `FocusDistance` onward is shifted +1
+/// (FocusDistance 0x09→0x0a, FocalLength 0x0a→0x0b, …, EffectiveMaxAperture
+/// 0x12→0x13). All members `int8u`.
+pub const LENS_DATA_0204: &[LensDataEntry] = &[
+  lens(0x04, "ExitPupilPosition", NikonConv::ExitPupilPosition),
+  lens(0x05, "AFAperture", NikonConv::LensDataAperture),
+  lens(0x08, "FocusPosition", NikonConv::FocusPosition),
+  lens(0x0a, "FocusDistance", NikonConv::FocusDistance),
+  lens(0x0b, "FocalLength", NikonConv::LensDataFocal),
+  lens(0x0c, "LensIDNumber", NikonConv::Raw),
+  lens(0x0d, "LensFStops", NikonConv::LensDataFStops),
+  lens(0x0e, "MinFocalLength", NikonConv::LensDataFocal),
+  lens(0x0f, "MaxFocalLength", NikonConv::LensDataFocal),
+  lens(0x10, "MaxApertureAtMinFocal", NikonConv::LensDataAperture),
+  lens(0x11, "MaxApertureAtMaxFocal", NikonConv::LensDataAperture),
+  lens(0x12, "MCUVersion", NikonConv::Raw),
+  lens(0x13, "EffectiveMaxAperture", NikonConv::LensDataAperture),
+];
+
+/// `%Image::ExifTool::Nikon::LensData0400` (`Nikon.pm:5668-5681`) — the
+/// `LensDataVersion 040[01]` layout (Nikon 1 J1/V1/J2). ENCRYPTED
+/// (`DecryptStart => 4`). The only readable member besides `LensDataVersion` is
+/// `LensModel` (`Format => 'string[64]'`) at offset 0x18a.
+pub const LENS_DATA_0400: &[LensDataEntry] = &[lens_str(0x18a, "LensModel", 64)];
+
+/// `%Image::ExifTool::Nikon::LensData0402` (`Nikon.pm:5683-5697`) — the
+/// `LensDataVersion 0402` layout (Nikon 1 J3/S1/V2). ENCRYPTED
+/// (`DecryptStart => 4`). `LensModel` (`string[64]`) at offset 0x18b.
+pub const LENS_DATA_0402: &[LensDataEntry] = &[lens_str(0x18b, "LensModel", 64)];
+
+/// `%Image::ExifTool::Nikon::LensData0403` (`Nikon.pm:5699-5713`) — the
+/// `LensDataVersion 0403` layout (Nikon 1 J4/J5). ENCRYPTED
+/// (`DecryptStart => 4`). `LensModel` (`string[64]`) at offset 0x2ac.
+pub const LENS_DATA_0403: &[LensDataEntry] = &[lens_str(0x2ac, "LensModel", 64)];
+
+/// `%Image::ExifTool::Nikon::LensData0800` OldLensData block
+/// (`Nikon.pm:5716-5808`) — the `LensDataVersion 080[012]` layout (Z6/Z7/Z9).
+/// ENCRYPTED (`DecryptStart => 4`, **`ByteOrder => 'LittleEndian'`**).
+///
+/// This table ports the LEGACY `$$self{OldLensData}` block (offsets 0x04-0x14),
+/// which is structurally [`LENS_DATA_0204`] shifted +1 again (a second extra
+/// byte at 0x08, `Nikon.pm:5745`) and gated on the forward-looking
+/// `OldLensData` flag (`Nikon.pm:5726-5731`: set unless the `undef[17]` at 0x03
+/// is `/^.\0+$/`). All these members are `int8u`, so the LittleEndian table
+/// order does not change their single-byte reads.
+///
+/// The NEWER Z-lens block (offsets 0x2f onward — `NewLensData`, `LensID` int16u
+/// with a ~90-entry PrintConv, `MaxAperture`/`FNumber`/`FocalLength` int16u, the
+/// `FocusMode`-gated focus telemetry) is a committed follow-up; its multi-byte
+/// LittleEndian fields + the `LensID`/`FocusMode`/`FocusStepsFromInfinity`
+/// DATAMEMBER state machine are out of scope here. `LensDataVersion` (always)
+/// plus the OldLensData fields still emit, so no Z file is silently dropped.
+pub const LENS_DATA_0800_OLD: &[LensDataEntry] = &[
+  lens(0x04, "ExitPupilPosition", NikonConv::ExitPupilPosition),
+  lens(0x05, "AFAperture", NikonConv::LensDataAperture),
+  lens(0x0b, "FocusDistance", NikonConv::FocusDistance),
+  lens(0x0c, "FocalLength", NikonConv::LensDataFocal),
+  lens(0x0d, "LensIDNumber", NikonConv::Raw),
+  lens(0x0e, "LensFStops", NikonConv::LensDataFStops),
+  lens(0x0f, "MinFocalLength", NikonConv::LensDataFocal),
+  lens(0x10, "MaxFocalLength", NikonConv::LensDataFocal),
+  lens(0x11, "MaxApertureAtMinFocal", NikonConv::LensDataAperture),
+  lens(0x12, "MaxApertureAtMaxFocal", NikonConv::LensDataAperture),
+  lens(0x13, "MCUVersion", NikonConv::Raw),
+  lens(0x14, "EffectiveMaxAperture", NikonConv::LensDataAperture),
+];
+
 /// `const`-fn leaf-tag constructor (no sub-table, no format override).
 const fn tag(id: u16, name: &'static str, conv: NikonConv) -> NikonTag {
   NikonTag {
@@ -675,5 +850,62 @@ mod tests {
     assert_eq!(AF_INFO.first().unwrap().name, "AFAreaMode");
     assert_eq!(AF_INFO.get(1).unwrap().name, "AFPoint");
     assert_eq!(AF_INFO.get(2).unwrap().name, "AFPointsInFocus");
+  }
+
+  /// The ported LensData version tables exist with the faithful
+  /// (`Nikon.pm`-cited) member offsets. `LensData0204` is the +1-shifted
+  /// `%LensData01` (extra byte at 0x09, `Nikon.pm:5616`); the `040x`/`0402`/
+  /// `0403` tables carry the single `LensModel` `string[64]` at their per-version
+  /// offset; `0800`'s legacy block runs 0x04-0x14.
+  #[test]
+  fn lens_data_version_tables_offsets() {
+    // 0204 — 13 members, EffectiveMaxAperture last at 0x13.
+    assert_eq!(LENS_DATA_0204.len(), 13);
+    assert_eq!(LENS_DATA_0204.first().unwrap().name, "ExitPupilPosition");
+    assert_eq!(LENS_DATA_0204.first().unwrap().offset, 0x04);
+    let eff = LENS_DATA_0204.last().unwrap();
+    assert_eq!(eff.name, "EffectiveMaxAperture");
+    assert_eq!(eff.offset, 0x13);
+    // The +1 shift relative to LENS_DATA_01: FocusDistance 0x09→0x0a.
+    let fd01 = LENS_DATA_01
+      .iter()
+      .find(|p| p.name == "FocusDistance")
+      .unwrap();
+    let fd04 = LENS_DATA_0204
+      .iter()
+      .find(|p| p.name == "FocusDistance")
+      .unwrap();
+    assert_eq!(fd01.offset, 0x09);
+    assert_eq!(fd04.offset, 0x0a);
+
+    // 040x / 0402 / 0403 — one LensModel string[64] member at the per-version
+    // offset.
+    for (table, off) in [
+      (LENS_DATA_0400, 0x18a),
+      (LENS_DATA_0402, 0x18b),
+      (LENS_DATA_0403, 0x2ac),
+    ] {
+      assert_eq!(table.len(), 1);
+      let m = table.first().unwrap();
+      assert_eq!(m.name, "LensModel");
+      assert_eq!(m.offset, off);
+      assert_eq!(m.read, LensRead::Str(64));
+    }
+
+    // 0800 legacy block — 12 members, the second +1 shift (FocusDistance 0x0b).
+    assert_eq!(LENS_DATA_0800_OLD.len(), 12);
+    assert_eq!(
+      LENS_DATA_0800_OLD
+        .iter()
+        .find(|p| p.name == "FocusDistance")
+        .unwrap()
+        .offset,
+      0x0b
+    );
+    assert_eq!(LENS_DATA_0800_OLD.last().unwrap().offset, 0x14);
+    // Every legacy/0204 member is a single-byte read (the table FORMAT default).
+    for p in LENS_DATA_0204.iter().chain(LENS_DATA_0800_OLD) {
+      assert_eq!(p.read, LensRead::Byte, "{} must be int8u", p.name);
+    }
   }
 }

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -4070,8 +4070,9 @@ fn canon_0x28_count_zero_no_trailing_decode() {
 
 /// Nikon.nef (D70 NEF, type-3 embedded-TIFF MakerNote). The ported
 /// `%Nikon::Main` scalars + the unencrypted `ColorBalance0103`
-/// (WB_RGBGLevels) match the oracle; the deferred encrypted children
-/// (LensData/etc.) stay absent without a bogus parent. Make/Model from IFD0.
+/// (WB_RGBGLevels) + the UNENCRYPTED `LensData0101` (0x0098) children match
+/// the oracle; the deferred ENCRYPTED sub-tables (ShotInfo/FlashInfo) stay
+/// absent without a bogus parent. Make/Model from IFD0.
 #[cfg(feature = "json")]
 #[test]
 fn real_fixture_nikon_nef_makernotes() {
@@ -4106,19 +4107,28 @@ fn real_fixture_nikon_nef_makernotes() {
       ("Nikon:RawImageCenter", r#""1520 1008""#),
       ("Nikon:SensorPixelSize", r#""7.8 x 7.8 um""#),
       ("Nikon:Saturation", r#""Normal""#),
+      // LensData0101 (UNENCRYPTED, walked): the full member set.
+      ("Nikon:LensDataVersion", r#""0101""#),
+      ("Nikon:ExitPupilPosition", r#""102.4 mm""#),
+      ("Nikon:AFAperture", "3.6"),
+      ("Nikon:FocusPosition", r#""0xf1""#),
+      ("Nikon:FocusDistance", r#""2.37 m""#),
+      ("Nikon:FocalLength", r#""18.3 mm""#),
+      ("Nikon:LensIDNumber", "127"),
+      ("Nikon:LensFStops", "5.33"),
+      ("Nikon:MinFocalLength", r#""18.3 mm""#),
+      ("Nikon:MaxFocalLength", r#""71.3 mm""#),
+      ("Nikon:MaxApertureAtMinFocal", "3.6"),
+      ("Nikon:MaxApertureAtMaxFocal", "4.5"),
+      ("Nikon:MCUVersion", "132"),
+      ("Nikon:EffectiveMaxAperture", "3.6"),
     ],
   );
-  // The DEFERRED ENCRYPTED sub-tables (LensData 0x0098 / ShotInfo 0x0091 /
-  // FlashInfo 0x00a8) are oracle-only — neither the bogus parent NOR the
-  // (un-decrypted) children are emitted (#177/#223).
-  for absent in [
-    "Nikon:LensData",        // bogus parent
-    "Nikon:LensDataVersion", // encrypted child
-    "Nikon:FocusDistance",
-    "Nikon:LensIDNumber",
-    "Nikon:ShotInfo",
-    "Nikon:FlashInfo",
-  ] {
+  // The DEFERRED ENCRYPTED sub-tables (ShotInfo 0x0091 / FlashInfo 0x00a8)
+  // stay oracle-only — neither the bogus parent NOR the (un-decrypted)
+  // children are emitted (#177/#223). The LensData PARENT pointer is likewise
+  // never emitted (only its decoded children, above).
+  for absent in ["Nikon:LensData", "Nikon:ShotInfo", "Nikon:FlashInfo"] {
     assert!(
       !map.contains_key(absent),
       "deferred/bogus key {absent} must be absent"
@@ -4315,8 +4325,13 @@ fn canon_223_second_pass_subdir_parents_suppressed() {
 }
 
 /// NikonD2Hs.jpg (type-3) — exercises the FlashType empty string, the
-/// `ColorSpace` hash, AFInfo (BigEndian DSLR path) + the deferred ENCRYPTED
-/// ColorBalance (WB_RGGBLevels) which must NOT appear.
+/// `ColorSpace` hash, AFInfo (BigEndian DSLR path), the deferred ENCRYPTED
+/// ColorBalance (WB_RGGBLevels) which must NOT appear, AND — the headline of
+/// this PR — the ENCRYPTED `LensData0201` block: decrypted with serial key
+/// `3001006` + count `2`, then decoded against `%LensData01` to LensIDNumber
+/// 118 / LensFStops 7.33 / FocalLength 50.4 mm etc. A wrong serial/count key
+/// or a wrong cipher would decode garbage, not these exact oracle values, so
+/// this test is the decrypt's end-to-end proof.
 #[cfg(feature = "json")]
 #[test]
 fn real_fixture_nikon_d2hs_makernotes() {
@@ -4344,17 +4359,39 @@ fn real_fixture_nikon_d2hs_makernotes() {
       ("Nikon:AFAreaMode", r#""Single Area""#),
       ("Nikon:AFPointsInFocus", r#""Center""#),
       ("Nikon:HighISONoiseReduction", r#""Normal""#),
+      // LensData0201 (ENCRYPTED → DECRYPTED with serial 3001006 / count 2,
+      // then `%LensData01`). These prove the Decrypt + SerialKey are correct.
+      ("Nikon:LensDataVersion", r#""0201""#),
+      ("Nikon:ExitPupilPosition", r#""60.2 mm""#),
+      ("Nikon:AFAperture", "1.9"),
+      ("Nikon:FocusPosition", r#""0x11""#),
+      ("Nikon:FocusDistance", r#""0.71 m""#),
+      ("Nikon:FocalLength", r#""50.4 mm""#),
+      ("Nikon:LensIDNumber", "118"),
+      ("Nikon:LensFStops", "7.33"),
+      ("Nikon:MinFocalLength", r#""50.4 mm""#),
+      ("Nikon:MaxFocalLength", r#""50.4 mm""#),
+      ("Nikon:MaxApertureAtMinFocal", "1.8"),
+      ("Nikon:MaxApertureAtMaxFocal", "1.8"),
+      ("Nikon:MCUVersion", "122"),
+      ("Nikon:EffectiveMaxAperture", "1.8"),
     ],
   );
   // The D2Hs ColorBalance is the ENCRYPTED 0206 variant ⇒ WB_RGGBLevels is
-  // deferred (oracle-only), and no bogus ColorBalance parent is emitted.
+  // deferred (oracle-only), and no bogus ColorBalance / LensData parent is
+  // emitted.
   assert!(!map.contains_key("Nikon:WB_RGGBLevels"));
   assert!(!map.contains_key("Nikon:ColorBalance"));
+  assert!(!map.contains_key("Nikon:LensData"));
 }
 
 /// NikonD70.jpg (type-3) — exercises the `FlashExposureComp` PrintFraction
-/// (`-5/3`) and `ExposureDifference` (`%+.1f` → `-4.9`), plus the title-cased
-/// `FlashType` ("Built-in,TTL") + the unencrypted WB_RGBGLevels.
+/// (`-5/3`) and `ExposureDifference` (`%+.1f` → `-4.9`), the title-cased
+/// `FlashType` ("Built-in,TTL"), the unencrypted WB_RGBGLevels, AND the
+/// UNENCRYPTED `LensData0101` children. The D70 SerialNumber is the STRING
+/// `"No= 20025585"` (→ `SerialKey` 0x60), but LensData0101 is unencrypted so
+/// the key is unused here — the FocalLength 56.6 mm / SerialNumber-string path
+/// still decodes correctly.
 #[cfg(feature = "json")]
 #[test]
 fn real_fixture_nikon_d70_makernotes() {
@@ -4376,6 +4413,21 @@ fn real_fixture_nikon_d70_makernotes() {
       ("Nikon:WB_RGBGLevels", r#""597 256 361 256""#),
       ("Nikon:SerialNumber", r#""No= 20025585""#),
       ("Nikon:Saturation", r#""Enhanced""#),
+      // LensData0101 (UNENCRYPTED, walked): the D70's FocalLength is 56.6 mm.
+      ("Nikon:LensDataVersion", r#""0101""#),
+      ("Nikon:ExitPupilPosition", r#""89.0 mm""#),
+      ("Nikon:AFAperture", "4.6"),
+      ("Nikon:FocusPosition", r#""0x21""#),
+      ("Nikon:FocusDistance", r#""0.63 m""#),
+      ("Nikon:FocalLength", r#""56.6 mm""#),
+      ("Nikon:LensIDNumber", "127"),
+      ("Nikon:LensFStops", "5.33"),
+      ("Nikon:MinFocalLength", r#""18.3 mm""#),
+      ("Nikon:MaxFocalLength", r#""71.3 mm""#),
+      ("Nikon:MaxApertureAtMinFocal", "3.6"),
+      ("Nikon:MaxApertureAtMaxFocal", "4.5"),
+      ("Nikon:MCUVersion", "132"),
+      ("Nikon:EffectiveMaxAperture", "4.5"),
     ],
   );
   assert!(!map.contains_key("Nikon:LensData"));


### PR DESCRIPTION
## Scope

Phase 1 of #227 — faithful port of Nikon MakerNote **decryption** and the **`LensData` (0x0098) sub-table** decode.

- **Cipher** (`decrypt.rs`): `Image::ExifTool::Nikon::Decrypt` + the two 256-byte `@xlat` tables; `SerialKey` derivation.
- **Key capture** (`body::prescan_decrypt_keys`): a faithful port of ExifTool's `PrescanExif` (`Nikon.pm:14067-14125`) — a separate raw-IFD pass with the prescan gates (needTags `0x001d`/`0x00a7`, format `1..=13`, 16 MB out-of-line cap, in-bounds) rather than the post-walk entries, so a `SerialNumber`/`ShutterCount` the main walk would drop is still keyed, exactly as ExifTool.
- **Numeric key model** (`decrypt::digit_key_u64`): shared 64-bit-saturating decimal coercion for both the serial and count keys, faithful to Perl's numeric model across the entire `u64` range (the cipher consumes only `serial & 0xff` and the count's four-byte XOR fold).
- **`LensData` dispatch** (`mod.rs`/`tags.rs`): the `0x0098` `LensDataVersion` conditional layout (`0100`–`0802` + the `LensDataUnknown` fallback) and the encrypted-body gate (`ProcessNikonEncrypted` / `DecryptStart => 4`), plus the `0800` Z-mirrorless telemetry block.
- **DoS hardening** (output-equivalent): implicit-`undef` binary-SubDirectory entries store a zero-copy empty value (the sub-decoders re-read the block from `walk_data`), bounding retained memory independent of entry count.

## Verify

`fmt=0` · `build=0` (`-Dwarnings`, `--all-features --all-targets`) · `clippy=0` (lib; the in-source `deny(clippy::indexing_slicing)` floor holds) · `test=0` (full suite) · **conformance 416/0 byte-identical** (the 3 real Nikon fixtures stay byte-exact throughout).

Codex adversarial review: **APPROVE** (R11, no material findings) — an 11-round loop drove the full `Decrypt`/`LensData` faithfulness (version dispatch, encrypted-key gate, serial-default-0, positional FocusMode, format-agnostic keys), the zero-copy DoS fix, the `PrescanExif`-faithful key capture, and the 64-bit-saturating numeric model to a clean approve.

## Follow-up

Phase 2 (`ShotInfo` + `FlashInfo` encrypted sub-tables) is a tracked follow-up, out of scope here.
