### PR TITLE
feat(exif/nikon): port the encrypted ColorBalance (0x0097 02xx) — WB_RGGBLevels (#256)

### DIFF
--- a/src/exif/makernotes/mod.rs
+++ b/src/exif/makernotes/mod.rs
@@ -137,7 +137,7 @@ pub struct MakerNotesMeta {
   dji: Option<DjiMakerNote>,
   /// Nikon decoded data — populated when [`Vendor::Nikon`] dispatched AND
   /// the Nikon port runs (`%Nikon::Main`, the readable scalars + AFInfo +
-  /// the unencrypted ColorBalance0103).
+  /// ColorBalance).
   nikon: Option<MakerNotesNikon>,
 }
 

--- a/src/exif/makernotes/vendors/nikon/mod.rs
+++ b/src/exif/makernotes/vendors/nikon/mod.rs
@@ -28,7 +28,7 @@
 //! ## Scope
 //!
 //! See [`tags`]: every readable `%Nikon::Main` scalar + the UNENCRYPTED
-//! fixture sub-tables (`AFInfo`, `ColorBalance0103`, `LensData00`/`01`, and the
+//! fixture sub-tables (`AFInfo`, `ColorBalance`, `LensData00`/`01`, and the
 //! UNENCRYPTED plaintext `FlashInfo0100`). `LensData` decrypts the `02xx`+ arms
 //! ([`decrypt`]); `FlashInfo` (0x00a8) is unencrypted `ProcessBinaryData`
 //! version-dispatched on the 4-byte `FlashInfoVersion` prefix
@@ -325,40 +325,164 @@ pub(crate) fn emit_af_info(
   }
 }
 
