### PR TITLE
feat(exif/nikon): decode FlashInfo0100 sub-table (#227 phase 2a)

### DIFF
--- a/src/exif/makernotes/vendors/nikon/mod.rs
+++ b/src/exif/makernotes/vendors/nikon/mod.rs
@@ -27,10 +27,14 @@
 //!
 //! ## Scope
 //!
-//! See [`tags`]: every readable `%Nikon::Main` scalar + the two UNENCRYPTED
-//! fixture sub-tables (`AFInfo`, `ColorBalance0103`). The ENCRYPTED
-//! sub-tables (`LensData`/`ShotInfo`/`FlashInfo`/encrypted `ColorBalance`)
-//! are deferred (they need `Nikon::Decrypt`) — they carry a deferred
+//! See [`tags`]: every readable `%Nikon::Main` scalar + the UNENCRYPTED
+//! fixture sub-tables (`AFInfo`, `ColorBalance0103`, `LensData00`/`01`, and the
+//! UNENCRYPTED plaintext `FlashInfo0100`). `LensData` decrypts the `02xx`+ arms
+//! ([`decrypt`]); `FlashInfo` (0x00a8) is unencrypted `ProcessBinaryData`
+//! version-dispatched on the 4-byte `FlashInfoVersion` prefix
+//! ([`emit_flash_info`], `Nikon.pm:2987-3009`) — only the `0100`/`0101` arm is
+//! ported here, other versions emit nothing (a committed follow-up). The
+//! deferred `ShotInfo` (0x0091) + encrypted `ColorBalance` carry a deferred
 //! [`tags::SubTable`] marker so the parent pointer is NOT emitted (the
 //! #177/#223 bogus-parent rule).
 
@@ -381,11 +385,11 @@ pub fn parse_in_tiff(
             &mut emissions,
           );
         }
+        SubTable::FlashInfo => {
+          emit_flash_info(walk_data, entry, layout, print_conv, &mut emissions);
+        }
         // Deferred (encrypted / unported child table): emit nothing.
-        SubTable::ShotInfo
-        | SubTable::FlashInfo
-        | SubTable::ColorBalanceEncrypted
-        | SubTable::OtherDeferred => {}
+        SubTable::ShotInfo | SubTable::ColorBalanceEncrypted | SubTable::OtherDeferred => {}
       }
       continue;
     }
@@ -508,6 +512,294 @@ fn emit_color_balance(
     return;
   };
   emissions.push(VendorEmission::new("WB_RGBGLevels".into(), value, false));
