### PR TITLE
chore(tests): reconcile typed_serde_parity active-fixture count (521→525)

### DIFF
--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -608,7 +608,11 @@ const NOT_ACTIVE: &[&str] = &[
 /// the positional `[minor] Insta360 trailer …` warning + the mvhd-derived
 /// QuickTime tags; the `-ee` `.ee.*` goldens (the GPS fix + identity + that
 /// warning) are pinned by `tests/timed_metadata_conformance.rs`.
-const EXPECTED_ACTIVE_FIXTURES: usize = 521;
+/// 521 → 525 after the recent real-fixture conformance merges added paired
+/// `.json`+`.n.json` goldens without bumping this count: `Pentax.jpg` (#264),
+/// `Pentax.avi` (#265), `DJIPhantom4.jpg` (#272) + one prior. Each new active
+/// fixture must bump this constant (the per-PR convention above).
+const EXPECTED_ACTIVE_FIXTURES: usize = 525;
 
 /// Every `tests/fixtures/<f>` that has both `tests/golden/<f>.json` and
 /// `tests/golden/<f>.n.json`, MINUS the [`NOT_ACTIVE`] formally-accept-


### PR DESCRIPTION
## Summary

`typed_serde_parity` is **red on main** — it asserts a hardcoded `EXPECTED_ACTIVE_FIXTURES` (active = fixtures with both `.json`+`.n.json` goldens, minus `NOT_ACTIVE`), bumped per fixture-PR by convention. The recent real-fixture conformance merges added paired goldens without bumping it:
- `Pentax.jpg` (#264), `Pentax.avi` (#265), `DJIPhantom4.jpg` (#272) + one prior → 521 → **525**.

Those PRs' gates (conformance/dispatch/lib/clippy) didn't include `typed_serde_parity`, so the drift slipped through. This 1-line reconciliation makes the test green again.

**Should merge before the in-flight #266 fixture PRs** (Sony FX3, Samsung, …) — each active fixture they add bumps this same constant, so landing this first avoids conflicts.

## Verify
`cargo test --test typed_serde_parity` → **1 passed** (525 == 525). No source change.