-/// Emit `%Nikon::ColorBalance3` (0x0097, the `0103` D70/D70s variant):
-/// `Start => '$valuePtr + 20'`, then `WB_RGBGLevels = int16u[4]` at the
-/// SubDirectory's offset 0, in the SubDirectory's byte order (inherited from
-/// the embedded TIFF). UNENCRYPTED.
+/// The decode plan for one 0x0097 ColorBalance version arm — the
+/// `(TagTable, DecryptStart, DirOffset, member-name)` quadruple transcribed from
+/// the `%Nikon::Main` 0x0097 SubDirectory conditions (`Nikon.pm:2681-2812`) and
+/// the per-table offset-0 `int16u[4]` member (`%ColorBalance2` `WB_RGGBLevels`,
+/// `Nikon.pm:5314`; `%ColorBalance3` `WB_RGBGLevels`, `Nikon.pm:5327`;
+/// `%ColorBalance4` `WB_GRBGLevels`, `Nikon.pm:5339`).
+struct ColorBalancePlan {
+  /// The decrypted-block byte offset at which the offset-0 member is read —
+  /// `ProcessNikonEncrypted`'s `DirStart = DirOffset + DecryptStart`
+  /// (`Nikon.pm:13989`). For the UNENCRYPTED `0103` arm this is the raw
+  /// `Start => '$valuePtr + 20'` delta (`Nikon.pm:2705`) with no decrypt.
+  member_offset: usize,
+  /// `DecryptStart` — the byte from which `ProcessNikonEncrypted` decrypts the
+  /// block (`Nikon.pm:13986`). `None` for the unencrypted `0103` arm (no
+  /// decrypt; the member is read straight from the cleartext value).
+  decrypt_start: Option<usize>,
+  /// The offset-0 member name of the chosen table (`WB_RGGBLevels` for
+  /// `%ColorBalance2`, `WB_RGBGLevels` for `%ColorBalance3`, `WB_GRBGLevels`
+  /// for `%ColorBalance4`).
+  member_name: &'static str,
+}
+
+/// Map the 4-byte `ColorBalanceVersion` prefix to its decode plan, faithfully
+/// transcribing the `%Nikon::Main` 0x0097 SubDirectory `Condition` chain
+/// (`Nikon.pm:2681-2812`). Only the arms whose TagTable carries a readable
+/// `int16u[4]` member are ported — `%ColorBalance2`/`3`/`4`; the
+/// `%ColorBalance1` (`0100`), `%ColorBalanceUnknown`/`Unknown2` arms decode no
+/// WB levels (their offset-0 member is `ColorBalanceVersion`, an `undef[4]`
+/// re-statement of the prefix) and return `None` here. The conditions are
+/// matched in the SAME ORDER as the Perl chain so a version satisfying two
+/// patterns (none do for the ported arms) picks the first.
+fn color_balance_plan(version: &[u8; 4]) -> Option<ColorBalancePlan> {
+  // `WB_RGGBLevels` = `%ColorBalance2` offset 0 (`Nikon.pm:5319`).
+  const CB2: &str = "WB_RGGBLevels";
+  // `WB_GRBGLevels` = `%ColorBalance4` offset 0 (`Nikon.pm:5343`).
+  const CB4: &str = "WB_GRBGLevels";
+  // The two ASCII digits after the leading `02` (e.g. `0206` ⇒ `06` ⇒ 6) for
+  // the numeric range conditions (`/^02(\d{2})/ and $1 < 11`, `Nikon.pm:2732`).
+  let two = |a: u8, b: u8| -> Option<u32> {
+    (a.is_ascii_digit() && b.is_ascii_digit())
+      .then(|| u32::from(a - b'0') * 10 + u32::from(b - b'0'))
+  };
+  // Helper for the encrypted CB2/CB4 arms: `member_offset = DirOffset +
+  // DecryptStart`, decrypt from `DecryptStart` (`Nikon.pm:13986-13989`).
+  let enc = |table: &'static str, decrypt_start: usize, dir_offset: usize| ColorBalancePlan {
+    member_offset: dir_offset + decrypt_start,
+    decrypt_start: Some(decrypt_start),
+    member_name: table,
+  };
+  match version {
+    // `/^0103/` (D70/D70s) — UNENCRYPTED `%ColorBalance3`, `Start =>
+    // '$valuePtr + 20'`, `WB_RGBGLevels` (`Nikon.pm:2700-2707`, `5327`).
+    b"0103" => Some(ColorBalancePlan {
+      member_offset: 20,
+      decrypt_start: None,
+      member_name: "WB_RGBGLevels",
+    }),
+    // `/^0205/` (D50) — `%ColorBalance2`, DecryptStart 4, DirOffset 14
+    // (`Nikon.pm:2709-2718`).
+    b"0205" => Some(enc(CB2, 4, 14)),
+    // `/^02(09|12|14)/` (D3/D300/…) — `%ColorBalance4`, DecryptStart 284,
+    // DirOffset 10 (`Nikon.pm:2720-2730`).
+    b"0209" | b"0212" | b"0214" => Some(enc(CB4, 284, 10)),
+    // `/^0211/` (D90/D5000) — `%ColorBalance4`, DecryptStart 284, DirOffset 16
+    // (`Nikon.pm:2742-2752`).
+    b"0211" => Some(enc(CB4, 284, 16)),
+    // `/^0213/` (D3000) — `%ColorBalance2`, DecryptStart 284, DirOffset 10
+    // (`Nikon.pm:2753-2763`).
+    b"0213" => Some(enc(CB2, 284, 10)),
+    // `/^021[567]/` (D3100/D7000/D5100/D4/…) — `%ColorBalance4`, DecryptStart
+    // 284, DirOffset 4 (`Nikon.pm:2764-2774`).
+    b"0215" | b"0216" | b"0217" => Some(enc(CB4, 284, 4)),
+    // `/^02(19|2[1234])/` (D5300/D3300/D4S/D750/D810/…) — `%ColorBalance2`,
+    // DecryptStart 4, DirOffset 0x7c (`Nikon.pm:2775-2786`).
+    b"0219" | b"0221" | b"0222" | b"0223" | b"0224" => Some(enc(CB2, 4, 0x7c)),
+    // `/^02(\d{2})/ and $1 < 11` (D2X/D2Hs=0206/D200/D40/D60/…) —
+    // `%ColorBalance2`, DecryptStart 284, DirOffset 6 (`Nikon.pm:2731-2741`).
+    // Placed AFTER the explicit `0205`/`0209`/`0211`/`0213` matches above —
+    // those would also satisfy `$1 < 11` (05/09) but the Perl chain tests them
+    // FIRST, so the explicit arms win; only the remaining `02xx` (`<11`) land
+    // here. `0210` (D60) and `0204`/`0207`/`0208` (D2X/D200/D40) match here.
+    [b'0', b'2', a, b] if two(*a, *b).is_some_and(|n| n < 11) => Some(enc(CB2, 284, 6)),
+    // Every other version — `%ColorBalance1` (`0100`), the `%ColorBalanceUnknown`
+    // / `Unknown2` arms (`0220`/`06xx`/`0218`/`02xx>=11 not listed`/`04xx`/`08xx`/
+    // the `0102`/`0500` fallbacks): their offset-0 member is `ColorBalance-
+    // Version` (an `undef[4]`), NOT a WB-levels array, so no `WB_*Levels` tag is
+    // emitted (a documented long-tail follow-up).
+    _ => None,
+  }
+}
+
+/// Emit the 0x0097 ColorBalance white-balance levels — the unencrypted
+/// `%ColorBalance3` (`0103` D70/D70s ⇒ `WB_RGBGLevels`) AND the ENCRYPTED
+/// `%ColorBalance2`/`%ColorBalance4` arms (`02xx` ⇒ `WB_RGGBLevels` /
+/// `WB_GRBGLevels`), version-dispatched on the 4-byte `ColorBalanceVersion`
+/// prefix ([`color_balance_plan`], `Nikon.pm:2681-2812`).
 ///