+}
+
+/// Emit the `%Nikon::FlashInfo0100` leaves (0x00a8) — an UNENCRYPTED plaintext
+/// `ProcessBinaryData` table (NO `DecryptStart` on any arm), version-dispatched
+/// on the 4-byte `FlashInfoVersion` prefix (`Nikon.pm:2987-3009`). Only the
+/// `010[01]` arm (`%Nikon::FlashInfo0100`, `Nikon.pm:10810`) is ported here;
+/// every other version (`0102`/`010[345]`/`0106`/`010[78]`/`030[01]`/other)
+/// emits NOTHING (a committed follow-up) — the dispatch is a one-line addition
+/// per arm. FlashInfo0100 has NO `ByteOrder` SubDirectory directive, so it
+/// inherits the parent MakerNote IFD order; every member is a single int8u/int8s
+/// byte, so the order is irrelevant for these reads.
+///
+/// The fields are read at their byte offsets into the value, in offset order,
+/// honouring the byte-9 dual read (`FlashCommanderMode` Mask 0x80 then
+/// `FlashControlMode` Mask 0x7f), the three DataMembers (`FlashControlMode`,
+/// `FlashGroup{A,B}ControlMode`), the offset-10/17/18 `>= 0x06` Manual/comp
+/// conditionals, and the offset-11/12/13 `RawConv => '$val ? $val : undef'`
+/// drops. A field whose offset is past the available value length emits nothing
+/// (bounds-safe, like [`emit_color_balance`]).
+fn emit_flash_info(
+  walk_data: &[u8],
+  entry: &NikonEntry,
+  layout: Layout,
+  print_conv: bool,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  let Some(sub) = walk_data.get(entry.value_offset..entry.value_offset + entry.value_size) else {
+    return;
+  };
+  // `FlashInfoVersion` = the first 4 ASCII bytes (`Format => 'string[4]'`).
+  let Some(version) = sub.get(0..4).and_then(|v| <&[u8; 4]>::try_from(v).ok()) else {
+    return;
+  };
+  // The 0x00a8 conditional SubDirectory list (`Nikon.pm:2987-3009`): only the
+  // `010[01]` arm (FlashInfo0100) is ported. Any other version is deferred —
+  // emit nothing (the parent SubDirectory pointer is already suppressed by the
+  // deferred dispatch; a follow-up adds the remaining arms here).
+  if !matches!(version, b"0100" | b"0101") {
+    return;
+  }
+  // offset 0 `FlashInfoVersion` (`string[4]`, no conversion — verbatim).
+  emissions.push(VendorEmission::new(
+    "FlashInfoVersion".into(),
+    TagValue::Str(SmolStr::new(String::from_utf8_lossy(version))),
+    false,
+  ));
+  // The shared int8u read + conv push (`FORMAT => 'int8u'` is the table
+  // default). A byte past the value length emits nothing; a `None` from a
+  // RawConv-undef drop (FlashFocalLength/RepeatingFlashRate 0) is skipped.
+  let push_u8 =
+    |emissions: &mut Vec<VendorEmission>, offset: usize, name: &'static str, conv: NikonConv| {
+      let Some(&byte) = sub.get(offset) else {
+        return;
+      };
+      let parsed = ParsedValue::new(RawValue::U64(std::vec![u64::from(byte)]));
+      if let Some(value) = conv.apply(&parsed, print_conv, None, layout.order) {
+        emissions.push(VendorEmission::new(name.into(), value, false));
+      }
+    };
+
+  // offset 4 `FlashSource` (int8u).
+  push_u8(emissions, 4, "FlashSource", NikonConv::FlashSource);
+
+  // offset 6 `ExternalFlashFirmware` (`int8u[2]`): the value is the space-joined
+  // pair "A B"; the PrintConv looks it up in `%flashFirmware`, with an OTHER
+  // sub `sprintf('%d.%.2d (Unknown model)', A, B)`. `-n` emits the raw "A B".
+  if let (Some(&a), Some(&b)) = (sub.get(6), sub.get(7)) {
+    let joined = std::format!("{a} {b}");
+    let value = if print_conv {
+      match flash_firmware_label(&joined) {
+        Some(s) => TagValue::Str(SmolStr::new(s)),
+        // OTHER => sprintf('%d.%.2d (Unknown model)', split(' ', $val)).
+        None => TagValue::Str(SmolStr::new(std::format!("{a}.{b:02} (Unknown model)"))),
+      }
+    } else {
+      TagValue::Str(SmolStr::new(joined))
+    };
+    emissions.push(VendorEmission::new(
+      "ExternalFlashFirmware".into(),
+      value,
+      false,
+    ));
+  }
+
+  // offset 8 `ExternalFlashFlags` (int8u BITMASK).
+  push_u8(
+    emissions,
+    8,
+    "ExternalFlashFlags",
+    NikonConv::ExternalFlashFlags,
+  );
+
+  // offset 9 read TWICE (two tags from one byte, via Mask + BitShift; ExifTool
+  // `$val = ($val & $mask) >> $bitShift`, `ExifTool.pm:10079`):
+  //   9.1 FlashCommanderMode — Mask 0x80 ⇒ (byte9 & 0x80) >> 7; {0=>Off,1=>On}.
+  //   9.2 FlashControlMode    — Mask 0x7f ⇒ (byte9 & 0x7f); DataMember; the
+  //                             %flashControlMode hash.
+  let flash_control_mode: Option<i64> = sub.get(9).map(|&b9| {
+    let commander = i64::from((b9 & 0x80) >> 7);
+    let parsed = ParsedValue::new(RawValue::I64(std::vec![commander]));
+    if let Some(value) = NikonConv::OffOn.apply(&parsed, print_conv, None, layout.order) {
+      emissions.push(VendorEmission::new(
+        "FlashCommanderMode".into(),
+        value,
+        false,
+      ));
+    }
+    let control = i64::from(b9 & 0x7f);
+    let parsed = ParsedValue::new(RawValue::I64(std::vec![control]));
+    if let Some(value) = NikonConv::FlashControlMode.apply(&parsed, print_conv, None, layout.order)
+    {
+      emissions.push(VendorEmission::new("FlashControlMode".into(), value, false));
+    }
+    control
+  });
+
+  // offset 10 CONDITIONAL on the FlashControlMode DataMember:
+  //   >= 0x06 ⇒ FlashOutput (int8u, 2**(-val/6), Full/%); else FlashCompensation
+  //   (int8s, -val/6, PrintFraction). A missing byte 9 leaves the member undef;
+  //   ExifTool's `$$self{FlashControlMode} >= 0x06` is then `undef >= 6` = false
+  //   ⇒ the FlashCompensation arm.
+  emit_flash_output_or_comp(
+    sub,
+    10,
+    flash_control_mode,
+    print_conv,
+    layout.order,
+    "FlashOutput",
+    "FlashCompensation",
+    NikonConv::FlashCompensation,
+    emissions,
+  );
+
+  // offset 11 FlashFocalLength (int8u, RawConv 0⇒undef, "$val mm").
+  push_u8(
+    emissions,
+    11,
+    "FlashFocalLength",
+    NikonConv::FlashFocalLength,
+  );
+  // offset 12 RepeatingFlashRate (int8u, RawConv 0⇒undef, "$val Hz").
+  push_u8(
+    emissions,
+    12,
+    "RepeatingFlashRate",
+    NikonConv::RepeatingFlashRate,
+  );
+  // offset 13 RepeatingFlashCount (int8u, RawConv 0⇒undef, no PrintConv — the
+  // raw integer).
+  if let Some(&byte) = sub.get(13)
+    && byte != 0
+  {
+    emissions.push(VendorEmission::new(
+      "RepeatingFlashCount".into(),
+      TagValue::I64(i64::from(byte)),
+      false,
+    ));
+  }
+  // offset 14 FlashGNDistance (int8u, %flashGNDistance).
+  push_u8(emissions, 14, "FlashGNDistance", NikonConv::FlashGnDistance);
+
+  // offset 15/16 FlashGroup{A,B}ControlMode (int8u, Mask 0x0f ⇒ byte & 0x0f;
+  // DataMembers; %flashControlMode).
+  let group_a_mode = emit_masked_control_mode(
+    sub,
+    15,
+    "FlashGroupAControlMode",
+    print_conv,
+    layout.order,
+    emissions,
+  );
+  let group_b_mode = emit_masked_control_mode(
+    sub,
+    16,
+    "FlashGroupBControlMode",
+    print_conv,
+    layout.order,
+    emissions,
+  );
+
+  // offset 17 CONDITIONAL on FlashGroupAControlMode: >= 0x06 ⇒ FlashGroupAOutput
+  // (2**(-val/6)); else FlashGroupACompensation (int8s, -val/6, '%+.1f'/0).
+  emit_flash_output_or_comp(
+    sub,
+    17,
+    group_a_mode,
+    print_conv,
+    layout.order,
+    "FlashGroupAOutput",
+    "FlashGroupACompensation",
+    NikonConv::FlashGroupCompensation,
+    emissions,
+  );
+  // offset 18 CONDITIONAL on FlashGroupBControlMode (same as 17, group B).
+  emit_flash_output_or_comp(
+    sub,
+    18,
+    group_b_mode,
+    print_conv,
+    layout.order,
+    "FlashGroupBOutput",
+    "FlashGroupBCompensation",
+    NikonConv::FlashGroupCompensation,
+    emissions,
+  );
+}
+
+/// `%flashFirmware` (`Nikon.pm:767-789`) — the `ExternalFlashFirmware` "A B"
+/// space-joined lookup. Returns `None` for an unlisted pair (the caller renders
+/// the OTHER `sprintf('%d.%.2d (Unknown model)', A, B)`).
+fn flash_firmware_label(joined: &str) -> Option<&'static str> {
+  Some(match joined {
+    "0 0" => "n/a",
+    "1 1" => "1.01 (SB-800 or Metz 58 AF-1)",
+    "1 3" => "1.03 (SB-800)",
+    "2 1" => "2.01 (SB-800)",
+    "2 4" => "2.04 (SB-600)",
+    "2 5" => "2.05 (SB-600)",
+    "3 1" => "3.01 (SU-800 Remote Commander)",
+    "4 1" => "4.01 (SB-400)",
+    "4 2" => "4.02 (SB-400)",
+    "4 4" => "4.04 (SB-400)",
+    "5 1" => "5.01 (SB-900)",
+    "5 2" => "5.02 (SB-900)",
+    "6 1" => "6.01 (SB-700)",
+    "7 1" => "7.01 (SB-910)",
+    "14 3" => "14.03 (SB-5000)",
+    _ => return None,
+  })
+}
+
+/// A `%Nikon::FlashInfo0100` `int8u Mask 0x0f` control-mode DataMember (offset
+/// 15/16). Reads byte at `offset`, masks to `byte & 0x0f` (BitShift 0), emits
+/// it via `%flashControlMode`, and RETURNS the masked value (the DataMember the
+/// offset-17/18 conditional reads). `None` when the byte is past the value
+/// length (the member emits nothing and the conditional sees `undef`).
+fn emit_masked_control_mode(
+  sub: &[u8],
+  offset: usize,
+  name: &'static str,
+  print_conv: bool,
+  order: ByteOrder,
+  emissions: &mut Vec<VendorEmission>,
+) -> Option<i64> {
+  let &byte = sub.get(offset)?;
+  let masked = i64::from(byte & 0x0f);
+  let parsed = ParsedValue::new(RawValue::I64(std::vec![masked]));
+  if let Some(value) = NikonConv::FlashControlMode.apply(&parsed, print_conv, None, order) {
+    emissions.push(VendorEmission::new(name.into(), value, false));
+  }
+  Some(masked)
+}
+
+/// The shared offset-10/17/18 `FlashControlMode`-gated conditional
+/// (`Nikon.pm:10854-10881`/`10920-10940`): `>= 0x06` ⇒ the `Output` tag (int8u,
+/// `NikonConv::FlashOutput`); else the `Comp` tag (int8s `Format` override,
+/// `comp_conv` = `FlashCompensation` PrintFraction at offset 10 /
+/// `FlashGroupCompensation` `%+.1f` at offset 17/18). `mode` is the gating
+/// DataMember (`None` = `undef >= 0x06` = false ⇒ the Comp arm). A byte past the
+/// value length emits nothing.
+#[expect(clippy::too_many_arguments)]
+fn emit_flash_output_or_comp(
+  sub: &[u8],
+  offset: usize,
+  mode: Option<i64>,
+  print_conv: bool,
+  order: ByteOrder,
+  output_name: &'static str,
+  comp_name: &'static str,
+  comp_conv: NikonConv,
+  emissions: &mut Vec<VendorEmission>,
+) {
+  let Some(&byte) = sub.get(offset) else {
+    return;
+  };
+  if mode.is_some_and(|m| m >= 0x06) {
+    // The `Manual`-arm `FlashOutput` (int8u).
+    let parsed = ParsedValue::new(RawValue::U64(std::vec![u64::from(byte)]));
+    if let Some(value) = NikonConv::FlashOutput.apply(&parsed, print_conv, None, order) {
+      emissions.push(VendorEmission::new(output_name.into(), value, false));
+    }
+  } else {
+    // The `Compensation`-arm (int8s `Format` override — the byte is signed).
+    let parsed = ParsedValue::new(RawValue::I64(std::vec![i64::from(byte as i8)]));
+    if let Some(value) = comp_conv.apply(&parsed, print_conv, None, order) {
+      emissions.push(VendorEmission::new(comp_name.into(), value, false));
+    }
+  }
 }
 
 /// The decryption keys captured for the encrypted Nikon sub-tables —
