### PR TITLE
feat(exif): unify maker-note processing on the shared Walker — Phase 0+1 (#243)

### DIFF
--- a/src/exif/makernotes/fixbase.rs
+++ b/src/exif/makernotes/fixbase.rs
@@ -1,0 +1,1393 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Shared maker-note offset / byte-order engine — the faithful port of the
+//! cross-vendor helpers in `Image::ExifTool::MakerNotes` (Phil Harvey) plus
+//! the one `Exif.pm` byte-order heuristic the maker-note path depends on.
+//!
+//! ## What this module owns
+//!
+//! Every camera vendor's private IFD lives inside the ExifIFD's 0x927C
+//! `MakerNote` tag, but the LAYOUT of that IFD's value blocks is vendor- and
+//! even model-specific: some put values 4 bytes past the IFD, some leave 24
+//! padding bytes, some write value offsets relative to the IFD entry (not the
+//! TIFF base), and some (Canon) append an 8-byte TIFF footer recording the
+//! ORIGINAL file offset so a tool that bodily relocated the maker-note block
+//! can recover the shift. ExifTool unifies all of this in a handful of shared
+//! subs:
+//!
+//! - [`detect_unknown_byte_order`] — `ByteOrder => 'Unknown'` resolution from
+//!   the IFD entry count (`Exif.pm:6982-6993`).
+//! - [`get_maker_note_offset`] — the per-`Make` table of expected
+//!   end-of-IFD-to-first-value offsets (`MakerNotes.pm:1149-1231`).
+//! - [`get_value_blocks`] — walk the IFD entries and record every out-of-line
+//!   value pointer → block size (`MakerNotes.pm:1241-1275`).
+//! - [`fix_base`] — analyse the value-offset gaps and compute the base shift
+//!   needed to make the offsets resolve (`MakerNotes.pm:1282-1484`).
+//! - [`locate_ifd`] — scan unknown maker-note data for a plausible IFD start +
+//!   byte order (`MakerNotes.pm:1486-1663` / `ProcessUnknown` `:1816-1837`).
+//!
+//! ## Phase scope (additive, NOT wired)
+//!
+//! These functions are PURE ports surfaced for the Phase-2+ MakerNote walker;
+//! NOTHING in the production `ProcessExif` path calls them yet (the Phase-1
+//! walker only IDENTIFIES the vendor — it does not recurse + re-base). Wiring
+//! is a later task. Conformance therefore stays byte-identical. Each function
+//! takes its inputs as plain values / a small input struct mirroring the
+//! relevant `$$dirInfo{…}` and `$$et{…}` fields, so it has NO dependency on
+//! the Walker.
+//!
+//! ## Faithfulness notes
+//!
+//! - ExifTool's `$$dirInfo{Base}` / `$$dirInfo{DataPos}` mutations are RETURNED
+//!   here (the caller applies them), since these functions own no `$dirInfo`.
+//!   The returned `shift` is exactly the Perl sub's scalar return; the result
+//!   struct additionally surfaces the `EntryBased` / `Relative` / `FixedBy`
+//!   side effects the Perl set on `$dirInfo`.
+//! - ExifTool's `$et->Warn(...)` calls are NOT side-effecting here (no et
+//!   object); the ones that change CONTROL FLOW (the early `return 0`s) are
+//!   ported faithfully, and the purely-informational warnings are documented
+//!   at their Perl line.
+
+#![deny(clippy::indexing_slicing)]
+
+use std::collections::BTreeMap;
+
+use crate::exif::ifd::{ByteOrder, Format, get_u16, get_u32};
+
+// ===========================================================================
+// Small string predicates — faithful Perl-regex equivalents (no regex dep).
+//
+// The maker-note path's Make/Model tests are anchored prefixes (`/^Canon/`),
+// case-insensitive prefixes (`/^…/i`), plain substrings (`/(PowerShot|…)/`),
+// and `\b`-word-boundary alternations (`/\b(20D|…)\b/`). This crate ports
+// every such test by hand (no `regex` dependency — see the vendor dispatcher
+// + `canon::file_info`), so these helpers reproduce the exact semantics.
+// ===========================================================================
+
+/// A byte is a Perl `\w` "word" char (`[A-Za-z0-9_]`).
+#[inline(always)]
+const fn is_word_byte(c: u8) -> bool {
+  c.is_ascii_alphanumeric() || c == b'_'
+}
+
+/// `$model =~ /\bNEEDLE\b/` — does `needle` occur in `hay` flanked by word
+/// boundaries on BOTH sides? A `\b` exists between a word char and a non-word
+/// char (or a string edge). Every `needle` here begins/ends with a word char,
+/// so the boundary holds iff the char immediately before/after the match is
+/// NOT a word char (or is a string edge).
+fn word_match(hay: &str, needle: &str) -> bool {
+  let nbytes = needle.as_bytes();
+  let (Some(&nf), Some(&nl)) = (nbytes.first(), nbytes.last()) else {
+    return false; // empty needle never matches under `\b…\b`
+  };
+  let need_lead_boundary = is_word_byte(nf);
+  let need_trail_boundary = is_word_byte(nl);
+  let hb = hay.as_bytes();
+  let mut start = 0usize;
+  while let Some(rel) = hay.get(start..).and_then(|tail| tail.find(needle)) {
+    let i = start + rel;
+    let end = i + needle.len();
+    // `\b` before the match.
+    let before_ok = if need_lead_boundary {
+      i == 0 || hb.get(i.wrapping_sub(1)).is_some_and(|&c| !is_word_byte(c))
+    } else {
+      i != 0 && hb.get(i.wrapping_sub(1)).is_some_and(|&c| is_word_byte(c))
+    };
+    // `\b` after the match.
+    let after_ok = if need_trail_boundary {
+      end >= hb.len() || hb.get(end).is_some_and(|&c| !is_word_byte(c))
+    } else {
+      end < hb.len() && hb.get(end).is_some_and(|&c| is_word_byte(c))
+    };
+    if before_ok && after_ok {
+      return true;
+    }
+    start = i + 1;
+  }
+  false
+}
+
+/// `$model =~ /^NEEDLE\b/` — `hay` STARTS with `needle` AND a `\b` follows the
+/// match. `needle` ends in a word char here, so the trailing boundary holds
+/// iff the next char (if any) is NOT a word char.
+fn starts_with_word(hay: &str, needle: &str) -> bool {
+  let Some(rest) = hay.strip_prefix(needle) else {
+    return false;
+  };
+  match rest.as_bytes().first() {
+    None => true, // string edge is a boundary
+    Some(&c) => !is_word_byte(c),
+  }
+}
+
+// ===========================================================================
+// Feature 1 — Unknown byte-order entry-count heuristic (Exif.pm:6982-6993)
+// ===========================================================================
+
+/// `ByteOrder => 'Unknown'` resolution for a headerless sub-directory body
+/// (`Exif.pm:6982-6993`): read the int16u entry-count at `dir_start` in the
+/// PARENT order; if `(num & 0xff00) != 0 && (num>>8) > (num & 0xff)` the count
+/// is implausibly large ⇒ the order is wrong ⇒ TOGGLE; else keep parent order.
+///
+/// Returns `None` if fewer than 2 bytes are available at `dir_start` — the
+/// Perl guard `$subdirStart + 2 <= $subdirDataLen` (`:6982`) leaves
+/// `$newByteOrder` unresolved, and the caller keeps the parent (`oldByteOrder`)
+/// order (`:6996`). Surfacing `None` lets the caller reproduce that.
+///
+/// Faithful: `my $num = Get16u($subdirDataPt, $subdirStart)` is read in the
+/// PARENT order (`SetByteOrder` has not been called for the child yet at
+/// `:6986`); the toggle test is EXACTLY `($num & 0xff00) and (($num>>8) >
+/// ($num & 0xff))` (`:6987`), and the toggle uses `%otherOrder` (`:6989`).
+#[must_use]
+pub fn detect_unknown_byte_order(
+  data: &[u8],
+  dir_start: usize,
+  parent: ByteOrder,
+) -> Option<ByteOrder> {
+  // `$subdirStart + 2 <= $subdirDataLen` (`:6982`).
+  let num = get_u16(data, dir_start, parent)?;
+  // `if ($num & 0xff00 and ($num>>8) > ($num&0xff))` (`:6987`).
+  if (num & 0xff00) != 0 && (num >> 8) > (num & 0xff) {
+    // "This looks wrong, we shouldn't have this many entries" → toggle (`:6990`).
+    Some(opposite_order(parent))
+  } else {
+    Some(parent) // "$newByteOrder = $oldByteOrder" (`:6992`).
+  }
+}
+
+/// `%otherOrder = ( II=>'MM', MM=>'II' )` (`Exif.pm:6989`, `MakerNotes.pm`
+/// `ToggleByteOrder`).
+#[inline(always)]
+const fn opposite_order(order: ByteOrder) -> ByteOrder {
+  match order {
+    ByteOrder::Little => ByteOrder::Big,
+    ByteOrder::Big => ByteOrder::Little,
+  }
+}
+
+// ===========================================================================
+// Feature 2 — GetMakerNoteOffset (MakerNotes.pm:1149-1231)
+// ===========================================================================
+
+/// Resolved expected-offset table for one camera (the return of
+/// `GetMakerNoteOffset`, `MakerNotes.pm:1145-1148`).
+///
+/// - `relative`: the `$relative` flag (element 0) — `None` for "no change"
+///   (Perl `undef`), `Some(false)` only where a make FORCES absolute
+///   addressing (PENTAX, `:1220`).
+/// - `offsets`: the expected offsets from the end of the IFD to the first
+///   value block (elements 1..N). The FIRST is the one used when writing;
+///   offsets of 0 and 4 are always allowed even when not listed (`:1158-1159`).
+///
+/// D8: no public fields; accessors only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MakerNoteOffset {
+  relative: Option<bool>,
+  offsets: Vec<i32>,
+}
+
+impl MakerNoteOffset {
+  /// The `$relative` flag (`None` = no change / `undef`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn relative(&self) -> Option<bool> {
+    self.relative
+  }
+
+  /// The expected end-of-IFD-to-first-value offsets (first is canonical).
+  #[must_use]
+  #[inline(always)]
+  pub fn offsets(&self) -> &[i32] {
+    &self.offsets
+  }
+
+  /// The canonical (first) offset — `$offsets[0]`, the bundled `$makeDiff`
+  /// (`MakerNotes.pm:1348`). `None` for the "no expected offset" makes (the
+  /// weird Olympus list, `:1191-1194`), where Perl leaves `@offsets` empty and
+  /// `$makeDiff` is `undef`.
+  #[must_use]
+  #[inline]
+  pub fn make_diff(&self) -> Option<i32> {
+    self.offsets.first().copied()
+  }
+}
+
+/// `GetMakerNoteOffset($et)` — the per-`Make`/`Model` table of expected
+/// offsets from the end of the maker-note IFD to its first value block
+/// (`MakerNotes.pm:1149-1231`).
+///
+/// Inputs mirror the `$$et{…}` fields the Perl reads:
+/// - `make` = `$$et{Make}`, `model` = `$$et{Model}`.
+/// - `file_type` = `$$et{FILE_TYPE}` (drives CASIO + Leica-S2 padding) —
+///   `None` if unknown.
+/// - `tiff_type` = `$$et{TIFF_TYPE}` (drives the SAMSUNG EK-GN120 SRW patch) —
+///   `None` if unknown.
+///
+/// NOTE (`$$et{OlympusCAMER}`, `:1201`): the SONY branch also pushes 4 when
+/// the obscure internal `OlympusCAMER` flag is set (a Sony body wrapped in an
+/// Olympus container). That flag is not part of this engine's input surface,
+/// so this port omits it — a faithful omission for the standalone helper; the
+/// model regex covers every documented Sony-4 body.
+#[must_use]
+pub fn get_maker_note_offset(
+  make: &str,
+  model: &str,
+  file_type: Option<&str>,
+  tiff_type: Option<&str>,
+) -> MakerNoteOffset {
+  let mut relative: Option<bool> = None;
+  let mut offsets: Vec<i32> = Vec::new();
+
+  // Normally value data starts 4 bytes after the end of the directory, so 4 is
+  // the default; offsets 0 and 4 are always allowed even if not specified, but
+  // the FIRST offset specified is the one used when writing (`:1157-1159`).
+  if make.starts_with("Canon") {
+    // `($model =~ /\b(20D|350D|REBEL XT|Kiss Digital N)\b/) ? 6 : 4` (`:1161`).
+    let six = ["20D", "350D", "REBEL XT", "Kiss Digital N"]
+      .iter()
+      .any(|n| word_match(model, n));
+    offsets.push(if six { 6 } else { 4 });
+    // `push @offsets, 28 if $model =~ /\b(FV\b|OPTURA)/` (`:1164`). The outer
+    // `\b` requires a leading boundary; the alternation is `FV\b` (FV + trailing
+    // boundary) OR `OPTURA` (plain, no trailing boundary).
+    if word_match(model, "FV") || word_match_lead_only(model, "OPTURA") {
+      offsets.push(28);
+    }
+    // `push @offsets, 16 if $model =~ /(PowerShot|IXUS|IXY)/` (`:1166`) — plain
+    // substring, NO word boundary.
+    if model.contains("PowerShot") || model.contains("IXUS") || model.contains("IXY") {
+      offsets.push(16);
+    }
+  } else if make.starts_with("CASIO") {
+    // `$$et{FILE_TYPE} =~ /^(RIFF|MOV)$/ ? 0 : (4, 16, 2)` (`:1171`).
+    if matches!(file_type, Some("RIFF" | "MOV")) {
+      offsets.push(0);
+    } else {
+      offsets.extend_from_slice(&[4, 16, 2]);
+    }
+  } else if starts_with_ci(make, "General Imaging Co.")
+    || starts_with_ci(make, "GEDSC IMAGING CORP.")
+  {
+    // `/^(General Imaging Co.|GEDSC IMAGING CORP.)/i` (`:1172`).
+    offsets.push(0);
+  } else if make.starts_with("KYOCERA") {
+    offsets.push(12); // (`:1175`).
+  } else if make.starts_with("Leica Camera AG") {
+    // (`:1176-1188`).
+    if model == "S2" {
+      // `4, ($$et{FILE_TYPE} eq 'JPEG' ? 286 : 274)` (`:1179`).
+      offsets.push(4);
+      offsets.push(if file_type == Some("JPEG") { 286 } else { 274 });
+    } else if model == "LEICA M MONOCHROM (Typ 246)" {
+      offsets.extend_from_slice(&[4, 130]); // (`:1181`).
+    } else if model == "LEICA M (Typ 240)" {
+      offsets.extend_from_slice(&[4, 118]); // (`:1183`).
+    } else if starts_with_word(model, "R8")
+      || starts_with_word(model, "R9")
+      || starts_with_word(model, "M8")
+    {
+      offsets.push(6); // `/^(R8|R9|M8)\b/` (`:1184`).
+    } else {
+      offsets.push(4); // (`:1187`).
+    }
+  } else if make.starts_with("OLYMPUS")
+    && (starts_with_word(model, "E-1")
+      || starts_with_word(model, "E-300")
+      || starts_with_word(model, "E-330"))
+  {
+    // `/^OLYMPUS/ and $model =~ /^E-(1|300|330)\b/` (`:1189`).
+    offsets.push(16);
+  } else if make.starts_with("OLYMPUS") && is_weird_olympus(model) {
+    // `/^OLYMPUS/ and $model =~ /^(C2500L|…)\b/` (`:1191-1194`): NO expected
+    // offset → `@offsets` left empty → offset determined empirically by
+    // `FixBase`. `$makeDiff` (`make_diff()`) is therefore `None`.
+  } else if starts_with_word(make, "Panasonic") || starts_with_word(make, "JVC") {
+    // `/^(Panasonic|JVC)\b/` (`:1196`).
+    offsets.push(0);
+  } else if make.starts_with("SONY") {
+    // `/^SONY/` (`:1198`). `$model =~ /^(DSLR-.*|SLT-A(33|35|55V)|NEX-(3|5|C3|
+    // VG10E))$/` ? 4 : 0 (`:1200-1206`). (`$$et{OlympusCAMER}` omitted — see
+    // the function doc.)
+    offsets.push(if sony_uses_offset_4(model) { 4 } else { 0 });
+  } else if tiff_type == Some("SRW") && make == "SAMSUNG" && model == "EK-GN120" {
+    offsets.push(40); // (`:1207`).
+  } else if make == "FUJIFILM" {
+    offsets.extend_from_slice(&[4, 6]); // (`:1209-1211`).
+  } else if make.starts_with("TOSHIBA") {
+    offsets.extend_from_slice(&[0, 24]); // (`:1212-1214`).
+  } else if make.starts_with("PENTAX") {
+    // (`:1215-1220`). Pentax always uses absolute addressing, so force it.
+    offsets.push(4);
+    relative = Some(false);
+  } else if starts_with_ci(make, "Konica Minolta") {
+    // `/^Konica Minolta/i` (`:1221-1223`). Patch for DiMAGE X50/Xg/Z2/Z10.
+    offsets.extend_from_slice(&[4, -16]);
+  } else if make.starts_with("Minolta") {
+    // (`:1224-1226`). Patch for DiMAGE 7/X20/Z1.
+    offsets.extend_from_slice(&[4, -8, -12]);
+  } else {
+    offsets.push(4); // the normal offset (`:1228`).
+  }
+
+  MakerNoteOffset { relative, offsets }
+}
+
+/// `$$self{Make} =~ /^prefix/i` — case-insensitive ASCII prefix (compared on
+/// BYTES so a lossy-decoded `Make` never panics on a char boundary; the
+/// bundled prefixes are pure ASCII).
+fn starts_with_ci(s: &str, prefix: &str) -> bool {
+  let sb = s.as_bytes();
+  let pb = prefix.as_bytes();
+  sb.get(..pb.len())
+    .is_some_and(|h| h.eq_ignore_ascii_case(pb))
+}
+
+/// `/\bNEEDLE/` with a LEADING boundary only (no trailing `\b`) — used for the
+/// `OPTURA` arm of `/\b(FV\b|OPTURA)/` (`MakerNotes.pm:1164`).
+fn word_match_lead_only(hay: &str, needle: &str) -> bool {
+  let nbytes = needle.as_bytes();
+  let Some(&nf) = nbytes.first() else {
+    return false;
+  };
+  let need_lead_boundary = is_word_byte(nf);
+  let hb = hay.as_bytes();
+  let mut start = 0usize;
+  while let Some(rel) = hay.get(start..).and_then(|tail| tail.find(needle)) {
+    let i = start + rel;
+    let before_ok = if need_lead_boundary {
+      i == 0 || hb.get(i.wrapping_sub(1)).is_some_and(|&c| !is_word_byte(c))
+    } else {
+      i != 0 && hb.get(i.wrapping_sub(1)).is_some_and(|&c| is_word_byte(c))
+    };
+    if before_ok {
+      return true;
+    }
+    start = i + 1;
+  }
+  false
+}
+
+/// The "just weird" Olympus models that get NO expected offset
+/// (`MakerNotes.pm:1193`): `/^(C2500L|C-1Z?|C-5000Z|X-2|C720UZ|C725UZ|C150|
+/// C2Z|E-10|E-20|FerrariMODEL2003|u20D|u10D)\b/`. `C-1Z?` = `C-1` optionally
+/// followed by `Z` (so both `C-1` and `C-1Z` match), each anchored at start
+/// with a trailing word boundary.
+fn is_weird_olympus(model: &str) -> bool {
+  const PLAIN: [&str; 11] = [
+    "C2500L",
+    "C-5000Z",
+    "X-2",
+    "C720UZ",
+    "C725UZ",
+    "C150",
+    "C2Z",
+    "E-10",
+    "E-20",
+    "FerrariMODEL2003",
+    "u20D",
+  ];
+  if PLAIN.iter().any(|n| starts_with_word(model, n)) {
+    return true;
+  }
+  // `u10D` (the 12th literal alternative).
+  if starts_with_word(model, "u10D") {
+    return true;
+  }
+  // `C-1Z?` — `C-1Z` first (longer), else bare `C-1` (`\b` after).
+  starts_with_word(model, "C-1Z") || starts_with_word(model, "C-1")
+}
+
+/// `$model =~ /^(DSLR-.*|SLT-A(33|35|55V)|NEX-(3|5|C3|VG10E))$/`
+/// (`MakerNotes.pm:1200`) — the Sony models that use an offset of 4. The `$`
+/// anchors the whole string (the `DSLR-.*` arm allows any suffix).
+fn sony_uses_offset_4(model: &str) -> bool {
+  // `DSLR-.*` — starts with `DSLR-` (then anything to end-of-string).
+  if model.starts_with("DSLR-") {
+    return true;
+  }
+  // `SLT-A(33|35|55V)$` — whole-string match.
+  if model == "SLT-A33" || model == "SLT-A35" || model == "SLT-A55V" {
+    return true;
+  }
+  // `NEX-(3|5|C3|VG10E)$` — whole-string match.
+  matches!(model, "NEX-3" | "NEX-5" | "NEX-C3" | "NEX-VG10E")
+}
+
+// ===========================================================================
+// Feature 3 — GetValueBlocks (MakerNotes.pm:1241-1275)
+// ===========================================================================
+
+/// The value-block maps from `GetValueBlocks` (`MakerNotes.pm:1237-1240`).
+///
+/// - `val_block`: offset → block size for every out-of-line value (keys are the
+///   raw value pointers; the FixBase gap analysis sorts these).
+/// - `val_blk_adj`: the same, but each key adjusted by `12 * index` to detect
+///   ENTRY-BASED offsets; carries the running `MIN`/`MAX` of the adjusted span.
+///
+/// D8: no public fields; accessors only.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ValueBlocks {
+  val_block: BTreeMap<usize, usize>,
+  val_blk_adj: BTreeMap<usize, usize>,
+  /// `$valBlkAdj{MIN}` — Perl stores it in the same hash under a string key;
+  /// the port lifts it to its own field. `None` until the first out-of-line
+  /// entry is seen.
+  min_adj: Option<usize>,
+  /// `$valBlkAdj{MAX}`.
+  max_adj: Option<usize>,
+}
+
+impl ValueBlocks {
+  /// `\%valBlock` — offset → longest block size at that offset.
+  #[must_use]
+  #[inline(always)]
+  pub const fn val_block(&self) -> &BTreeMap<usize, usize> {
+    &self.val_block
+  }
+
+  /// `\%valBlkAdj` — entry-position-adjusted offset → block size.
+  #[must_use]
+  #[inline(always)]
+  pub const fn val_blk_adj(&self) -> &BTreeMap<usize, usize> {
+    &self.val_blk_adj
+  }
+
+  /// `$valBlkAdj{MIN}` (`MakerNotes.pm:1264-1269`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn min_adj(&self) -> Option<usize> {
+    self.min_adj
+  }
+
+  /// `$valBlkAdj{MAX}` (`MakerNotes.pm:1264-1269`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn max_adj(&self) -> Option<usize> {
+    self.max_adj
+  }
+
+  /// `%$valBlock` truthiness — `false` when no out-of-line values were found
+  /// (the `return 0 unless %$valBlock` guard, `MakerNotes.pm:1300`).
+  #[must_use]
+  #[inline(always)]
+  pub fn is_empty(&self) -> bool {
+    self.val_block.is_empty()
+  }
+}
+
+/// `GetValueBlocks($dataPt, $dirStart, $tagPtr)` (`MakerNotes.pm:1241-1275`):
+/// walk the IFD entries at `dir_start` (entry stride `2 + 12*index`) and record
+/// every value whose decoded size exceeds 4 bytes (i.e. is stored OUT-OF-LINE)
+/// as `value-pointer → size`.
+///
+/// Returns the [`ValueBlocks`] maps and the `tagPtr` map (tag-id → value
+/// pointer) that the Perl populates via its third `$tagPtr` out-param — FixBase
+/// uses `$tagPtr{0xe00}` (PrintIM) and `0xe00` lookups, so it is surfaced here.
+///
+/// Faithful: `$numEntries = Get16u($dataPt, $dirStart)` (`:1244`); per entry
+/// `$format = Get16u($dataPt, $entry+2)`, `last if $format < 1 or $format > 13`
+/// (`:1248-1249` — note the `1..=13` gate is NARROWER than the IFD walker's
+/// `1..=18|129`: BigTIFF/Exif-3.0 codes terminate the scan here); `$count =
+/// Get32u($dataPt, $entry+4)`; `$size = $count * formatSize[$format]` (`:1251`);
+/// `next if $size <= 4` (`:1252`); `$valPtr = Get32u($dataPt, $entry+8)`
+/// (`:1253`). The `unless defined … and … > $size` keeps the LONGEST block at
+/// a shared offset (`:1256-1258`).
+#[must_use]
+pub fn get_value_blocks(
+  data: &[u8],
+  dir_start: usize,
+  order: ByteOrder,
+) -> (ValueBlocks, BTreeMap<u16, u32>) {
+  let mut out = ValueBlocks::default();
+  let mut tag_ptr: BTreeMap<u16, u32> = BTreeMap::new();
+  // `my $numEntries = Get16u($dataPt, $dirStart)` (`:1244`). A truncated count
+  // read yields 0 (no entries) — the Perl `unpack` would warn + read 0.
+  let num_entries = get_u16(data, dir_start, order).unwrap_or(0);
+
+  for index in 0..usize::from(num_entries) {
+    // `my $entry = $dirStart + 2 + 12 * $index` (`:1247`). On arithmetic
+    // overflow (a degenerate `dir_start`/`index` on a 32-bit/wasm `usize`),
+    // STOP the walk — there is no in-bounds entry past the overflow point.
+    let Some(entry) = 12usize
+      .checked_mul(index)
+      .and_then(|off| off.checked_add(2))
+      .and_then(|off| dir_start.checked_add(off))
+    else {
+      break;
+    };
+    // `my $format = Get16u($dataPt, $entry+2)` (`:1248`).
+    let Some(format_code) = entry.checked_add(2).and_then(|p| get_u16(data, p, order)) else {
+      break;
+    };
+    // `last if $format < 1 or $format > 13` (`:1249`) — the GetValueBlocks gate
+    // is the 13 standard TIFF types ONLY (no BigTIFF/Exif-3.0, unlike the IFD
+    // walker's `1..=13 | 129`).
+    if !matches!(format_code, 1..=13) {
+      break;
+    }
+    // `my $count = Get32u($dataPt, $entry+4)` (`:1250`).
+    let Some(count) = entry.checked_add(4).and_then(|p| get_u32(data, p, order)) else {
+      break;
+    };
+    // `my $size = $count * formatSize[$format]` (`:1251`). `formatSize[1..=13]`
+    // == `Format::byte_size`; the gate above guarantees code ∈ 1..=13.
+    let size = u64::from(count).saturating_mul(Format::from_code(format_code).byte_size() as u64);
+    // `next if $size <= 4` (`:1252`).
+    if size <= 4 {
+      continue;
+    }
+    let size = usize_from_u64(size);
+    // `$valPtr = Get32u($dataPt, $entry+8)` (`:1253`).
+    let Some(val_ptr_u32) = entry.checked_add(8).and_then(|p| get_u32(data, p, order)) else {
+      break;
+    };
+    let val_ptr = val_ptr_u32 as usize;
+    // `$tagPtr and $$tagPtr{Get16u($dataPt, $entry)} = $valPtr` (`:1254`).
+    if let Some(tag_id) = get_u16(data, entry, order) {
+      tag_ptr.insert(tag_id, val_ptr_u32);
+    }
+    // "save location and size of longest block at this offset" (`:1256-1258`):
+    // `unless (defined $valBlock{$valPtr} and $valBlock{$valPtr} > $size)` —
+    // keep when the slot is empty OR the existing block is not longer.
+    let keep = out
+      .val_block
+      .get(&val_ptr)
+      .is_none_or(|&existing| existing <= size);
+    if keep {
+      out.val_block.insert(val_ptr, size);
+    }
+    // "adjust for case of value-based offsets": `$valPtr += 12 * $index`
+    // (`:1260`).
+    let adj_ptr = val_ptr.wrapping_add(12usize.wrapping_mul(index));
+    // `unless (defined $valBlkAdj{$valPtr} and $valBlkAdj{$valPtr} > $size)`
+    // (`:1261`).
+    let keep_adj = out
+      .val_blk_adj
+      .get(&adj_ptr)
+      .is_none_or(|&existing| existing <= size);
+    if keep_adj {
+      out.val_blk_adj.insert(adj_ptr, size);
+      // `my $end = $valPtr + $size` (`:1263`).
+      let end = adj_ptr.wrapping_add(size);
+      match out.min_adj {
+        Some(min) => {
+          // "save minimum only if it has a value of 12 or greater" (`:1265-
+          // 1267`): `$valBlkAdj{MIN} = $valPtr if $valBlkAdj{MIN} < 12 or
+          // $valBlkAdj{MIN} > $valPtr;`
+          if min < 12 || min > adj_ptr {
+            out.min_adj = Some(adj_ptr);
+          }
+          // `$valBlkAdj{MAX} = $end if $valBlkAdj{MAX} > $end;` (`:1267`).
+          // `max_adj` is `Some` here (set with `min_adj` in the `None` arm).
+          if out.max_adj.is_some_and(|max| max > end) {
+            out.max_adj = Some(end);
+          }
+        }
+        None => {
+          // `$valBlkAdj{MIN} = $valPtr; $valBlkAdj{MAX} = $end;` (`:1269-1270`).
+          out.min_adj = Some(adj_ptr);
+          out.max_adj = Some(end);
+        }
+      }
+    }
+  }
+  (out, tag_ptr)
+}
+
+/// `usize::try_from(u64)` saturating at `usize::MAX` — a value-block size that
+/// overflows a 32-bit/wasm `usize` cannot be a real in-bounds offset; clamp so
+/// no arithmetic below panics. On 64-bit hosts this never clamps.
+#[inline(always)]
+fn usize_from_u64(v: u64) -> usize {
+  usize::try_from(v).unwrap_or(usize::MAX)
+}
+
+// ===========================================================================
+// Feature 4 — FixBase (MakerNotes.pm:1282-1484)
+// ===========================================================================
+
+/// Inputs to [`fix_base`] — the `$$dirInfo{…}` + `$$et{…}` fields the Perl
+/// `FixBase` reads. The function owns no `$dirInfo`/`$et`, so these are passed
+/// explicitly.
+///
+/// D8: a plain input bag (no invariants to encapsulate); fields are
+/// `pub(crate)`-free — construct via [`FixBaseInput::new`] + the setters so the
+/// option fields default faithfully.
+#[derive(Debug, Clone)]
+pub struct FixBaseInput<'a> {
+  data: &'a [u8],
+  dir_start: usize,
+  dir_len: usize,
+  data_pos: i64,
+  base: i64,
+  order: ByteOrder,
+  make: &'a str,
+  model: &'a str,
+  file_type: Option<&'a str>,
+  tiff_type: Option<&'a str>,
+  /// `$$dirInfo{EntryBased}` on entry (a caller may pre-seed it).
+  entry_based: bool,
+  /// `$$dirInfo{FixOffsets}` — early-return 0 when set (`:1287`).
+  fix_offsets: bool,
+  /// `$$dirInfo{NoFixBase}` — early-return 0 when set (`:1287`).
+  no_fix_base: bool,
+  /// `$$dirInfo{FixBase}` — the per-directory fix mode (1 = fix, 2 = "Unknown
+  /// maker notes, allow a range"). `None` = absent.
+  dir_fix_base: Option<u8>,
+  /// The `FixBase` OPTION (`$et->Options('FixBase')`) → `$setBase` (`:1294-
+  /// 1295`). `Some(n)` forces the fix to exactly `n`; `None` = unset.
+  opt_fix_base: Option<i64>,
+}
+
+impl<'a> FixBaseInput<'a> {
+  /// Construct with the required directory fields; option flags default to the
+  /// Perl "absent" state (no early-return, no forced base).
+  #[must_use]
+  #[allow(clippy::too_many_arguments)]
+  pub fn new(
+    data: &'a [u8],
+    dir_start: usize,
+    dir_len: usize,
+    data_pos: i64,
+    base: i64,
+    order: ByteOrder,
+    make: &'a str,
+    model: &'a str,
+  ) -> Self {
+    Self {
+      data,
+      dir_start,
+      dir_len,
+      data_pos,
+      base,
+      order,
+      make,
+      model,
+      file_type: None,
+      tiff_type: None,
+      entry_based: false,
+      fix_offsets: false,
+      no_fix_base: false,
+      dir_fix_base: None,
+      opt_fix_base: None,
+    }
+  }
+
+  /// Set `$$et{FILE_TYPE}` / `$$et{TIFF_TYPE}` (feed `GetMakerNoteOffset`).
+  #[must_use]
+  #[inline]
+  pub const fn with_file_types(
+    mut self,
+    file_type: Option<&'a str>,
+    tiff_type: Option<&'a str>,
+  ) -> Self {
+    self.file_type = file_type;
+    self.tiff_type = tiff_type;
+    self
+  }
+
+  /// Pre-seed `$$dirInfo{EntryBased}` (`:1292`).
+  #[must_use]
+  #[inline]
+  pub const fn with_entry_based(mut self, entry_based: bool) -> Self {
+    self.entry_based = entry_based;
+    self
+  }
+
+  /// Set `$$dirInfo{FixOffsets}` / `$$dirInfo{NoFixBase}` (`:1287`).
+  #[must_use]
+  #[inline]
+  pub const fn with_early_returns(mut self, fix_offsets: bool, no_fix_base: bool) -> Self {
+    self.fix_offsets = fix_offsets;
+    self.no_fix_base = no_fix_base;
+    self
+  }
+
+  /// Set `$$dirInfo{FixBase}` (1 = fix, 2 = allow-range; `:1408`/`:1457`).
+  #[must_use]
+  #[inline]
+  pub const fn with_dir_fix_base(mut self, mode: Option<u8>) -> Self {
+    self.dir_fix_base = mode;
+    self
+  }
+
+  /// Set the `FixBase` OPTION → `$setBase` (`:1294-1295`).
+  #[must_use]
+  #[inline]
+  pub const fn with_opt_fix_base(mut self, opt: Option<i64>) -> Self {
+    self.opt_fix_base = opt;
+    self
+  }
+}
+
+/// The result of [`fix_base`] — the scalar return PLUS the `$$dirInfo`
+/// mutations the Perl applies in place.
+///
+/// D8: no public fields; accessors only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FixBaseResult {
+  /// The Perl sub's scalar return — the total base shift (`$fix + $shift`,
+  /// or one of the early `return` values).
+  shift: i64,
+  /// New `$$dirInfo{Base}` after the in-place `$$dirInfo{Base} += …`.
+  new_base: i64,
+  /// New `$$dirInfo{DataPos}` after `$$dirInfo{DataPos} -= …`.
+  new_data_pos: i64,
+  /// `$$dirInfo{EntryBased}` after the run (set to 1 in the entry-based arm,
+  /// undef'd in the "do NOT look entry-based" arm).
+  entry_based: bool,
+  /// `$$dirInfo{Relative}` after the run (`None` = undef).
+  relative: Option<bool>,
+  /// `$$dirInfo{FixedBy}` after the run (`None` = unset).
+  fixed_by: Option<i64>,
+}
+
+impl FixBaseResult {
+  /// The base shift returned by the Perl sub.
+  #[must_use]
+  #[inline(always)]
+  pub const fn shift(&self) -> i64 {
+    self.shift
+  }
+
+  /// `$$dirInfo{Base}` after the fix.
+  #[must_use]
+  #[inline(always)]
+  pub const fn new_base(&self) -> i64 {
+    self.new_base
+  }
+
+  /// `$$dirInfo{DataPos}` after the fix.
+  #[must_use]
+  #[inline(always)]
+  pub const fn new_data_pos(&self) -> i64 {
+    self.new_data_pos
+  }
+
+  /// `$$dirInfo{EntryBased}` after the fix.
+  #[must_use]
+  #[inline(always)]
+  pub const fn entry_based(&self) -> bool {
+    self.entry_based
+  }
+
+  /// `$$dirInfo{Relative}` after the fix (`None` = undef).
+  #[must_use]
+  #[inline(always)]
+  pub const fn relative(&self) -> Option<bool> {
+    self.relative
+  }
+
+  /// `$$dirInfo{FixedBy}` after the fix (`None` = unset).
+  #[must_use]
+  #[inline(always)]
+  pub const fn fixed_by(&self) -> Option<i64> {
+    self.fixed_by
+  }
+}
+
+/// `FixBase($et, $dirInfo)` (`MakerNotes.pm:1282-1484`) — analyse the
+/// maker-note IFD's value offsets and compute the base shift that makes them
+/// resolve. See the block-by-block comments + the module doc for the
+/// faithfulness contract.
+///
+/// The early `return 0`s, the Canon TIFF-footer special case (`:1306-1337`),
+/// the value-offset gap analysis (`:1356-1414`), the entry-based base mutation
+/// (`:1418-1436`), and the final base fix (`:1450-1483`) are all ported.
+#[must_use]
+pub fn fix_base(input: &FixBaseInput<'_>) -> FixBaseResult {
+  let no_shift = FixBaseResult {
+    shift: 0,
+    new_base: input.base,
+    new_data_pos: input.data_pos,
+    entry_based: input.entry_based,
+    relative: None,
+    fixed_by: None,
+  };
+
+  // "don't fix base if fixing offsets individually or if we don't want to fix
+  // them" — `return 0 if $$dirInfo{FixOffsets} or $$dirInfo{NoFixBase}`
+  // (`:1286-1287`).
+  if input.fix_offsets || input.no_fix_base {
+    return no_shift;
+  }
+
+  let data = input.data;
+  let data_pos = input.data_pos;
+  let dir_start = input.dir_start;
+  let mut entry_based = input.entry_based;
+  let order = input.order;
+  // `$setBase = (defined $fixBase and $fixBase ne '') ? 1 : 0` (`:1294-1295`).
+  let set_base = input.opt_fix_base.is_some();
+
+  // "get hash of value block positions" (`:1298-1299`).
+  let (val_blocks, tag_ptr) = get_value_blocks(data, dir_start, order);
+  // `return 0 unless %$valBlock` (`:1300`).
+  if val_blocks.is_empty() {
+    return no_shift;
+  }
+  // "get sorted list of value offsets" — BTreeMap keys are already ascending
+  // (`:1302` `sort { $a <=> $b }`).
+  let val_ptrs: Vec<usize> = val_blocks.val_block().keys().copied().collect();
+
+  // -----------------------------------------------------------------------
+  // Canon maker notes with TIFF footer containing original offset
+  // (`:1304-1338`).
+  // -----------------------------------------------------------------------
+  // `my $footerPos = $dirStart + $$dirInfo{DirLen} - 8` (`:1307`).
+  if input.make.starts_with("Canon")
+    && input.dir_len > 8
+    && let Some(footer_pos) = dir_start
+      .checked_add(input.dir_len)
+      .and_then(|p| p.checked_sub(8))
+    && let Some(footer) = data.get(footer_pos..footer_pos.saturating_add(8))
+  {
+    // `$footer =~ /^(II\x2a\0|MM\0\x2a)/` (`:1309`) AND `substr($footer,0,2)
+    // eq GetByteOrder()` (`:1310`).
+    let footer_order = ByteOrder::from_marker(footer);
+    let magic_ok = matches!(footer.get(..4), Some(b"II\x2a\0" | b"MM\x00\x2a"));
+    if magic_ok && footer_order == Some(order) {
+      // `my $oldOffset = Get32u(\$footer, 4)` (`:1312`).
+      let old_offset = i64::from(get_u32(footer, 4, order).unwrap_or(0));
+      // `my $newOffset = $dirStart + $dataPos` (`:1313`).
+      let new_offset = dir_start as i64 + data_pos;
+      let fix: i64 = if let Some(forced) = input.opt_fix_base {
+        forced // `$fix = $fixBase` (`:1315`).
+      } else {
+        // `$fix = $newOffset - $oldOffset; return 0 unless $fix` (`:1317-1318`).
+        let fix = new_offset - old_offset;
+        if fix == 0 {
+          return no_shift;
+        }
+        // Picasa/ACDSee footer-bug check (`:1319-1330`): `$maxPt = $valPtrs[-1]
+        // + $valBlock{$valPtrs[-1]}` then `$endDiff = $dirStart + $$dirInfo
+        // {DirLen} - ($maxPt - $dataPos) - 8`; ignore footer if `$endDiff` is 0
+        // or 1.
+        if let Some(&last_ptr) = val_ptrs.last() {
+          let last_size = val_blocks.val_block().get(&last_ptr).copied().unwrap_or(0);
+          let max_pt = last_ptr as i64 + last_size as i64;
+          let end_diff = dir_start as i64 + input.dir_len as i64 - (max_pt - data_pos) - 8;
+          if end_diff == 0 || end_diff == 1 {
+            // `$et->Warn('Canon maker note footer may be invalid (ignored)')` →
+            // `return 0` (`:1328-1329`).
+            return no_shift;
+          }
+        }
+        fix
+      };
+      // `$$dirInfo{FixedBy} = $fix; $$dirInfo{Base} += $fix; $$dirInfo{DataPos}
+      // -= $fix; return $fix` (`:1332-1336`). (The "Adjusted … base by $fix"
+      // warning is informational, `:1332`.)
+      return FixBaseResult {
+        shift: fix,
+        new_base: input.base + fix,
+        new_data_pos: data_pos - fix,
+        entry_based,
+        relative: None,
+        fixed_by: Some(fix),
+      };
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // analyse value offsets to find the minimum valid offset (`:1339-1414`).
+  // -----------------------------------------------------------------------
+  // `my $minPt = $$dirInfo{MinOffset} = $valPtrs[0]` (`:1344`). val_ptrs is
+  // non-empty (val_block not empty), so `.first()` is `Some`.
+  let mut min_pt = val_ptrs.first().copied().unwrap_or(0) as i64;
+  // `my $ifdLen = 2 + 12 * Get16u($$dirInfo{DataPt}, $dirStart)` (`:1345`).
+  let num_entries = i64::from(get_u16(data, dir_start, order).unwrap_or(0));
+  let ifd_len = 2 + 12 * num_entries;
+  // `my $ifdEnd = $dirStart + $ifdLen` (`:1346`).
+  let ifd_end = dir_start as i64 + ifd_len;
+  // `my ($relative, @offsets) = GetMakerNoteOffset($et)` (`:1347`).
+  let mn_off = get_maker_note_offset(input.make, input.model, input.file_type, input.tiff_type);
+  let mut relative = mn_off.relative();
+  let mut offsets = mn_off.offsets().to_vec();
+  // `my $makeDiff = $offsets[0]` (`:1348`) — `undef` for the weird-Olympus list.
+  let mut make_diff = mn_off.make_diff();
+
+  // `my $expected = $dataPos + $ifdEnd + (defined $makeDiff ? $makeDiff : 4)`
+  // (`:1353`).
+  let expected = data_pos + ifd_end + i64::from(make_diff.unwrap_or(4));
+
+  // "zero our counters" (`:1357`).
+  let mut count_neg12 = 0i64;
+  let mut count_zero = 0i64;
+  let mut count_overlap = 0i64;
+  let mut last: Option<i64> = None;
+  // `foreach $valPtr (@valPtrs)` (`:1359-1381`).
+  for &vp in &val_ptrs {
+    let val_ptr = vp as i64;
+    if let Some(last_v) = last {
+      // `my $gap = $valPtr - $last` (`:1363`).
+      let gap = val_ptr - last_v;
+      if gap == 0 || gap == 1 {
+        count_zero += 1; // (`:1364-1365`).
+      } else if gap == -12 && !entry_based {
+        // "value offsets are relative to the IFD entry" (`:1366-1368`).
+        count_neg12 += 1;
+      } else if gap < 0 {
+        // "any other negative difference indicates overlapping values"
+        // (`:1369-1371`) — but ignore zero value pointers.
+        if val_ptr != 0 {
+          count_overlap += 1;
+        }
+      } else if gap >= ifd_len {
+        // "ignore previous minimum if we took a jump to near the expected
+        // value" (`:1372-1375`): `$minPt = $valPtr if abs($valPtr - $expected)
+        // <= 4`.
+        if (val_ptr - expected).abs() <= 4 {
+          min_pt = val_ptr;
+        }
+      }
+      // "an offset less than 12 is surely garbage, so ignore it" — `$minPt =
+      // $valPtr if $minPt < 12` (`:1377-1378`).
+      if min_pt < 12 {
+        min_pt = val_ptr;
+      }
+    }
+    // `$last = $valPtr + $$valBlock{$valPtr}` (`:1380`).
+    let size = val_blocks.val_block().get(&vp).copied().unwrap_or(0) as i64;
+    last = Some(val_ptr + size);
+  }
+
+  let mut diff: i64 = 0;
+  let mut shift: i64 = 0;
+
+  // "could this IFD be using entry-based offsets?" (`:1382-1414`). The
+  // `$valBlkAdj{MIN}`/`MAX` come from `get_value_blocks`; a None MIN/MAX means
+  // no out-of-line value contributed (can't be entry-based then).
+  let min_adj = val_blocks.min_adj();
+  let max_adj = val_blocks.max_adj();
+  // `(($countNeg12 > $countZero and $$valBlkAdj{MIN} >= $ifdLen - 2) or
+  //   ($$valBlkAdj{MIN} == $ifdLen - 2 or $$valBlkAdj{MIN} == $ifdLen + 2))
+  //  and $$valBlkAdj{MAX} <= $$dirInfo{DirLen}-2` (`:1383-1385`).
+  let entry_based_detected = {
+    let min_ok_a = count_neg12 > count_zero && min_adj.is_some_and(|m| m as i64 >= ifd_len - 2);
+    let min_ok_b = min_adj.is_some_and(|m| m as i64 == ifd_len - 2 || m as i64 == ifd_len + 2);
+    let max_ok = max_adj.is_some_and(|m| m as i64 <= input.dir_len as i64 - 2);
+    (min_ok_a || min_ok_b) && max_ok
+  };
+
+  if entry_based_detected {
+    // "looks like these offsets are entry-based" (`:1387-1390`).
+    entry_based = true;
+  } else {
+    // `$diff = ($minPt - $dataPos) - $ifdEnd; $shift = 0` (`:1393-1394`).
+    diff = (min_pt - data_pos) - ifd_end;
+    shift = 0;
+    // `$countOverlap and $et->Warn("Overlapping … values")` (`:1395`) — info.
+    if entry_based {
+      // "do NOT look entry-based" — undef both (`:1396-1400`).
+      entry_based = false;
+      relative = None;
+    }
+    let _ = count_overlap;
+    // PrintIM absolute-offset special check (`:1401-1406`): `if ($tagPtr
+    // {0xe00}) { my $ptr = $tagPtr{0xe00} - $dataPos; return 0 if $ptr > 0 and
+    // $ptr <= length($$dataPt) - 8 and substr($$dataPt, $ptr, 8) eq
+    // "PrintIM\0"; }`.
+    if let Some(&pim) = tag_ptr.get(&0x0e00) {
+      let ptr = i64::from(pim) - data_pos;
+      let data_len = data.len() as i64;
+      if ptr > 0 && ptr <= data_len - 8 {
+        let ptr_us = ptr as usize;
+        if data.get(ptr_us..ptr_us.saturating_add(8)) == Some(b"PrintIM\0") {
+          return no_shift;
+        }
+      }
+    }
+    // "allow a range of reasonable differences for Unknown maker notes"
+    // (`:1407-1410`): `if ($$dirInfo{FixBase} and $$dirInfo{FixBase} == 2) {
+    // return 0 if $diff >=0 and $diff <= 24; }`.
+    if input.dir_fix_base == Some(2) && (0..=24).contains(&diff) {
+      return no_shift;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // handle entry-based offsets (`:1415-1436`).
+  // -----------------------------------------------------------------------
+  let mut new_base = input.base;
+  let mut new_data_pos = data_pos;
+  let mut fix_base_dir_active = input.dir_fix_base.is_some();
+  if entry_based {
+    // `$makeDiff = 0; push @offsets, 4` (`:1422-1423`).
+    make_diff = Some(0);
+    offsets.push(4);
+    // "corrected entry-based offsets are relative to start of first entry":
+    // `my $expected = 12 * Get16u(…); $diff = $$valBlkAdj{MIN} - $expected`
+    // (`:1425-1426`).
+    let expected_eb = 12 * num_entries;
+    diff = min_adj.map_or(0, |m| m as i64) - expected_eb;
+    // "set base to start of first entry": `$shift = $dataPos + $dirStart + 2`
+    // (`:1429`).
+    shift = data_pos + dir_start as i64 + 2;
+    new_base += shift; // `$$dirInfo{Base} += $shift` (`:1430`).
+    new_data_pos -= shift; // `$$dirInfo{DataPos} -= $shift` (`:1431`).
+    entry_based = true; // `$$dirInfo{EntryBased} = 1` (`:1432`).
+    relative = Some(true); // `$$dirInfo{Relative} = 1` (`:1433`).
+    fix_base_dir_active = false; // `delete $$dirInfo{FixBase}` (`:1434`).
+  }
+
+  // -----------------------------------------------------------------------
+  // return without doing shift if offsets look OK (`:1437-1449`).
+  // -----------------------------------------------------------------------
+  if !set_base {
+    // `return $shift unless defined $makeDiff` (`:1442`).
+    let Some(_md) = make_diff else {
+      return FixBaseResult {
+        shift,
+        new_base,
+        new_data_pos,
+        entry_based,
+        relative,
+        fixed_by: None,
+      };
+    };
+    // `return $shift if $diff == 0 or $diff == 4` (`:1444`).
+    if diff == 0 || diff == 4 {
+      return FixBaseResult {
+        shift,
+        new_base,
+        new_data_pos,
+        entry_based,
+        relative,
+        fixed_by: None,
+      };
+    }
+    // `foreach (@offsets) { return $shift if $diff == $_ }` (`:1446-1448`).
+    if offsets.iter().any(|&o| i64::from(o) == diff) {
+      return FixBaseResult {
+        shift,
+        new_base,
+        new_data_pos,
+        entry_based,
+        relative,
+        fixed_by: None,
+      };
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // apply the fix, or issue a warning (`:1450-1483`).
+  // -----------------------------------------------------------------------
+  // `$makeDiff = 4 unless defined $makeDiff` (`:1454`).
+  let make_diff_val = i64::from(make_diff.unwrap_or(4));
+  // `$fix = $makeDiff - $diff` (`:1455`).
+  let mut fix = make_diff_val - diff;
+  let mut fixed_by: Option<i64> = None;
+
+  if fix_base_dir_active {
+    // `if ($dataPos - $fix + $dirStart <= 0) { $$dirInfo{Relative} = (defined
+    // $relative) ? $relative : 1; }` (`:1458-1461`).
+    if data_pos - fix + dir_start as i64 <= 0 {
+      relative = Some(relative.unwrap_or(true));
+    }
+    if let Some(forced) = input.opt_fix_base {
+      // `$fixedBy = $fixBase; $fix += $fixBase` (`:1463-1464`).
+      fixed_by = Some(forced);
+      fix += forced;
+    }
+  } else if let Some(forced) = input.opt_fix_base {
+    // `} elsif (defined $fixBase) { $fix = $fixBase if $fixBase ne '';
+    // $fixedBy = $fix; }` (`:1466-1468`).
+    fix = forced;
+    fixed_by = Some(fix);
+  } else {
+    // "print warning unless difference looks reasonable" (`:1470-1472`): `if
+    // ($diff < 0 or $diff > 16 or ($diff & 0x01))` → Warn (informational).
+    // "don't do the fix (but we already adjusted base if entry-based)" —
+    // `return $shift` (`:1474-1475`).
+    return FixBaseResult {
+      shift,
+      new_base,
+      new_data_pos,
+      entry_based,
+      relative,
+      fixed_by: None,
+    };
+  }
+
+  // `if (defined $fixedBy) { $$dirInfo{FixedBy} = $fixedBy; }` (`:1477-1480`).
+  // `$$dirInfo{Base} += $fix; $$dirInfo{DataPos} -= $fix; return $fix + $shift`
+  // (`:1481-1483`).
+  new_base += fix;
+  new_data_pos -= fix;
+  FixBaseResult {
+    shift: fix + shift,
+    new_base,
+    new_data_pos,
+    entry_based,
+    relative,
+    fixed_by,
+  }
+}
+
+// ===========================================================================
+// Feature 5 — LocateIFD (MakerNotes.pm:1486-1663) + ProcessUnknown
+// (:1816-1837)
+// ===========================================================================
+
+/// `LocateIFD($et, $dirInfo)` (`MakerNotes.pm:1486-1663`) — scan unknown
+/// maker-note data for the start of a plausible IFD, trying the parent order
+/// first and TOGGLING when the entry count's low byte is zero. The bundled sub
+/// "Changes byte ordering!" (`:1493`) and updates `DirStart`/`DirLen`/`Base`/
+/// `DataPos`; this port returns the located IFD start + the resolved order
+/// (the caller applies the dir/base updates).
+///
+/// Returns `Some((ifd_start /* relative to dir_start */, order))` on success,
+/// or `None` (the caller warns `Unrecognized <dir>`, `ProcessUnknown` `:1834`).
+///
+/// This is the SIMPLIFIED scan arm only — the bundled sub also has a
+/// TagInfo/SubDirectory `Start`/`Base`/`OffsetPt` pre-positioning block
+/// (`:1514-1565`). That block needs the `$dirInfo{TagInfo}{SubDirectory}`
+/// directives (Perl `eval` of `Start`/`Base`/`OffsetPt` expressions) which are
+/// dispatched separately in this port; here `first_try == last_try == 0`'s
+/// extension is folded by accepting the default `(0, 32)` scan window
+/// (`:1506`). When a vendor needs the pre-positioning, the dispatcher supplies
+/// the resolved start and this scan runs from there. The standard-IFD
+/// plausibility checks (`:1599-1659`) are ported faithfully below.
+///
+/// `make`/`model` thread the Samsung/Sony/Apple/Canon model-specific patches
+/// (`:1624-1639`). The TIFF-header arm (`:1576-1598`) is ported too.
+#[must_use]
+pub fn locate_ifd(
+  data: &[u8],
+  dir_start: usize,
+  dir_len: Option<usize>,
+  parent_order: ByteOrder,
+  make: Option<&str>,
+  model: Option<&str>,
+) -> Option<(usize, ByteOrder)> {
+  // `my $size = $$dirInfo{DataLen} - $dirStart` (`:1500`) — "ignore MakerNotes
+  // DirLen since sometimes this is incorrect".
+  let size = data.len().checked_sub(dir_start)?;
+  // `my $dirLen = defined $$dirInfo{DirLen} ? $$dirInfo{DirLen} : $size`
+  // (`:1501`).
+  let dir_len = dir_len.unwrap_or(size);
+  // "the IFD should be within the first 32 bytes" — `my ($firstTry, $lastTry) =
+  // (0, 32)` (`:1506`). (The TagInfo pre-positioning that narrows these is
+  // handled by the dispatcher in this port; see the fn doc.)
+  let first_try = 0usize;
+  let last_try = 32usize;
+
+  // `if ($dirLen >= 14 + $firstTry)` — "minimum size for an IFD" (`:1570`).
+  if dir_len < 14 + first_try {
+    return None;
+  }
+
+  let mut offset = first_try;
+  // `IFD_TRY: for ($offset=$firstTry; $offset<=$lastTry; $offset+=2)`
+  // (`:1572`).
+  while offset <= last_try {
+    // `last if $offset + 14 > $dirLen` (`:1573`).
+    if offset.checked_add(14).is_none_or(|e| e > dir_len) {
+      break;
+    }
+    let Some(pos) = dir_start.checked_add(offset) else {
+      break;
+    };
+
+    // -------------------------------------------------------------------
+    // standard TIFF header arm (`:1576-1598`).
+    // -------------------------------------------------------------------
+    // `if (SetByteOrder(substr($$dataPt,$pos,2)) and Get16u($dataPt,$pos+2) ==
+    // 0x2a) { $ifdOffsetPos = 4; }` (`:1578-1582`). FAITHFUL SUBTLETY:
+    // `SetByteOrder` is the FIRST `and` operand and runs UNCONDITIONALLY — for
+    // an `II`/`MM` marker it SUCCEEDS and MUTATES the global order BEFORE the
+    // `Get16u == 0x2a` short-circuits. So even when the `0x2a` check fails, the
+    // order is left as the marker's, and the standard-IFD arm below reads its
+    // entry count in THAT order. We mirror that by updating `order` whenever the
+    // marker parses, but gating `ifd_offset_pos` on the full TIFF magic.
+    let mut order = parent_order;
+    let mut ifd_offset_pos: Option<usize> = None;
+    if let Some(marker_order) = data
+      .get(pos..pos.checked_add(2)?)
+      .and_then(ByteOrder::from_marker)
+    {
+      order = marker_order; // `SetByteOrder` side effect (`:1578`).
+      if get_u16(data, pos.checked_add(2)?, marker_order) == Some(0x2a) {
+        ifd_offset_pos = Some(4);
+      }
+    }
+    if let Some(iop) = ifd_offset_pos {
+      // `my $ptr = Get32u($dataPt, $pos + $ifdOffsetPos)` (`:1585`).
+      if let Some(ptr) = pos.checked_add(iop).and_then(|p| get_u32(data, p, order)) {
+        let ptr = ptr as usize;
+        // `if ($ptr >= $ifdOffsetPos + 4 and $ptr + $offset + 14 <= $dirLen)`
+        // (`:1586`).
+        let in_range = ptr >= iop + 4
+          && ptr
+            .checked_add(offset)
+            .and_then(|s| s.checked_add(14))
+            .is_some_and(|end| end <= dir_len);
+        if in_range {
+          // `return $ptr + $offset` (`:1595`) — relative to `dir_start`; the
+          // TIFF-header base shift + `Relative` flag are applied by the caller.
+          return Some((ptr + offset, order));
+        }
+      }
+      // `undef $ifdOffsetPos` (`:1597`) — fall through to the standard-IFD arm
+      // (which re-derives the order from the raw entry count).
+    }
+
+    // -------------------------------------------------------------------
+    // standard IFD arm — starts with a 2-byte entry count (`:1599-1659`).
+    // `order` is the live `GetByteOrder()` here: it carries the TIFF arm's
+    // `SetByteOrder` side effect (the marker order when `$pos` held `II`/`MM`),
+    // else the parent order. The `ToggleByteOrder` below mutates it further.
+    // -------------------------------------------------------------------
+    // `my $num = Get16u($dataPt, $pos); next unless $num` (`:1602-1603`).
+    let Some(mut num) = get_u16(data, pos, order) else {
+      offset += 2;
+      continue;
+    };
+    if num == 0 {
+      offset += 2;
+      continue;
+    }
+    // `if (!($num & 0xff)) { ToggleByteOrder(); $num >>= 8; }` (`:1605-1608`).
+    if (num & 0xff) == 0 {
+      order = opposite_order(order);
+      num >>= 8;
+    } else if (num & 0xff00) != 0 {
+      // "upper byte isn't zero -- not an IFD" — `next` (`:1609-1611`).
+      offset += 2;
+      continue;
+    }
+    let num = usize::from(num);
+    // `my $bytesFromEnd = $size - ($offset + 2 + 12 * $num)` (`:1613`). Use i64
+    // so a count past the end goes negative (Perl arithmetic), not a wrap.
+    let bytes_from_end = size as i64 - (offset as i64 + 2 + 12 * num as i64);
+    // `if ($bytesFromEnd < 4) { next unless $bytesFromEnd == 2 or == 0; }`
+    // (`:1614-1616`).
+    if bytes_from_end < 4 && !(bytes_from_end == 2 || bytes_from_end == 0) {
+      offset += 2;
+      continue;
+    }
+    // "do a quick validation of all format types" (`:1617-1656`).
+    if !validate_ifd_entries(data, pos, num, size, order, make, model) {
+      offset += 2;
+      continue;
+    }
+    // `$$dirInfo{DirStart} += $offset; $$dirInfo{DirLen} -= $offset; return
+    // $offset` (`:1657-1659`).
+    return Some((offset, order));
+  }
+  // `return undef` (`:1662`).
+  None
+}
+
+/// The per-entry format/count/offset plausibility loop inside `LocateIFD`'s
+/// standard-IFD arm (`MakerNotes.pm:1617-1656`). Returns `false` to `next
+/// IFD_TRY` (try the next `$offset`) — i.e. this candidate IFD is rejected.
+///
+/// `model`/`make` thread the documented per-camera patches: the Samsung NX200
+/// 23-entry quirk (`:1624-1629` — the port DETECTS it but cannot mutate the
+/// buffer; it accepts the candidate as the Perl does after `Set16u`), the
+/// Canon EOS 40D zero-format last entry (`:1633-1634`), the Sony DSC-P10
+/// 12-entry quirk (`:1636-1637`), and the Apple ProRaw format-16 entries
+/// (`:1638-1639`).
+#[allow(clippy::too_many_arguments)]
+fn validate_ifd_entries(
+  data: &[u8],
+  pos: usize,
+  num: usize,
+  size: usize,
+  order: ByteOrder,
+  make: Option<&str>,
+  model: Option<&str>,
+) -> bool {
+  for index in 0..num {
+    // `my $entry = $pos + 2 + 12 * $index` (`:1620`).
+    let Some(entry) = pos
+      .checked_add(2)
+      .and_then(|p| p.checked_add(12usize.checked_mul(index)?))
+    else {
+      return false;
+    };
+    // `my $format = Get16u($dataPt, $entry+2)` (`:1621`).
+    let format = entry
+      .checked_add(2)
+      .and_then(|p| get_u16(data, p, order))
+      .unwrap_or(0);
+    // `my $count = Get32u($dataPt, $entry+4)` (`:1622`).
+    let count = entry
+      .checked_add(4)
+      .and_then(|p| get_u32(data, p, order))
+      .unwrap_or(0);
+    if format == 0 {
+      // Samsung NX200 23-entry patch (`:1624-1629`): really 21 entries. The
+      // Perl mutates the buffer (`Set16u(21,…)`) + `last`s; this read-only port
+      // accepts the candidate (stops validating) — the equivalent observable
+      // outcome (the IFD is accepted) without mutating the borrowed slice.
+      if num == 23 && index == 21 && make == Some("SAMSUNG") {
+        break;
+      }
+      // "allow everything to be zero if not first entry" — `next unless $count
+      // or $index == 0` (`:1630-1632`). A zero-format, zero-count, non-first
+      // entry is padding ⇒ skip it. (When count != 0 OR index == 0 we fall
+      // through: a first/with-count zero-format entry reaches the reject below,
+      // except for the EOS-40D last-entry allowance.)
+      if count == 0 && index != 0 {
+        continue;
+      }
+      // Canon EOS 40D firmware 1.0.4: zero format allowed for the LAST entry —
+      // `next if $index==$num-1 and $$et{Model}=~/EOS 40D/` (`:1633-1634`).
+      if index == num - 1 && model.is_some_and(|m| m.contains("EOS 40D")) {
+        continue;
+      }
+    }
+    // Sony DSC-P10 invalid-entry patch — `next if $num == 12 and $$et{Make} eq
+    // 'SONY' and $index >= 8` (`:1636-1637`).
+    if num == 12 && make == Some("SONY") && index >= 8 {
+      continue;
+    }
+    // Apple ProRaw DNG format-16 patch — `next if $format == 16 and $$et{Make}
+    // eq 'Apple'` (`:1638-1639`).
+    if format == 16 && make == Some("Apple") {
+      continue;
+    }
+    // "verify format" — `next IFD_TRY if $format < 1 or $format > 13`
+    // (`:1644`).
+    if !matches!(format, 1..=13) {
+      return false;
+    }
+    // "count must be reasonable" — `next IFD_TRY if $count & 0xff000000`
+    // (`:1647`).
+    if count & 0xff00_0000 != 0 {
+      return false;
+    }
+    // "extra tests to avoid mis-identifying Samsung makernotes" — `next unless
+    // $num == 1` (`:1649`). For `$num != 1` the per-entry value-size check
+    // below is SKIPPED (the `next` continues the entry loop).
+    if num != 1 {
+      continue;
+    }
+    // `my $valueSize = $count * formatSize[$format]` (`:1650`); the gate above
+    // guarantees `format ∈ 1..=13`.
+    let value_size = u64::from(count).saturating_mul(Format::from_code(format).byte_size() as u64);
+    if value_size > 4 {
+      // `next IFD_TRY if $valueSize > $size` (`:1652`).
+      if value_size > size as u64 {
+        return false;
+      }
+      // `my $valuePtr = Get32u($dataPt, $entry+8); next IFD_TRY if $valuePtr >
+      // 0x10000` (`:1653-1654`).
+      let value_ptr = entry
+        .checked_add(8)
+        .and_then(|p| get_u32(data, p, order))
+        .unwrap_or(0);
+      if value_ptr > 0x1_0000 {
+        return false;
+      }
+    }
+  }
+  true
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/exif/makernotes/fixbase/tests.rs
+++ b/src/exif/makernotes/fixbase/tests.rs
@@ -1,0 +1,516 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Oracle tests for the shared maker-note engine. Every expected value is
+//! HAND-DERIVED from the cited `MakerNotes.pm` / `Exif.pm` line (the bundled
+//! subs are internal, so a live perl-oracle harness is impractical; the
+//! fixture-less-port convention applies — see the module docs).
+
+use super::*;
+
+// ===========================================================================
+// Feature 1 — detect_unknown_byte_order (Exif.pm:6982-6993)
+// ===========================================================================
+
+/// A sane LE entry count keeps the parent order. `num = 0x0003` read LE = 3.
+/// `0x0003 & 0xff00 == 0` ⇒ the toggle test is false (`:6987`) ⇒ keep parent
+/// (`:6992`).
+#[test]
+fn unknown_order_sane_le_count_keeps_parent() {
+  let data = [0x03u8, 0x00]; // LE 3
+  assert_eq!(
+    detect_unknown_byte_order(&data, 0, ByteOrder::Little),
+    Some(ByteOrder::Little)
+  );
+}
+
+/// A byte-swapped count toggles. Bytes `00 03` read as parent-LE = 0x0300 =
+/// 768. `0x0300 & 0xff00 != 0` AND `(0x0300>>8)=3 > (0x0300&0xff)=0` ⇒ "too
+/// many entries" ⇒ TOGGLE to Big (`:6987-6990`). (Read as Big it would be 3 —
+/// the plausible value — confirming the order was wrong.)
+#[test]
+fn unknown_order_byteswapped_count_toggles() {
+  let data = [0x00u8, 0x03]; // parent-LE reads 0x0300
+  assert_eq!(
+    detect_unknown_byte_order(&data, 0, ByteOrder::Little),
+    Some(ByteOrder::Big)
+  );
+}
+
+/// Mirror case: a Big parent that reads an implausible count toggles to Little.
+/// Bytes `03 00` read as parent-BE = 0x0300 = 768 ⇒ toggle to Little.
+#[test]
+fn unknown_order_byteswapped_count_toggles_be_parent() {
+  let data = [0x03u8, 0x00]; // parent-BE reads 0x0300
+  assert_eq!(
+    detect_unknown_byte_order(&data, 0, ByteOrder::Big),
+    Some(ByteOrder::Little)
+  );
+}
+
+/// `num>>8 == num&0xff` does NOT toggle — the test is strict `>` (`:6987`).
+/// `0x0303` (high == low byte) keeps parent even though the high byte is set.
+#[test]
+fn unknown_order_equal_bytes_keeps_parent() {
+  let data = [0x03u8, 0x03]; // LE 0x0303
+  assert_eq!(
+    detect_unknown_byte_order(&data, 0, ByteOrder::Little),
+    Some(ByteOrder::Little)
+  );
+}
+
+/// Fewer than 2 bytes at `dir_start` ⇒ `None` — the `$subdirStart + 2 <=
+/// $subdirDataLen` guard (`:6982`) leaves the order unresolved.
+#[test]
+fn unknown_order_too_short_is_none() {
+  assert_eq!(
+    detect_unknown_byte_order(&[0x03], 0, ByteOrder::Little),
+    None
+  );
+  assert_eq!(detect_unknown_byte_order(&[], 0, ByteOrder::Big), None);
+  // Also when dir_start pushes the read past the end.
+  assert_eq!(
+    detect_unknown_byte_order(&[0x03, 0x00], 1, ByteOrder::Little),
+    None
+  );
+}
+
+// ===========================================================================
+// Feature 2 — get_maker_note_offset (MakerNotes.pm:1149-1231)
+// ===========================================================================
+
+/// Canon 20D ⇒ first offset 6 (`:1161`); a non-listed Canon ⇒ 4.
+#[test]
+fn canon_offsets() {
+  let o = get_maker_note_offset("Canon", "Canon EOS 20D", None, None);
+  assert_eq!(o.offsets(), &[6]);
+  assert_eq!(o.make_diff(), Some(6));
+  assert_eq!(o.relative(), None);
+
+  let o = get_maker_note_offset("Canon", "Canon EOS 5D", None, None);
+  assert_eq!(o.offsets(), &[4]);
+
+  // PowerShot adds 16 (plain substring, `:1166`); OPTURA adds 28 (`:1164`).
+  let o = get_maker_note_offset("Canon", "Canon PowerShot S30", None, None);
+  assert_eq!(o.offsets(), &[4, 16]);
+  let o = get_maker_note_offset("Canon", "Canon OPTURA60", None, None);
+  assert_eq!(o.offsets(), &[4, 28]);
+  // FV<boundary> adds 28 too (`FV\b`): "FV" then non-word.
+  let o = get_maker_note_offset("Canon", "Canon FV M30", None, None);
+  assert_eq!(o.offsets(), &[4, 28]);
+}
+
+/// PENTAX ⇒ offset 4 AND forces ABSOLUTE addressing (`relative = 0`, `:1215-
+/// 1220`).
+#[test]
+fn pentax_forces_absolute() {
+  let o = get_maker_note_offset("PENTAX Corporation", "PENTAX *ist DS", None, None);
+  assert_eq!(o.offsets(), &[4]);
+  assert_eq!(o.relative(), Some(false));
+}
+
+/// SONY DSLR ⇒ 4 (`:1200-1203`); a non-DSLR/SLT/NEX Sony ⇒ 0 (`:1205`).
+#[test]
+fn sony_offsets() {
+  let o = get_maker_note_offset("SONY", "DSLR-A100", None, None);
+  assert_eq!(o.offsets(), &[4]);
+  let o = get_maker_note_offset("SONY", "SLT-A55V", None, None);
+  assert_eq!(o.offsets(), &[4]);
+  let o = get_maker_note_offset("SONY", "NEX-5", None, None);
+  assert_eq!(o.offsets(), &[4]);
+  let o = get_maker_note_offset("SONY", "DSC-RX100", None, None);
+  assert_eq!(o.offsets(), &[0]);
+}
+
+/// FUJIFILM ⇒ `4, 6` (`:1209-1211`).
+#[test]
+fn fujifilm_offsets() {
+  let o = get_maker_note_offset("FUJIFILM", "FinePix A345", None, None);
+  assert_eq!(o.offsets(), &[4, 6]);
+  assert_eq!(o.make_diff(), Some(4));
+}
+
+/// The "just weird" Olympus models get NO expected offset ⇒ empty list,
+/// `make_diff() == None` (`:1191-1194`), so `FixBase` resolves empirically.
+#[test]
+fn weird_olympus_has_no_offset() {
+  let o = get_maker_note_offset("OLYMPUS IMAGING CORP.", "C2500L", None, None);
+  assert!(o.offsets().is_empty());
+  assert_eq!(o.make_diff(), None);
+  // C-1Z? matches both C-1 and C-1Z.
+  assert!(
+    get_maker_note_offset("OLYMPUS", "C-1", None, None)
+      .offsets()
+      .is_empty()
+  );
+  assert!(
+    get_maker_note_offset("OLYMPUS", "C-1Z", None, None)
+      .offsets()
+      .is_empty()
+  );
+  // But a normal Olympus E-1 uses offset 16 (`:1189`), NOT the weird list.
+  let e1 = get_maker_note_offset("OLYMPUS", "E-1", None, None);
+  assert_eq!(e1.offsets(), &[16]);
+}
+
+/// CASIO RIFF/MOV ⇒ 0; CASIO JPEG ⇒ `4, 16, 2` (`:1171`).
+#[test]
+fn casio_offsets_depend_on_file_type() {
+  assert_eq!(
+    get_maker_note_offset("CASIO", "EX-Z70", Some("MOV"), None).offsets(),
+    &[0]
+  );
+  assert_eq!(
+    get_maker_note_offset("CASIO", "EX-Z70", Some("JPEG"), None).offsets(),
+    &[4, 16, 2]
+  );
+}
+
+/// Konica Minolta (CI prefix) ⇒ `4, -16` (`:1221-1223`); plain Minolta ⇒
+/// `4, -8, -12` (`:1224-1226`); unknown make ⇒ `4` (`:1228`).
+#[test]
+fn minolta_and_default() {
+  assert_eq!(
+    get_maker_note_offset("KONICA MINOLTA", "DiMAGE X50", None, None).offsets(),
+    &[4, -16]
+  );
+  assert_eq!(
+    get_maker_note_offset("Minolta Co., Ltd.", "DiMAGE 7", None, None).offsets(),
+    &[4, -8, -12]
+  );
+  assert_eq!(
+    get_maker_note_offset("Acme", "Widget", None, None).offsets(),
+    &[4]
+  );
+}
+
+// ===========================================================================
+// Feature 3 — get_value_blocks (MakerNotes.pm:1241-1275)
+// ===========================================================================
+
+/// Helper: write a single 12-byte IFD entry into `buf` at `off`.
+fn put_entry(buf: &mut [u8], off: usize, tag: u16, format: u16, count: u32, val: u32) {
+  buf[off..off + 2].copy_from_slice(&tag.to_le_bytes());
+  buf[off + 2..off + 4].copy_from_slice(&format.to_le_bytes());
+  buf[off + 4..off + 8].copy_from_slice(&count.to_le_bytes());
+  buf[off + 8..off + 12].copy_from_slice(&val.to_le_bytes());
+}
+
+/// A crafted IFD with three entries — two out-of-line (size > 4), one inline
+/// (size == 4, skipped per `:1252`). The block map records only the out-of-line
+/// pointers → sizes; the adjusted map adds `12*index` (`:1260`).
+#[test]
+fn value_blocks_two_out_of_line() {
+  // 3 entries: index0 ASCII×8 (size 8) @ 100; index1 INT32U×1 (size 4, inline,
+  // skipped); index2 INT16U×10 (size 20) @ 200.
+  let mut buf = vec![0u8; 256];
+  buf[0..2].copy_from_slice(&3u16.to_le_bytes()); // numEntries = 3
+  put_entry(&mut buf, 2, 0x0001, 2, 8, 100); // size 8  > 4 → recorded
+  put_entry(&mut buf, 14, 0x0002, 4, 1, 999); // size 4 == 4 → skipped (:1252)
+  put_entry(&mut buf, 26, 0x0003, 3, 10, 200); // size 20 > 4 → recorded
+
+  let (vb, tag_ptr) = get_value_blocks(&buf, 0, ByteOrder::Little);
+
+  // val_block: {100: 8, 200: 20}. The inline entry contributes nothing.
+  assert_eq!(vb.val_block().get(&100), Some(&8));
+  assert_eq!(vb.val_block().get(&200), Some(&20));
+  assert_eq!(vb.val_block().len(), 2);
+
+  // val_blk_adj: index0 → 100+0 = 100 (size 8); index2 → 200+24 = 224 (size 20).
+  assert_eq!(vb.val_blk_adj().get(&100), Some(&8));
+  assert_eq!(vb.val_blk_adj().get(&224), Some(&20));
+
+  // MIN = 100 (first ≥ 12, never raised since 100 < 224). MAX is an ExifTool
+  // QUIRK (`:1263-1270`): it is SEEDED by the FIRST out-of-line block's end
+  // (`100 + 8 = 108`) and thereafter only ever LOWERED (`$valBlkAdj{MAX} = $end
+  // if $valBlkAdj{MAX} > $end`) — it is NOT a running maximum. index2's end
+  // (244) is larger, so `108 > 244` is false ⇒ MAX stays 108. The port
+  // reproduces this faithfully.
+  assert_eq!(vb.min_adj(), Some(100));
+  assert_eq!(vb.max_adj(), Some(108));
+
+  // tag_ptr records tag → raw valPtr ONLY for OUT-OF-LINE entries: the `next
+  // if $size <= 4` (`:1252`) skips the inline entry BEFORE the `$$tagPtr{…} =
+  // $valPtr` assignment (`:1254`), so the inline tag 0x0002 is absent.
+  assert_eq!(tag_ptr.get(&0x0001), Some(&100));
+  assert_eq!(tag_ptr.get(&0x0002), None);
+  assert_eq!(tag_ptr.get(&0x0003), Some(&200));
+
+  assert!(!vb.is_empty());
+}
+
+/// `last if $format < 1 or $format > 13` (`:1249`) — a BigTIFF code (16)
+/// TERMINATES the walk; later entries are NOT recorded even if out-of-line.
+#[test]
+fn value_blocks_stops_at_out_of_range_format() {
+  let mut buf = vec![0u8; 64];
+  buf[0..2].copy_from_slice(&2u16.to_le_bytes());
+  put_entry(&mut buf, 2, 0x0001, 16, 4, 40); // format 16 (>13) → `last`
+  put_entry(&mut buf, 14, 0x0002, 2, 8, 50); // never reached
+  let (vb, _tp) = get_value_blocks(&buf, 0, ByteOrder::Little);
+  assert!(vb.is_empty());
+}
+
+/// No entries / all inline ⇒ empty block map (the `return 0 unless %$valBlock`
+/// guard, `:1300`).
+#[test]
+fn value_blocks_all_inline_is_empty() {
+  let mut buf = vec![0u8; 32];
+  buf[0..2].copy_from_slice(&1u16.to_le_bytes());
+  put_entry(&mut buf, 2, 0x0001, 4, 1, 7); // size 4 → skipped
+  let (vb, _tp) = get_value_blocks(&buf, 0, ByteOrder::Little);
+  assert!(vb.is_empty());
+}
+
+// ===========================================================================
+// Feature 4 — fix_base (MakerNotes.pm:1282-1484)
+// ===========================================================================
+
+/// (a) Absolute offsets that land exactly 4 bytes past the IFD ⇒ shift 0.
+///
+/// One ASCII×8 entry whose value sits at offset 18. `ifdLen = 2 + 12 = 14`,
+/// `ifdEnd = 14`. `diff = (minPt 18 - dataPos 0) - ifdEnd 14 = 4` ⇒ the `return
+/// $shift if $diff == 0 or $diff == 4` early-out (`:1444`) returns shift 0 with
+/// NO base mutation.
+#[test]
+fn fix_base_absolute_offsets_shift_zero() {
+  let mut buf = vec![0u8; 26];
+  buf[0..2].copy_from_slice(&1u16.to_le_bytes()); // 1 entry
+  put_entry(&mut buf, 2, 0x0001, 2, 8, 18); // ASCII×8 @ 18 (4 past IFD end)
+  // bytes 14..18 = next-IFD ptr (0); 18..26 = the 8 value bytes.
+
+  let input = FixBaseInput::new(&buf, 0, 26, 0, 0, ByteOrder::Little, "TestCam", "Model");
+  let r = fix_base(&input);
+  assert_eq!(r.shift(), 0);
+  assert_eq!(r.new_base(), 0);
+  assert_eq!(r.new_data_pos(), 0);
+  assert!(!r.entry_based());
+  assert_eq!(r.relative(), None);
+  assert_eq!(r.fixed_by(), None);
+}
+
+/// (b) An entry-based layout ⇒ nonzero shift + `entry_based = true` +
+/// `relative = Some(true)`.
+///
+/// Two ASCII×8 entries. `ifdLen = 2 + 24 = 26`, `ifdLen-2 = 24`. Stored
+/// valPtrs: entry0 → 24, entry1 → 12. Adjusted (`+12*index`): adj0 = 24,
+/// adj1 = 12+12 = 24 ⇒ `valBlkAdj{MIN} == 24 == ifdLen-2` ⇒ the second
+/// entry-based-detection arm fires (`:1384`); `valBlkAdj{MAX} = 32 <= dirLen-2
+/// = 32` (`:1385`). Entry arm (`:1418-1436`): `shift = dataPos 0 + dirStart 0 +
+/// 2 = 2`; `expected = 12*2 = 24`; `diff = MIN 24 - 24 = 0`; base += 2,
+/// dataPos -= 2, Relative = 1. Then `diff == 0` early-out (`:1444`) returns
+/// `shift = 2`.
+#[test]
+fn fix_base_entry_based_layout() {
+  let mut buf = vec![0u8; 40]; // dirLen = 34 ⇒ MAX 32 <= 32 ✓
+  buf[0..2].copy_from_slice(&2u16.to_le_bytes()); // 2 entries
+  put_entry(&mut buf, 2, 0x0001, 2, 8, 24); // entry0 valPtr = 24
+  put_entry(&mut buf, 14, 0x0002, 2, 8, 12); // entry1 valPtr = 12
+
+  let input = FixBaseInput::new(&buf, 0, 34, 0, 0, ByteOrder::Little, "TestCam", "Model");
+  let r = fix_base(&input);
+  assert_eq!(r.shift(), 2);
+  assert_eq!(r.new_base(), 2); // base 0 + shift 2
+  assert_eq!(r.new_data_pos(), -2); // dataPos 0 - shift 2
+  assert!(r.entry_based());
+  assert_eq!(r.relative(), Some(true));
+}
+
+/// (c) Canon TIFF-footer case (`:1304-1338`). A `II\x2a\0` footer whose
+/// recorded `oldOffset = 1000` against `newOffset = dirStart 0 + dataPos 1100`
+/// gives `fix = newOffset - oldOffset = 100` (`:1317`). The Picasa end-diff
+/// guard (`:1322-1330`) computes `endDiff = 0 + 30 - (22 - 1100) - 8 = 1100`
+/// (≠ 0,1) so the fix proceeds: base += 100, dataPos -= 100, FixedBy = 100,
+/// return 100.
+#[test]
+fn fix_base_canon_footer() {
+  // 1 entry (ASCII×8 @ 14), then 8 value bytes (14..22), then 8-byte footer.
+  let mut buf = vec![0u8; 30];
+  buf[0..2].copy_from_slice(&1u16.to_le_bytes());
+  put_entry(&mut buf, 2, 0x0001, 2, 8, 14); // value @ 14, size 8 → maxPt = 22
+  // footer @ 22..30: "II\x2a\0" + oldOffset(4) = 1000.
+  buf[22..26].copy_from_slice(b"II\x2a\x00");
+  buf[26..30].copy_from_slice(&1000u32.to_le_bytes());
+
+  let input = FixBaseInput::new(
+    &buf,
+    0,
+    30,
+    1100,
+    0,
+    ByteOrder::Little,
+    "Canon",
+    "Canon EOS 5D",
+  );
+  let r = fix_base(&input);
+  assert_eq!(r.shift(), 100);
+  assert_eq!(r.new_base(), 100); // base 0 + 100
+  assert_eq!(r.new_data_pos(), 1000); // dataPos 1100 - 100
+  assert_eq!(r.fixed_by(), Some(100));
+  assert!(!r.entry_based());
+}
+
+/// The Canon footer's "no shift" early-out: when `fix == newOffset - oldOffset
+/// == 0` the sub `return 0 unless $fix` (`:1318`). With `dataPos == oldOffset`,
+/// newOffset == oldOffset ⇒ fix 0 ⇒ no mutation.
+#[test]
+fn fix_base_canon_footer_zero_fix_returns_zero() {
+  let mut buf = vec![0u8; 30];
+  buf[0..2].copy_from_slice(&1u16.to_le_bytes());
+  put_entry(&mut buf, 2, 0x0001, 2, 8, 14);
+  buf[22..26].copy_from_slice(b"II\x2a\x00");
+  buf[26..30].copy_from_slice(&1000u32.to_le_bytes());
+  // dataPos == oldOffset (1000) ⇒ newOffset == oldOffset ⇒ fix 0.
+  let input = FixBaseInput::new(
+    &buf,
+    0,
+    30,
+    1000,
+    0,
+    ByteOrder::Little,
+    "Canon",
+    "Canon EOS 5D",
+  );
+  let r = fix_base(&input);
+  assert_eq!(r.shift(), 0);
+  assert_eq!(r.new_base(), 0);
+  assert_eq!(r.fixed_by(), None);
+}
+
+/// `FixOffsets` / `NoFixBase` short-circuit to 0 before any analysis
+/// (`:1286-1287`).
+#[test]
+fn fix_base_early_returns() {
+  let mut buf = vec![0u8; 26];
+  buf[0..2].copy_from_slice(&1u16.to_le_bytes());
+  put_entry(&mut buf, 2, 0x0001, 2, 8, 18);
+  let base = FixBaseInput::new(&buf, 0, 26, 0, 0, ByteOrder::Little, "TestCam", "Model");
+
+  let r = fix_base(&base.clone().with_early_returns(true, false));
+  assert_eq!(r.shift(), 0);
+  let r = fix_base(&base.with_early_returns(false, true));
+  assert_eq!(r.shift(), 0);
+}
+
+/// Empty value-block map ⇒ `return 0 unless %$valBlock` (`:1300`). An IFD with
+/// only inline values produces no blocks.
+#[test]
+fn fix_base_no_value_blocks_returns_zero() {
+  let mut buf = vec![0u8; 20];
+  buf[0..2].copy_from_slice(&1u16.to_le_bytes());
+  put_entry(&mut buf, 2, 0x0001, 4, 1, 7); // INT32U×1, inline (size 4)
+  let input = FixBaseInput::new(&buf, 0, 20, 0, 0, ByteOrder::Little, "TestCam", "Model");
+  assert_eq!(fix_base(&input).shift(), 0);
+}
+
+// ===========================================================================
+// Feature 5 — locate_ifd (MakerNotes.pm:1486-1663)
+// ===========================================================================
+
+/// A garbage-prefixed body: a valid 1-entry IFD begins after a 4-byte
+/// non-IFD prefix. The scan steps `+2` and finds the IFD at offset 4 with the
+/// parent order. (`num == 1` so the per-entry value-size check at `:1649-1655`
+/// runs; the single ASCII×4 inline entry passes.)
+#[test]
+fn locate_ifd_found_after_prefix() {
+  // offset 0..4: garbage that does NOT look like an IFD count/TIFF magic.
+  // offset 4: IFD count = 1; entry @ 6: ASCII×4 (inline). bytesFromEnd check:
+  // size = len - dirStart. We make the IFD self-terminate cleanly.
+  let mut buf = vec![0u8; 64];
+  // Prefix: 0xFFFF count would be "upper byte nonzero → not IFD" at offset 0,
+  // and the high byte set keeps it from matching; also not II/MM.
+  buf[0..2].copy_from_slice(&0x0707u16.to_le_bytes()); // not an IFD (high byte set)
+  buf[2..4].copy_from_slice(&0x0707u16.to_le_bytes());
+  // IFD at offset 4:
+  buf[4..6].copy_from_slice(&1u16.to_le_bytes()); // numEntries = 1
+  put_entry(&mut buf, 6, 0x0100, 2, 4, 0); // ASCII×4 inline
+
+  let got = locate_ifd(&buf, 0, Some(64), ByteOrder::Little, None, None);
+  assert_eq!(got, Some((4, ByteOrder::Little)));
+}
+
+/// `locate_ifd` returns the located IFD offset RELATIVE to the `dir_start` it is
+/// handed — NOT an absolute offset into the buffer. Here the scan begins at
+/// `dir_start == 8` (a maker note whose blob starts 8 bytes into the TIFF) and
+/// the IFD sits 4 bytes past that (absolute 12), so the return is the RELATIVE
+/// `4`. `process_subdir` adds `dir_start` back to recover the absolute position;
+/// a non-zero blob offset must not be dropped. (Codex R1 finding 2.)
+#[test]
+fn locate_ifd_returns_relative_to_nonzero_dir_start() {
+  let mut buf = vec![0u8; 80];
+  // bytes 0..8: leading TIFF content before the maker-note blob (dir_start == 8).
+  // bytes 8..12: a 4-byte non-IFD prefix inside the blob; IFD at absolute 12.
+  buf[8..10].copy_from_slice(&0x0707u16.to_le_bytes()); // not an IFD (high byte set)
+  buf[10..12].copy_from_slice(&0x0707u16.to_le_bytes());
+  buf[12..14].copy_from_slice(&1u16.to_le_bytes()); // numEntries = 1
+  put_entry(&mut buf, 14, 0x0100, 2, 4, 0); // ASCII×4 inline
+  // dir_len is measured from dir_start: 80 - 8 = 72.
+  let got = locate_ifd(&buf, 8, Some(72), ByteOrder::Little, None, None);
+  assert_eq!(
+    got,
+    Some((4, ByteOrder::Little)),
+    "the offset is RELATIVE to dir_start=8 (the IFD is at absolute 12)"
+  );
+}
+
+/// A standard TIFF header inside the body (`II\x2a\0` + IFD pointer) is located
+/// via the TIFF-header arm (`:1576-1598`): the returned start is `ptr + offset`
+/// and the order comes from the magic.
+#[test]
+fn locate_ifd_tiff_header() {
+  let mut buf = vec![0u8; 64];
+  // TIFF header at offset 0: "II", 0x002a, then 4-byte IFD pointer = 8.
+  buf[0..2].copy_from_slice(b"II");
+  buf[2..4].copy_from_slice(&0x002au16.to_le_bytes());
+  buf[4..8].copy_from_slice(&8u32.to_le_bytes()); // IFD pointer = 8
+  // IFD at offset 8: 1 entry.
+  buf[8..10].copy_from_slice(&1u16.to_le_bytes());
+  put_entry(&mut buf, 10, 0x0100, 2, 4, 0);
+
+  // ptr 8 >= ifdOffsetPos(4)+4 = 8 ✓; ptr + offset 0 + 14 = 22 <= dirLen ✓ ⇒
+  // returns ptr + offset = 8 (`:1595`).
+  let got = locate_ifd(&buf, 0, Some(64), ByteOrder::Big, None, None);
+  assert_eq!(got, Some((8, ByteOrder::Little))); // order from the "II" magic
+}
+
+/// The byte-order TOGGLE arm (`:1605-1608`): an IFD whose count's LOW byte is
+/// zero (read in the parent order) is re-read in the toggled order. Count bytes
+/// `00 01` read parent-LE = 0x0100 (low byte 0) ⇒ toggle to Big ⇒ count = 1.
+#[test]
+fn locate_ifd_toggles_byte_order() {
+  let mut buf = vec![0u8; 32];
+  // IFD at offset 0, count = 0x0100 in LE bytes (`00 01`): low byte 0 → toggle.
+  buf[0..2].copy_from_slice(&[0x00, 0x01]);
+  // After toggling to Big, count = 1. Entry @ 2 must validate in BIG order.
+  buf[2..4].copy_from_slice(&0x0100u16.to_be_bytes()); // tag
+  buf[4..6].copy_from_slice(&2u16.to_be_bytes()); // format ASCII
+  buf[6..10].copy_from_slice(&4u32.to_be_bytes()); // count 4 (inline)
+  buf[10..14].copy_from_slice(&0u32.to_be_bytes()); // value/offset
+
+  let got = locate_ifd(&buf, 0, Some(32), ByteOrder::Little, None, None);
+  assert_eq!(got, Some((0, ByteOrder::Big)));
+}
+
+/// Pure garbage ⇒ `None` (`:1662`) — no offset in `0..=32` yields a plausible
+/// IFD. (Every 2-byte window's entry count fails the format/count validation
+/// or the upper-byte-nonzero gate.)
+#[test]
+fn locate_ifd_garbage_is_none() {
+  // 0xFF filler: every entry-count window has its upper byte set → "not an IFD"
+  // (`:1609-1611`); the TIFF-magic arm fails (no II/MM). Result: None.
+  let buf = vec![0xFFu8; 48];
+  assert_eq!(
+    locate_ifd(&buf, 0, Some(48), ByteOrder::Little, None, None),
+    None
+  );
+}
+
+/// Too small to hold an IFD (`dirLen < 14`) ⇒ `None` (`:1570`).
+#[test]
+fn locate_ifd_too_small_is_none() {
+  let buf = vec![0u8; 10];
+  assert_eq!(
+    locate_ifd(&buf, 0, Some(10), ByteOrder::Little, None, None),
+    None
+  );
+}

--- a/src/exif/makernotes/mod.rs
+++ b/src/exif/makernotes/mod.rs
@@ -52,7 +52,9 @@
 pub mod byte_order;
 pub mod detected;
 pub mod dispatcher;
+pub mod fixbase;
 pub mod offset;
+pub mod subdir;
 pub mod vendor;
 pub mod vendors;
 

--- a/src/exif/makernotes/subdir.rs
+++ b/src/exif/makernotes/subdir.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! The two `SubDirectory` directives the unified maker-note engine needs on top
+//! of the ones [`DetectedMakerNote`](super::detected::DetectedMakerNote) already
+//! models — `TableRef` (which tag table) and [`ProcessProc`] (which processor).
+//!
+//! ExifTool processes every maker note through the ONE shared engine
+//! (`ProcessExif`, `Exif.pm:6278`); a vendor is not a walker but a **tag table
+//! plus a set of `SubDirectory` directives** (`Start`/`Base`/`ByteOrder`/
+//! `FixBase`/`ProcessProc`, `MakerNotes.pm:37-1127`). The directive *data* lives
+//! in [`DetectedMakerNote`](super::detected::DetectedMakerNote) (the dispatcher's
+//! per-blob result — `body_offset`=Start, `base_rule`=Base, `byte_order`,
+//! `fix_base`, `not_ifd`, `entry_based`, `offset_pt`); this module adds only the
+//! two pieces that the pre-unification code derived implicitly inside the
+//! per-vendor walkers:
+//!
+//! - [`TableRef`] — which tag table the shared `Walker` resolves
+//!   names/formats/conversions against (replaces the `IfdKind`-keyed lookup so
+//!   the one walker serves Exif/GPS/Interop AND every vendor table).
+//! - [`ProcessProc`] — the directory processor (`ProcessExif`/`ProcessCanon`/
+//!   `ProcessUnknown`/`ProcessBinaryData`).
+//!
+//! `Walker::process_subdir` consumes a `&DetectedMakerNote` together with these.
+//! It is THE only way a maker note is processed — there is no per-vendor IFD
+//! walker (enforced by `tests/makernote_engine_invariant.rs`).
+//!
+//! See `docs/superpowers/specs/2026-06-15-makernote-engine-unification-design.md`.
+
+use crate::exif::ifd::ByteOrder;
+
+/// Which tag table the shared walker resolves names/formats/conversions against
+/// while walking a (sub-)directory. Replaces the `IfdKind`-keyed lookup so the
+/// one `Walker` can process Exif/GPS/Interop IFDs AND every vendor maker note
+/// with identical machinery.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TableRef {
+  /// `%Exif::Main` — IFD0, ExifIFD, trailing IFDs, SubIFDs.
+  Exif,
+  /// `%GPS::Main`.
+  Gps,
+  /// `%Exif::Main` reused for the Interop IFD (faithful — InteropOffset has no
+  /// own table, `Exif.pm:6939`).
+  Interop,
+  /// `%Canon::Main`.
+  Canon,
+  /// `%Sony::Main`.
+  Sony,
+  /// `%Panasonic::Main`.
+  Panasonic,
+  /// `%Nikon::Main`.
+  Nikon,
+  /// `%Apple::Main`.
+  Apple,
+  /// `%Samsung::Type2`.
+  Samsung,
+}
+
+/// `ProcessProc` (`MakerNotes.pm`) — the directory processor. The four real
+/// processors maker notes use; all but [`ProcessProc::BinaryData`] ultimately
+/// run the shared `ProcessExif` IFD walk (the difference is the pre-walk step).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProcessProc {
+  /// Default — `ProcessExif` directly (Sony/Panasonic/Nikon/Apple).
+  Exif,
+  /// `ProcessCanon` — `ProcessExif` plus Canon footer/CNDC hooks (`Canon.pm`).
+  Canon,
+  /// `ProcessUnknown` — `LocateIFD` then `ProcessExif` (`MakerNotes.pm:1816`;
+  /// Samsung2/Pentax/Casio2, whose offsets are inconsistent).
+  Unknown,
+  /// `ProcessBinaryData` — a fixed-layout sub-table (ShotInfo/AFInfo/…).
+  BinaryData,
+}
+
+/// `ByteOrder => 'BigEndian' | 'LittleEndian' | 'Unknown'` — the endianness
+/// rule for a (sub-)directory walk (`MakerNotes.pm` SubDirectory key,
+/// `Exif.pm:6982-6996`).
+///
+/// [`Fixed`](Self::Fixed) is a hard-coded order (also the rule the core
+/// Exif/GPS/Interop sub-IFDs use — they always inherit the parent TIFF order,
+/// `Exif.pm:7064-7077`). [`Unknown`](Self::Unknown) defers the order to the
+/// entry-count heuristic
+/// ([`fixbase::detect_unknown_byte_order`](super::fixbase::detect_unknown_byte_order),
+/// `Exif.pm:6982-6993`); it fires only for vendor maker notes, never a core
+/// IFD.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ByteOrderRule {
+  /// A fixed endianness — `ByteOrder => 'LittleEndian'`/`'BigEndian'`, or (for
+  /// a core sub-IFD) the inherited parent order.
+  Fixed(ByteOrder),
+  /// `ByteOrder => 'Unknown'` — probe the body's entry-count word to pick the
+  /// order at walk time (`Exif.pm:6982-6993`).
+  Unknown,
+}
+
+/// `FixBase => 0 | 1 | 2` (`MakerNotes.pm` SubDirectory key) — the
+/// offset-correction heuristic mode for a (sub-)directory walk.
+///
+/// [`No`](Self::No) is the absence of a `FixBase` directive (every core
+/// Exif/GPS/Interop sub-IFD — their offsets are already TIFF-correct).
+/// [`Heuristic`](Self::Heuristic) (`FixBase => 1`) and
+/// [`Aggressive`](Self::Aggressive) (`FixBase => 2`, "allow a range" for
+/// genuinely Unknown maker notes) run [`fixbase::fix_base`](super::fixbase::fix_base).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FixBaseMode {
+  /// No `FixBase` directive — do not run the heuristic.
+  No,
+  /// `FixBase => 1` — run the standard offset-correction heuristic.
+  Heuristic,
+  /// `FixBase => 2` — run the heuristic in "allow a range" mode (Unknown
+  /// maker notes, `MakerNotes.pm:1124`).
+  Aggressive,
+}
+
+impl ByteOrderRule {
+  /// `true` if the rule is [`Unknown`](Self::Unknown) (probe at walk time).
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_unknown(self) -> bool {
+    matches!(self, ByteOrderRule::Unknown)
+  }
+
+  /// The fixed endianness, if any. `None` for [`Unknown`](Self::Unknown).
+  #[must_use]
+  #[inline(always)]
+  pub const fn fixed(self) -> Option<ByteOrder> {
+    match self {
+      ByteOrderRule::Fixed(b) => Some(b),
+      ByteOrderRule::Unknown => None,
+    }
+  }
+}
+
+impl FixBaseMode {
+  /// `true` if the mode is [`No`](Self::No) (no `FixBase` directive).
+  #[must_use]
+  #[inline(always)]
+  pub const fn is_no(self) -> bool {
+    matches!(self, FixBaseMode::No)
+  }
+
+  /// The `$$dirInfo{FixBase}` value (`1`/`2`) the heuristic reads, or `None`
+  /// for [`No`](Self::No).
+  #[must_use]
+  #[inline(always)]
+  pub const fn dir_fix_base(self) -> Option<u8> {
+    match self {
+      FixBaseMode::No => None,
+      FixBaseMode::Heuristic => Some(1),
+      FixBaseMode::Aggressive => Some(2),
+    }
+  }
+}
+
+impl TableRef {
+  /// `true` for the three core IFD tables (the pre-existing `IfdKind` set);
+  /// `false` for a vendor maker-note table.
+  #[must_use]
+  pub const fn is_core_ifd(self) -> bool {
+    matches!(self, TableRef::Exif | TableRef::Gps | TableRef::Interop)
+  }
+}

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -97,9 +97,12 @@ pub mod jpeg;
 
 use std::{string::String, vec::Vec};
 
-use crate::format_parser::{FormatParser, parser_sealed};
-use crate::recovery::Step;
+use crate::{
+  format_parser::{FormatParser, parser_sealed},
+  recovery::Step,
+};
 use ifd::{ByteOrder, Format, RawValue, get_u16, get_u32, get_u64, read_value};
+use makernotes::subdir::{ByteOrderRule, FixBaseMode, ProcessProc, TableRef};
 use tables::Conv;
 
 // ====================================================================// IFD identity — the family-1 group an IFD's tags carry
@@ -294,6 +297,23 @@ impl IfdKind {
   }
 }
 
+/// The tag table a core IFD walks against, derived from its [`IfdKind`] — the
+/// faithful `$tagTablePtr` each `ProcessExif` directory carries
+/// (`Exif.pm:6341`). IFD0/ExifIFD/trailing IFDs and the Interop IFD use
+/// `%Exif::Main` (Interop has no table of its own — `Exif.pm:6939`); the GPS
+/// IFD uses `%GPS::Main`. This is the bridge that lets [`Walker::active_table`]
+/// be seeded from an `IfdKind` so the table-keyed lookup reproduces the prior
+/// `IfdKind::is_gps`-keyed selection byte-for-byte.
+#[must_use]
+#[inline]
+const fn table_for_ifd_kind(kind: IfdKind) -> TableRef {
+  match kind {
+    IfdKind::Gps => TableRef::Gps,
+    IfdKind::Interop => TableRef::Interop,
+    IfdKind::Ifd0 | IfdKind::Trailing(_) | IfdKind::ExifIfd => TableRef::Exif,
+  }
+}
+
 // ====================================================================// SubDirectory dispatch seam — `SubDirKind`
 // ====================================================================
 /// The SubDirectory a pointer tag dispatches into — the seam that keeps the
@@ -453,15 +473,19 @@ impl ExifEntry {
   }
 }
 
-/// Which conversion table an entry's value goes through at serialize time.
-/// Internal — `ExifEntry` carries it so `serialize_tags` does not re-look-up.
+/// Which tag-table descriptor an entry's value is converted under at serialize
+/// time. Internal — `ExifEntry` carries the resolved `'static` descriptor so the
+/// emit reads its golden [`ExifTag::value_conv`]/[`ExifTag::print_conv`] (the
+/// `Walker`'s golden conversion-resolution point, #243 phase 0) without
+/// re-looking-up, and reads its raw [`Conv`]/[`gps::GpsConv`] for the bespoke
+/// `RawValue`-shaped fallback.
 #[derive(Debug, Clone, Copy)]
 enum ResolvedConv {
-  /// A plain Exif conversion ([`Conv`]).
-  Exif(Conv),
-  /// A GPS conversion ([`gps::GpsConv`]).
+  /// An Exif IFD leaf (`%Exif::Main` descriptor).
+  Exif(&'static tables::ExifTag),
+  /// A GPS IFD leaf (`%GPS::Main` descriptor).
   #[cfg(feature = "gps")]
-  Gps(gps::GpsConv),
+  Gps(&'static gps::GpsTag),
 }
 
 // ====================================================================// MakerNote capture — the deferred-vendor-parsing seam
@@ -1822,6 +1846,9 @@ fn parse_tiff_with_base_no_raf<'a>(
     // `$warnCount` starts at 0 (`Exif.pm:6453`); `walk_one_ifd_body` re-zeroes
     // it per directory.
     warn_count: 0,
+    // The walk starts on the Exif table; `walk_ifd_chain` re-affirms it and
+    // `process_subdir` swaps it for a sub-IFD's table (GPS) and restores it.
+    active_table: TableRef::Exif,
   };
   // Walk the IFD0 → IFD1 chain (the next-IFD pointer). ExifIFD/GPS/Interop
   // are reached as SubDirectories from inside the walk. `ifd0_kind` is `Ifd0`
@@ -1948,6 +1975,9 @@ fn parse_bigtiff<'a>(
     file_type: file_type.clone(),
     no_raf,
     warn_count: 0,
+    // The BigTIFF walker keys its leaf lookup off `kind` directly
+    // (`big_tag_known`), not `active_table`; this just satisfies the struct.
+    active_table: TableRef::Exif,
   };
   w.walk_big_ifd_chain(ifd0_offset, ifd0_kind);
   debug_assert!(
@@ -2127,6 +2157,8 @@ fn parse_tiff_with_base_shared<'a>(
     no_raf: false,
     // `$warnCount` starts at 0 (`Exif.pm:6453`); re-zeroed per directory.
     warn_count: 0,
+    // Starts on the Exif table; `walk_ifd_chain` re-affirms it.
+    active_table: TableRef::Exif,
   };
   w.walk_ifd_chain(ifd0_offset, IfdKind::Ifd0);
 
@@ -2367,6 +2399,25 @@ struct Walker<'a, 'g> {
   /// the cap is enforced in [`walk_entries`](Self::walk_entries). `u32` because
   /// the only entries that bump it are bounded by `num_entries` (≤ 65535).
   warn_count: u32,
+  /// The tag table the walk currently resolves names/formats/conversions
+  /// against — `$tagTablePtr` in `ProcessExif` (`Exif.pm:6341`). The shared
+  /// `Walker` walks IFD0/ExifIFD/Interop/trailing IFDs against `%Exif::Main`
+  /// and the GPS IFD against `%GPS::Main`; ExifTool keys the leaf lookup off
+  /// the directory's OWN table, not its `DirName`. The pre-unification code
+  /// derived the table implicitly from [`IfdKind`] at each lookup site
+  /// ([`IfdKind::is_gps`]); threading it as state lets [`process_subdir`]
+  /// (the ONE sub-directory entry point) save/set/restore it around a
+  /// sub-IFD recursion so a GPS sub-IFD's table never leaks into the parent
+  /// IFD0's remaining entries, and lets a future vendor maker note walk the
+  /// same machinery against `%Canon::Main`/etc.
+  ///
+  /// INVARIANT (the Phase-0 byte-identity proof): on every REGULAR-walk
+  /// lookup site this field equals [`table_for_ifd_kind`] of the `kind`
+  /// being walked — `walk_ifd_chain` sets it to `Exif` for the IFD0→IFD1
+  /// chain and `process_subdir` sets it to the sub-IFD's table for the
+  /// duration of that recursion — so routing the lookups through it
+  /// reproduces the prior `IfdKind`-keyed selection exactly.
+  active_table: TableRef,
 }
 
 impl Walker<'_, '_> {
@@ -2408,6 +2459,17 @@ impl Walker<'_, '_> {
   /// …) — faithful to `ProcessExif`'s `$$dirInfo{Multi}` trailing-IFD scan
   /// (`Exif.pm:7202-7228`). `Multi` is set for IFD0 (`Exif.pm:6339`).
   fn walk_ifd_chain(&mut self, start: usize, first_kind: IfdKind) {
+    // Seed the active table from the chain's FIRST kind. The IFD0 → IFD1 → …
+    // chain re-enters `ProcessExif` with the SAME `$tagTablePtr` (`Exif.pm:7211`
+    // `for (;;)`), so the whole chain shares the first kind's table. This is
+    // `Exif` for a standard TIFF (`first_kind == Ifd0`), but `parse_gps_block`
+    // walks a GPS-only top-level block (`first_kind == Gps`, e.g. a Canon CR3
+    // CMT4 directory) against `%GPS::Main` — seeding from `first_kind` keeps that
+    // routing correct (a hard-coded `Exif` would resolve the GPS tags in the Exif
+    // table and drop/mis-name them). A sub-IFD recursion swaps the table for its
+    // own via `process_subdir` (save/set/restore) and restores it on return, so a
+    // GPS/Interop sub-IFD cannot leak its table into the chain's later entries.
+    self.active_table = table_for_ifd_kind(first_kind);
     let mut offset = start;
     let mut kind = first_kind;
     // The 1-based number of the NEXT trailing IFD. ExifTool strips the
@@ -3133,29 +3195,34 @@ impl Walker<'_, '_> {
     true
   }
 
-  /// Resolve a tag NAME for a warning message, against the table that owns
-  /// the IFD currently being walked. GPS and Interop tag IDs OVERLAP (e.g.
-  /// 0x0002 is `GPSLatitude` in `%GPS::Main` but `InteropVersion` in
-  /// `%Interop::Main`); ExifTool resolves a warning's `$$tagInfo{Name}`
-  /// against the IFD's own `$tagTablePtr` (`Exif.pm:6464`/6674), so the GPS
-  /// IFD must look up the GPS table. Returns `Some(name)` for a known tag,
+  /// Resolve a tag NAME against `table` — the table the active (sub-)directory
+  /// walks under. GPS and Interop/Exif tag IDs OVERLAP (e.g. 0x0002 is
+  /// `GPSLatitude` in `%GPS::Main` but `InteropVersion`/`GPSLatitude` shape in
+  /// `%Exif::Main`); ExifTool resolves `$$tagInfo{Name}` against the
+  /// directory's OWN `$tagTablePtr` (`Exif.pm:6464`/6674), so the GPS IFD must
+  /// look up `%GPS::Main`. `TableRef::Interop` reuses `%Exif::Main` for the
+  /// lookup (the Interop IFD has no table of its own — `Exif.pm:6939`). The
+  /// vendor arms are unreachable in Phase 1 (no maker note routes through this
+  /// walker yet); they map to `%Exif::Main` as a faithful placeholder until
+  /// Phase 2 wires their tables in. Returns `Some(name)` for a known tag,
   /// `None` for an unknown one (caller emits the `tag 0x%.4x` form).
-  fn warn_tag_name(kind: IfdKind, tag_id: u16) -> Option<&'static str> {
-    if kind.is_gps() {
-      #[cfg(feature = "gps")]
-      {
-        gps::lookup(tag_id).map(|t| t.name)
+  fn lookup_name_in(table: TableRef, tag_id: u16) -> Option<&'static str> {
+    match table {
+      TableRef::Gps => {
+        #[cfg(feature = "gps")]
+        {
+          gps::lookup(tag_id).map(|t| t.name)
+        }
+        // `gps` feature OFF ⇒ the GPS module is "not loaded": ExifTool's
+        // `GetTagInfo` yields nothing, so the warning uses the unknown-tag
+        // form. Faithful to the module-not-loaded path (`docs/tracking.md`).
+        #[cfg(not(feature = "gps"))]
+        {
+          let _ = tag_id;
+          None
+        }
       }
-      // `gps` feature OFF ⇒ the GPS module is "not loaded": ExifTool's
-      // `GetTagInfo` yields nothing, so the warning uses the unknown-tag
-      // form. Faithful to the module-not-loaded path (`docs/tracking.md`).
-      #[cfg(not(feature = "gps"))]
-      {
-        let _ = tag_id;
-        None
-      }
-    } else {
-      tables::lookup(tag_id).map(|t| t.name)
+      _ => tables::lookup(tag_id).map(|t| t.name),
     }
   }
 
@@ -3281,7 +3348,7 @@ impl Walker<'_, '_> {
       // `TagName` (`Exif.pm:6252`): `tag 0x%.4x` plus ` Name` for a known tag.
       if size > 0x7fff_ffff {
         let dir = kind.as_str();
-        let tag = match Self::warn_tag_name(kind, tag_id) {
+        let tag = match Self::lookup_name_in(self.active_table, tag_id) {
           Some(name) => std::format!("tag 0x{tag_id:04x} {name}"),
           None => std::format!("tag 0x{tag_id:04x}"),
         };
@@ -3357,7 +3424,7 @@ impl Walker<'_, '_> {
         // suspect test below (the read happens first, `Exif.pm:6660` before
         // `:6672`).
         _ if self.no_raf => {
-          let warning = match Self::warn_tag_name(kind, tag_id) {
+          let warning = match Self::lookup_name_in(self.active_table, tag_id) {
             Some(name) => std::format!("Bad offset for {dir} {name}"),
             None => std::format!("Bad offset for {dir} tag 0x{tag_id:04x}"),
           };
@@ -3373,7 +3440,7 @@ impl Walker<'_, '_> {
           // The name is resolved against the IFD's OWN table (GPS vs
           // Exif/Interop — see `warn_tag_name`); a GPS IFD's 0x0002 is
           // `GPSLatitude`, not the Interop table's `InteropVersion`.
-          let tag = match Self::warn_tag_name(kind, tag_id) {
+          let tag = match Self::lookup_name_in(self.active_table, tag_id) {
             Some(name) => std::format!(" {name}"),
             None => String::new(),
           };
@@ -3394,7 +3461,7 @@ impl Walker<'_, '_> {
         // `$tagStr = $tagInfo ? $$tagInfo{Name} : sprintf('tag 0x%.4x', …)`
         // (Exif.pm:6674). The name is resolved against the IFD's own table
         // (`warn_tag_name`) — GPS IDs overlap the Interop table.
-        let warning = match Self::warn_tag_name(kind, tag_id) {
+        let warning = match Self::lookup_name_in(self.active_table, tag_id) {
           Some(name) => std::format!("Suspicious {dir} offset for {name}"),
           None => std::format!("Suspicious {dir} offset for tag 0x{tag_id:04x}"),
         };
@@ -3478,21 +3545,25 @@ impl Walker<'_, '_> {
     // gating all GPS entries off) honors 0x001d while leaving the GPS text
     // tags 0x001b/0x001c — `Writable => 'undef'` but NO `Format`, GPS.pm:296/
     // 304 — correctly NUL-trimmed, exactly as bundled does.
-    let table_override = if kind.is_gps() {
-      #[cfg(feature = "gps")]
-      {
-        gps::format_override(tag_id)
+    // Resolved against the active table (`Exif.pm:6729-6744` reads the
+    // override off the directory's `$tagTablePtr`). `Interop`/vendor arms
+    // (unreachable in Phase 1) share the `%Exif::Main` override table.
+    let table_override = match self.active_table {
+      TableRef::Gps => {
+        #[cfg(feature = "gps")]
+        {
+          gps::format_override(tag_id)
+        }
+        // `gps` feature OFF ⇒ the GPS module is "not loaded": no GPS-table
+        // `Format` override is resolvable (the leaf isn't decoded as a GPS tag
+        // either), so fall through with the on-disk format unchanged.
+        #[cfg(not(feature = "gps"))]
+        {
+          let _ = tag_id;
+          None
+        }
       }
-      // `gps` feature OFF ⇒ the GPS module is "not loaded": no GPS-table
-      // `Format` override is resolvable (the leaf isn't decoded as a GPS tag
-      // either), so fall through with the on-disk format unchanged.
-      #[cfg(not(feature = "gps"))]
-      {
-        let _ = tag_id;
-        None
-      }
-    } else {
-      tables::format_override(tag_id)
+      _ => tables::format_override(tag_id),
     };
     let (format, count) = if let Some(over) = table_override {
       let new_elem = over.byte_size();
@@ -3521,7 +3592,7 @@ impl Walker<'_, '_> {
       // (Exif.pm:6762). NOTE the excessive-count message uses `$dirName`
       // (Exif.pm:6766); `$dir == $dirName == kind.as_str()` for every
       // non-MakerNotes IFD this walker reaches (Exif.pm:6341).
-      let known = Self::warn_tag_name(kind, tag_id);
+      let known = Self::lookup_name_in(self.active_table, tag_id);
 
       // Guard (a) — `if ($count > 100000 and ...)` (Exif.pm:6760-6770).
       if count > 100_000 {
@@ -3624,6 +3695,131 @@ impl Walker<'_, '_> {
     Step::Keep
   }
 
+  /// THE one sub-directory entry point — the faithful
+  /// `ProcessExif`-on-a-`SubDirectory` path (`Exif.pm:6919-7102`), parameterized
+  /// by the `SubDirectory` directive set the engine unification models
+  /// (`MakerNotes.pm:37-1127`). Every IFD-pointer subdirectory (ExifIFD/GPS/
+  /// Interop today; every vendor maker note in Phase 2+) is processed here, so
+  /// `FixBase`, `ByteOrder=Unknown` detection, the per-entry warnings, the
+  /// `warn_count>10` abort, sub-IFD recursion and `run_emission` are shared
+  /// engine features each directory inherits — not re-derived per vendor.
+  ///
+  /// It SAVES, sets, and RESTORES both [`active_table`](Self::active_table) (so
+  /// a sub-IFD's table never leaks into the parent's remaining entries) and
+  /// [`order`](Self::order) (so a `Fixed(other)` / `Unknown`-toggled child order
+  /// is honored only for the duration of the child walk — `Exif.pm:7078`'s
+  /// `SetByteOrder` is scoped to the subdirectory and the parent order is
+  /// restored on return).
+  ///
+  /// ## Pre-walk hooks — provably INERT for the core Exif/GPS/Interop sub-IFDs
+  ///
+  /// The core descriptors pass `ByteOrder = Fixed(parent_order)`,
+  /// `FixBase = No`, `Process = Exif`, so NONE of the three hooks fires and the
+  /// `ifd_start`/`order` handed to [`walk_one_ifd`] are EXACTLY the values the
+  /// pre-unification `self.walk_one_ifd(sub_offset, kind)` used — byte-identical
+  /// by construction. The hooks (each faithful to the cited Perl) fire only for
+  /// a maker-note descriptor (Phase 2+):
+  ///
+  /// - [`ByteOrderRule::Unknown`] → [`fixbase::detect_unknown_byte_order`]
+  ///   (`Exif.pm:6982-6993`) — probe the entry-count word; fall back to the
+  ///   parent order when fewer than 2 bytes are available.
+  /// - [`FixBaseMode`] `!= No` → [`fixbase::fix_base`] (`MakerNotes.pm:1282-
+  ///   1484`) — the offset-correction heuristic; relocates the value base.
+  /// - [`ProcessProc::Unknown`] → [`fixbase::locate_ifd`] (`MakerNotes.pm:1486-
+  ///   1663`) — scan for the real IFD start and resolve its order.
+  ///
+  /// `Fixed(parent_order)` resolves to `self.order` unchanged, `No` runs no
+  /// `fix_base`, and `Exif` runs no `locate_ifd`, so the save/restore of
+  /// `self.order` and the `ifd_start` passed on are no-ops for every current
+  /// caller. The full base/`data_pos` mutation that a non-`No` `fix_base`
+  /// implies is applied by the Phase-2 vendor migration (the Walker's `base`
+  /// model is threaded then); here `fix_base` is INVOKED behind the
+  /// `!= No` gate (wiring the feature in) but the core path never reaches it.
+  #[cfg_attr(not(feature = "alloc"), allow(dead_code))]
+  fn process_subdir(
+    &mut self,
+    ifd_start: usize,
+    kind: IfdKind,
+    table: TableRef,
+    byte_order: ByteOrderRule,
+    fix_base: FixBaseMode,
+    process: ProcessProc,
+  ) {
+    // ---- Pre-walk hook 1: resolve the child byte order (`Exif.pm:6982-6996`).
+    // `Fixed(o)` keeps `o`; `Unknown` probes the entry-count word, falling back
+    // to the parent order when the probe is inconclusive (`:6996`). For a core
+    // sub-IFD this is `Fixed(self.order)` ⇒ `resolved_order == self.order`.
+    let resolved_order = match byte_order {
+      ByteOrderRule::Fixed(o) => o,
+      ByteOrderRule::Unknown => {
+        makernotes::fixbase::detect_unknown_byte_order(self.data, ifd_start, self.order)
+          .unwrap_or(self.order)
+      }
+    };
+
+    // ---- Pre-walk hook 2: ProcessUnknown's `LocateIFD` (`MakerNotes.pm:1816-
+    // 1837`). Only `ProcessProc::Unknown` relocates the IFD start + order; the
+    // other processors keep `ifd_start`/`resolved_order` as derived. A failed
+    // locate leaves them unchanged (the walk then bounds-rejects, mirroring
+    // `ProcessUnknown`'s `Unrecognized` warn arm). Inert for `Exif`/`Canon`.
+    //
+    // `locate_ifd` returns the located IFD offset RELATIVE to the `ifd_start` it
+    // was handed (its scan runs `0..=32` from `dir_start`), so the ABSOLUTE
+    // position in `self.data` is `ifd_start + located`. Adding it back is
+    // essential for any maker note whose blob begins at a non-zero TIFF offset;
+    // a `checked_add` overflow (degenerate input) falls back to the unrelocated
+    // start, which the walk then bounds-rejects.
+    let (ifd_start, resolved_order) = match process {
+      ProcessProc::Unknown => makernotes::fixbase::locate_ifd(
+        self.data,
+        ifd_start,
+        None,
+        resolved_order,
+        self.captured_make.as_deref(),
+        self.captured_model.as_deref(),
+      )
+      .and_then(|(located, order)| ifd_start.checked_add(located).map(|abs| (abs, order)))
+      .unwrap_or((ifd_start, resolved_order)),
+      ProcessProc::Exif | ProcessProc::Canon | ProcessProc::BinaryData => {
+        (ifd_start, resolved_order)
+      }
+    };
+
+    // ---- Pre-walk hook 3: FixBase (`MakerNotes.pm:1282-1484`). The offset-
+    // correction heuristic runs ONLY when a `FixBase` directive is present
+    // (`!= No`); its base/`data_pos` mutation is applied by the Phase-2 vendor
+    // migration (the Walker's `base` is threaded then). Computing it here wires
+    // the feature behind the directive gate. INERT for `FixBaseMode::No` (every
+    // core sub-IFD), so the result is discarded with no effect on the walk.
+    if let Some(dir_fix_base) = fix_base.dir_fix_base() {
+      let input = makernotes::fixbase::FixBaseInput::new(
+        self.data,
+        ifd_start,
+        self.data.len().saturating_sub(ifd_start),
+        i64::from(self.base),
+        i64::from(self.base),
+        resolved_order,
+        self.captured_make.as_deref().unwrap_or(""),
+        self.captured_model.as_deref().unwrap_or(""),
+      )
+      .with_file_types(self.file_type.as_deref(), None)
+      .with_dir_fix_base(Some(dir_fix_base));
+      // Phase-0/1: the heuristic is wired but its base shift is consumed by the
+      // Phase-2 vendor migration; ignore it here (core never reaches this).
+      let _ = makernotes::fixbase::fix_base(&input);
+    }
+
+    // ---- The walk: SAME `walk_one_ifd` machinery IFD0/ExifIFD/GPS use, under
+    // the child table + resolved order, with both restored on return.
+    let saved_table = self.active_table;
+    let saved_order = self.order;
+    self.active_table = table;
+    self.order = resolved_order;
+    let _ = self.walk_one_ifd(ifd_start, kind);
+    self.order = saved_order;
+    self.active_table = saved_table;
+  }
+
   /// Dispatch a SubDirectory pointer tag.
   ///
   /// For ExifIFD/GPS/Interop the value is the 32-bit IFD offset
@@ -3679,8 +3875,21 @@ impl Walker<'_, '_> {
         // self-pointer.
         // Sub-IFDs are NOT chained via a next-IFD pointer (`MaxSubdirs => 1`
         // for GPS/Interop, `Exif.pm:2138`; ExifIFD is a single IFD too) —
-        // walk exactly one IFD.
-        let _ = self.walk_one_ifd(sub_offset, kind);
+        // walk exactly one IFD, through THE shared sub-directory entry point.
+        // The core descriptor (`Fixed(self.order)` + `No` + `Exif`) makes every
+        // `process_subdir` pre-walk hook inert, so this is byte-identical to the
+        // prior direct `walk_one_ifd(sub_offset, kind)` while routing GPS/
+        // Interop/ExifIFD recursion through the same machinery a vendor maker
+        // note will use — and it sets/restores `active_table` so the GPS table
+        // does not leak into the parent IFD0's remaining entries.
+        self.process_subdir(
+          sub_offset,
+          kind,
+          table_for_ifd_kind(kind),
+          ByteOrderRule::Fixed(self.order),
+          FixBaseMode::No,
+          ProcessProc::Exif,
+        );
       }
       SubDirKind::MakerNote => {
         // **MakerNotes Phase 1: identify vendor + capture `SubDirectory`
@@ -4113,8 +4322,13 @@ impl Walker<'_, '_> {
     // `%GPS::Main` instead (the same `kind.is_gps()` split that routes the leaf
     // lookup below to `gps::lookup`), and `%GPS::Main` has NO 0xc612 entry — so
     // an unknown GPS-IFD tag with id 0xc612 must NOT touch the DataMember. Gate
-    // the assignment on `!kind.is_gps()` to match that scoping exactly.
-    if tag_id == tables::TAG_DNG_VERSION && !kind.is_gps() {
+    // the assignment on the ACTIVE TABLE (not `kind`): `%GPS::Main` is selected
+    // by `active_table == Gps`, which holds for the GPS IFD AND for every IFD of
+    // a GPS-only chain (`parse_gps_block`, where the trailing dirs are `kind =
+    // Trailing` but still walk `%GPS::Main`). `kind.is_gps()` would wrongly fire
+    // the Exif `DNGVersion` tap in such a chain. Byte-identical for a normal
+    // TIFF, where `active_table == table_for_ifd_kind(kind)`.
+    if tag_id == tables::TAG_DNG_VERSION && self.active_table != TableRef::Gps {
       self.dng_version = raw.is_perl_truthy();
     }
 
@@ -4127,32 +4341,41 @@ impl Walker<'_, '_> {
     // (standalone TIFF) this is a no-op, so the existing TIFF goldens are
     // unaffected; for a JPEG `APP1` block `base` is the TIFF block's file
     // offset, matching bundled's absolute `ThumbnailOffset`.
-    let raw = if self.base != 0 && !kind.is_gps() && is_offset_tag(tag_id) {
+    // `!kind.is_gps()` → `active_table != Gps`: GPS has no `IsOffset` tags, and
+    // the gate must follow the ACTIVE TABLE so a GPS-only chain's trailing dirs
+    // (`kind = Trailing`, `active_table = Gps`) do not apply the Exif
+    // `StripOffsets`/`ThumbnailOffset` base-add. Byte-identical for a normal TIFF.
+    let raw = if self.base != 0 && self.active_table != TableRef::Gps && is_offset_tag(tag_id) {
       add_offset_base(raw, self.base)
     } else {
       raw
     };
-    let (name, conv): (&'static str, ResolvedConv) = if kind.is_gps() {
-      #[cfg(feature = "gps")]
-      {
-        match gps::lookup(tag_id) {
-          Some(t) => (t.name, ResolvedConv::Gps(t.conv)),
-          None => return, // unknown GPS tag — verbose-only, omit.
+    // Leaf name + conversions come from the ACTIVE table (`$tagTablePtr`,
+    // `Exif.pm:6464`). `Interop` and the Phase-1-unreachable vendor arms share
+    // `%Exif::Main` (`Exif.pm:6939` — InteropOffset has no own table); only the
+    // GPS IFD resolves against `%GPS::Main`.
+    let (name, conv): (&'static str, ResolvedConv) = match self.active_table {
+      TableRef::Gps => {
+        #[cfg(feature = "gps")]
+        {
+          match gps::lookup(tag_id) {
+            Some(t) => (t.name, ResolvedConv::Gps(t)),
+            None => return, // unknown GPS tag — verbose-only, omit.
+          }
+        }
+        // GPS IFD reached but the `gps` feature is OFF: faithful to ExifTool
+        // "module not loaded ⇒ tags not decoded". The GPS IFD's leaf tags are
+        // simply not emitted (the IFD walker still descended into it via the
+        // 0x8825 dispatch, which is harmless). `docs/tracking.md`.
+        #[cfg(not(feature = "gps"))]
+        {
+          return;
         }
       }
-      // GPS IFD reached but the `gps` feature is OFF: faithful to ExifTool
-      // "module not loaded ⇒ tags not decoded". The GPS IFD's leaf tags are
-      // simply not emitted (the IFD walker still descended into it via the
-      // 0x8825 dispatch, which is harmless). `docs/tracking.md`.
-      #[cfg(not(feature = "gps"))]
-      {
-        return;
-      }
-    } else {
-      match tables::lookup(tag_id) {
-        Some(t) => (t.name, ResolvedConv::Exif(t.conv)),
+      _ => match tables::lookup(tag_id) {
+        Some(t) => (t.name, ResolvedConv::Exif(t)),
         None => return, // unknown Exif tag — verbose-only, omit.
-      }
+      },
     };
 
     // Capture `Make` (0x010f) and `Model` (0x0110) — both are IFD0 string
@@ -4705,7 +4928,12 @@ impl ExifSink for crate::tagmap::TagMap {
     // with the provider `serialize_tags` paths that were its last callers;
     // this `ExifSink for TagMap` impl is the only remaining `write_bytes`
     // user and owns the insert directly now).
-    self.write_value(group, name, crate::value::TagValue::Bytes(value.to_vec()))
+    crate::tagmap::TagMap::write_value(
+      self,
+      group,
+      name,
+      crate::value::TagValue::Bytes(value.to_vec()),
+    )
   }
 }
 
@@ -4828,14 +5056,19 @@ fn emit_entry<S: ExifSink>(
   let group = entry.group();
   let group = group.as_str();
   let name = entry.name();
+  let raw = entry.value.raw();
+  // Emit the leaf through the bespoke `emit_exif_value` / `emit_gps_value`
+  // renderer keyed on the entry's [`tables::Conv`] / [`gps::GpsConv`]. (The
+  // Exif/GPS leaf convs operate on the RAW value's first scalar / exact rational
+  // / byte shape, which the golden `convert::apply` runtime — written for the
+  // already-rendered `TagValue` — cannot reproduce byte-identically for a
+  // multi-element value or preserve in TagValue shape; #243 Codex R1/R2. The
+  // Phase-2 vendor tables are golden `TagDef`s and DO emit through
+  // `convert::apply`, via a separate path.)
   match entry.conv {
-    ResolvedConv::Exif(conv) => {
-      emit_exif_value(group, name, entry.value.raw(), conv, order, print_conv, out)
-    }
+    ResolvedConv::Exif(tag) => emit_exif_value(group, name, raw, tag.conv, order, print_conv, out),
     #[cfg(feature = "gps")]
-    ResolvedConv::Gps(conv) => {
-      emit_gps_value(group, name, entry.value.raw(), conv, order, print_conv, out)
-    }
+    ResolvedConv::Gps(tag) => emit_gps_value(group, name, raw, tag.conv, order, print_conv, out),
   }
 }
 
@@ -5950,6 +6183,88 @@ mod tests {
   fn rejects_ifd0_offset_below_8() {
     // Valid MM marker but IFD0 offset = 4 (< 8 ⇒ DoProcessTIFF return 0).
     assert!(parse_exif_block(b"MM\0\x2a\0\0\0\x04").is_none());
+  }
+
+  /// `parse_gps_block` walks a GPS-ONLY top-level TIFF block (a Canon CR3 `CMT4`
+  /// directory, `first_kind == Gps`) against `%GPS::Main`. The chain seeds its
+  /// `active_table` from `first_kind`, so tag 0x0001 resolves as `GPSLatitudeRef`
+  /// (its `%GPS::Main` name). A hard-coded `Exif` seed would look 0x0001 up in
+  /// `%Exif::Main` and drop the GPS tag entirely. (Codex R1 finding 1.)
+  #[test]
+  fn parse_gps_block_resolves_top_directory_via_gps_table() {
+    // MM, magic 0x002a, IFD0 offset 8.
+    let mut t: Vec<u8> = vec![b'M', b'M', 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08];
+    // IFD0: 1 entry = GPSLatitudeRef (0x0001), ASCII, count 2, "N\0" inline.
+    t.extend_from_slice(&[0x00, 0x01]); // numEntries = 1
+    t.extend_from_slice(&[0x00, 0x01]); // tag 0x0001
+    t.extend_from_slice(&[0x00, 0x02]); // format = ASCII
+    t.extend_from_slice(&[0x00, 0x00, 0x00, 0x02]); // count = 2
+    t.extend_from_slice(b"N\0\0\0"); // inline value "N\0"
+    t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+    let meta = parse_gps_block(&t).expect("GPS block parses");
+    assert!(
+      meta.entry("GPSLatitudeRef").is_some(),
+      "tag 0x0001 must resolve as GPSLatitudeRef via %GPS::Main, not the Exif table"
+    );
+  }
+
+  /// A GPS-table directory (`parse_gps_block`, `first_kind == Gps`) must NOT
+  /// apply Exif STRUCTURAL semantics — the `DNGVersion` 0xc612 RawConv
+  /// DataMember tap — because that tap now follows [`Walker::active_table`]
+  /// (`!= Gps`), NOT `kind` (`!is_gps()`). (Codex R2-1.)
+  ///
+  /// NOTE on the reachable shape: the R2-1 fix is written to also hold for a
+  /// trailing directory of a GPS chain (`kind == Trailing`, `active_table` still
+  /// `Gps`), but that exact shape is NOT reachable through the current walker —
+  /// a GPS directory does not follow the next-IFD pointer (no `Multi`:
+  /// [`Walker::walk_one_ifd_body`]'s `follows_chain` is `Ifd0`/`Trailing` only,
+  /// `Exif.pm:7203`), and a GPS sub-IFD is walked as a SINGLE dir via
+  /// [`Walker::process_subdir`]. So a GPS-only block is always one directory and
+  /// `active_table == Gps ⟺ kind.is_gps()` for every reachable input. This test
+  /// therefore pins the reachable analog: 0xc612 inside a GPS-table dir does NOT
+  /// set the DNG DataMember (the tap is gated off whenever `active_table` is the
+  /// GPS table), and the dir's leaves resolve via `%GPS::Main`.
+  #[test]
+  fn parse_gps_block_chain_trailing_dir_uses_gps_semantics() {
+    // MM, magic 0x002a, IFD0 offset 8. IFD0 is the GPS dir (first_kind == Gps);
+    // it holds a GPS leaf (0x0009 GPSStatus) AND tag 0xc612 (DNGVersion) with a
+    // TRUTHY `1 1 0 0` value. The 0xc612 tap must stay off under the GPS table.
+    let mut t: Vec<u8> = vec![b'M', b'M', 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08];
+    t.extend_from_slice(&[0x00, 0x02]); // numEntries = 2
+    // entry A: GPSStatus (0x0009), ASCII, count 2, "A\0" inline — a %GPS::Main
+    // leaf, present iff the dir is walked under the GPS table.
+    t.extend_from_slice(&[0x00, 0x09]); // tag 0x0009
+    t.extend_from_slice(&[0x00, 0x02]); // format = ASCII
+    t.extend_from_slice(&[0x00, 0x00, 0x00, 0x02]); // count = 2
+    t.extend_from_slice(b"A\0\0\0"); // inline value "A\0"
+    // entry B: DNGVersion (0xc612), int8u[4], TRUTHY `1 1 0 0` inline — the Exif
+    // DNG RawConv tap, which must NOT fire because `active_table == Gps`.
+    t.extend_from_slice(&[0xc6, 0x12]); // tag 0xc612
+    t.extend_from_slice(&[0x00, 0x01]); // format = int8u
+    t.extend_from_slice(&[0x00, 0x00, 0x00, 0x04]); // count = 4
+    t.extend_from_slice(&[0x01, 0x01, 0x00, 0x00]); // truthy DNGVersion value
+    t.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // next-IFD = 0
+    let meta = parse_gps_block(&t).expect("GPS block parses");
+    // THE DISCRIMINATOR: the 0xc612 DNG tap was skipped because the dir's
+    // `active_table == Gps`. (`%GPS::Main` has no 0xc612 entry; the Exif-only
+    // tap must not run under the GPS table.)
+    assert!(
+      !meta.has_dng_version(),
+      "0xc612 in a GPS-table dir must NOT fire the Exif DNGVersion tap \
+       (the gate follows active_table == Gps)"
+    );
+    // Corroborate that the dir IS walked under %GPS::Main: its GPSStatus leaf
+    // resolves (an Exif-table walk would read 0x0009 as a different/unknown tag).
+    assert!(
+      meta.entry("GPSStatus").is_some(),
+      "tag 0x0009 must resolve as GPSStatus via %GPS::Main"
+    );
+    // And the 0xc612 DNGVersion tag is itself absent from the leaf output (it is
+    // unknown to %GPS::Main — dropped, never emitted as an Exif DNGVersion).
+    assert!(
+      meta.entry("DNGVersion").is_none(),
+      "0xc612 is not a %GPS::Main leaf, so no DNGVersion tag is emitted"
+    );
   }
 
   #[test]
@@ -7459,6 +7774,7 @@ mod tests {
       // no-RAF CTMD `0x8769` path is covered via `parse_ctmd_exif_ifd_redispatch`.
       no_raf: false,
       warn_count: 0,
+      active_table: TableRef::Exif,
     }
   }
 


### PR DESCRIPTION
## What

Begins collapsing exifast's **two parallel IFD engines** — the shared `Walker` (the faithful `ProcessExif` port) and the N hand-written per-vendor maker-note walkers — into ExifTool's actual architecture: **one engine + per-vendor `SubDirectory` directives**. The per-vendor walkers re-derive (and diverge on) exactly the hard features the shared `Walker` already has — `FixBase`, `ByteOrder=Unknown`, malformed-entry warnings, recursion — which is the root cause behind #243 (Samsung blocked on FixBase), #230 (dropped warnings), and #231 (per-vendor value Vec).

This PR is **Phase 0 + Phase 1** (infrastructure + the shared engine features). It is **byte-identical** — no vendor is migrated yet, so conformance stays 416/0 and `typed_serde_parity` holds. The vendor migration (Phase 2+) and the features going live land in follow-ups.

Design: `docs/superpowers/specs/2026-06-15-makernote-engine-unification-design.md`.

## Changes (5 files)
- **`makernotes/subdir.rs`** (new) — the `SubDirectory` directive vocabulary: `TableRef`, `ProcessProc`, `ByteOrderRule`, `FixBaseMode`. (`DetectedMakerNote` already carries Start/Base/ByteOrder/FixBase/NotIFD/EntryBased.)
- **`makernotes/fixbase.rs`** (new) — faithful ports of the shared maker-note engine features, **additive + oracle-tested, not yet wired into production**: `detect_unknown_byte_order` (`Exif.pm:6982`), `get_maker_note_offset` + `get_value_blocks` + `FixBase` (`MakerNotes.pm:1149/1241/1282`), `locate_ifd`/`ProcessUnknown` (`MakerNotes.pm:1486/1816`).
- **`exif/mod.rs`** — an `active_table` field keys the `Walker`'s tag lookup by `TableRef` (defaulted from `IfdKind`, seeded from `first_kind` so `parse_gps_block` resolves a GPS-only block via `%GPS::Main`; the DNGVersion/IsOffset taps are table-scoped too). `process_subdir` is the single sub-directory entry point — it saves/restores `active_table`+`order` around the walk and wires the Phase-1 features as pre-walk hooks (inert for the core ExifIFD/GPS/Interop IFDs, so byte-identical).

The Exif/GPS leaf emission stays on the proven bespoke renderer (the golden `convert::apply` runtime, written for already-rendered `TagValue`s, can't preserve first-scalar/exact-rational shape for these convs); Phase-2 vendor `TagDef` tables emit golden via `convert::apply` through `process_subdir`.

## Verify
`stable fmt --check=0` · build `-Dwarnings=0` · **conformance 416/0 byte-identical** · `typed_serde_parity` pass · 3003 lib tests · clippy `indexing_slicing` clean.

Codex adversarial review: **APPROVE** (R3). R1/R2 findings — GPS-chain table seed, `locate_ifd` rebase, count>1 + typed-shape conv divergence — all fixed; regression tests added.

> Note: developed on a branch that also carried a whole-tree nightly-rustfmt import normalization; that pure-formatting churn was dropped from this PR to keep it focused on the 5 substantive files.