-/// The other 0x0097 variants (encrypted `02xx`, the early `0100`/`0102`) are
-/// NOT walked here — the version prefix gates them; a non-`0103` prefix emits
-/// nothing (deferred). This keeps the byte-exact D70/.nef WB_RGBGLevels while
-/// the encrypted variants await `Nikon::Decrypt`.
+/// The encrypted arms are processed by `ProcessNikonEncrypted` (`Nikon.pm:13942`):
+/// it RETURNS 0 — extracting NOTHING — when the serial/count decrypt keys are
+/// missing/invalid (`Nikon.pm:13948-13961`), so a `None` `keys` emits nothing for
+/// those versions (the unencrypted `0103` arm is `keys`-independent). For an
+/// encrypted arm with valid keys, the block is decrypted from `DecryptStart`
+/// (mirroring [`emit_lens_data`]); the offset-0 `int16u[4]` member is then read
+/// at `DirOffset + DecryptStart` (`ProcessNikonEncrypted`'s `DirStart`,
+/// `Nikon.pm:13989`), in the SubDirectory's inherited byte order. A short or
+/// malformed value (the member runs past the block) emits nothing.
 pub(crate) fn emit_color_balance(
   sub: &[u8],
   order: ByteOrder,
   print_conv: bool,
+  keys: Option<DecryptKeys>,
   emissions: &mut Vec<VendorEmission>,
 ) {
-  // The version prefix is the first 4 ASCII bytes of the ColorBalance value.
-  let prefix = sub.get(0..4).unwrap_or(&[]);
-  if prefix != b"0103" {
-    // Not the unencrypted D70 variant — deferred (encrypted or unported).
-    return;
-  }
-  // `Start => '$valuePtr + 20'` (`Nikon.pm:2705`) then `WB_RGBGLevels =
-  // int16u[4]` at the ColorBalance3 table's offset 0 (`Nikon.pm:5327-5335`) —
-  // 8 bytes. The child read is bounded by the PARENT tag's declared value
-  // (ExifTool's `ProcessBinaryData` `DirLen` = the parent value size adjusted
-  // by the `Start` delta, and it stops when no bytes remain), so read EXACTLY
-  // those 8 bytes from WITHIN `sub` at offset 20 — NOT from any bytes past the
-  // parent value's declared extent. A ColorBalance value shorter than 28 bytes (20-byte
-  // `Start` delta + the 8-byte record) cannot hold the record: emit nothing
-  // rather than over-reading the next IFD entry / trailing buffer.
-  let Some(record) = sub.get(20..28) else {
+  // `ColorBalanceVersion` = the first 4 ASCII bytes (`Condition => '$$valPt =~
+  // /^…/'`). A value shorter than 4 bytes matches no arm.
+  let Some(version) = sub.get(0..4).and_then(|v| <&[u8; 4]>::try_from(v).ok()) else {
     return;
   };
-  // 4 × int16u, in the SubDirectory's inherited byte order.
+  let Some(plan) = color_balance_plan(version) else {
+    return; // An unported / WB-less version (deferred long-tail).
+  };
+  // The decoded block: the raw bytes for the UNENCRYPTED `0103` arm, or a
+  // decrypted copy for the encrypted CB2/CB4 arms. The 4-byte version prefix is
+  // NEVER encrypted (every encrypted arm's `DecryptStart >= 4`).
+  let decoded: std::borrow::Cow<'_, [u8]> = match plan.decrypt_start {
+    Some(decrypt_start) => {
+      // `ProcessNikonEncrypted` returns 0 (NOTHING) without valid keys
+      // (`Nikon.pm:13948-13961`); `scan_decrypt_keys` returns `Some` IFF the
+      // keys are present + valid, so gate the whole emission on it.
+      let Some(keys) = keys else {
+        return;
+      };
+      // Cap the clone+decrypt to the byte range actually read (the member runs
+      // `[member_offset, member_offset + 8)`), so a large in-bounds value does
+      // not force a copy + linear decrypt of bytes never read (the
+      // [`emit_lens_data`] R2 discipline). `member_offset >= decrypt_start`, so
+      // the read window is within the decrypted region.
+      let cap = plan.member_offset.saturating_add(8).min(sub.len());
+      let mut buf = sub.get(..cap).unwrap_or(sub).to_vec();
+      let len = buf.len().saturating_sub(decrypt_start);
+      decrypt::decrypt(&mut buf, decrypt_start, len, keys.serial, keys.count);
+      std::borrow::Cow::Owned(buf)
+    }
+    None => std::borrow::Cow::Borrowed(sub),
+  };
+  let body = decoded.as_ref();
+  // The offset-0 `int16u[4]` member at the resolved `member_offset` — 8 bytes.
+  // The read is bounded by the value's declared extent (a value too short to
+  // hold the member emits nothing rather than over-reading), mirroring
+  // `ProcessBinaryData` stopping when no bytes remain.
+  let Some(record) = body
+    .get(plan.member_offset..)
+    .and_then(|tail| tail.get(..8))
+  else {
+    return;
+  };
+  // 4 × int16u, in the SubDirectory's inherited byte order (no table-level
+  // `ByteOrder` directive on any ColorBalance arm).
   let Some(raw) = read_value(record, 0, Format::Int16u, 4, record.len(), order) else {
     return;
   };
@@ -367,7 +491,7 @@ pub(crate) fn emit_color_balance(
   let Some(value) = NikonConv::Raw.apply(&parsed, print_conv, None, order) else {
     return;
   };
-  emissions.push(VendorEmission::new("WB_RGBGLevels".into(), value, false));
+  emissions.push(VendorEmission::new(plan.member_name.into(), value, false));
 }
 
 /// Emit the `%Nikon::FlashInfo0100` leaves (0x00a8) — an UNENCRYPTED plaintext
@@ -1966,6 +2090,98 @@ mod tests {
     );
     // And no bogus ColorBalance parent (the SubDirectory pointer never emits it).
     assert!(emissions.iter().all(|e| e.name() != "ColorBalance"));
+  }
+
+  /// The ENCRYPTED ColorBalance2 arm (`0206`, NikonD2Hs — `%ColorBalance2`,
+  /// `DecryptStart => 284`, `DirOffset => 6`): `emit_color_balance` decrypts the
+  /// block from offset 284 and reads `WB_RGGBLevels = int16u[4]` at the
+  /// `ProcessNikonEncrypted` `DirStart = DirOffset + DecryptStart = 290`. Forge a
+  /// known-plaintext block (the levels live at decrypted offset 290), ENCRYPT it
+  /// with the crafted keys (the symmetric cipher), and assert the round-trip
+  /// decode reproduces the levels. With `keys = None` (ProcessNikonEncrypted
+  /// returns nothing) the arm emits nothing.
+  #[test]
+  fn color_balance_encrypted_cb2_round_trips_wb_rggblevels() {
+    // DecryptStart 284 + DirOffset 6 = member at decrypted offset 290.
+    let mut plain = std::vec![0u8; 298];
+    plain.get_mut(0..4).unwrap().copy_from_slice(b"0206");
+    // WB_RGGBLevels = 562 256 256 537 (big-endian int16u[4]) at offset 290.
+    let levels: [u16; 4] = [562, 256, 256, 537];
+    for (i, v) in levels.iter().enumerate() {
+      plain
+        .get_mut(290 + i * 2..290 + i * 2 + 2)
+        .unwrap()
+        .copy_from_slice(&v.to_be_bytes());
+    }
+    // Encrypt from DecryptStart 284 (the cipher is symmetric).
+    let mut enc = plain.clone();
+    let len = enc.len().saturating_sub(284);
+    decrypt::decrypt(&mut enc, 284, len, KEY_SERIAL, KEY_COUNT);
+    assert_ne!(enc, plain, "the crafted block must actually be encrypted");
+
+    let keys = DecryptKeys {
+      serial: KEY_SERIAL,
+      count: KEY_COUNT,
+    };
+    let mut em: Vec<VendorEmission> = Vec::new();
+    emit_color_balance(&enc, ByteOrder::Big, false, Some(keys), &mut em);
+    let wb = em
+      .iter()
+      .find(|e| e.name() == "WB_RGGBLevels")
+      .map(|e| e.value().clone());
+    assert_eq!(
+      wb,
+      Some(TagValue::Str(SmolStr::new("562 256 256 537"))),
+      "encrypted ColorBalance2 must decode WB_RGGBLevels, got {em:?}"
+    );
+
+    // Without keys, ProcessNikonEncrypted extracts nothing.
+    let mut em_nokey: Vec<VendorEmission> = Vec::new();
+    emit_color_balance(&enc, ByteOrder::Big, false, None, &mut em_nokey);
+    assert!(
+      em_nokey.is_empty(),
+      "no decrypt keys ⇒ the encrypted arm emits nothing, got {em_nokey:?}"
+    );
+  }
+
+  /// The ENCRYPTED ColorBalance4 arm (`0211`, D90/D5000 — `%ColorBalance4`,
+  /// `DecryptStart => 284`, `DirOffset => 16`): the offset-0 member is
+  /// `WB_GRBGLevels` (a DIFFERENT name from CB2's `WB_RGGBLevels`), read at
+  /// `DirStart = 16 + 284 = 300`. Confirms the CB4 family is dispatched with its
+  /// own member name + offset.
+  #[test]
+  fn color_balance_encrypted_cb4_round_trips_wb_grbglevels() {
+    // DecryptStart 284 + DirOffset 16 = member at decrypted offset 300.
+    let mut plain = std::vec![0u8; 308];
+    plain.get_mut(0..4).unwrap().copy_from_slice(b"0211");
+    let levels: [u16; 4] = [600, 256, 256, 580];
+    for (i, v) in levels.iter().enumerate() {
+      plain
+        .get_mut(300 + i * 2..300 + i * 2 + 2)
+        .unwrap()
+        .copy_from_slice(&v.to_be_bytes());
+    }
+    let mut enc = plain.clone();
+    let len = enc.len().saturating_sub(284);
+    decrypt::decrypt(&mut enc, 284, len, KEY_SERIAL, KEY_COUNT);
+
+    let keys = DecryptKeys {
+      serial: KEY_SERIAL,
+      count: KEY_COUNT,
+    };
+    let mut em: Vec<VendorEmission> = Vec::new();
+    emit_color_balance(&enc, ByteOrder::Big, false, Some(keys), &mut em);
+    let wb = em
+      .iter()
+      .find(|e| e.name() == "WB_GRBGLevels")
+      .map(|e| e.value().clone());
+    assert_eq!(
+      wb,
+      Some(TagValue::Str(SmolStr::new("600 256 256 580"))),
+      "encrypted ColorBalance4 must decode WB_GRBGLevels, got {em:?}"
+    );
+    // And it must NOT use the CB2 name.
+    assert!(em.iter().all(|e| e.name() != "WB_RGGBLevels"));
   }
 
   /// An empty / too-short blob yields nothing (no panic).