@@ -1316,9 +1608,10 @@ mod tests {
     assert_eq!(q.value(), &TagValue::Str(SmolStr::new("Fine")));
   }
 
-  /// A deferred (encrypted) SubDirectory pointer (LensData 0x0098, ShotInfo
-  /// 0x0091, FlashInfo 0x00a8) emits NEITHER a parent NOR children — the
-  /// #177/#223 bogus-parent rule.
+  /// A deferred (encrypted) SubDirectory pointer (ShotInfo 0x0091) emits
+  /// NEITHER a parent NOR children — the #177/#223 bogus-parent rule. (LensData
+  /// 0x0098 defers only the PARENT; FlashInfo 0x00a8 is now WALKED — see
+  /// [`flash_info_0100_decodes`].)
   #[test]
   fn deferred_encrypted_subdir_emits_no_parent() {
     let mut b: Vec<u8> = Vec::new();
@@ -2725,5 +3018,182 @@ mod tests {
     assert_eq!(lens_get(&em, "LensDataVersion"), Some(str_val("0101")));
     assert_eq!(lens_get(&em, "FocalLength"), Some(str_val("151.0 mm")));
     assert_eq!(lens_get(&em, "LensIDNumber"), Some(TagValue::I64(24)));
+  }
+
+  /// Build a type-3 Nikon blob with a single out-of-line `0x00a8` FlashInfo
+  /// value (UNENCRYPTED, so no key prescan is needed). Mirrors
+  /// [`type3_lens_data_only`] for the FlashInfo SubDirectory.
+  fn type3_flash_info(flash_block: &[u8]) -> Vec<u8> {
+    let n_entries: u16 = 1;
+    let off_flash: u32 = 8 + 2 + u32::from(n_entries) * 12 + 4; // embedded-relative
+    let mut b: Vec<u8> = Vec::new();
+    b.extend_from_slice(b"Nikon\x00\x02\x10\x00\x00");
+    b.extend_from_slice(b"MM");
+    b.extend_from_slice(&[0x00, 0x2a]);
+    b.extend_from_slice(&8u32.to_be_bytes());
+    b.extend_from_slice(&n_entries.to_be_bytes());
+    b.extend_from_slice(&0x00a8u16.to_be_bytes()); // FlashInfo, undef, out-of-line
+    b.extend_from_slice(&[0x00, 0x07]);
+    b.extend_from_slice(&(flash_block.len() as u32).to_be_bytes());
+    b.extend_from_slice(&off_flash.to_be_bytes());
+    b.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD
+    b.extend_from_slice(flash_block);
+    b
+  }
+
+  /// `%Nikon::FlashInfo0100` (0x00a8) decode — a crafted `0100` block exercising
+  /// the full conditional matrix, BYTE-EXACT to the `perl exiftool 13.59`
+  /// ProcessBinaryData oracle (verified directly against
+  /// `Image::ExifTool::Nikon::FlashInfo0100`):
+  ///   FlashSource Internal, ExternalFlashFirmware OTHER `"9.05 (Unknown
+  ///   model)"`, ExternalFlashFlags BITMASK `Fired, Bounce Flash, Wide Flash
+  ///   Adapter`, FlashCommanderMode On + FlashControlMode Manual (byte-9 dual
+  ///   read), the Manual-branch FlashOutput `25%`, FlashFocalLength `35 mm`,
+  ///   RepeatingFlashRate `10 Hz`, RepeatingFlashCount `3`, FlashGNDistance
+  ///   `1.0 m`, FlashGroupAControlMode Manual → FlashGroupAOutput `50%`,
+  ///   FlashGroupBControlMode iTTL → FlashGroupBCompensation `-1.5`.
+  #[test]
+  fn flash_info_0100_decodes() {
+    let block: Vec<u8> = b"0100"
+      .iter()
+      .copied()
+      .chain([2, 48, 9, 5, 0x15, 0x86, 12, 35, 10, 3, 10, 0x06, 0x02, 6, 9])
+      .collect();
+    let (_t, em) = parse(&type3_flash_info(&block), ByteOrder::Big, Some("NIKON D70"));
+    let get = |n: &str| lens_get(&em, n);
+    assert_eq!(get("FlashInfoVersion"), Some(str_val("0100")));
+    assert_eq!(get("FlashSource"), Some(str_val("Internal")));
+    assert_eq!(
+      get("ExternalFlashFirmware"),
+      Some(str_val("9.05 (Unknown model)"))
+    );
+    assert_eq!(
+      get("ExternalFlashFlags"),
+      Some(str_val("Fired, Bounce Flash, Wide Flash Adapter"))
+    );
+    assert_eq!(get("FlashCommanderMode"), Some(str_val("On")));
+    assert_eq!(get("FlashControlMode"), Some(str_val("Manual")));
+    // FlashControlMode Manual (0x06) ⇒ the Output arm at offset 10, NOT the
+    // FlashCompensation arm.
+    assert_eq!(get("FlashOutput"), Some(str_val("25%")));
+    assert!(get("FlashCompensation").is_none());
+    assert_eq!(get("FlashFocalLength"), Some(str_val("35 mm")));
+    assert_eq!(get("RepeatingFlashRate"), Some(str_val("10 Hz")));
+    assert_eq!(get("RepeatingFlashCount"), Some(TagValue::I64(3)));
+    assert_eq!(get("FlashGNDistance"), Some(str_val("1.0 m")));
+    assert_eq!(get("FlashGroupAControlMode"), Some(str_val("Manual")));
+    assert_eq!(get("FlashGroupBControlMode"), Some(str_val("iTTL")));
+    // GroupA Manual (0x06) ⇒ Output arm; GroupB iTTL (0x02) ⇒ Compensation arm.
+    assert_eq!(get("FlashGroupAOutput"), Some(str_val("50%")));
+    assert!(get("FlashGroupACompensation").is_none());
+    assert_eq!(get("FlashGroupBCompensation"), Some(str_val("-1.5")));
+    assert!(get("FlashGroupBOutput").is_none());
+    // No bogus FlashInfo parent (the SubDirectory pointer never emits it).
+    assert!(em.iter().all(|e| e.name() != "FlashInfo"));
+  }
+
+  /// `%Nikon::FlashInfo0100` — the all-Off fixture shape (NikonD2Hs/D70 oracle):
+  /// firmware `"0 0"` → `"n/a"`, flags `0` → `"(none)"`, the byte-9 Off/Off, the
+  /// FlashControlMode-Off branch ⇒ FlashCompensation `0` (a BARE number, NOT the
+  /// FlashOutput arm), GN `0`, both group comps `0`. The offset-11/12/13
+  /// `RawConv => '$val ? $val : undef'` drops (focal/rate/count 0) emit NOTHING.
+  #[test]
+  fn flash_info_0100_all_off_with_rawconv_drops() {
+    // 19 bytes, all zero after the version + firmware "0 0" + the GN/groups 0.
+    let mut block = std::vec![0u8; 19];
+    block.get_mut(0..4).unwrap().copy_from_slice(b"0100");
+    let (_t, em) = parse(
+      &type3_flash_info(&block),
+      ByteOrder::Big,
+      Some("NIKON D2Hs"),
+    );
+    let get = |n: &str| lens_get(&em, n);
+    assert_eq!(get("FlashInfoVersion"), Some(str_val("0100")));
+    assert_eq!(get("FlashSource"), Some(str_val("None")));
+    assert_eq!(get("ExternalFlashFirmware"), Some(str_val("n/a")));
+    assert_eq!(get("ExternalFlashFlags"), Some(str_val("(none)")));
+    assert_eq!(get("FlashCommanderMode"), Some(str_val("Off")));
+    assert_eq!(get("FlashControlMode"), Some(str_val("Off")));
+    // FlashControlMode Off (< 0x06) ⇒ FlashCompensation; -0/6 = 0 ⇒
+    // `PrintFraction(0)` = the STRING "0" (the shared `SignedFractionPrintFraction`
+    // contract), which the JSON layer serializes as the BARE number 0 — matching
+    // the oracle `"Nikon:FlashCompensation": 0`.
+    assert_eq!(get("FlashCompensation"), Some(str_val("0")));
+    assert!(get("FlashOutput").is_none());
+    assert_eq!(get("FlashGNDistance"), Some(str_val("0")));
+    assert_eq!(get("FlashGroupAControlMode"), Some(str_val("Off")));
+    assert_eq!(get("FlashGroupBControlMode"), Some(str_val("Off")));
+    assert_eq!(get("FlashGroupACompensation"), Some(TagValue::I64(0)));
+    assert_eq!(get("FlashGroupBCompensation"), Some(TagValue::I64(0)));
+    // RawConv `$val ? $val : undef` drops for a 0 byte — NOT emitted.
+    assert!(
+      get("FlashFocalLength").is_none(),
+      "FlashFocalLength 0 must drop (RawConv undef)"
+    );
+    assert!(
+      get("RepeatingFlashRate").is_none(),
+      "RepeatingFlashRate 0 must drop (RawConv undef)"
+    );
+    assert!(
+      get("RepeatingFlashCount").is_none(),
+      "RepeatingFlashCount 0 must drop (RawConv undef)"
+    );
+  }
+
+  /// `%Nikon::FlashInfo0100` — a NON-`0100`/`0101` version (`0103`) is DEFERRED:
+  /// the dispatch emits NOTHING (no FlashInfoVersion, no children, no parent),
+  /// matching the still-unported FlashInfo0103 arm. A `0101` version IS walked.
+  #[test]
+  fn flash_info_version_dispatch_gate() {
+    // 0103 — deferred arm, emits nothing.
+    let mut v0103 = std::vec![0u8; 19];
+    v0103.get_mut(0..4).unwrap().copy_from_slice(b"0103");
+    let (_t, em) = parse(&type3_flash_info(&v0103), ByteOrder::Big, Some("NIKON D80"));
+    assert!(
+      em.iter().all(|e| !e.name().starts_with("Flash")),
+      "a 0103 FlashInfo must emit nothing (deferred), got {em:?}"
+    );
+    // 0101 — walked (same FlashInfo0100 table as 0100).
+    let mut v0101 = std::vec![0u8; 19];
+    v0101.get_mut(0..4).unwrap().copy_from_slice(b"0101");
+    let (_t, em) = parse(&type3_flash_info(&v0101), ByteOrder::Big, Some("NIKON D80"));
+    assert_eq!(lens_get(&em, "FlashInfoVersion"), Some(str_val("0101")));
+    assert_eq!(lens_get(&em, "FlashSource"), Some(str_val("None")));
+  }
+
+  /// `%Nikon::FlashInfo0100` `-n` mode (PrintConv off): the post-ValueConv raw
+  /// scalars (the firmware "A B" join, the raw int8u flags/GN, the
+  /// FlashControlMode masked integer) — verified against `perl exiftool -n`.
+  #[test]
+  fn flash_info_0100_value_mode() {
+    let block: Vec<u8> = b"0100"
+      .iter()
+      .copied()
+      .chain([2, 48, 9, 5, 0x15, 0x86, 12, 35, 10, 3, 10, 0x06, 0x02, 6, 9])
+      .collect();
+    // print_conv = false ⇒ -n.
+    let (_t, em) = parse_with_print_conv(
+      &type3_flash_info(&block),
+      ByteOrder::Big,
+      false,
+      Some("NIKON D70"),
+    );
+    let get = |n: &str| lens_get(&em, n);
+    assert_eq!(get("FlashInfoVersion"), Some(str_val("0100")));
+    assert_eq!(get("FlashSource"), Some(TagValue::I64(2)));
+    // int8u[2] raw join "A B".
+    assert_eq!(get("ExternalFlashFirmware"), Some(str_val("9 5")));
+    assert_eq!(get("ExternalFlashFlags"), Some(TagValue::I64(0x15)));
+    assert_eq!(get("FlashCommanderMode"), Some(TagValue::I64(1)));
+    assert_eq!(get("FlashControlMode"), Some(TagValue::I64(6)));
+    // FlashOutput -n: post-ValueConv 2**(-12/6) = 0.25.
+    assert_eq!(get("FlashOutput"), Some(TagValue::F64(0.25)));
+    assert_eq!(get("FlashFocalLength"), Some(TagValue::I64(35)));
+    assert_eq!(get("RepeatingFlashRate"), Some(TagValue::I64(10)));
+    assert_eq!(get("FlashGNDistance"), Some(TagValue::I64(10)));
+    assert_eq!(get("FlashGroupAControlMode"), Some(TagValue::I64(6)));
+    assert_eq!(get("FlashGroupBControlMode"), Some(TagValue::I64(2)));
+    // GroupB Compensation -n: post-ValueConv -9/6 = -1.5.
+    assert_eq!(get("FlashGroupBCompensation"), Some(TagValue::F64(-1.5)));
   }
 }

