### PR TITLE
fix(tests): correct typed_serde EXPECTED_ACTIVE_FIXTURES 528 → 530 (un-break main)

### DIFF
--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -623,14 +623,16 @@ const NOT_ACTIVE: &[&str] = &[
 /// `.json`+`.n.json` goldens without bumping this count: `Pentax.jpg` (#264),
 /// `Pentax.avi` (#265), `DJIPhantom4.jpg` (#272) + one prior. Each new active
 /// fixture must bump this constant (the per-PR convention above).
-/// 525 → 528 after the SP4 brand-variant real-fixture conformance (#151) added
-/// paired `.json`+`.n.json` goldens for three brand-detection fixtures, ALL
-/// ACTIVE (each routes through the golden-migrated QuickTime `Taggable` engine,
-/// so the typed-serde path equals the writer path byte-for-byte):
-/// `AVIF_sample.avif` (brand `avif` → AVIF), `HEIF_C001_msf1.heic` (brand
-/// `heic`, `msf1`-compatible → HEIC), `ISOBMFF_iso5_brand.mp4` (brand `iso5` →
-/// MP4).
-const EXPECTED_ACTIVE_FIXTURES: usize = 528;
+/// 525 → 530 after the #266 real-device-fixture batch merged four conformance
+/// PRs, each adding paired `.json`+`.n.json` goldens for ALL-ACTIVE fixtures
+/// (each routes through the golden-migrated `Taggable` engine, so the
+/// typed-serde path equals the writer path byte-for-byte): `SamsungNX500.srw`
+/// (#276, +1); the three SP4 brand-detection fixtures `AVIF_sample.avif`,
+/// `HEIF_C001_msf1.heic`, `ISOBMFF_iso5_brand.mp4` (#151/#277, +3); and
+/// `QuickTime_gopro_gpmf.mp4` (#127/#278, +1). (The sequential squash-merges of
+/// these PRs landed a stale 528 — only the brand +3 — silently dropping
+/// Samsung's and GoPro's +1 each; corrected to 530 here.)
+const EXPECTED_ACTIVE_FIXTURES: usize = 530;
 
 /// Every `tests/fixtures/<f>` that has both `tests/golden/<f>.json` and
 /// `tests/golden/<f>.n.json`, MINUS the [`NOT_ACTIVE`] formally-accept-


### PR DESCRIPTION
## Summary

main's `typed_serde_parity` is **red**: `EXPECTED_ACTIVE_FIXTURES = 528` but there are **530** active conformance fixtures.

## Cause

The #266 real-fixture batch merged four conformance PRs, three of which added active fixtures and bumped this constant — all branched off the same base **525**:
- #276 Samsung NX500 → `525 → 526` (+1)
- #277 SP4 brands (AVIF/msf1/iso5) → `525 → 528` (+3)
- #278 GoPro .mp4 → `525 → 526` (+1)

Merged sequentially via squash, the `EXPECTED_ACTIVE_FIXTURES` line conflict resolved to #277's **528** (the brand +3 only), silently dropping Samsung's and GoPro's +1 each. Actual cumulative = 525 + 1 + 3 + 1 = **530**.

## Fix

One line: `528 → 530` (+ the doc comment updated to record all four PRs' contributions). `cargo test --test typed_serde_parity` green at 530.

Data-safe — no golden or fixture touched; restores the active-fixture invariant the four merges established.