--- a/src/exif/makernotes/vendors/nikon/tags.rs
+++ b/src/exif/makernotes/vendors/nikon/tags.rs
@@ -15,9 +15,12 @@
 //! - `AFInfo` (0x0088, `Nikon.pm:2113-2158`) — a `ProcessBinaryData` table
 //!   (BigEndian for DSLRs), UNENCRYPTED → AFAreaMode / AFPoint /
 //!   AFPointsInFocus. WALKED.
-//! - `ColorBalance0103` (0x0097 `0103` variant, `Nikon.pm:2980`/
-//!   `Nikon.pm` `%ColorBalance3`) — D70/D70s, UNENCRYPTED, `Start =>
-//!   '$valuePtr + 20'`, 4×int16u → WB_RGBGLevels. WALKED.
+//! - `ColorBalance` (0x0097, `Nikon.pm:2681-2812`) — version-dispatched on the
+//!   4-byte `ColorBalanceVersion` prefix: the UNENCRYPTED `0103` D70/D70s arm
+//!   (`%ColorBalance3`, `Start => '$valuePtr + 20'`, 4×int16u → WB_RGBGLevels)
+//!   AND the ENCRYPTED `02xx` arms (`%ColorBalance2` → WB_RGGBLevels,
+//!   `%ColorBalance4` → WB_GRBGLevels, decrypted via the SerialNumber +
+//!   ShutterCount keystream). WALKED.
 //! - `LensData` (0x0098, `%Nikon::LensData00`/`LensData01`/…,
 //!   `Nikon.pm:5456`/`5497`/`5582`+) — a `ProcessBinaryData` table
 //!   version-dispatched on the 4-byte `LensDataVersion` prefix