--- a/src/exif/makernotes/vendors/nikon/printconv.rs
+++ b/src/exif/makernotes/vendors/nikon/printconv.rs
@@ -198,6 +198,52 @@ pub enum NikonConv {
   /// by the caller BEFORE this PrintConv; the raw value here is already masked
   /// to 0/1. `-n` emits the masked integer.
   LensMountType,
+  /// `%Nikon::FlashInfo0100` `FlashSource` (offset 4, `Nikon.pm:10824`) —
+  /// `{0=>'None',1=>'External',2=>'Internal'}`.
+  FlashSource,
+  /// `%Nikon::FlashInfo0100` `FlashControlMode` / `FlashGroupAControlMode` /
+  /// `FlashGroupBControlMode` (`Nikon.pm:829-838`, the shared `%flashControlMode`
+  /// hash) — `{0=>'Off',1=>'iTTL-BL',…,7=>'Repeating Flash'}`. The `Mask` is
+  /// applied by the caller; the raw value here is already masked.
+  FlashControlMode,
+  /// `%Nikon::FlashInfo0100` `ExternalFlashFlags` (offset 8, `Nikon.pm:10838`) —
+  /// `PrintConv => { 0 => '(none)', BITMASK => { 0=>'Fired', 2=>'Bounce Flash',
+  /// 4=>'Wide Flash Adapter', 5=>'Dome Diffuser' } }`. The `0` key short-circuits
+  /// `(none)`; otherwise the `DecodeBits` walk (the same path `LensType` uses) —
+  /// an unlisted set bit renders `[n]`. `-n` emits the raw int8u.
+  ExternalFlashFlags,
+  /// `%Nikon::FlashInfo0100` `FlashGNDistance` (offset 14, `Nikon.pm:792-815`,
+  /// the `%flashGNDistance` hash) — `{0=>'0',1=>'0.1 m',…,255=>'n/a'}`. Key `0`
+  /// maps to the bare string `"0"`; an unlisted value renders `Unknown (N)` —
+  /// the standard ExifTool HASH-PrintConv miss fallback (`ExifTool.pm:3632`,
+  /// no `BITMASK`/`OTHER`/`PrintHex` on this hash), via the shared `hash_conv`.
+  /// `-n` emits the raw int8u.
+  FlashGnDistance,
+  /// `%Nikon::FlashInfo0100` `FlashOutput` / `FlashGroupAOutput` /
+  /// `FlashGroupBOutput` (the `Manual`-arm of the offset-10/17/18 conditional,
+  /// `Nikon.pm:10864`) — `ValueConv => '2 ** (-$val/6)'`, `PrintConv =>
+  /// '$val>0.99 ? "Full" : sprintf("%.0f%%",$val*100)'`. `-n` emits the
+  /// post-ValueConv float.
+  FlashOutput,
+  /// `%Nikon::FlashInfo0100` `FlashCompensation` (the non-Manual arm of offset
+  /// 10, `Nikon.pm:10872-10879`) — `int8s`, `ValueConv => '-$val/6'`, `PrintConv
+  /// => Image::ExifTool::Exif::PrintFraction`. `-n` emits the post-ValueConv
+  /// float.
+  FlashCompensation,
+  /// `%Nikon::FlashInfo0100` `FlashGroupACompensation` / `FlashGroupBCompensation`
+  /// (the non-Manual arm of offset 17/18, `Nikon.pm:10934-10939`) — `int8s`,
+  /// `ValueConv => '-$val/6'`, `PrintConv => '$val ? sprintf("%+.1f",$val) : 0'`
+  /// (NOT PrintFraction — a `%+.1f` render, and exactly 0 renders the integer
+  /// `0`). `-n` emits the post-ValueConv float.
+  FlashGroupCompensation,
+  /// `%Nikon::FlashInfo0100` `FlashFocalLength` (offset 11, `Nikon.pm:10882`) —
+  /// `RawConv => '$val ? $val : undef'` (a raw `0` ⇒ the tag is NOT emitted),
+  /// `PrintConv => '"$val mm"'`. `-n` emits the raw int8u.
+  FlashFocalLength,
+  /// `%Nikon::FlashInfo0100` `RepeatingFlashRate` (offset 12, `Nikon.pm:10889`) —
+  /// `RawConv => '$val ? $val : undef'` (0 ⇒ drop), `PrintConv => '"$val Hz"'`.
+  /// `-n` emits the raw int8u.
+  RepeatingFlashRate,
 }
 
 impl NikonConv {
@@ -500,6 +546,84 @@ impl NikonConv {
             1 => TagValue::Str(SmolStr::new("F-mount")),
             _ => TagValue::Str(SmolStr::new(std::format!("Unknown ({n})"))),
           }
+        } else {
+          TagValue::I64(n)
+        }
+      }
+      NikonConv::FlashSource => hash_conv(raw, print_conv, flash_source_label),
+      NikonConv::FlashControlMode => hash_conv(raw, print_conv, flash_control_mode_label),
+      NikonConv::ExternalFlashFlags => external_flash_flags_conv(raw, print_conv),
+      NikonConv::FlashGnDistance => hash_conv(raw, print_conv, flash_gn_distance_label),
+      NikonConv::FlashOutput => {
+        // `ValueConv => '2 ** (-$val/6)'`; PrintConv `$val>0.99 ? "Full" :
+        // sprintf("%.0f%%",$val*100)`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = 2f64.powf(-(n as f64) / 6.0);
+        if print_conv {
+          if v > 0.99 {
+            TagValue::Str(SmolStr::new("Full"))
+          } else {
+            TagValue::Str(SmolStr::new(std::format!("{}%", flash_pct(v * 100.0))))
+          }
+        } else {
+          TagValue::F64(v)
+        }
+      }
+      NikonConv::FlashCompensation => {
+        // `int8s`, `ValueConv => '-$val/6'`, PrintConv PrintFraction.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = -(n as f64) / 6.0;
+        if print_conv {
+          TagValue::Str(SmolStr::new(print_fraction(v)))
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::FlashGroupCompensation => {
+        // `int8s`, `ValueConv => '-$val/6'`, PrintConv `$val ?
+        // sprintf("%+.1f",$val) : 0` (the integer 0 for an exact-zero value).
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        let v = -(n as f64) / 6.0;
+        if print_conv {
+          if v == 0.0 {
+            TagValue::I64(0)
+          } else {
+            TagValue::Str(SmolStr::new(std::format!("{v:+.1}")))
+          }
+        } else {
+          value_conv_number(v)
+        }
+      }
+      NikonConv::FlashFocalLength => {
+        // `RawConv => '$val ? $val : undef'` (0 ⇒ drop), PrintConv `"$val mm"`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if n == 0 {
+          return None;
+        }
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{n} mm")))
+        } else {
+          TagValue::I64(n)
+        }
+      }
+      NikonConv::RepeatingFlashRate => {
+        // `RawConv => '$val ? $val : undef'` (0 ⇒ drop), PrintConv `"$val Hz"`.
+        let Some(n) = raw.first_i64() else {
+          return Some(raw.to_default_tag_value());
+        };
+        if n == 0 {
+          return None;
+        }
+        if print_conv {
+          TagValue::Str(SmolStr::new(std::format!("{n} Hz")))
         } else {
           TagValue::I64(n)
         }
@@ -1402,6 +1526,107 @@ fn af_point_label(n: i64) -> Option<&'static str> {
   })
 }
 
+/// `%Nikon::FlashInfo0100` `FlashSource` (offset 4, `Nikon.pm:10826-10828`).
+fn flash_source_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "None",
+    1 => "External",
+    2 => "Internal",
+    _ => return None,
+  })
+}
+
+/// `%flashControlMode` (`Nikon.pm:829-838`) — the shared
+/// `FlashControlMode`/`FlashGroupAControlMode`/`FlashGroupBControlMode` hash.
+fn flash_control_mode_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0x00 => "Off",
+    0x01 => "iTTL-BL",
+    0x02 => "iTTL",
+    0x03 => "Auto Aperture",
+    0x04 => "Automatic",
+    0x05 => "GN (distance priority)",
+    0x06 => "Manual",
+    0x07 => "Repeating Flash",
+    _ => return None,
+  })
+}
+
+/// `ExternalFlashFlags` (offset 8, `Nikon.pm:10829-10843`) — `PrintConv =>
+/// { 0 => '(none)', BITMASK => {…} }`. ExifTool tries the direct hash key
+/// FIRST (`0 => '(none)'`), then the `DecodeBits` BITMASK (the same
+/// `0 → "(none)"` / set-bit-label / `[n]` path `LensType` 0x0083 uses); an
+/// unlisted set bit renders `[n]`. The lone direct key is `0`, which the empty
+/// DecodeBits already renders `"(none)"`, so the BITMASK path subsumes it.
+/// `-n` emits the raw int8u.
+fn external_flash_flags_conv(raw: &ParsedValue, print_conv: bool) -> TagValue {
+  let Some(n) = raw.first_i64() else {
+    return raw.to_default_tag_value();
+  };
+  if !print_conv {
+    return TagValue::I64(n);
+  }
+  TagValue::Str(SmolStr::new(crate::convert::decode_bits(
+    &n.to_string(),
+    Some(EXTERNAL_FLASH_FLAGS_BITS),
+    8,
+  )))
+}
+
+/// `%flashGNDistance` labels (`Nikon.pm:792-815`). Key `0` is the bare string
+/// `"0"` (NOT a metre value); `255` is `"n/a"`.
+fn flash_gn_distance_label(n: i64) -> Option<&'static str> {
+  Some(match n {
+    0 => "0",
+    1 => "0.1 m",
+    2 => "0.2 m",
+    3 => "0.3 m",
+    4 => "0.4 m",
+    5 => "0.5 m",
+    6 => "0.6 m",
+    7 => "0.7 m",
+    8 => "0.8 m",
+    9 => "0.9 m",
+    10 => "1.0 m",
+    11 => "1.1 m",
+    12 => "1.3 m",
+    13 => "1.4 m",
+    14 => "1.6 m",
+    15 => "1.8 m",
+    16 => "2.0 m",
+    17 => "2.2 m",
+    18 => "2.5 m",
+    19 => "2.8 m",
+    20 => "3.2 m",
+    21 => "3.6 m",
+    22 => "4.0 m",
+    23 => "4.5 m",
+    24 => "5.0 m",
+    25 => "5.6 m",
+    26 => "6.3 m",
+    27 => "7.1 m",
+    28 => "8.0 m",
+    29 => "9.0 m",
+    30 => "10.0 m",
+    31 => "11.0 m",
+    32 => "13.0 m",
+    33 => "14.0 m",
+    34 => "16.0 m",
+    35 => "18.0 m",
+    36 => "20.0 m",
+    255 => "n/a",
+    _ => return None,
+  })
+}
+
+/// `sprintf("%.0f", v)` for the `FlashOutput` percent — `{:.0}` rounds
+/// half-to-even like glibc `printf` (the `Manual`-arm of offset 10/17/18; never
+/// reached by the bundled DSLR fixtures, which take the `FlashCompensation`
+/// arm).
+fn flash_pct(v: f64) -> String {
+  std::format!("{v:.0}")
+}
+
 /// `%afPoints11` BITMASK labels (`Nikon.pm:2152`). Sorted by bit.
 const AF_POINTS11_BITS: &[(u8, &str)] = &[
   (0, "Center"),
@@ -1546,6 +1771,15 @@ const LENS_TYPE_BITS: &[(u8, &str)] = &[
   (7, "AF-P"),
 ];
 
+/// `ExternalFlashFlags` BITMASK labels (`Nikon.pm:10840-10843`). Sorted by bit
+/// for the `DecodeBits` walk; bits 1/3/6/7 are unlisted ⇒ render `[n]`.
+const EXTERNAL_FLASH_FLAGS_BITS: &[(u8, &str)] = &[
+  (0, "Fired"),
+  (2, "Bounce Flash"),
+  (4, "Wide Flash Adapter"),
+  (5, "Dome Diffuser"),
+];
+
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
@@ -1664,6 +1898,26 @@ mod tests {
       NikonConv::MakerNoteVersion.apply(&v, true, None, ByteOrder::Big),
       Some(TagValue::Str(SmolStr::new("1.00")))
     );
+  }
+
+  /// `FlashGNDistance` (`%flashGNDistance`) is a plain HASH PrintConv: key 0 →
+  /// the bare `"0"`, listed bytes render their metre label, 255 → `"n/a"`, and
+  /// an UNLISTED valid byte (37-254) renders ExifTool's HASH-miss fallback
+  /// `Unknown (N)` (`ExifTool.pm:3632` — no `BITMASK`/`OTHER`/`PrintHex`), NOT
+  /// the raw number. `-n` (print_conv false) emits the raw int8u.
+  #[test]
+  fn flash_gn_distance_hash_miss_is_unknown() {
+    let c = |n: u64, pc: bool| NikonConv::FlashGnDistance.apply(&u8v(n), pc, None, ByteOrder::Big);
+    let s = |t: &str| Some(TagValue::Str(SmolStr::new(t)));
+    assert_eq!(c(0, true), s("0")); // key 0 → bare "0"
+    assert_eq!(c(10, true), s("1.0 m"));
+    assert_eq!(c(36, true), s("20.0 m")); // last listed metre value
+    assert_eq!(c(255, true), s("n/a"));
+    // Unlisted valid byte ⇒ the standard hash-miss "Unknown (N)" (was: raw N).
+    assert_eq!(c(37, true), s("Unknown (37)"));
+    assert_eq!(c(200, true), s("Unknown (200)"));
+    // -n value mode emits the raw int.
+    assert_eq!(c(37, false), Some(TagValue::I64(37)));
   }
 
   /// `ShootingMode` (0x0089) — value 0 → "Single-Frame"; the DecodeBits path.