@@ -46,17 +49,14 @@
 //!   `DecryptStart => 4`), else PLAINTEXT. The ~30 model-specific arms
 //!   (ShotInfoD40…Z9 EXTRA fields) are a phase-3 follow-up.
 //!
-//! ## Deferred (encrypted — need the remaining `ProcessNikonEncrypted` tables)
+//! ## Deferred follow-ups
 //!
-//! The ENCRYPTED `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) are
-//! `ProcessNikonEncrypted` sub-tables keyed on the SerialNumber + ShutterCount
-//! XOR keystream (`Nikon.pm:13604` `Decrypt`). They carry a deferred [`SubTable`]
-//! marker so the parent is NOT emitted (the #177/#223 bogus-parent rule), and
-//! their decrypted children stay unported here (a committed Phase 2 follow-up).
-//! The `%LensData0800` NEW Z-lens block (offsets
-//! 0x2f onward — int16u `LensID`/`MaxAperture`/`FNumber` + the
-//! `FocusMode`-gated focus telemetry) likewise stays a follow-up; its
-//! `LensDataVersion` + legacy OldLensData fields ARE emitted.
+//! The `%LensData0800` NEW Z-lens block (offsets 0x2f onward — int16u
+//! `LensID`/`MaxAperture`/`FNumber` + the `FocusMode`-gated focus telemetry)
+//! stays a follow-up; its `LensDataVersion` + legacy OldLensData fields ARE
+//! emitted. The WB-less 0x0097 ColorBalance arms (`0100` `%ColorBalance1`, the
+//! `%ColorBalanceUnknown`/`Unknown2` versions whose offset-0 member is the
+//! `ColorBalanceVersion` re-statement, not a WB-levels array) emit nothing.
 
 #![deny(clippy::indexing_slicing)]
 