--- a/src/exif/makernotes/vendors/nikon/tags.rs
+++ b/src/exif/makernotes/vendors/nikon/tags.rs
@@ -29,15 +29,23 @@
 //!   ([`LENS_DATA_00`]/[`LENS_DATA_01`]/[`LENS_DATA_0204`]/[`LENS_DATA_0400`]/
 //!   [`LENS_DATA_0402`]/[`LENS_DATA_0403`]/[`LENS_DATA_0800_OLD`]).
 //!
+//! - `FlashInfo` (0x00a8, `%Nikon::FlashInfo0100`, `Nikon.pm:2987-3009`/
+//!   `10810`) — an UNENCRYPTED plaintext `ProcessBinaryData` table
+//!   version-dispatched on the 4-byte `FlashInfoVersion` prefix. The `010[01]`
+//!   arm is WALKED → FlashInfoVersion, FlashSource, ExternalFlashFirmware/Flags,
+//!   FlashCommanderMode, FlashControlMode, the Manual/comp conditional outputs,
+//!   FlashGNDistance, the FlashGroup{A,B} modes/outputs. The other versions
+//!   (`0102`/`010[345]`/`0106`/`010[78]`/`030[01]`/other) are a committed
+//!   follow-up (the dispatch adds them one arm at a time).
+//!
 //! ## Deferred (encrypted — need the remaining `ProcessNikonEncrypted` tables)
 //!
-//! `ShotInfo*` (0x0091), `FlashInfo*` (0x00a8), and the ENCRYPTED
-//! `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) are
-//! `ProcessNikonEncrypted` sub-tables keyed on the SerialNumber +
-//! ShutterCount XOR keystream (`Nikon.pm:13604` `Decrypt`). They carry a
-//! deferred [`SubTable`] marker so the parent is NOT emitted (the #177/#223
-//! bogus-parent rule), and their decrypted children stay unported here (a
-//! committed Phase 2 follow-up). The `%LensData0800` NEW Z-lens block (offsets
+//! `ShotInfo*` (0x0091) and the ENCRYPTED `ColorBalance` variants (0x0097
+//! `0205`/`0209`/`02xx`) are `ProcessNikonEncrypted` sub-tables keyed on the
+//! SerialNumber + ShutterCount XOR keystream (`Nikon.pm:13604` `Decrypt`). They
+//! carry a deferred [`SubTable`] marker so the parent is NOT emitted (the
+//! #177/#223 bogus-parent rule), and their decrypted children stay unported here
+//! (a committed Phase 2 follow-up). The `%LensData0800` NEW Z-lens block (offsets
 //! 0x2f onward — int16u `LensID`/`MaxAperture`/`FNumber` + the
 //! `FocusMode`-gated focus telemetry) likewise stays a follow-up; its
 //! `LensDataVersion` + legacy OldLensData fields ARE emitted.