@@ -153,9 +153,15 @@ pub enum SubTable {
   /// BigEndian for DSLRs. AFAreaMode (0) / AFPoint (1) / AFPointsInFocus (2).
   /// WALKED.
   AfInfo,
-  /// `%Nikon::ColorBalance3` (`%ColorBalance3`) — D70/D70s, `Start =>
-  /// '$valuePtr + 20'`, 4×int16u → WB_RGBGLevels. UNENCRYPTED. WALKED.
-  ColorBalance0103,
+  /// `ColorBalance` (0x0097) — version-dispatched on the 4-byte
+  /// `ColorBalanceVersion` prefix (`Nikon.pm:2681-2812`): the UNENCRYPTED
+  /// `0103` D70/D70s arm (`%ColorBalance3`, `Start => '$valuePtr + 20'`,
+  /// `WB_RGBGLevels`) AND the ENCRYPTED `02xx` arms (`%ColorBalance2` ⇒
+  /// `WB_RGGBLevels`, `%ColorBalance4` ⇒ `WB_GRBGLevels`, decrypted via
+  /// [`super::decrypt`] with the SerialNumber + ShutterCount keystream). The
+  /// `0100`/`%ColorBalanceUnknown`/`Unknown2` (WB-less) arms emit nothing.
+  /// WALKED.
+  ColorBalance,
   /// `LensData00`/`01`/`02`/… (0x0098) — `ProcessNikonEncrypted`. DEFERRED.
   LensData,
   /// `ShotInfo` (0x0091, `%Nikon::ShotInfo`, `Nikon.pm:5976-6090`) — the BASE
@@ -172,10 +178,6 @@ pub enum SubTable {
   /// WALKED; the other versions (`0102`/`010[345]`/`0106`/`010[78]`/`030[01]`/
   /// other) are not yet ported (a committed follow-up) and emit nothing.
   FlashInfo,
-  /// The ENCRYPTED `ColorBalance` variants (0x0097 `0205`/`0209`/`02xx`) —
-  /// `ProcessNikonEncrypted`. DEFERRED. (The unencrypted `0100`/`0102`/`0103`
-  /// route to [`Self::ColorBalance0103`] / are walked.)
-  ColorBalanceEncrypted,
   /// Any OTHER `%Nikon::Main` SubDirectory (`PreviewIFD`, `VRInfo`,
   /// `PictureControl`, `ISOInfo`, `WorldTime`, `LocationInfo`, `HDRInfo`,
   /// `AFInfo2`, `NikonSettings`, …) — present in the table so the parent
@@ -191,7 +193,7 @@ impl SubTable {
   pub const fn is_walked(self) -> bool {
     matches!(
       self,
-      SubTable::AfInfo | SubTable::ColorBalance0103 | SubTable::FlashInfo | SubTable::ShotInfo
+      SubTable::AfInfo | SubTable::ColorBalance | SubTable::FlashInfo | SubTable::ShotInfo
     )
   }
 }
@@ -305,10 +307,11 @@ pub const NIKON_TAGS: &[NikonTag] = &[
   tag(0x0095, "NoiseReduction", NikonConv::FormatString),
   // 0x0096 — NEFLinearizationTable (`Nikon.pm`) — `Binary`/`Drop`, no PrintConv.
   tag(0x0096, "NEFLinearizationTable", NikonConv::Raw),
-  // 0x0097 — ColorBalance: the unencrypted `0103` (D70/D70s) is WALKED; the
-  // other variants (encrypted `02xx`, the early `0100`/`0102`) carry a deferred
-  // marker (the dispatcher inspects the version prefix at parse time).
-  sub(0x0097, "ColorBalance", SubTable::ColorBalance0103),
+  // 0x0097 — ColorBalance: WALKED for the unencrypted `0103` (D70/D70s,
+  // WB_RGBGLevels) AND the encrypted `02xx` arms (WB_RGGBLevels / WB_GRBGLevels,
+  // decrypted in `emit_color_balance`); the `emit_color_balance` dispatcher
+  // inspects the 4-byte version prefix and decrypts as needed at parse time.
+  sub(0x0097, "ColorBalance", SubTable::ColorBalance),
   sub(0x0098, "LensData", SubTable::LensData),
   tag(0x0099, "RawImageCenter", NikonConv::Raw),
   tag(0x009a, "SensorPixelSize", NikonConv::SensorPixelSize),
@@ -812,9 +815,9 @@ mod tests {
     assert!(SubTable::AfInfo.is_walked());
     assert_eq!(
       lookup(0x0097).unwrap().sub_table(),
-      Some(SubTable::ColorBalance0103)
+      Some(SubTable::ColorBalance)
     );
-    assert!(SubTable::ColorBalance0103.is_walked());
+    assert!(SubTable::ColorBalance.is_walked());
   }
 
   /// `Flags => 'SubIFD'` (`$$tagInfo{SubIFD}`) is set on EXACTLY the two

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -8077,8 +8077,8 @@ pub(in crate::exif) fn nikon_makernote_isolated(
           .unwrap_or(&[]);
         match sub {
           SubTable::AfInfo => nikon::emit_af_info(block, print_conv, model, &mut *sink.emissions),
-          SubTable::ColorBalance0103 => {
-            nikon::emit_color_balance(block, order, print_conv, &mut *sink.emissions);
+          SubTable::ColorBalance => {
+            nikon::emit_color_balance(block, order, print_conv, decrypt_keys, &mut *sink.emissions);
           }
           SubTable::LensData => nikon::emit_lens_data(
             block,
@@ -8094,8 +8094,8 @@ pub(in crate::exif) fn nikon_makernote_isolated(
           SubTable::ShotInfo => {
             nikon::emit_shot_info(block, print_conv, decrypt_keys, &mut *sink.emissions);
           }
-          // Deferred (encrypted / unported child table): emit nothing.
-          SubTable::ColorBalanceEncrypted | SubTable::OtherDeferred => {}
+          // Deferred (unported child table): emit nothing.
+          SubTable::OtherDeferred => {}
         }
         continue;
       }

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -8669,13 +8669,13 @@ fn makernotes_nikon_d2hs_conformance() {
   //                          documented engine-wide gap).
   //   -x ExifIFD:CFAPattern  — a standard EXIF tag (0xa302) not in exifast's
   //                          EXIF table; unrelated to MakerNotes.
-  //   -x Nikon:WB_RGGBLevels — this file's ColorBalance is the ENCRYPTED `02xx`
-  //                          (ColorBalance02) variant; `emit_color_balance`
-  //                          ports only the unencrypted `0103` (D70/D70s) arm,
-  //                          and the encrypted variants are a documented
-  //                          Phase-2/3 follow-up (nikon/tags.rs ColorBalance-
-  //                          Encrypted). The ONE deferred Nikon tag on this
-  //                          file; the other 65 Nikon tags are byte-identical.
+  //
+  // `Nikon:WB_RGGBLevels` is NO LONGER excluded — this file's ColorBalance is
+  // the ENCRYPTED `02xx` (ColorBalance02, version `0206`) variant, now PORTED
+  // (`emit_color_balance` decrypts the block with the serial-3001006 /
+  // ShutterCount keystream and reads `WB_RGGBLevels` = 562 256 256 537 at
+  // `DecryptStart 284 + DirOffset 6`, #256). All 66 Nikon tags are now
+  // byte-identical to bundled ExifTool.
   check("NikonD2Hs.jpg", "NikonD2Hs.jpg.json", true);
   check("NikonD2Hs.jpg", "NikonD2Hs.jpg.n.json", false);
 }

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -3556,7 +3556,7 @@ fn canon_1dmk3_real_fixture_no_mismarked_subdir_parents() {
 }
 
 /// Nikon.nef (D70 NEF, type-3 embedded-TIFF MakerNote). The ported
-/// `%Nikon::Main` scalars + the unencrypted `ColorBalance0103`
+/// `%Nikon::Main` scalars + the unencrypted `ColorBalance` `0103` arm
 /// (WB_RGBGLevels) + the UNENCRYPTED `LensData0101` (0x0098) children match
 /// the oracle; the deferred ENCRYPTED sub-tables (ShotInfo/FlashInfo) stay
 /// absent without a bogus parent. Make/Model from IFD0.
@@ -3587,7 +3587,7 @@ fn real_fixture_nikon_nef_makernotes() {
       ("Nikon:LightSource", r#""Natural""#),
       ("Nikon:NEFCompression", r#""Lossy (type 1)""#),
       ("Nikon:NoiseReduction", r#""Off""#),
-      // ColorBalance0103 (UNENCRYPTED, walked): WB_RGBGLevels = int16u[4].
+      // ColorBalance `0103` arm (UNENCRYPTED, walked): WB_RGBGLevels = int16u[4].
       ("Nikon:WB_RGBGLevels", r#""478 265 493 265""#),
       ("Nikon:SerialNumber", "12345678"),
       ("Nikon:ShutterCount", "3619"),
@@ -3679,8 +3679,8 @@ fn real_fixture_nikon_jpg_makernotes() {
 
 /// NikonD2Hs.jpg (type-3) — exercises the FlashType empty string, the
 /// `ColorSpace` hash, AFInfo (BigEndian DSLR path), the UNENCRYPTED
-/// `FlashInfo0100` (0x00a8) block, the deferred ENCRYPTED ColorBalance
-/// (WB_RGGBLevels) which must NOT appear, AND the ENCRYPTED `LensData0201`
+/// `FlashInfo0100` (0x00a8) block, the ENCRYPTED ColorBalance02 (WB_RGGBLevels,
+/// decrypted #256), AND the ENCRYPTED `LensData0201`
 /// block: decrypted with serial key `3001006` + count `2`, then decoded against
 /// `%LensData01` to LensIDNumber 118 / LensFStops 7.33 / FocalLength 50.4 mm
 /// etc. A wrong serial/count key or a wrong cipher would decode garbage, not
@@ -3750,12 +3750,15 @@ fn real_fixture_nikon_d2hs_makernotes() {
       // no 0206-conditional base field exists ⇒ ShotInfoVersion is the ONLY new
       // ShotInfo tag.
       ("Nikon:ShotInfoVersion", r#""0206""#),
+      // ColorBalance: ENCRYPTED 0206 (%ColorBalance2) WB_RGGBLevels, decrypted
+      // via the prescanned keys (#256).
+      ("Nikon:WB_RGGBLevels", r#""562 256 256 537""#),
     ],
   );
   // The D2Hs ColorBalance is the ENCRYPTED 0206 variant ⇒ WB_RGGBLevels is
-  // deferred (oracle-only), and no bogus ColorBalance / LensData / FlashInfo
+  // now emitted (562 256 256 537, decrypted via the prescanned keys, #256). The
+  // ColorBalance SubDirectory PARENT is suppressed; no bogus LensData / FlashInfo
   // parent is emitted.
-  assert!(!map.contains_key("Nikon:WB_RGGBLevels"));
   assert!(!map.contains_key("Nikon:ColorBalance"));
   assert!(!map.contains_key("Nikon:LensData"));
   assert!(!map.contains_key("Nikon:FlashInfo"));

--- a/tests/golden/NikonD2Hs.jpg.json
+++ b/tests/golden/NikonD2Hs.jpg.json
@@ -83,6 +83,7 @@
   "Nikon:ShotInfoVersion": "0206",
   "Nikon:HueAdjustment": 0,
   "Nikon:NoiseReduction": "Off",
+  "Nikon:WB_RGGBLevels": "562 256 256 537",
   "Nikon:LensDataVersion": "0201",
   "Nikon:ExitPupilPosition": "60.2 mm",
   "Nikon:AFAperture": 1.9,

--- a/tests/golden/NikonD2Hs.jpg.n.json
+++ b/tests/golden/NikonD2Hs.jpg.n.json
@@ -83,6 +83,7 @@
   "Nikon:ShotInfoVersion": "0206",
   "Nikon:HueAdjustment": 0,
   "Nikon:NoiseReduction": "OFF ",
+  "Nikon:WB_RGGBLevels": "562 256 256 537",
   "Nikon:LensDataVersion": "0201",
   "Nikon:ExitPupilPosition": 60.2352941176471,
   "Nikon:AFAperture": 1.88774862536339,


### PR DESCRIPTION
## Summary

Port the **encrypted Nikon ColorBalance** (tag `0x0097`, the `02xx` variants) so exifast emits `Nikon:WB_RGGBLevels` (`%ColorBalance2` family) and `Nikon:WB_GRBGLevels` (`%ColorBalance4` family). Previously `emit_color_balance` handled only the unencrypted `0103` (D70) arm; the encrypted variants were a no-op, so the conformance golden had to **exclude** `WB_RGGBLevels`. **Closes #256.**

- generalized `emit_color_balance` to take the (already-prescanned) `DecryptKeys` and dispatch by the 4-byte version prefix — a `color_balance_plan(version) → (table, DecryptStart, DirOffset, member)`. The `0103` unencrypted path is unchanged.
- the encrypted `02xx` path mirrors `emit_lens_data`: gate on keys present (else emit nothing, matching `ProcessNikonEncrypted` with no keys), decrypt the block from `DecryptStart`, read `int16u[4]` at `DirOffset + DecryptStart` (the Perl `DirStart`) in the inherited MakerNote byte order, emit under the table's member name.
- the version → `(table, DecryptStart, DirOffset, member)` map is transcribed from `Nikon.pm:2681-2812`, preserving the Perl condition-chain order (explicit arms before the `02xx<11` catch-all, so e.g. `0211`/`0213` aren't swallowed): CB2→`WB_RGGBLevels`, CB4→`WB_GRBGLevels`.
- removed the dead `SubTable::ColorBalanceEncrypted` variant; `0x0097` now routes to `emit_color_balance` for all versions with the keys threaded.
- dropped only the `-x Nikon:WB_RGGBLevels` exclusion from the `NikonD2Hs.jpg` golden (kept the unrelated engine-gap exclusions: Composite / PreviewIFD / File-SOF / thumbnail / CFAPattern) and regenerated.

## Byte-identity

The conformance fixture `NikonD2Hs.jpg` is version `0206` → `%ColorBalance2` (DecryptStart 284, DirOffset 6). It now emits **`WB_RGGBLevels = "562 256 256 537"`, byte-matching bundled ExifTool** (the golden is regenerated from ExifTool, the source of truth). Two unit tests cover the CB2 and CB4 round-trips + the keys-None-emits-nothing gate. The CB4 versions have no conformance fixture and are source-faithful transcriptions.

## Verify

`fmt=0  build(-Dwarnings, --all-targets)=0  conformance=417/0  exif_makernotes_dispatch=63/0 (with EXIFTOOL_T_IMAGES)  lib=3031/0  clippy=0`

**Codex adversarial review: APPROVE (R2).** R1 caught a latent real-fixture test (`real_fixture_nikon_d2hs_makernotes`) that still asserted `WB_RGGBLevels` *absent* (the old deferred invariant — it would have failed the external-fixture suite); R2 fix moved it to a positive `== "562 256 256 537"` assertion + corrected the stale comments.