@@ -144,7 +152,11 @@ pub enum SubTable {
   LensData,
   /// `ShotInfo*` (0x0091) — `ProcessNikonEncrypted`. DEFERRED.
   ShotInfo,
-  /// `FlashInfo*` (0x00a8) — `ProcessNikonEncrypted`. DEFERRED.
+  /// `FlashInfo*` (0x00a8) — an UNENCRYPTED plaintext `ProcessBinaryData` table
+  /// version-dispatched on the 4-byte `FlashInfoVersion` prefix
+  /// (`Nikon.pm:2987-3009`). The `010[01]` arm (`%Nikon::FlashInfo0100`) is
+  /// WALKED; the other versions (`0102`/`010[345]`/`0106`/`010[78]`/`030[01]`/
+  /// other) are not yet ported (a committed follow-up) and emit nothing.
   FlashInfo,
   /// The ENCRYPTED `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) —
   /// `ProcessNikonEncrypted`. DEFERRED. (The unencrypted `0100`/`0102`/`0103`
@@ -163,7 +175,10 @@ impl SubTable {
   #[must_use]
   #[inline(always)]
   pub const fn is_walked(self) -> bool {
-    matches!(self, SubTable::AfInfo | SubTable::ColorBalance0103)
+    matches!(
+      self,
+      SubTable::AfInfo | SubTable::ColorBalance0103 | SubTable::FlashInfo
+    )
   }
 }
 
@@ -689,11 +704,12 @@ mod tests {
     assert_eq!(lookup(0x00a7).unwrap().name(), "ShutterCount");
   }
 
-  /// The encrypted sub-tables carry a DEFERRED (`!is_walked`) marker so the
-  /// parent pointer is suppressed (#177/#223), while the two unencrypted ones
-  /// are walked.
+  /// The deferred sub-tables carry a DEFERRED (`!is_walked`) marker so the
+  /// parent pointer is suppressed (#177/#223), while the walked ones emit their
+  /// leaves. `LensData` (0x0098) defers the parent but DECRYPTS+emits children;
+  /// `FlashInfo` (0x00a8) is UNENCRYPTED and walked.
   #[test]
-  fn encrypted_subdirs_are_deferred() {
+  fn deferred_subdirs_marker() {
     assert_eq!(
       lookup(0x0091).unwrap().sub_table(),
       Some(SubTable::ShotInfo)
@@ -704,12 +720,12 @@ mod tests {
       Some(SubTable::LensData)
     );
     assert!(!SubTable::LensData.is_walked());
+    // Walked sub-tables — incl. the UNENCRYPTED FlashInfo0100 (0x00a8).
     assert_eq!(
       lookup(0x00a8).unwrap().sub_table(),
       Some(SubTable::FlashInfo)
     );
-    assert!(!SubTable::FlashInfo.is_walked());
-    // Walked sub-tables.
+    assert!(SubTable::FlashInfo.is_walked());
     assert_eq!(lookup(0x0088).unwrap().sub_table(), Some(SubTable::AfInfo));
     assert!(SubTable::AfInfo.is_walked());
     assert_eq!(

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -4325,13 +4325,13 @@ fn canon_223_second_pass_subdir_parents_suppressed() {
 }
 
 /// NikonD2Hs.jpg (type-3) — exercises the FlashType empty string, the
-/// `ColorSpace` hash, AFInfo (BigEndian DSLR path), the deferred ENCRYPTED
-/// ColorBalance (WB_RGGBLevels) which must NOT appear, AND — the headline of
-/// this PR — the ENCRYPTED `LensData0201` block: decrypted with serial key
-/// `3001006` + count `2`, then decoded against `%LensData01` to LensIDNumber
-/// 118 / LensFStops 7.33 / FocalLength 50.4 mm etc. A wrong serial/count key
-/// or a wrong cipher would decode garbage, not these exact oracle values, so
-/// this test is the decrypt's end-to-end proof.
+/// `ColorSpace` hash, AFInfo (BigEndian DSLR path), the UNENCRYPTED
+/// `FlashInfo0100` (0x00a8) block, the deferred ENCRYPTED ColorBalance
+/// (WB_RGGBLevels) which must NOT appear, AND the ENCRYPTED `LensData0201`
+/// block: decrypted with serial key `3001006` + count `2`, then decoded against
+/// `%LensData01` to LensIDNumber 118 / LensFStops 7.33 / FocalLength 50.4 mm
+/// etc. A wrong serial/count key or a wrong cipher would decode garbage, not
+/// these exact oracle values, so this test is the decrypt's end-to-end proof.
 #[cfg(feature = "json")]
 #[test]
 fn real_fixture_nikon_d2hs_makernotes() {
@@ -4359,6 +4359,22 @@ fn real_fixture_nikon_d2hs_makernotes() {
       ("Nikon:AFAreaMode", r#""Single Area""#),
       ("Nikon:AFPointsInFocus", r#""Center""#),
       ("Nikon:HighISONoiseReduction", r#""Normal""#),
+      // FlashInfo0100 (UNENCRYPTED plaintext ProcessBinaryData, 0x00a8). The
+      // all-Off SB-less shape: FlashCompensation/GNDistance/GroupA/BCompensation
+      // are the bare number 0 (the FlashControlMode-Off branch, NOT FlashOutput);
+      // FlashFocalLength/RepeatingFlashRate/Count drop (RawConv `$val?:undef`).
+      ("Nikon:FlashInfoVersion", r#""0100""#),
+      ("Nikon:FlashSource", r#""None""#),
+      ("Nikon:ExternalFlashFirmware", r#""n/a""#),
+      ("Nikon:ExternalFlashFlags", r#""(none)""#),
+      ("Nikon:FlashCommanderMode", r#""Off""#),
+      ("Nikon:FlashControlMode", r#""Off""#),
+      ("Nikon:FlashCompensation", "0"),
+      ("Nikon:FlashGNDistance", "0"),
+      ("Nikon:FlashGroupAControlMode", r#""Off""#),
+      ("Nikon:FlashGroupBControlMode", r#""Off""#),
+      ("Nikon:FlashGroupACompensation", "0"),
+      ("Nikon:FlashGroupBCompensation", "0"),
       // LensData0201 (ENCRYPTED → DECRYPTED with serial 3001006 / count 2,
       // then `%LensData01`). These prove the Decrypt + SerialKey are correct.
       ("Nikon:LensDataVersion", r#""0201""#),
@@ -4378,17 +4394,30 @@ fn real_fixture_nikon_d2hs_makernotes() {
     ],
   );
   // The D2Hs ColorBalance is the ENCRYPTED 0206 variant ⇒ WB_RGGBLevels is
-  // deferred (oracle-only), and no bogus ColorBalance / LensData parent is
-  // emitted.
+  // deferred (oracle-only), and no bogus ColorBalance / LensData / FlashInfo
+  // parent is emitted.
   assert!(!map.contains_key("Nikon:WB_RGGBLevels"));
   assert!(!map.contains_key("Nikon:ColorBalance"));
   assert!(!map.contains_key("Nikon:LensData"));
+  assert!(!map.contains_key("Nikon:FlashInfo"));
+  // The RawConv-undef FlashInfo0100 members (raw 0) drop (oracle has none).
+  for absent in [
+    "Nikon:FlashFocalLength",
+    "Nikon:RepeatingFlashRate",
+    "Nikon:RepeatingFlashCount",
+    "Nikon:FlashOutput",
+    "Nikon:FlashGroupAOutput",
+    "Nikon:FlashGroupBOutput",
+  ] {
+    assert!(!map.contains_key(absent), "{absent} must be absent");
+  }
 }
 
 /// NikonD70.jpg (type-3) — exercises the `FlashExposureComp` PrintFraction
 /// (`-5/3`) and `ExposureDifference` (`%+.1f` → `-4.9`), the title-cased
-/// `FlashType` ("Built-in,TTL"), the unencrypted WB_RGBGLevels, AND the
-/// UNENCRYPTED `LensData0101` children. The D70 SerialNumber is the STRING
+/// `FlashType` ("Built-in,TTL"), the unencrypted WB_RGBGLevels, the UNENCRYPTED
+/// `FlashInfo0100` (0x00a8) block, AND the UNENCRYPTED `LensData0101` children.
+/// The D70 SerialNumber is the STRING
 /// `"No= 20025585"` (→ `SerialKey` 0x60), but LensData0101 is unencrypted so
 /// the key is unused here — the FocalLength 56.6 mm / SerialNumber-string path
 /// still decodes correctly.
@@ -4413,6 +4442,19 @@ fn real_fixture_nikon_d70_makernotes() {
       ("Nikon:WB_RGBGLevels", r#""597 256 361 256""#),
       ("Nikon:SerialNumber", r#""No= 20025585""#),
       ("Nikon:Saturation", r#""Enhanced""#),
+      // FlashInfo0100 (UNENCRYPTED, 0x00a8) — the same all-Off shape as D2Hs.
+      ("Nikon:FlashInfoVersion", r#""0100""#),
+      ("Nikon:FlashSource", r#""None""#),
+      ("Nikon:ExternalFlashFirmware", r#""n/a""#),
+      ("Nikon:ExternalFlashFlags", r#""(none)""#),
+      ("Nikon:FlashCommanderMode", r#""Off""#),
+      ("Nikon:FlashControlMode", r#""Off""#),
+      ("Nikon:FlashCompensation", "0"),
+      ("Nikon:FlashGNDistance", "0"),
+      ("Nikon:FlashGroupAControlMode", r#""Off""#),
+      ("Nikon:FlashGroupBControlMode", r#""Off""#),
+      ("Nikon:FlashGroupACompensation", "0"),
+      ("Nikon:FlashGroupBCompensation", "0"),
       // LensData0101 (UNENCRYPTED, walked): the D70's FocalLength is 56.6 mm.
       ("Nikon:LensDataVersion", r#""0101""#),
       ("Nikon:ExitPupilPosition", r#""89.0 mm""#),
@@ -4431,4 +4473,15 @@ fn real_fixture_nikon_d70_makernotes() {
     ],
   );
   assert!(!map.contains_key("Nikon:LensData"));
+  assert!(!map.contains_key("Nikon:FlashInfo"));
+  for absent in [
+    "Nikon:FlashFocalLength",
+    "Nikon:RepeatingFlashRate",
+    "Nikon:RepeatingFlashCount",
+    "Nikon:FlashOutput",
+    "Nikon:FlashGroupAOutput",
+    "Nikon:FlashGroupBOutput",
+  ] {
+    assert!(!map.contains_key(absent), "{absent} must be absent");
+  }
 }


### PR DESCRIPTION
## Scope

Phase 2a of #227 — faithful port of the Nikon **FlashInfo (0x00a8)** MakerNote sub-table, version `0100`.

- **Dispatch** (`mod.rs`): the 0x00a8 conditional SubDirectory keyed on the 4-byte `FlashInfoVersion` prefix. FlashInfo is **unencrypted** plaintext `ProcessBinaryData` (no `DecryptStart` on any arm). This PR decodes `0100`/`0101`; the later version tables (`0102`/`0103`/`0106`/`0107`/`0300`) are the explicit next increment (fixture-less).
- **`emit_flash_info`** (`mod.rs`, bespoke, mirroring `emit_color_balance`): decodes the `%Nikon::FlashInfo0100` table — `FlashSource`, `ExternalFlashFirmware` (the `%flashFirmware` hash + the `(Unknown model)` OTHER fallback), `ExternalFlashFlags` (BITMASK via the shared `DecodeBits`), the byte-9 dual-`Mask` `FlashCommanderMode`/`FlashControlMode`, the `FlashControlMode`-gated `FlashOutput`/`FlashCompensation`, `FlashFocalLength`/`RepeatingFlashRate`/`RepeatingFlashCount` (RawConv-undef drops), `FlashGNDistance`, and the `FlashGroupA/B` control-mode-gated output/compensation pairs.
- **`printconv.rs`**: 9 new `NikonConv` variants reusing the existing `decode_bits` / `print_fraction` / `hash_conv` helpers. `FlashGNDistance` uses the standard ExifTool HASH-PrintConv miss fallback `Unknown (N)` (`ExifTool.pm:3632`).

## Verify

`fmt=0` · `build=0` (`-Dwarnings`, `--all-features --all-targets`) · `clippy=0` (lib; in-source `deny(indexing_slicing)` floor holds) · `test=0` (full suite, **107 Nikon tests**) · **conformance 416/0 byte-identical**.

**Byte-exact** against the live `perl exiftool -G1 -j` oracle: the `real_fixture_nikon_d2hs` / `real_fixture_nikon_d70` tests assert all 12 emitted FlashInfo0100 tags (FlashInfoVersion, FlashSource, ExternalFlashFirmware, ExternalFlashFlags, FlashCommanderMode, FlashControlMode, FlashCompensation, FlashGNDistance, FlashGroupA/BControlMode, FlashGroupA/BCompensation) match exactly, and that the RawConv-dropped / conditional-branched-off tags are absent.

Codex adversarial review: **APPROVE** (R2, no material findings) — R1 caught the FlashGNDistance hash-miss fallback (raw N → `Unknown (N)`), fixed + ground-truthed against `ExifTool.pm:3614-3634`.

## Follow-up (tracked, next increments — not deferred work)

FlashInfo versions `0102`/`0103`/`0106`/`0107`/`0300` (fixture-less) and #227 Phase 2b (ShotInfo base table + the encrypted-02xx path) are the next PRs in this chain. The ~30 model-specific ShotInfo tables (D40…Z9) are a genuinely-separate large subsystem (Phase 3).
