### PR TITLE
feat(exif/makernotes): port the Leica2-9 MakerNote variant tables (#259)

### DIFF
--- a/src/exif/makernotes/mod.rs
+++ b/src/exif/makernotes/mod.rs
@@ -104,7 +104,7 @@ pub use vendor::{Vendor, VendorStatus};
 #[cfg(feature = "alloc")]
 pub use vendors::VendorEmission;
 pub use vendors::{
-  AppleMakerNote, CanonMakerNote, DjiMakerNote, MakerNotesNikon, MakerNotesPentax,
+  AppleMakerNote, CanonMakerNote, DjiMakerNote, MakerNotesLeica, MakerNotesNikon, MakerNotesPentax,
   MakerNotesSamsung, PanasonicMakerNote, SonyMakerNote,
 };
 
@@ -147,6 +147,11 @@ pub struct MakerNotesMeta {
   /// the Samsung Type2 port runs (`%Samsung::Type2`, the plain leaves +
   /// PictureWizard).
   samsung: Option<MakerNotesSamsung>,
+  /// Leica decoded data — populated when [`Vendor::Leica`] dispatched to one of
+  /// the Leica2..Leica9 variant tables (`%Panasonic::Leica2`..`Leica9`, the
+  /// plain camera-identity leaves). The Leica1/Leica10 cross-vendor routes
+  /// populate [`panasonic`](Self::panasonic) instead (they are Panasonic tags).
+  leica: Option<MakerNotesLeica>,
 }
 
 impl MakerNotesMeta {
@@ -166,6 +171,7 @@ impl MakerNotesMeta {
       nikon: None,
       pentax: None,
       samsung: None,
+      leica: None,
     }
   }
 
@@ -218,6 +224,12 @@ impl MakerNotesMeta {
   #[inline(always)]
   pub fn set_samsung(&mut self, samsung: MakerNotesSamsung) {
     self.samsung = Some(samsung);
+  }
+
+  /// Replace the Leica slot — used by the IFD walker during walk (#259).
+  #[inline(always)]
+  pub fn set_leica(&mut self, leica: MakerNotesLeica) {
+    self.leica = Some(leica);
   }
 
   /// Build a `MakerNotesMeta` and POPULATE the per-vendor slot when the
@@ -455,6 +467,37 @@ impl MakerNotesMeta {
         });
         if let Some((typed, _emissions)) = parsed {
           meta.panasonic = Some(typed);
+        } else if let Some(variant) = vendors::leica::discriminate_variant(blob, make, model) {
+          // The Leica2..Leica9 variant tables (#259). Leica1/Leica10 did not
+          // match, so route the blob through the SAME isolated shared-`Walker`
+          // helper the production `-j`/`-n` dispatch uses
+          // (`exif::leica_makernote_isolated`), over the captured blob
+          // (`mn_offset = 0`, `mn_len = blob.len()`). The dispatched `detected`
+          // carries the per-variant `Start`/`Base`/`ByteOrder`; `model` threads
+          // the Leica6 Typ-006 `Condition`. The emissions are discarded —
+          // `from_blob` sets only the typed slot. A genuinely-unrecognized blob
+          // returns `None` from `discriminate_variant` and leaves the slot absent.
+          meta.leica = Some(
+            crate::exif::leica_makernote_isolated(
+              blob,
+              0,
+              blob.len(),
+              variant,
+              detected,
+              parent_order,
+              // The blob IS the whole buffer here (`mn_offset = 0`), with no
+              // parent TIFF slice — so the parent base is 0 and Leica7's
+              // `-$base` rebase is a no-op (`-0`). A Leica7 blob whose value
+              // pointers are absolute FILE offsets is only faithfully decoded on
+              // the in-TIFF path (which threads the real parent base); this
+              // blob-only constructor decodes blob-relative pointers, unchanged.
+              0,
+              model,
+              true,
+            )
+            .map(|(_emissions, typed)| typed)
+            .unwrap_or_default(),
+          );
         }
       }
       Vendor::Dji => {
@@ -643,6 +686,16 @@ impl MakerNotesMeta {
   #[inline(always)]
   pub const fn samsung(&self) -> Option<&MakerNotesSamsung> {
     self.samsung.as_ref()
+  }
+
+  /// Leica decoded data — populated when the dispatcher resolved
+  /// [`Vendor::Leica`](Vendor::Leica) to a Leica2..Leica9 variant table (#259).
+  /// `None` for the Leica1/Leica10 cross-vendor routes (see
+  /// [`panasonic`](Self::panasonic)).
+  #[must_use]
+  #[inline(always)]
+  pub const fn leica(&self) -> Option<&MakerNotesLeica> {
+    self.leica.as_ref()
   }
 }
 

--- a/src/exif/makernotes/subdir.rs
+++ b/src/exif/makernotes/subdir.rs
@@ -28,6 +28,7 @@
 //! See `docs/superpowers/specs/2026-06-15-makernote-engine-unification-design.md`.
 
 use crate::exif::ifd::ByteOrder;
+use crate::exif::makernotes::vendors::leica::tags::LeicaVariant;
 
 /// Which tag table the shared walker resolves names/formats/conversions against
 /// while walking a (sub-)directory. Replaces the `IfdKind`-keyed lookup so the
@@ -63,6 +64,16 @@ pub enum TableRef {
   Pentax,
   /// `%Samsung::Type2`.
   Samsung,
+  /// One of `%Panasonic::Leica2`..`Leica9` — the Leica MakerNote variant
+  /// tables (`Panasonic.pm:1604-2256`). The payload selects which of the SIX
+  /// distinct tables (Leica7 reuses `%Leica6`, Leica8 reuses `%Leica5`); the
+  /// dispatcher resolves the signature to the table-bearing [`LeicaVariant`].
+  /// A SIBLING-payload `TableRef` (rather than six bare variants) keeps the
+  /// shared-`Walker` dispatch matches to ONE `TableRef::Leica(v)` arm each, and
+  /// equality is variant-sensitive (`TableRef::Leica(a) == TableRef::Leica(b)`
+  /// iff `a == b`) — every existing `active_table == TableRef::X` check is for a
+  /// non-Leica table, so the payload does not affect them.
+  Leica(LeicaVariant),
 }
 
 /// `ProcessProc` (`MakerNotes.pm`) — the directory processor. The four real

--- a/src/exif/makernotes/vendors/leica/lens_types.rs
+++ b/src/exif/makernotes/vendors/leica/lens_types.rs
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%leicaLensTypes` (`Panasonic.pm:46-133`) — the shared Leica M lens lookup,
+//! referenced by the `LensType` PrintConv on Leica2 0x310, the M9 `Subdir`
+//! 0x3405, and `Data1` 0x0016 (`Panasonic.pm:1644`/`1894`/`1980`).
+//!
+//! The key is a STRING — ExifTool splits the stored int32u value into
+//! `"<id> <bits>"` (`($val>>2)." ".($val&0x3)`), and the PrintConv tries the
+//! full `"id bits"` key first, then (the table's `OTHER` closure,
+//! `Panasonic.pm:48-52`) the bare leading integer. So the table carries BOTH
+//! integer-string keys (`"6"`) and `"id bits"` keys (`"6 0"`) verbatim.
+//!
+//! Faithful 1:1 port against bundled ExifTool 13.59. Sorted by key string
+//! (binary-search-ready).
+
+#![deny(clippy::indexing_slicing)]
+
+use smol_str::SmolStr;
+
+/// One row of the `%leicaLensTypes` lookup.
+#[derive(Debug, Clone, Copy)]
+pub struct LeicaLensType {
+  /// The lookup key — either a bare integer string (`"6"`) or an `"id bits"`
+  /// string (`"6 0"`), kept exactly as the bundled hash key.
+  pub key: &'static str,
+  /// The lens name (verbatim from bundled).
+  pub name: &'static str,
+}
+
+/// `%leicaLensTypes` rows — sorted by key string (binary-search-ready).
+pub const LEICA_LENS_TYPES: &[LeicaLensType] = &[
+  LeicaLensType {
+    key: "0 0",
+    name: "Uncoded lens",
+  },
+  LeicaLensType {
+    key: "1",
+    name: "Elmarit-M 21mm f/2.8",
+  },
+  LeicaLensType {
+    key: "11",
+    name: "Summaron-M 28mm f/5.6",
+  },
+  LeicaLensType {
+    key: "12",
+    name: "Thambar-M 90mm f/2.2",
+  },
+  LeicaLensType {
+    key: "16",
+    name: "Tri-Elmar-M 16-18-21mm f/4 ASPH.",
+  },
+  LeicaLensType {
+    key: "16 1",
+    name: "Tri-Elmar-M 16-18-21mm f/4 ASPH. (at 16mm)",
+  },
+  LeicaLensType {
+    key: "16 2",
+    name: "Tri-Elmar-M 16-18-21mm f/4 ASPH. (at 18mm)",
+  },
+  LeicaLensType {
+    key: "16 3",
+    name: "Tri-Elmar-M 16-18-21mm f/4 ASPH. (at 21mm)",
+  },
+  LeicaLensType {
+    key: "23",
+    name: "Summicron-M 50mm f/2 (III)",
+  },
+  LeicaLensType {
+    key: "24",
+    name: "Elmarit-M 21mm f/2.8 ASPH.",
+  },
+  LeicaLensType {
+    key: "25",
+    name: "Elmarit-M 24mm f/2.8 ASPH.",
+  },
+  LeicaLensType {
+    key: "26",
+    name: "Summicron-M 28mm f/2 ASPH.",
+  },
+  LeicaLensType {
+    key: "27",
+    name: "Elmarit-M 28mm f/2.8 (IV)",
+  },
+  LeicaLensType {
+    key: "28",
+    name: "Elmarit-M 28mm f/2.8 ASPH.",
+  },
+  LeicaLensType {
+    key: "29",
+    name: "Summilux-M 35mm f/1.4 ASPH.",
+  },
+  LeicaLensType {
+    key: "29 0",
+    name: "Summilux-M 35mm f/1.4 ASPHERICAL",
+  },
+  LeicaLensType {
+    key: "3",
+    name: "Elmarit-M 28mm f/2.8 (III)",
+  },
+  LeicaLensType {
+    key: "30",
+    name: "Summicron-M 35mm f/2 ASPH.",
+  },
+  LeicaLensType {
+    key: "31",
+    name: "Noctilux-M 50mm f/1",
+  },
+  LeicaLensType {
+    key: "31 0",
+    name: "Noctilux-M 50mm f/1.2",
+  },
+  LeicaLensType {
+    key: "32",
+    name: "Summilux-M 50mm f/1.4 ASPH.",
+  },
+  LeicaLensType {
+    key: "33",
+    name: "Summicron-M 50mm f/2 (IV, V)",
+  },
+  LeicaLensType {
+    key: "34",
+    name: "Elmar-M 50mm f/2.8",
+  },
+  LeicaLensType {
+    key: "35",
+    name: "Summilux-M 75mm f/1.4",
+  },
+  LeicaLensType {
+    key: "36",
+    name: "Apo-Summicron-M 75mm f/2 ASPH.",
+  },
+  LeicaLensType {
+    key: "37",
+    name: "Apo-Summicron-M 90mm f/2 ASPH.",
+  },
+  LeicaLensType {
+    key: "38",
+    name: "Elmarit-M 90mm f/2.8",
+  },
+  LeicaLensType {
+    key: "39",
+    name: "Macro-Elmar-M 90mm f/4",
+  },
+  LeicaLensType {
+    key: "39 0",
+    name: "Tele-Elmar-M 135mm f/4 (II)",
+  },
+  LeicaLensType {
+    key: "4",
+    name: "Tele-Elmarit-M 90mm f/2.8 (II)",
+  },
+  LeicaLensType {
+    key: "40",
+    name: "Macro-Adapter M",
+  },
+  LeicaLensType {
+    key: "41",
+    name: "Apo-Summicron-M 50mm f/2 ASPH.",
+  },
+  LeicaLensType {
+    key: "41 3",
+    name: "Apo-Summicron-M 50mm f/2 ASPH.",
+  },
+  LeicaLensType {
+    key: "42",
+    name: "Tri-Elmar-M 28-35-50mm f/4 ASPH.",
+  },
+  LeicaLensType {
+    key: "42 1",
+    name: "Tri-Elmar-M 28-35-50mm f/4 ASPH. (at 28mm)",
+  },
+  LeicaLensType {
+    key: "42 2",
+    name: "Tri-Elmar-M 28-35-50mm f/4 ASPH. (at 35mm)",
+  },
+  LeicaLensType {
+    key: "42 3",
+    name: "Tri-Elmar-M 28-35-50mm f/4 ASPH. (at 50mm)",
+  },
+  LeicaLensType {
+    key: "43",
+    name: "Summarit-M 35mm f/2.5",
+  },
+  LeicaLensType {
+    key: "44",
+    name: "Summarit-M 50mm f/2.5",
+  },
+  LeicaLensType {
+    key: "45",
+    name: "Summarit-M 75mm f/2.5",
+  },
+  LeicaLensType {
+    key: "46",
+    name: "Summarit-M 90mm f/2.5",
+  },
+  LeicaLensType {
+    key: "47",
+    name: "Summilux-M 21mm f/1.4 ASPH.",
+  },
+  LeicaLensType {
+    key: "48",
+    name: "Summilux-M 24mm f/1.4 ASPH.",
+  },
+  LeicaLensType {
+    key: "49",
+    name: "Noctilux-M 50mm f/0.95 ASPH.",
+  },
+  LeicaLensType {
+    key: "5",
+    name: "Summilux-M 50mm f/1.4 (II)",
+  },
+  LeicaLensType {
+    key: "50",
+    name: "Elmar-M 24mm f/3.8 ASPH.",
+  },
+  LeicaLensType {
+    key: "51",
+    name: "Super-Elmar-M 21mm f/3.4 Asph",
+  },
+  LeicaLensType {
+    key: "51 2",
+    name: "Super-Elmar-M 14mm f/3.8 Asph",
+  },
+  LeicaLensType {
+    key: "52",
+    name: "Apo-Telyt-M 18mm f/3.8 ASPH.",
+  },
+  LeicaLensType {
+    key: "53",
+    name: "Apo-Telyt-M 135mm f/3.4",
+  },
+  LeicaLensType {
+    key: "53 2",
+    name: "Apo-Telyt-M 135mm f/3.4",
+  },
+  LeicaLensType {
+    key: "53 3",
+    name: "Apo-Summicron-M 50mm f/2 (VI)",
+  },
+  LeicaLensType {
+    key: "58",
+    name: "Noctilux-M 75mm f/1.25 ASPH.",
+  },
+  LeicaLensType {
+    key: "6",
+    name: "Summicron-M 35mm f/2 (IV)",
+  },
+  LeicaLensType {
+    key: "6 0",
+    name: "Summilux-M 35mm f/1.4",
+  },
+  LeicaLensType {
+    key: "7",
+    name: "Summicron-M 90mm f/2 (II)",
+  },
+  LeicaLensType {
+    key: "9",
+    name: "Elmarit-M 135mm f/2.8 (I/II)",
+  },
+  LeicaLensType {
+    key: "9 0",
+    name: "Apo-Telyt-M 135mm f/3.4",
+  },
+];
+
+/// Resolve a `%leicaLensTypes` key (an `"id bits"` or bare-`"id"` string) to its
+/// lens name. `None` ⇒ the key is not in the table (the caller then tries the
+/// leading-integer fallback, and failing that keeps the ValueConv string).
+#[must_use]
+pub fn lookup_name(key: &str) -> Option<SmolStr> {
+  match LEICA_LENS_TYPES.binary_search_by(|e| e.key.cmp(key)) {
+    Ok(i) => LEICA_LENS_TYPES.get(i).map(|e| SmolStr::from(e.name)),
+    Err(_) => None,
+  }
+}

--- a/src/exif/makernotes/vendors/leica/mod.rs
+++ b/src/exif/makernotes/vendors/leica/mod.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Leica MakerNotes — the `%Image::ExifTool::Panasonic::Leica2`..`Leica9`
+//! variant-table port (`Panasonic.pm:1604-2256`).
+//!
+//! The MakerNotes dispatcher (`MakerNotes.pm:611-721`) detects EIGHT Leica
+//! signature variants (Leica2..Leica9) — all `Vendor::Leica`, each with its own
+//! `Base`/byte-order rules — and resolves them to one of SIX distinct tables
+//! (Leica7 reuses `%Leica6`, Leica8 reuses `%Leica5`). The shared `Walker`
+//! walks each under [`TableRef::Leica`](crate::exif::makernotes::subdir::TableRef::Leica)
+//! carrying the [`tags::LeicaVariant`] payload, applying the dispatched
+//! `Start`/`Base`/`ByteOrder` per the descriptor (the same machinery the other
+//! migrated vendors use, #243 phase 3).
+//!
+//! Leica1 + Leica10 are NOT here — they reuse `%Panasonic::Main` (they are
+//! Panasonic tags) and emit under the `Panasonic` group via the
+//! `panasonic::parse_leica{1,10}_gated` cross-vendor route.
+//!
+//! ## Leica7 `Base => '-$base'` (`NegativeOfBase`)
+//!
+//! Leica7 (`MakerNotes.pm:699`) is the ONLY `Base => '-$base'` in the module —
+//! its out-of-line value pointers are ABSOLUTE FILE offsets, so the inline-IFD
+//! walk must rebase them to the slice it walks by SUBTRACTING the parent TIFF
+//! base. The isolated helper therefore maps `NegativeOfBase` to
+//! `value_offset_base = -parent_base`, where `parent_base` is the base of the
+//! IFD that contains the 0x927c MakerNote entry (threaded from the parent
+//! `Walker`):
+//!
+//! * For a standalone / base-0 TIFF `parent_base == 0`, so `value_offset_base =
+//!   -0 = 0` — identical to `Inherit`, and an absolute pointer resolves directly
+//!   against the buffer.
+//! * For a real JPEG `APP1` Exif block the TIFF is SLICED at its NONZERO file
+//!   offset and walked with that base retained, so an absolute Leica7 pointer
+//!   `P` resolves at `data[P - parent_base]` — the slice-relative index. (A
+//!   hardcoded `value_offset_base = 0` would read these from the wrong offset /
+//!   out of bounds — the production bug the base-0 standalone fixture missed.)
+//!
+//! `value_offset_base` is a signed `i64`, so the negated base is expressible
+//! directly; the value-resolution site range-checks the result both ends
+//! (`off_signed >= 0 && off + size <= len`), so a pointer landing outside the
+//! slice is dropped, never wrapped. (The Leica7 *trailer* layout some JPEGs use
+//! — a `ProcessLeicaTrailer` blob whose base is the trailer's absolute file
+//! position — is a separate, deferred case.) Verified byte-exact against the
+//! `perl exiftool` oracle on the crafted standalone + nonzero-base Leica7
+//! fixtures (`tests/exif_makernotes_dispatch.rs`).
+//!
+//! ## D8 compliance
+//!
+//! No public fields on the typed surface. `#[non_exhaustive]` so a future phase
+//! can add fields without a breaking change.
+
+#![deny(clippy::indexing_slicing)]
+
+pub mod lens_types;
+pub mod printconv;
+pub mod tags;
+
+use crate::exif::ifd::RawValue;
+use smol_str::SmolStr;
+
+pub use lens_types::{LEICA_LENS_TYPES, LeicaLensType};
+pub use printconv::LeicaPrintConv;
+pub use tags::{
+  LEICA2_TAGS, LEICA3_TAGS, LEICA4_TAGS, LEICA5_TAGS, LEICA6_TAGS, LEICA9_TAGS, LeicaCondition,
+  LeicaTag, LeicaVariant, format_override, lookup,
+};
+
+/// Decoded Leica MakerNotes data — populated by
+/// [`crate::exif::leica_makernote_isolated`] when the dispatcher resolved
+/// [`Vendor::Leica`](crate::exif::makernotes::Vendor::Leica) to one of the
+/// Leica2..Leica9 variant tables.
+///
+/// D8: no public fields; accessor-only. The fields are the cross-variant
+/// camera-identity leaves (lens + serial); their tag IDs differ per variant, so
+/// [`populate_typed`] keys off `(variant, tag_id)`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct MakerNotesLeica {
+  /// The resolved lens name — Leica2 0x310 / Leica5 0x0303 (string) / Leica6
+  /// 0x303 (trimmed string). For the `%leicaLensTypes`-coded variants this is
+  /// the looked-up name; for the string variants it is the raw lens string.
+  lens_name: Option<SmolStr>,
+  /// The camera serial number — Leica2 0x303 (`sprintf("%.7d")`) / Leica5
+  /// 0x0305 (int32u).
+  serial_number: Option<SmolStr>,
+}
+
+impl MakerNotesLeica {
+  /// Build an empty Leica metadata bag.
+  #[must_use]
+  #[inline(always)]
+  pub const fn new() -> Self {
+    Self {
+      lens_name: None,
+      serial_number: None,
+    }
+  }
+
+  /// The resolved lens name (LensType / lens string). `None` when no lens leaf
+  /// was emitted.
+  #[must_use]
+  #[inline]
+  pub fn lens_name(&self) -> Option<&str> {
+    self.lens_name.as_deref()
+  }
+
+  /// The camera serial number. `None` when no serial leaf was emitted.
+  #[must_use]
+  #[inline]
+  pub fn serial_number(&self) -> Option<&str> {
+    self.serial_number.as_deref()
+  }
+}
+
+/// Populate the typed struct from one gate-passing Leica leaf-tag emission.
+/// `rendered` is the already-PrintConv-rendered lens/serial value (so the typed
+/// `lens_name` carries the resolved `%leicaLensTypes` name, not the raw int).
+///
+/// MUST be called ONLY for an entry that the capture loop actually emits, so a
+/// dropped/Condition-failed entry populates no typed field — mirroring the
+/// Sony/Samsung/Pentax contract.
+pub(crate) fn populate_typed(
+  typed: &mut MakerNotesLeica,
+  variant: LeicaVariant,
+  tag_id: u16,
+  rendered: &crate::value::TagValue,
+  raw: &RawValue,
+) {
+  use crate::value::TagValue;
+  // The lens leaf — its ID differs per variant.
+  let is_lens = matches!(
+    (variant, tag_id),
+    (LeicaVariant::Leica2, 0x310) | (LeicaVariant::Leica5, 0x0303) | (LeicaVariant::Leica6, 0x303)
+  );
+  if is_lens {
+    if let TagValue::Str(s) = rendered {
+      typed.lens_name = Some(s.clone());
+    }
+    return;
+  }
+  // The serial leaf.
+  let is_serial = matches!(
+    (variant, tag_id),
+    (LeicaVariant::Leica2, 0x303) | (LeicaVariant::Leica5, 0x0305)
+  );
+  if is_serial {
+    match rendered {
+      TagValue::Str(s) => typed.serial_number = Some(s.clone()),
+      _ => {
+        // The int32u Leica5 serial (no PrintConv) — render the first integer.
+        if let RawValue::U64(v) = raw {
+          if let Some(&n) = v.first() {
+            typed.serial_number = Some(SmolStr::from(std::format!("{n}")));
+          }
+        }
+      }
+    }
+  }
+}
+
+/// Re-discriminate WHICH Leica2..Leica9 variant table a `Vendor::Leica` blob
+/// resolves to, from the blob signature + the parent `Make`/`Model` — the
+/// faithful mirror of the dispatcher's sub-arm gating (`MakerNotes.pm:611-721`).
+///
+/// The dispatcher collapses all the Leica variants onto `Vendor::Leica` and
+/// hands back only the `Base`/`Start`/`ByteOrder` of the matched arm; the
+/// production decode needs the VARIANT to pick the table. This re-runs the SAME
+/// signature tests (in `%Main` order), mapping the eight signature variants onto
+/// the six table-bearing [`LeicaVariant`]s (Leica7→Leica6, Leica8→Leica5). It
+/// returns `None` for the cross-vendor Leica1/Leica10 routes (handled by the
+/// `%Panasonic::Main` path) and for an unrecognized blob.
+///
+/// `blob` is the captured MakerNote value (`blob[..body_offset]` is the vendor
+/// header). The tests read bytes 5..8 exactly as the dispatcher does.
+#[must_use]
+pub fn discriminate_variant(
+  blob: &[u8],
+  make: Option<&str>,
+  model: Option<&str>,
+) -> Option<LeicaVariant> {
+  let make = make.unwrap_or("");
+  let model = model.unwrap_or("");
+  let ag_make = make.starts_with("Leica Camera AG");
+  // Leica1 (`MakerNotes.pm:600`) — make-only `eq "LEICA"`, the %Panasonic::Main
+  // route. NOT a variant table.
+  if make == "LEICA" {
+    return None;
+  }
+  // Leica10 (`:724`) — `LEICA CAMERA AG\0` signature, the %Panasonic::Main route.
+  if blob.starts_with(b"LEICA CAMERA AG\x00") {
+    return None;
+  }
+  if blob.starts_with(b"LEICA") {
+    let b6 = blob.get(5).copied();
+    let b7 = blob.get(6).copied();
+    let b8 = blob.get(7).copied();
+    // Leica2 (`:611`) — `^Leica Camera AG` make + `LEICA\0\0\0`.
+    if ag_make && b6 == Some(0x00) && b7 == Some(0x00) && b8 == Some(0x00) {
+      return Some(LeicaVariant::Leica2);
+    }
+    // Leica4 (`:639`) — `^Leica Camera AG` make + `LEICA0` (byte 5 = '0').
+    if ag_make && b6 == Some(b'0') {
+      return Some(LeicaVariant::Leica4);
+    }
+    // Leica5 (`:650`) — SIG-ONLY `LEICA\0[\x01\x04\x05\x06\x07\x10\x1a]\0`.
+    if b6 == Some(0x00)
+      && matches!(b7, Some(0x01 | 0x04 | 0x05 | 0x06 | 0x07 | 0x10 | 0x1a))
+      && b8 == Some(0x00)
+    {
+      return Some(LeicaVariant::Leica5);
+    }
+    // Leica6 (`:666`) — make+model gated (S2 / M-Typ240 / S-Typ006), MUST precede
+    // Leica7 in `%Main` order. Make is `eq` (exact).
+    if make == "Leica Camera AG"
+      && (model == "S2" || model == "LEICA M (Typ 240)" || model == "LEICA S (Typ 006)")
+    {
+      return Some(LeicaVariant::Leica6);
+    }
+    // Leica7 (`:690`) — SIG-ONLY `LEICA\0\x02\xff` → reuses the Leica6 table.
+    if b6 == Some(0x00) && b7 == Some(0x02) && b8 == Some(0xff) {
+      return Some(LeicaVariant::Leica6);
+    }
+    // Leica8 (`:703`) — SIG-ONLY `LEICA\0[\x08\x09\x0a]\0` → reuses the Leica5 table.
+    if b6 == Some(0x00) && matches!(b7, Some(0x08 | 0x09 | 0x0a)) && b8 == Some(0x00) {
+      return Some(LeicaVariant::Leica5);
+    }
+    // Leica9 (`:714`) — `^Leica Camera AG` make + `LEICA\0\x02\0`.
+    if ag_make && b6 == Some(0x00) && b7 == Some(0x02) && b8 == Some(0x00) {
+      return Some(LeicaVariant::Leica9);
+    }
+    // No generic LEICA fallback (faithful to bundled).
+    return None;
+  }
+  // Leica3 (`:626`) — `^Leica Camera AG` make, NON-`LEICA` blob, Model not S2 /
+  // M-Typ240. (Leica6's non-LEICA-blob make+model fallback is the %Panasonic
+  // route's concern via the dispatcher; here a non-LEICA blob that satisfies
+  // Leica3 lands on the Leica3 table.)
+  if ag_make && !blob.starts_with(b"LEICA") && model != "S2" && model != "LEICA M (Typ 240)" {
+    return Some(LeicaVariant::Leica3);
+  }
+  None
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/exif/makernotes/vendors/leica/printconv.rs
+++ b/src/exif/makernotes/vendors/leica/printconv.rs
@@ -1,0 +1,550 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Leica-specific PrintConv/ValueConv enum — covers the per-tag conversions in
+//! the `%Image::ExifTool::Panasonic::Leica2`..`Leica9` MakerNote variant tables
+//! (`Panasonic.pm:1604-2256`) plus the shared `%leicaLensTypes` lens lookup
+//! (`Panasonic.pm:46-133`).
+//!
+//! Faithful 1:1 port against bundled ExifTool 13.59. Every variant is a named
+//! arm with a `Panasonic.pm` citation, and the bundled label text is kept
+//! verbatim. The big `%leicaLensTypes` lookup lives in [`lens_types`].
+
+#![deny(clippy::indexing_slicing)]
+
+use super::lens_types;
+use crate::exif::ifd::RawValue;
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Per-tag conversion strategy for the Leica2..Leica9 IFD variant tables.
+///
+/// A Leica leaf renders the SAME way in both modes unless it carries a
+/// `PrintConv` (the hash / `sprintf` rows): then `-j` applies the PrintConv and
+/// `-n` keeps the ValueConv value. Where a row has a `ValueConv` (`LensType`,
+/// the `/1e5` brightness rows, `FNumber`), that conversion applies in BOTH modes
+/// — it is the value the PrintConv then formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LeicaPrintConv {
+  /// No conversion — emit the raw scalar/array (string/int/space-joined list).
+  None,
+  /// `Quality` (Leica2 0x300, `Panasonic.pm:1612`) — `1=>Fine, 2=>Basic`.
+  Quality,
+  /// `UserProfile` (Leica2 0x302, `Panasonic.pm:1617`) — int32u label hash.
+  UserProfile2,
+  /// `SerialNumber` (Leica2 0x303, `Panasonic.pm:1625`) — `sprintf("%.7d",$val)`.
+  SerialNumber7,
+  /// `WhiteBalance` (Leica2 0x304, `Panasonic.pm:1631`) — label hash with an
+  /// `OTHER => \&WhiteBalanceConv` Kelvin fallback (`Panasonic.pm:2732`): a
+  /// stored value `> 0x8000` renders `"<val-0x8000> Kelvin"`.
+  WhiteBalance2,
+  /// `LensType` (Leica2 0x310 / Subdir 0x3405 / Data1 0x0016, all
+  /// `%leicaLensTypes`) — the `($val>>2)." ".($val&0x3)` ValueConv then the
+  /// `%leicaLensTypes` lookup (with its leading-integer `OTHER` fallback).
+  LensType,
+  /// `sprintf("%.2f",$val)` on a (signed) rational — the
+  /// `ExternalSensorBrightnessValue` / `MeasuredLV` rows whose value is the raw
+  /// rational (Leica2 0x311/0x312, Leica6/Leica9 0x311/0x312).
+  Sprintf2f,
+  /// `ApproximateFNumber` (Leica2 0x313 / Subdir 0x3406, `Panasonic.pm:1650`) —
+  /// `sprintf("%.1f",$val)` on a rational.
+  Sprintf1f,
+  /// `CameraTemperature` (Leica2 0x320 / Subdir 0x3402 / Leica6 …) — int32s,
+  /// `"$val C"`.
+  CameraTemperatureC,
+  /// `UV-IRFilterCorrection` (Leica2 0x325, `Panasonic.pm:1668`) —
+  /// `0=>'Not Active', 1=>'Active'`.
+  UvIrFilterCorrection,
+  /// `MeasuredLV` (Subdir 0x3407 / 0x3408, `Panasonic.pm`) — int32s,
+  /// ValueConv `$val / 1e5` then `sprintf("%.2f",$val)`.
+  Div1e5Sprintf2f,
+  /// `Contrast` (Subdir 0x300a) — `0=>Low,1=>Medium Low,2=>Normal,
+  /// 3=>Medium High,4=>High`.
+  ContrastLevel,
+  /// `Sharpening` (Subdir 0x300b) — `0=>Off,1=>Low,2=>Normal,3=>Medium High,
+  /// 4=>High`.
+  Sharpening,
+  /// `Saturation` (Subdir 0x300d) — the Contrast hash plus
+  /// `5=>'Black & White', 6=>'Vintage B&W'`.
+  SaturationLevel,
+  /// `WhiteBalance` (Subdir 0x3033) — the M9 white-balance hash.
+  WhiteBalanceM9,
+  /// `JPEGQuality` (Subdir 0x3034) — `94=>Basic, 97=>Fine`.
+  JpegQuality,
+  /// `JPEGSize` (Subdir 0x303a) — the M9 resolution hash.
+  JpegSize,
+  /// `LensTypeTrim` (Leica6 0x303, `Panasonic.pm:2150`) — string, ValueConv
+  /// `$val=~s/ +$//` (trailing-space trim), no PrintConv.
+  LensTypeTrim,
+  /// `FirmwareVersion` (Leica6 0x320, `Panasonic.pm:2174`) — `$val=~tr/ /./`
+  /// (spaces → dots) over the int8u[4] value.
+  FirmwareVersionDots,
+  /// `LensSerialNumber` (Leica6 0x321, `Panasonic.pm:2184`) —
+  /// `sprintf("%.10d",$val)`.
+  Sprintf10d,
+  /// `ExposureMode` (Leica5 0x040d, `Panasonic.pm:2047`) — `Format =>
+  /// 'int8u', Count => 4`, a PrintConv hash keyed by the space-joined int8u[4]
+  /// string (`'0 0 0 0' => 'Program AE'`, …).
+  ExposureMode5,
+  /// `InternalSerialNumber` (Leica5 0x0500, `Panasonic.pm:2047`) — `undef`,
+  /// PrintConv decodes the embedded date: a value matching
+  /// `^(.{3})(\d{2})(\d{2})(\d{2})(\d{4})` renders `"($1) YYYY:$3:$4 no. $5"`
+  /// (year = `$2 + ($2<70 ? 2000 : 1900)`); otherwise the raw `$val` passes
+  /// through. `-n` keeps the raw `undef` bytes.
+  InternalSerialNumber,
+  /// `ISOSelected` (Leica9 0x359, `Panasonic.pm:2221`) — `0=>'Auto'`, with an
+  /// `OTHER => sub{ return shift }` identity passthrough.
+  IsoSelected,
+  /// `FNumber` (Leica9 0x35a, `Panasonic.pm:2227`) — int32s, ValueConv
+  /// `$val / 1000` then `sprintf("%.1f",$val)`.
+  Div1000Sprintf1f,
+}
+
+impl LeicaPrintConv {
+  /// Apply the conversion to a raw value, producing the rendered [`TagValue`]
+  /// for the requested mode (`print_conv` = `-j` PrintConv, else `-n`
+  /// ValueConv).
+  #[must_use]
+  pub fn apply(self, raw: &RawValue, print_conv: bool) -> TagValue {
+    match self {
+      LeicaPrintConv::None => raw_to_tag_value(raw),
+      LeicaPrintConv::Quality => simple_label(raw, print_conv, |n| match n {
+        1 => Some("Fine"),
+        2 => Some("Basic"),
+        _ => None,
+      }),
+      LeicaPrintConv::UserProfile2 => simple_label(raw, print_conv, |n| match n {
+        1 => Some("User Profile 1"),
+        2 => Some("User Profile 2"),
+        3 => Some("User Profile 3"),
+        4 => Some("User Profile 0 (Dynamic)"),
+        _ => None,
+      }),
+      LeicaPrintConv::SerialNumber7 => {
+        let Some(n) = first_i64(raw) else {
+          return raw_to_tag_value(raw);
+        };
+        if !print_conv {
+          return TagValue::I64(n);
+        }
+        TagValue::Str(SmolStr::from(sprintf_zero_pad(n, 7)))
+      }
+      LeicaPrintConv::WhiteBalance2 => {
+        let Some(n) = first_i64(raw) else {
+          return raw_to_tag_value(raw);
+        };
+        if !print_conv {
+          return TagValue::I64(n);
+        }
+        // The hash (`Panasonic.pm:1633-1640`) first; then the `OTHER` Kelvin
+        // fallback (`WhiteBalanceConv`, `Panasonic.pm:2732`): `$val > 0x8000`
+        // ⇒ `"<val-0x8000> Kelvin"`. An unmatched value below 0x8000 returns
+        // `undef` from `WhiteBalanceConv` ⇒ ExifTool's `PrintConv` falls back
+        // to the raw value (the `Unknown (N)` form is for explicit hashes; an
+        // OTHER that returns undef yields the raw `$val`).
+        match n {
+          0 => TagValue::Str("Auto or Manual".into()),
+          1 => TagValue::Str("Daylight".into()),
+          2 => TagValue::Str("Fluorescent".into()),
+          3 => TagValue::Str("Tungsten".into()),
+          4 => TagValue::Str("Flash".into()),
+          10 => TagValue::Str("Cloudy".into()),
+          11 => TagValue::Str("Shade".into()),
+          _ if n > 0x8000 => TagValue::Str(SmolStr::from(std::format!("{} Kelvin", n - 0x8000))),
+          // `WhiteBalanceConv` returns undef ⇒ raw `$val` passthrough.
+          _ => TagValue::I64(n),
+        }
+      }
+      LeicaPrintConv::LensType => lens_type(raw, print_conv),
+      LeicaPrintConv::Sprintf2f => sprintf_rational(raw, print_conv, 2),
+      LeicaPrintConv::Sprintf1f => sprintf_rational(raw, print_conv, 1),
+      LeicaPrintConv::CameraTemperatureC => {
+        let Some(n) = first_i64(raw) else {
+          return raw_to_tag_value(raw);
+        };
+        if !print_conv {
+          return TagValue::I64(n);
+        }
+        TagValue::Str(SmolStr::from(std::format!("{n} C")))
+      }
+      LeicaPrintConv::UvIrFilterCorrection => simple_label(raw, print_conv, |n| match n {
+        0 => Some("Not Active"),
+        1 => Some("Active"),
+        _ => None,
+      }),
+      LeicaPrintConv::Div1e5Sprintf2f => {
+        // int32s, ValueConv `$val / 1e5`, PrintConv `sprintf("%.2f",$val)`.
+        let Some(n) = first_i64(raw) else {
+          return raw_to_tag_value(raw);
+        };
+        let v = n as f64 / 1e5;
+        if !print_conv {
+          return TagValue::F64(v);
+        }
+        TagValue::Str(SmolStr::from(std::format!("{v:.2}")))
+      }
+      LeicaPrintConv::ContrastLevel => simple_label(raw, print_conv, contrast_label),
+      LeicaPrintConv::Sharpening => simple_label(raw, print_conv, |n| match n {
+        0 => Some("Off"),
+        1 => Some("Low"),
+        2 => Some("Normal"),
+        3 => Some("Medium High"),
+        4 => Some("High"),
+        _ => None,
+      }),
+      LeicaPrintConv::SaturationLevel => simple_label(raw, print_conv, |n| match n {
+        5 => Some("Black & White"),
+        6 => Some("Vintage B&W"),
+        other => contrast_label(other),
+      }),
+      LeicaPrintConv::WhiteBalanceM9 => simple_label(raw, print_conv, |n| match n {
+        0 => Some("Auto"),
+        1 => Some("Tungsten"),
+        2 => Some("Fluorescent"),
+        3 => Some("Daylight Fluorescent"),
+        4 => Some("Daylight"),
+        5 => Some("Flash"),
+        6 => Some("Cloudy"),
+        7 => Some("Shade"),
+        8 => Some("Manual"),
+        9 => Some("Kelvin"),
+        _ => None,
+      }),
+      LeicaPrintConv::JpegQuality => simple_label(raw, print_conv, |n| match n {
+        94 => Some("Basic"),
+        97 => Some("Fine"),
+        _ => None,
+      }),
+      LeicaPrintConv::JpegSize => simple_label(raw, print_conv, |n| match n {
+        0 => Some("5216x3472"),
+        1 => Some("3840x2592"),
+        2 => Some("2592x1728"),
+        3 => Some("1728x1152"),
+        4 => Some("1280x864"),
+        _ => None,
+      }),
+      LeicaPrintConv::LensTypeTrim => {
+        // string, ValueConv `$val=~s/ +$//` (trim trailing spaces), no
+        // PrintConv ⇒ identical under both modes.
+        let s = text_value(raw);
+        let Some(s) = s else {
+          return raw_to_tag_value(raw);
+        };
+        TagValue::Str(SmolStr::from(s.trim_end_matches(' ')))
+      }
+      LeicaPrintConv::FirmwareVersionDots => {
+        // int8u[4], PrintConv `$val=~tr/ /./` — the space-joined int8u array
+        // with spaces turned into dots (e.g. `"1 2 3 4"` ⇒ `"1.2.3.4"`).
+        // `-n` keeps the space-joined `$val`.
+        let joined = match raw_to_tag_value(raw) {
+          TagValue::Str(s) => s,
+          TagValue::I64(n) => SmolStr::from(std::format!("{n}")),
+          TagValue::U64(n) => SmolStr::from(std::format!("{n}")),
+          other => return other,
+        };
+        if !print_conv {
+          return TagValue::Str(joined);
+        }
+        TagValue::Str(SmolStr::from(joined.replace(' ', ".")))
+      }
+      LeicaPrintConv::Sprintf10d => {
+        let Some(n) = first_i64(raw) else {
+          return raw_to_tag_value(raw);
+        };
+        if !print_conv {
+          return TagValue::I64(n);
+        }
+        TagValue::Str(SmolStr::from(sprintf_zero_pad(n, 10)))
+      }
+      LeicaPrintConv::ExposureMode5 => {
+        // int8u[4] hash keyed by the space-joined value string. `-n` keeps the
+        // space-joined raw; `-j` looks the string up, falling back to the raw
+        // (Unknown form) on a miss.
+        let key = match raw_to_tag_value(raw) {
+          TagValue::Str(s) => s,
+          other if !print_conv => return other,
+          TagValue::I64(n) => SmolStr::from(std::format!("{n}")),
+          TagValue::U64(n) => SmolStr::from(std::format!("{n}")),
+          other => return other,
+        };
+        if !print_conv {
+          return TagValue::Str(key);
+        }
+        let label = match key.as_str() {
+          "0 0 0 0" => Some("Program AE"),
+          "1 0 0 0" => Some("Aperture-priority AE"),
+          "1 1 0 0" => Some("Aperture-priority AE (1)"),
+          "2 0 0 0" => Some("Shutter speed priority AE"),
+          "3 0 0 0" => Some("Manual"),
+          _ => None,
+        };
+        match label {
+          Some(l) => TagValue::Str(l.into()),
+          None => TagValue::Str(SmolStr::from(std::format!("Unknown ({key})"))),
+        }
+      }
+      LeicaPrintConv::InternalSerialNumber => {
+        // `undef` ⇒ `raw` is `RawValue::Bytes`. `-n` keeps the raw value; `-j`
+        // applies the date-decoding PrintConv on the ASCII text.
+        if !print_conv {
+          return raw_to_tag_value(raw);
+        }
+        let bytes = match raw {
+          RawValue::Bytes(b) => b.as_slice(),
+          RawValue::Text { raw: b, .. } => b.as_ref(),
+          _ => return raw_to_tag_value(raw),
+        };
+        match decode_internal_serial(bytes) {
+          Some(s) => TagValue::Str(SmolStr::from(s)),
+          // No date match ⇒ the bundled `return $val` passthrough.
+          None => raw_to_tag_value(raw),
+        }
+      }
+      LeicaPrintConv::IsoSelected => {
+        // int32s, `0=>'Auto'` with `OTHER => sub{ return shift }` (identity).
+        let Some(n) = first_i64(raw) else {
+          return raw_to_tag_value(raw);
+        };
+        if !print_conv {
+          return TagValue::I64(n);
+        }
+        match n {
+          0 => TagValue::Str("Auto".into()),
+          // `OTHER` returns the value unchanged ⇒ the raw int.
+          _ => TagValue::I64(n),
+        }
+      }
+      LeicaPrintConv::Div1000Sprintf1f => {
+        // int32s, ValueConv `$val / 1000`, PrintConv `sprintf("%.1f",$val)`.
+        let Some(n) = first_i64(raw) else {
+          return raw_to_tag_value(raw);
+        };
+        let v = n as f64 / 1000.0;
+        if !print_conv {
+          return TagValue::F64(v);
+        }
+        TagValue::Str(SmolStr::from(std::format!("{v:.1}")))
+      }
+    }
+  }
+}
+
+/// Leica `LensType` (`Panasonic.pm:1644`) — the `($val>>2)." ".($val&0x3)`
+/// ValueConv then the `%leicaLensTypes` lookup. The ValueConv splits the stored
+/// int32u into `"<id> <bits>"`; the PrintConv tries the full `"id bits"` key,
+/// then (the `%leicaLensTypes` `OTHER` closure, `Panasonic.pm:48-52`) strips
+/// from the first space and re-looks-up the bare leading integer.
+fn lens_type(raw: &RawValue, print_conv: bool) -> TagValue {
+  let Some(n) = first_u64(raw) else {
+    return raw_to_tag_value(raw);
+  };
+  let id = n >> 2;
+  let bits = n & 0x3;
+  // ValueConv `"<id> <bits>"` — the `-n` value.
+  let value_conv = std::format!("{id} {bits}");
+  if !print_conv {
+    return TagValue::Str(SmolStr::from(value_conv));
+  }
+  // PrintConv: the full `"id bits"` key first, then the leading-integer
+  // `OTHER` fallback (strip from the first space, look up the integer alone).
+  if let Some(name) = lens_types::lookup_name(&value_conv) {
+    return TagValue::Str(name);
+  }
+  let id_key = std::format!("{id}");
+  if let Some(name) = lens_types::lookup_name(&id_key) {
+    return TagValue::Str(name);
+  }
+  // No match anywhere ⇒ the `OTHER` returns `$$conv{$val}` which is undef ⇒
+  // ExifTool keeps the ValueConv string as the rendered value.
+  TagValue::Str(SmolStr::from(value_conv))
+}
+
+/// `0=>Low, 1=>Medium Low, 2=>Normal, 3=>Medium High, 4=>High` — the shared
+/// Contrast/Saturation base hash (`Panasonic.pm:1779`/`1797`).
+const fn contrast_label(n: i64) -> Option<&'static str> {
+  match n {
+    0 => Some("Low"),
+    1 => Some("Medium Low"),
+    2 => Some("Normal"),
+    3 => Some("Medium High"),
+    4 => Some("High"),
+    _ => None,
+  }
+}
+
+/// `sprintf("%.<prec>f", $val)` on the first rational. The ValueConv'd `$val` is
+/// the rational's decimal; `-n` keeps the rational, `-j` formats it. An undef
+/// (`0/0`) rational follows ExifTool's numeric formatting of `undef` → 0.
+fn sprintf_rational(raw: &RawValue, print_conv: bool, prec: usize) -> TagValue {
+  let Some(v) = first_f64(raw) else {
+    return raw_to_tag_value(raw);
+  };
+  if !print_conv {
+    return rational_first_value(raw);
+  }
+  match prec {
+    1 => TagValue::Str(SmolStr::from(std::format!("{v:.1}"))),
+    _ => TagValue::Str(SmolStr::from(std::format!("{v:.2}"))),
+  }
+}
+
+/// Perl `sprintf("%.Nd", $val)` zero-padded decimal — preserves a leading `-`
+/// then pads the magnitude to `width` digits.
+fn sprintf_zero_pad(n: i64, width: usize) -> std::string::String {
+  if n < 0 {
+    let mag = n.unsigned_abs();
+    std::format!("-{mag:0width$}")
+  } else {
+    let mag = n as u64;
+    std::format!("{mag:0width$}")
+  }
+}
+
+/// First scalar value as an unsigned `u64`.
+fn first_u64(raw: &RawValue) -> Option<u64> {
+  match raw {
+    RawValue::U64(v) => v.first().copied(),
+    RawValue::I64(v) => v.first().and_then(|&n| u64::try_from(n).ok()),
+    _ => None,
+  }
+}
+
+/// First scalar value as a signed `i64`.
+fn first_i64(raw: &RawValue) -> Option<i64> {
+  match raw {
+    RawValue::I64(v) => v.first().copied(),
+    RawValue::U64(v) => v.first().and_then(|&n| i64::try_from(n).ok()),
+    _ => None,
+  }
+}
+
+/// First scalar value as `f64` — handles rationals (for the rational tags).
+fn first_f64(raw: &RawValue) -> Option<f64> {
+  match raw {
+    RawValue::F64(v) => v.first().copied(),
+    RawValue::I64(v) => v.first().map(|&n| n as f64),
+    RawValue::U64(v) => v.first().map(|&n| n as f64),
+    RawValue::Rational(rs) => rs.first().map(|r| {
+      let d = r.denominator();
+      if d == 0 {
+        0.0
+      } else {
+        r.numerator() as f64 / d as f64
+      }
+    }),
+    _ => None,
+  }
+}
+
+/// Render the first element as the `-n` ValueConv value of a single-value
+/// rational tag.
+fn rational_first_value(raw: &RawValue) -> TagValue {
+  match raw {
+    RawValue::Rational(rs) => match rs.first() {
+      Some(r) => TagValue::Rational(*r),
+      None => raw_to_tag_value(raw),
+    },
+    _ => raw_to_tag_value(raw),
+  }
+}
+
+/// The display text of a `string` value, if any.
+fn text_value(raw: &RawValue) -> Option<&str> {
+  match raw {
+    RawValue::Text { text: s, .. } => Some(s.as_str()),
+    _ => None,
+  }
+}
+
+/// Map a `u64` to the narrowest `TagValue` integer.
+fn u64_tag(n: u64) -> TagValue {
+  match i64::try_from(n) {
+    Ok(n) => TagValue::I64(n),
+    Err(_) => TagValue::U64(n),
+  }
+}
+
+/// Generic int -> label PrintConv with a DECIMAL `Unknown (N)` fallback.
+fn simple_label<F: Fn(i64) -> Option<&'static str>>(
+  raw: &RawValue,
+  print_conv: bool,
+  f: F,
+) -> TagValue {
+  let Some(n) = first_i64(raw) else {
+    return raw_to_tag_value(raw);
+  };
+  if !print_conv {
+    return TagValue::I64(n);
+  }
+  match f(n) {
+    Some(l) => TagValue::Str(l.into()),
+    None => TagValue::Str(SmolStr::from(std::format!("Unknown ({n})"))),
+  }
+}
+
+/// `InternalSerialNumber` PrintConv (`Panasonic.pm:2049-2053`):
+/// `^(.{3})(\d{2})(\d{2})(\d{2})(\d{4})` ⇒ `"($1) YYYY:$3:$4 no. $5"` with
+/// `YYYY = $2 + ($2 < 70 ? 2000 : 1900)`. `None` ⇒ no match (the raw `$val`
+/// passthrough). Operates on the raw `undef` bytes (ASCII); `.` in Perl matches
+/// any byte (the value carries no newline), so a 3-byte prefix + 10 ASCII
+/// digits is required.
+fn decode_internal_serial(bytes: &[u8]) -> Option<std::string::String> {
+  // Need 3 (prefix) + 2+2+2+4 = 13 bytes; the trailing 10 must be ASCII digits.
+  let prefix = bytes.get(..3)?;
+  let digits = bytes.get(3..13)?;
+  if !digits.iter().all(u8::is_ascii_digit) {
+    return None;
+  }
+  let yr2: i32 = std::str::from_utf8(digits.get(0..2)?).ok()?.parse().ok()?;
+  let mm = std::str::from_utf8(digits.get(2..4)?).ok()?;
+  let dd = std::str::from_utf8(digits.get(4..6)?).ok()?;
+  let no = std::str::from_utf8(digits.get(6..10)?).ok()?;
+  let yr = yr2 + if yr2 < 70 { 2000 } else { 1900 };
+  let prefix = std::string::String::from_utf8_lossy(prefix);
+  Some(std::format!("({prefix}) {yr}:{mm}:{dd} no. {no}"))
+}
+
+/// Render a raw value as a default [`TagValue`] (no conversion) — mirrors the
+/// Sony/Pentax/Samsung helpers (single element ⇒ scalar; multi ⇒ space-joined
+/// string; a multi-rational renders each element's ExifTool decimal).
+pub(crate) fn raw_to_tag_value(raw: &RawValue) -> TagValue {
+  use std::string::ToString;
+  match raw {
+    RawValue::I64(v) if let [n] = v.as_slice() => TagValue::I64(*n),
+    RawValue::I64(v) => TagValue::Str(
+      v.iter()
+        .map(|n| n.to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .into(),
+    ),
+    RawValue::U64(v) if let [n] = v.as_slice() => u64_tag(*n),
+    RawValue::U64(v) => TagValue::Str(
+      v.iter()
+        .map(|n| n.to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .into(),
+    ),
+    RawValue::F64(v) if let [n] = v.as_slice() => TagValue::F64(*n),
+    RawValue::F64(v) => TagValue::Str(
+      v.iter()
+        .map(|f| f.to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .into(),
+    ),
+    RawValue::Rational(rs) if let [r] = rs.as_slice() => TagValue::Rational(*r),
+    RawValue::Rational(rs) => TagValue::Str(
+      rs.iter()
+        .map(|r| r.exiftool_val_str())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .into(),
+    ),
+    RawValue::Text { text: s, .. } => TagValue::Str(s.as_str().into()),
+    RawValue::Bytes(b) => TagValue::Bytes(b.clone()),
+  }
+}

--- a/src/exif/makernotes/vendors/leica/tags.rs
+++ b/src/exif/makernotes/vendors/leica/tags.rs
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! The Leica MakerNote variant IFD tag tables —
+//! `%Image::ExifTool::Panasonic::Leica2`..`Leica9` (`Panasonic.pm:1604-2256`).
+//!
+//! Faithful 1:1 port against bundled ExifTool 13.59 (`Panasonic.pm` `$VERSION`).
+//! The dispatcher (`MakerNotes.pm:611-721`) detects EIGHT signature variants
+//! (`MakerNoteLeica2`..`Leica9`), but two REUSE another variant's table:
+//!
+//! - **Leica7** (`MakerNotes.pm:690-701`, M Monochrom Typ 246) → `%Leica6`.
+//! - **Leica8** (`MakerNotes.pm:703-712`, Q/SL/CL) → `%Leica5`.
+//!
+//! so there are SIX distinct tables: [`LeicaVariant::Leica2`]/`Leica3`/`Leica4`/
+//! `Leica5`/`Leica6`/`Leica9`. The variant is threaded through the shared
+//! `Walker` as the payload of
+//! [`TableRef::Leica`](crate::exif::makernotes::subdir::TableRef::Leica).
+//!
+//! ## Phase scope (the plain camera-indexing leaves)
+//!
+//! Mirroring the Samsung/Pentax ports, this ports the PLAIN scalar/enum/string/
+//! lookup LEAVES of each table. The binary `ProcessBinaryData` sub-tables and
+//! the chained IFD SubDirectories are DEFERRED — their tag IDs are simply ABSENT
+//! from the tables, so the shared `Walker` drops them (unknown-tag skip):
+//!
+//! - **Leica3** `0x0b SerialInfo` (`%Panasonic::SerialInfo` binary) — deferred;
+//!   only `0x0d WB_RGBLevels` is a plain leaf.
+//! - **Leica4** — every row is a SubDirectory into `%Panasonic::Subdir` (which
+//!   chains into `Data1`/`Data2`); deferred. Leica4 therefore emits no plain
+//!   leaf of its own (it routes correctly + emits nothing, not spurious tags).
+//! - **Leica5** `0x040a FocusInfo` / `0x0410 ShotInfo` (binary) + `0x05ff
+//!   CameraIFD` (a nested TIFF) — deferred.
+//! - **Leica6** `0x300 PreviewImage` (a `RawConv` preview blob) + `0x301
+//!   UnknownBlock` (`Unknown`+`Binary`+`Drop`) — deferred.
+
+#![deny(clippy::indexing_slicing)]
+
+use super::printconv::LeicaPrintConv;
+use crate::exif::{ifd::Format, makernotes::vendors::FormatOverride};
+
+/// Which Leica variant table a (sub-)directory walk resolves against. The
+/// payload of [`TableRef::Leica`](crate::exif::makernotes::subdir::TableRef::Leica),
+/// set by the dispatched MakerNote variant.
+///
+/// Six distinct tables; the eight dispatched signatures map here with Leica7 →
+/// [`Leica6`](Self::Leica6) and Leica8 → [`Leica5`](Self::Leica5)
+/// (`MakerNotes.pm:696`/`708`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum LeicaVariant {
+  /// `%Panasonic::Leica2` (`Panasonic.pm:1604`) — the M8.
+  Leica2,
+  /// `%Panasonic::Leica3` (`Panasonic.pm:1706`) — the R8/R9 backs.
+  Leica3,
+  /// `%Panasonic::Leica4` (`Panasonic.pm:1736`) — the M9/M-Monochrom (all rows
+  /// are deferred SubDirectories ⇒ emits nothing).
+  Leica4,
+  /// `%Panasonic::Leica5` (`Panasonic.pm:1997`) — the X1/X2/X-VARIO/T/X-U AND
+  /// (via Leica8) the Q/SL/CL.
+  Leica5,
+  /// `%Panasonic::Leica6` (`Panasonic.pm:2112`) — the S2/M-Typ240/S-Typ006 AND
+  /// (via Leica7) the M Monochrom Typ 246.
+  Leica6,
+  /// `%Panasonic::Leica9` (`Panasonic.pm:2193`) — the S-Typ007/M10.
+  Leica9,
+}
+
+impl LeicaVariant {
+  /// The family-1 group the variant emits under — always `"Leica"`
+  /// (`Panasonic.pm` Leica tables declare `GROUPS => { 1 => 'Leica' }`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn group1(self) -> &'static str {
+    "Leica"
+  }
+}
+
+/// One Leica variant-table IFD tag (a plain LEAF — the deferred SubDirectory /
+/// binary rows are absent from the tables).
+#[derive(Debug, Clone, Copy)]
+pub struct LeicaTag {
+  /// Tag ID (the `Panasonic.pm` Leica hash key).
+  pub id: u16,
+  /// `Name => '…'` from bundled.
+  pub name: &'static str,
+  /// Conversion strategy.
+  pub conv: LeicaPrintConv,
+  /// `Some(FormatOverride)` when bundled carries a `Format => '…'` directive
+  /// that RE-INTERPRETS the entry's on-disk bytes (`Exif.pm:6728-6745`) — the
+  /// `rational64s` brightness rows.
+  pub format: Option<FormatOverride>,
+  /// `Some(condition)` when the row carries a `Condition` that gates emission
+  /// (the Leica5 0x0303 `$format eq "string"`, the Leica6 Typ-006 rows).
+  pub condition: Option<LeicaCondition>,
+}
+
+impl LeicaTag {
+  /// The resolved tag name (`Name => '…'`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn name(&self) -> &'static str {
+    self.name
+  }
+
+  /// The tag's optional `Format =>` directive (`Exif.pm:6728-6745`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn format_override(&self) -> Option<FormatOverride> {
+    self.format
+  }
+
+  /// The tag's emission `Condition`, if any.
+  #[must_use]
+  #[inline(always)]
+  pub const fn condition(&self) -> Option<LeicaCondition> {
+    self.condition
+  }
+}
+
+/// A row-level `Condition` that gates whether the tag is emitted (the faithful
+/// port of ExifTool's `GetTagInfo` returning no tag when the `Condition` fails).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LeicaCondition {
+  /// `$format eq "string"` (Leica5 0x0303 `LensType`, `Panasonic.pm:2007`) —
+  /// emit only when the entry's ON-DISK format is `string` (ASCII). The T body
+  /// writes a string here; other bodies write a non-string `LensType` (a binary
+  /// id) that this row must NOT claim.
+  FormatIsString,
+  /// `$$self{Model} =~ /Typ 006/` (Leica6 0x311/0x312/0x320/0x321,
+  /// `Panasonic.pm:2160`+) — emit only for the Leica S (Typ 006).
+  ModelTyp006,
+}
+
+/// `%Panasonic::Leica2` (`Panasonic.pm:1604-1703`) — the M8. 19 plain leaves.
+pub const LEICA2_TAGS: &[LeicaTag] = &[
+  // 0x300 Quality (Panasonic.pm:1610) — int16u, 1=>Fine 2=>Basic.
+  LeicaTag {
+    id: 0x300,
+    name: "Quality",
+    conv: LeicaPrintConv::Quality,
+    format: None,
+    condition: None,
+  },
+  // 0x302 UserProfile (Panasonic.pm:1617) — int32u label hash.
+  LeicaTag {
+    id: 0x302,
+    name: "UserProfile",
+    conv: LeicaPrintConv::UserProfile2,
+    format: None,
+    condition: None,
+  },
+  // 0x303 SerialNumber (Panasonic.pm:1628) — int32u, sprintf("%.7d",$val).
+  LeicaTag {
+    id: 0x303,
+    name: "SerialNumber",
+    conv: LeicaPrintConv::SerialNumber7,
+    format: None,
+    condition: None,
+  },
+  // 0x304 WhiteBalance (Panasonic.pm:1631) — int16u label hash + Kelvin OTHER.
+  LeicaTag {
+    id: 0x304,
+    name: "WhiteBalance",
+    conv: LeicaPrintConv::WhiteBalance2,
+    format: None,
+    condition: None,
+  },
+  // 0x310 LensType (Panasonic.pm:1649) — int32u, %leicaLensTypes.
+  LeicaTag {
+    id: 0x310,
+    name: "LensType",
+    conv: LeicaPrintConv::LensType,
+    format: None,
+    condition: None,
+  },
+  // 0x311 ExternalSensorBrightnessValue (Panasonic.pm:1657) — Format rational64s, sprintf("%.2f").
+  LeicaTag {
+    id: 0x311,
+    name: "ExternalSensorBrightnessValue",
+    conv: LeicaPrintConv::Sprintf2f,
+    format: Some(FormatOverride::new(Format::Rational64s, None)),
+    condition: None,
+  },
+  // 0x312 MeasuredLV (Panasonic.pm:1663) — Format rational64s, sprintf("%.2f").
+  LeicaTag {
+    id: 0x312,
+    name: "MeasuredLV",
+    conv: LeicaPrintConv::Sprintf2f,
+    format: Some(FormatOverride::new(Format::Rational64s, None)),
+    condition: None,
+  },
+  // 0x313 ApproximateFNumber (Panasonic.pm:1669) — rational64u, sprintf("%.1f").
+  LeicaTag {
+    id: 0x313,
+    name: "ApproximateFNumber",
+    conv: LeicaPrintConv::Sprintf1f,
+    format: None,
+    condition: None,
+  },
+  // 0x320 CameraTemperature (Panasonic.pm:1679) — int32s, "$val C".
+  LeicaTag {
+    id: 0x320,
+    name: "CameraTemperature",
+    conv: LeicaPrintConv::CameraTemperatureC,
+    format: None,
+    condition: None,
+  },
+  // 0x321 ColorTemperature (Panasonic.pm:1658) — int32u, raw.
+  LeicaTag {
+    id: 0x321,
+    name: "ColorTemperature",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x322 WBRedLevel (Panasonic.pm:1659) — rational64u, raw.
+  LeicaTag {
+    id: 0x322,
+    name: "WBRedLevel",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x323 WBGreenLevel (Panasonic.pm:1660) — rational64u, raw.
+  LeicaTag {
+    id: 0x323,
+    name: "WBGreenLevel",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x324 WBBlueLevel (Panasonic.pm:1661) — rational64u, raw.
+  LeicaTag {
+    id: 0x324,
+    name: "WBBlueLevel",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x325 UV-IRFilterCorrection (Panasonic.pm:1689) — int32u, 0=>Not Active 1=>Active.
+  LeicaTag {
+    id: 0x325,
+    name: "UV-IRFilterCorrection",
+    conv: LeicaPrintConv::UvIrFilterCorrection,
+    format: None,
+    condition: None,
+  },
+  // 0x330 CCDVersion (Panasonic.pm:1671) — int32u, raw.
+  LeicaTag {
+    id: 0x330,
+    name: "CCDVersion",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x331 CCDBoardVersion (Panasonic.pm:1672) — int32u, raw.
+  LeicaTag {
+    id: 0x331,
+    name: "CCDBoardVersion",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x332 ControllerBoardVersion (Panasonic.pm:1673) — int32u, raw.
+  LeicaTag {
+    id: 0x332,
+    name: "ControllerBoardVersion",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x333 M16CVersion (Panasonic.pm:1674) — int32u, raw.
+  LeicaTag {
+    id: 0x333,
+    name: "M16CVersion",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x340 ImageIDNumber (Panasonic.pm:1702) — int32u, raw.
+  LeicaTag {
+    id: 0x340,
+    name: "ImageIDNumber",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+];
+
+/// `%Panasonic::Leica3` (`Panasonic.pm:1706-1721`) — the R8/R9 backs. The
+/// `0x0b SerialInfo` binary SubDirectory is deferred; `0x0d WB_RGBLevels` is the
+/// only plain leaf.
+pub const LEICA3_TAGS: &[LeicaTag] = &[
+  // 0x0d WB_RGBLevels (Panasonic.pm:1719) — int16u Count 3, space-joined.
+  LeicaTag {
+    id: 0x0d,
+    name: "WB_RGBLevels",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+];
+
+/// `%Panasonic::Leica4` (`Panasonic.pm:1736-1770`) — the M9. EVERY row is a
+/// SubDirectory into `%Panasonic::Subdir` (deferred), so this table carries NO
+/// plain leaf (the walk routes correctly + emits nothing).
+pub const LEICA4_TAGS: &[LeicaTag] = &[];
+
+/// `%Panasonic::Leica5` (`Panasonic.pm:1997-2066`) — X1/X2/X-VARIO/T/X-U +
+/// (via Leica8) Q/SL/CL. `PRIORITY => 0` at the table level. The `0x040a
+/// FocusInfo` / `0x0410 ShotInfo` binary SubDirectories + `0x05ff CameraIFD`
+/// nested TIFF are deferred.
+pub const LEICA5_TAGS: &[LeicaTag] = &[
+  // 0x0303 LensType (Panasonic.pm:2004) — string, Condition $format eq "string" (Leica T only).
+  LeicaTag {
+    id: 0x0303,
+    name: "LensType",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: Some(LeicaCondition::FormatIsString),
+  },
+  // 0x0305 SerialNumber (Panasonic.pm:2014) — int32u, raw.
+  LeicaTag {
+    id: 0x0305,
+    name: "SerialNumber",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x0407 OriginalFileName (Panasonic.pm:2023) — string.
+  LeicaTag {
+    id: 0x0407,
+    name: "OriginalFileName",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x0408 OriginalDirectory (Panasonic.pm:2024) — string.
+  LeicaTag {
+    id: 0x0408,
+    name: "OriginalDirectory",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x040d ExposureMode (Panasonic.pm:2047) — Format int8u[4], PrintConv hash.
+  LeicaTag {
+    id: 0x040d,
+    name: "ExposureMode",
+    conv: LeicaPrintConv::ExposureMode5,
+    format: Some(FormatOverride::new(Format::Int8u, Some(4))),
+    condition: None,
+  },
+  // 0x0412 FilmMode (Panasonic.pm:2065) — string.
+  LeicaTag {
+    id: 0x0412,
+    name: "FilmMode",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x0413 WB_RGBLevels (Panasonic.pm:2066) — rational64u Count 3, space-joined.
+  LeicaTag {
+    id: 0x0413,
+    name: "WB_RGBLevels",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x0500 InternalSerialNumber (Panasonic.pm:2047) — undef, date-encoded PrintConv.
+  LeicaTag {
+    id: 0x0500,
+    name: "InternalSerialNumber",
+    conv: LeicaPrintConv::InternalSerialNumber,
+    format: None,
+    condition: None,
+  },
+];
+
+/// `%Panasonic::Leica6` (`Panasonic.pm:2112-2190`) — S2/M-Typ240/S-Typ006 +
+/// (via Leica7) M Monochrom Typ 246. The `0x300 PreviewImage` /
+/// `0x301 UnknownBlock` binary rows are deferred. The Typ-006-only rows
+/// (0x311/0x312/0x320/0x321) carry a Model `Condition`.
+pub const LEICA6_TAGS: &[LeicaTag] = &[
+  // 0x303 LensType (Panasonic.pm:2142) — string, ValueConv trailing-space trim, no PrintConv.
+  LeicaTag {
+    id: 0x303,
+    name: "LensType",
+    conv: LeicaPrintConv::LensTypeTrim,
+    format: None,
+    condition: None,
+  },
+  // 0x304 FocusDistance (Panasonic.pm:2154) — int32u, raw.
+  LeicaTag {
+    id: 0x304,
+    name: "FocusDistance",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x311 ExternalSensorBrightnessValue (Panasonic.pm:2153) — Format rational64s, Condition Typ 006, sprintf("%.2f").
+  LeicaTag {
+    id: 0x311,
+    name: "ExternalSensorBrightnessValue",
+    conv: LeicaPrintConv::Sprintf2f,
+    format: Some(FormatOverride::new(Format::Rational64s, None)),
+    condition: Some(LeicaCondition::ModelTyp006),
+  },
+  // 0x312 MeasuredLV (Panasonic.pm:2160) — Format rational64s, Condition Typ 006, sprintf("%.2f").
+  LeicaTag {
+    id: 0x312,
+    name: "MeasuredLV",
+    conv: LeicaPrintConv::Sprintf2f,
+    format: Some(FormatOverride::new(Format::Rational64s, None)),
+    condition: Some(LeicaCondition::ModelTyp006),
+  },
+  // 0x320 FirmwareVersion (Panasonic.pm:2171) — int8u Count 4, Condition Typ 006, $val=~tr/ /./.
+  LeicaTag {
+    id: 0x320,
+    name: "FirmwareVersion",
+    conv: LeicaPrintConv::FirmwareVersionDots,
+    format: None,
+    condition: Some(LeicaCondition::ModelTyp006),
+  },
+  // 0x321 LensSerialNumber (Panasonic.pm:2179) — int32u, Condition Typ 006, sprintf("%.10d").
+  LeicaTag {
+    id: 0x321,
+    name: "LensSerialNumber",
+    conv: LeicaPrintConv::Sprintf10d,
+    format: None,
+    condition: Some(LeicaCondition::ModelTyp006),
+  },
+];
+
+/// `%Panasonic::Leica9` (`Panasonic.pm:2193-2256`) — S-Typ007/M10. 10 plain
+/// leaves.
+pub const LEICA9_TAGS: &[LeicaTag] = &[
+  // 0x304 FocusDistance (Panasonic.pm:2197) — int32u, raw.
+  LeicaTag {
+    id: 0x304,
+    name: "FocusDistance",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x311 ExternalSensorBrightnessValue (Panasonic.pm:2203) — Format rational64s, sprintf("%.2f").
+  LeicaTag {
+    id: 0x311,
+    name: "ExternalSensorBrightnessValue",
+    conv: LeicaPrintConv::Sprintf2f,
+    format: Some(FormatOverride::new(Format::Rational64s, None)),
+    condition: None,
+  },
+  // 0x312 MeasuredLV (Panasonic.pm:2208) — Format rational64s, sprintf("%.2f").
+  LeicaTag {
+    id: 0x312,
+    name: "MeasuredLV",
+    conv: LeicaPrintConv::Sprintf2f,
+    format: Some(FormatOverride::new(Format::Rational64s, None)),
+    condition: None,
+  },
+  // 0x34c UserProfile (Panasonic.pm:2218) — string.
+  LeicaTag {
+    id: 0x34c,
+    name: "UserProfile",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x359 ISOSelected (Panasonic.pm:2223) — int32s, 0=>Auto + identity OTHER.
+  LeicaTag {
+    id: 0x359,
+    name: "ISOSelected",
+    conv: LeicaPrintConv::IsoSelected,
+    format: None,
+    condition: None,
+  },
+  // 0x35a FNumber (Panasonic.pm:2231) — int32s, ValueConv /1000, sprintf("%.1f").
+  LeicaTag {
+    id: 0x35a,
+    name: "FNumber",
+    conv: LeicaPrintConv::Div1000Sprintf1f,
+    format: None,
+    condition: None,
+  },
+  // 0x35b CorrelatedColorTemp (Panasonic.pm:2233) — int16u, raw.
+  LeicaTag {
+    id: 0x35b,
+    name: "CorrelatedColorTemp",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x35c ColorTint (Panasonic.pm:2234) — int16s, raw.
+  LeicaTag {
+    id: 0x35c,
+    name: "ColorTint",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x35d WhitePoint (Panasonic.pm:2235) — rational64u Count 2, space-joined.
+  LeicaTag {
+    id: 0x35d,
+    name: "WhitePoint",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+  // 0x370 LensProfileName (Panasonic.pm:2238) — string.
+  LeicaTag {
+    id: 0x370,
+    name: "LensProfileName",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+  },
+];
+
+/// The tag slice for a variant. Leica7 → Leica6, Leica8 → Leica5
+/// (handled by the dispatcher mapping the signatures to the table-bearing
+/// [`LeicaVariant`]).
+#[must_use]
+const fn table_for(variant: LeicaVariant) -> &'static [LeicaTag] {
+  match variant {
+    LeicaVariant::Leica2 => LEICA2_TAGS,
+    LeicaVariant::Leica3 => LEICA3_TAGS,
+    LeicaVariant::Leica4 => LEICA4_TAGS,
+    LeicaVariant::Leica5 => LEICA5_TAGS,
+    LeicaVariant::Leica6 => LEICA6_TAGS,
+    LeicaVariant::Leica9 => LEICA9_TAGS,
+  }
+}
+
+/// Resolve a Leica tag by ID within `variant`'s table. `None` ⇒ not a ported
+/// leaf (the shared `Walker` then drops it, the unknown-tag skip). Every table
+/// is sorted by tag ID (binary-search-ready).
+#[must_use]
+pub fn lookup(variant: LeicaVariant, tag_id: u16) -> Option<&'static LeicaTag> {
+  let tags = table_for(variant);
+  match tags.binary_search_by_key(&tag_id, |t| t.id) {
+    Ok(i) => tags.get(i),
+    Err(_) => None,
+  }
+}
+
+/// The `Format =>` directive's FORMAT for tag `id` under `variant`'s table, if
+/// any — the per-table override the shared `Walker` resolves
+/// (`Exif.pm:6729`). `None` for an unknown tag or a tag with no directive.
+#[must_use]
+pub fn format_override(variant: LeicaVariant, id: u16) -> Option<Format> {
+  lookup(variant, id)
+    .and_then(LeicaTag::format_override)
+    .map(FormatOverride::format)
+}

--- a/src/exif/makernotes/vendors/leica/tests.rs
+++ b/src/exif/makernotes/vendors/leica/tests.rs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Unit tests for the Leica typed surface, the per-variant tag tables, and the
+//! `LeicaPrintConv` conversions (`%Panasonic::Leica2`..`Leica9`).
+
+use super::*;
+use crate::exif::ifd::RawValue;
+use crate::value::TagValue;
+
+/// Leica2 0x310 LensType: stored int32u splits into `"<id> <bits>"` then
+/// `%leicaLensTypes`. `5 << 2 = 20` ⇒ id 5, bits 0 ⇒ `"5"` ⇒
+/// "Summilux-M 50mm f/1.4 (II)".
+#[test]
+fn lens_type_leica2_resolves_name() {
+  let raw = RawValue::U64(std::vec![20]);
+  let v = LeicaPrintConv::LensType.apply(&raw, true);
+  assert_eq!(v, TagValue::Str("Summilux-M 50mm f/1.4 (II)".into()));
+  // -n keeps the ValueConv "id bits" string.
+  let n = LeicaPrintConv::LensType.apply(&raw, false);
+  assert_eq!(n, TagValue::Str("5 0".into()));
+}
+
+/// LensType `"id bits"` key wins over the bare-`id` fallback: `6 << 2 | 0 = 24`
+/// ⇒ `"6 0"` => "Summilux-M 35mm f/1.4" (NOT the `"6"` => "Summicron-M 35mm").
+#[test]
+fn lens_type_id_bits_key_preferred() {
+  let raw = RawValue::U64(std::vec![24]); // id 6, bits 0
+  let v = LeicaPrintConv::LensType.apply(&raw, true);
+  assert_eq!(v, TagValue::Str("Summilux-M 35mm f/1.4".into()));
+  // id 6 bits 2 ⇒ "6 2" absent ⇒ falls back to "6" => "Summicron-M 35mm f/2 (IV)".
+  let raw2 = RawValue::U64(std::vec![(6 << 2) | 2]);
+  let v2 = LeicaPrintConv::LensType.apply(&raw2, true);
+  assert_eq!(v2, TagValue::Str("Summicron-M 35mm f/2 (IV)".into()));
+}
+
+/// An entirely unmatched LensType keeps the ValueConv `"id bits"` string.
+#[test]
+fn lens_type_unmatched_keeps_value_conv() {
+  let raw = RawValue::U64(std::vec![(999 << 2) | 1]);
+  let v = LeicaPrintConv::LensType.apply(&raw, true);
+  assert_eq!(v, TagValue::Str("999 1".into()));
+}
+
+/// Leica2 0x303 SerialNumber: `sprintf("%.7d", $val)`.
+#[test]
+fn serial_number_7_zero_pads() {
+  let raw = RawValue::U64(std::vec![1234]);
+  assert_eq!(
+    LeicaPrintConv::SerialNumber7.apply(&raw, true),
+    TagValue::Str("0001234".into())
+  );
+  assert_eq!(
+    LeicaPrintConv::SerialNumber7.apply(&raw, false),
+    TagValue::I64(1234)
+  );
+}
+
+/// Leica2 0x304 WhiteBalance: the hash, then the `> 0x8000` Kelvin OTHER.
+#[test]
+fn white_balance_2_hash_and_kelvin() {
+  assert_eq!(
+    LeicaPrintConv::WhiteBalance2.apply(&RawValue::U64(std::vec![1]), true),
+    TagValue::Str("Daylight".into())
+  );
+  // 0x8000 + 5500 = 38268 ⇒ "5500 Kelvin".
+  assert_eq!(
+    LeicaPrintConv::WhiteBalance2.apply(&RawValue::U64(std::vec![0x8000 + 5500]), true),
+    TagValue::Str("5500 Kelvin".into())
+  );
+  // An unmatched value below 0x8000 ⇒ raw passthrough (WhiteBalanceConv undef).
+  assert_eq!(
+    LeicaPrintConv::WhiteBalance2.apply(&RawValue::U64(std::vec![99]), true),
+    TagValue::I64(99)
+  );
+}
+
+/// The `rational64s` brightness rows: `sprintf("%.2f", $val)`.
+#[test]
+fn sprintf_2f_on_rational() {
+  use crate::value::Rational;
+  let raw = RawValue::Rational(std::vec![Rational::new(-325, 100, 7)]);
+  assert_eq!(
+    LeicaPrintConv::Sprintf2f.apply(&raw, true),
+    TagValue::Str("-3.25".into())
+  );
+}
+
+/// Leica6 0x303 LensType trims trailing spaces (ValueConv `$val=~s/ +$//`).
+#[test]
+fn lens_type_trim_strips_trailing_spaces() {
+  let raw = RawValue::Text {
+    text: std::string::String::from("APO-Summicron   "),
+    raw: Box::from(&b"APO-Summicron   "[..]),
+  };
+  let v = LeicaPrintConv::LensTypeTrim.apply(&raw, true);
+  assert_eq!(v, TagValue::Str("APO-Summicron".into()));
+}
+
+/// Leica6 0x320 FirmwareVersion: int8u[4] `$val=~tr/ /./`.
+#[test]
+fn firmware_version_dots() {
+  let raw = RawValue::U64(std::vec![1, 2, 3, 4]);
+  assert_eq!(
+    LeicaPrintConv::FirmwareVersionDots.apply(&raw, true),
+    TagValue::Str("1.2.3.4".into())
+  );
+  // -n keeps the space-joined value.
+  assert_eq!(
+    LeicaPrintConv::FirmwareVersionDots.apply(&raw, false),
+    TagValue::Str("1 2 3 4".into())
+  );
+}
+
+/// Leica9 0x35a FNumber: int32s ValueConv `/1000`, PrintConv `%.1f`.
+#[test]
+fn fnumber_div1000() {
+  let raw = RawValue::I64(std::vec![2800]);
+  assert_eq!(
+    LeicaPrintConv::Div1000Sprintf1f.apply(&raw, true),
+    TagValue::Str("2.8".into())
+  );
+  assert_eq!(
+    LeicaPrintConv::Div1000Sprintf1f.apply(&raw, false),
+    TagValue::F64(2.8)
+  );
+}
+
+/// Leica9 0x359 ISOSelected: 0 => Auto, else identity.
+#[test]
+fn iso_selected_auto_and_identity() {
+  assert_eq!(
+    LeicaPrintConv::IsoSelected.apply(&RawValue::I64(std::vec![0]), true),
+    TagValue::Str("Auto".into())
+  );
+  assert_eq!(
+    LeicaPrintConv::IsoSelected.apply(&RawValue::I64(std::vec![3200]), true),
+    TagValue::I64(3200)
+  );
+}
+
+/// Leica5 0x040d ExposureMode: int8u[4] string hash.
+#[test]
+fn exposure_mode_5_hash() {
+  let raw = RawValue::U64(std::vec![1, 1, 0, 0]);
+  assert_eq!(
+    LeicaPrintConv::ExposureMode5.apply(&raw, true),
+    TagValue::Str("Aperture-priority AE (1)".into())
+  );
+  assert_eq!(
+    LeicaPrintConv::ExposureMode5.apply(&raw, false),
+    TagValue::Str("1 1 0 0".into())
+  );
+}
+
+/// Leica5 0x0500 InternalSerialNumber: the date-decoding PrintConv.
+/// "ABC" + "1903150042" ⇒ year 19→2019, "(ABC) 2019:03:15 no. 0042".
+#[test]
+fn internal_serial_number_decodes_date() {
+  let bytes = b"ABC1903150042".to_vec();
+  let raw = RawValue::Bytes(bytes);
+  let v = LeicaPrintConv::InternalSerialNumber.apply(&raw, true);
+  assert_eq!(v, TagValue::Str("(ABC) 2019:03:15 no. 0042".into()));
+  // A non-matching value passes through unchanged (the bundled `return $val`).
+  let raw2 = RawValue::Bytes(b"not-a-serial".to_vec());
+  let v2 = LeicaPrintConv::InternalSerialNumber.apply(&raw2, true);
+  assert_eq!(v2, TagValue::Bytes(b"not-a-serial".to_vec()));
+}
+
+/// The dispatcher signature-variant → table mapping: Leica7 reuses the Leica6
+/// table, Leica8 reuses the Leica5 table (we model that as the dispatcher
+/// resolving Leica7/8 to the table-bearing variant; here we assert the tables
+/// themselves carry the right tags).
+#[test]
+fn variant_tables_carry_expected_leaves() {
+  // Leica2 has 0x310 LensType.
+  assert!(lookup(LeicaVariant::Leica2, 0x310).is_some());
+  // Leica4 is all-SubDirectory ⇒ no plain leaf.
+  assert!(lookup(LeicaVariant::Leica4, 0x3000).is_none());
+  assert_eq!(LEICA4_TAGS.len(), 0);
+  // Leica5 has the Condition-gated 0x0303 LensType + 0x040d ExposureMode.
+  assert!(lookup(LeicaVariant::Leica5, 0x0303).is_some());
+  assert!(lookup(LeicaVariant::Leica5, 0x040d).is_some());
+  // Leica6 has the trimmed 0x303 LensType + the Typ-006 0x321.
+  assert_eq!(
+    lookup(LeicaVariant::Leica6, 0x303).map(LeicaTag::name),
+    Some("LensType")
+  );
+  assert_eq!(
+    lookup(LeicaVariant::Leica6, 0x321).and_then(LeicaTag::condition),
+    Some(LeicaCondition::ModelTyp006)
+  );
+  // Leica9 has 0x35a FNumber.
+  assert!(lookup(LeicaVariant::Leica9, 0x35a).is_some());
+}
+
+/// The `rational64s` Format override is present on the brightness rows.
+#[test]
+fn brightness_rows_have_rational64s_override() {
+  use crate::exif::ifd::Format;
+  assert_eq!(
+    format_override(LeicaVariant::Leica2, 0x311),
+    Some(Format::Rational64s)
+  );
+  assert_eq!(
+    format_override(LeicaVariant::Leica9, 0x312),
+    Some(Format::Rational64s)
+  );
+}
+
+/// The typed surface captures the lens name + serial.
+#[test]
+fn populate_typed_lens_and_serial() {
+  let mut t = MakerNotesLeica::new();
+  populate_typed(
+    &mut t,
+    LeicaVariant::Leica2,
+    0x310,
+    &TagValue::Str("Summicron-M 50mm f/2 (IV, V)".into()),
+    &RawValue::U64(std::vec![132]),
+  );
+  populate_typed(
+    &mut t,
+    LeicaVariant::Leica2,
+    0x303,
+    &TagValue::Str("0001234".into()),
+    &RawValue::U64(std::vec![1234]),
+  );
+  assert_eq!(t.lens_name(), Some("Summicron-M 50mm f/2 (IV, V)"));
+  assert_eq!(t.serial_number(), Some("0001234"));
+}

--- a/src/exif/makernotes/vendors/mod.rs
+++ b/src/exif/makernotes/vendors/mod.rs
@@ -32,6 +32,7 @@
 pub mod apple;
 pub mod canon;
 pub mod dji;
+pub mod leica;
 pub mod nikon;
 pub mod panasonic;
 pub mod pentax;
@@ -41,6 +42,7 @@ pub mod sony;
 pub use apple::MakerNotesApple;
 pub use canon::MakerNotesCanon;
 pub use dji::MakerNotesDji;
+pub use leica::MakerNotesLeica;
 pub use nikon::MakerNotesNikon;
 pub use panasonic::MakerNotesPanasonic;
 pub use pentax::MakerNotesPentax;

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -623,6 +623,24 @@ enum ResolvedConv {
   /// dedicated capture loop emits (the parent pointer is never emitted, the
   /// Nikon/Pentax SubDirectory pattern).
   Samsung(&'static makernotes::vendors::samsung::tags::SamsungTag),
+  /// A Leica maker-note leaf (`%Panasonic::Leica2`..`Leica9` descriptor, #259).
+  /// Carries the resolved
+  /// [`LeicaTag`](makernotes::vendors::leica::tags::LeicaTag) PLUS the
+  /// [`LeicaVariant`](makernotes::vendors::leica::tags::LeicaVariant) it
+  /// resolved under, so the emit ([`emit_leica_value`]) reapplies its
+  /// [`LeicaPrintConv`](makernotes::vendors::leica::printconv::LeicaPrintConv)
+  /// and evaluates its row `Condition` (the Leica5 0x0303 `$format eq "string"`
+  /// gate, the Leica6 Typ-006 rows). Leica is a SIMPLE vendor like
+  /// Pentax/Samsung: a plain LEAF table walked under
+  /// `active_table == TableRef::Leica(variant)`; the deferred SubDirectory /
+  /// binary rows are absent from the tables. The dispatcher fans the EIGHT
+  /// detected signatures (Leica2..Leica9) onto the SIX table-bearing variants
+  /// (Leica7→Leica6, Leica8→Leica5) and supplies the per-variant
+  /// `Start`/`Base`/`ByteOrder`, which the shared `Walker` applies.
+  Leica(
+    makernotes::vendors::leica::tags::LeicaVariant,
+    &'static makernotes::vendors::leica::tags::LeicaTag,
+  ),
 }
 
 impl ResolvedConv {
@@ -647,6 +665,9 @@ impl ResolvedConv {
       ResolvedConv::Nikon(_) => vendor_group1_of(TableRef::Nikon),
       ResolvedConv::Pentax(_) => vendor_group1_of(TableRef::Pentax),
       ResolvedConv::Samsung(_) => vendor_group1_of(TableRef::Samsung),
+      // Every Leica variant emits under the `Leica` family-1 group; the
+      // discriminant carries the variant, so `vendor_group1_of` resolves it.
+      ResolvedConv::Leica(variant, _) => vendor_group1_of(TableRef::Leica(variant)),
     }
   }
 }
@@ -709,6 +730,11 @@ const fn vendor_group1_of(table: TableRef) -> Option<&'static str> {
     // 'MakerNotes' }`, so family-1 follows family-0's `MakerNotes`→vendor
     // mapping — `exiftool -j -G1` emits `Samsung:LensType` on a Samsung body).
     TableRef::Samsung => Some("Samsung"),
+    // `%Panasonic::Leica2`..`Leica9` (#259). Every Leica variant table declares
+    // `GROUPS => { 1 => 'Leica' }` (`Panasonic.pm`), so `exiftool -j -G1` emits
+    // `Leica:LensType` on a Leica body — distinct from the Leica1/Leica10
+    // cross-vendor routes (which emit `Panasonic:*` via `%Panasonic::Main`).
+    TableRef::Leica(_) => Some("Leica"),
     TableRef::Exif | TableRef::Gps | TableRef::Interop => None,
   }
 }
@@ -854,6 +880,32 @@ enum MakerNoteValueConvDecode<'a> {
     detected: makernotes::DetectedMakerNote,
     order: ByteOrder,
     make: Option<smol_str::SmolStr>,
+    model: Option<smol_str::SmolStr>,
+  },
+  /// Leica2..Leica9 — re-drive the SHARED `Walker`'s Leica variant walk +
+  /// emission capture ([`leica_makernote_isolated`]) with `print_conv = false`
+  /// (#259). The walk is deterministic across the PrintConv flag (same bytes,
+  /// same `detected` modes; only the per-leaf render differs), so the recomputed
+  /// `-n` emissions are byte-identical to the eager `-n` cache. The resolved
+  /// [`LeicaVariant`](makernotes::vendors::leica::tags::LeicaVariant) selects the
+  /// table; the dispatched `detected` carries the body offset / `Base` rule /
+  /// `Unknown` byte order. `model` is the parent `$$self{Model}` the Leica6
+  /// Typ-006 `Condition` reads (retained so the `-n` recompute gates the same
+  /// rows as the `-j` decode). Distinct from [`Leica1`](Self::Leica1) /
+  /// [`Leica10`](Self::Leica10), which decode through `%Panasonic::Main`.
+  Leica {
+    data: &'a [u8],
+    mn_offset: usize,
+    mn_len: usize,
+    variant: makernotes::vendors::leica::tags::LeicaVariant,
+    detected: makernotes::DetectedMakerNote,
+    order: ByteOrder,
+    /// The parent TIFF base (the base of the IFD that contained the 0x927c
+    /// MakerNote entry). Leica7's `Base => '-$base'` ([`NegativeOfBase`]
+    /// (makernotes::BaseRule::NegativeOfBase)) rebases absolute value pointers
+    /// to the slice via `-parent_base`, so the `-n` recompute must replay the
+    /// SAME base the eager `-j` walk used (nonzero for an embedded JPEG `APP1`).
+    parent_base: u32,
     model: Option<smol_str::SmolStr>,
   },
 }
@@ -1062,6 +1114,38 @@ impl MakerNoteValueConvDecode<'_> {
           *detected,
           *order,
           make.as_deref(),
+          model.as_deref(),
+          false,
+        )
+        .map(|(e, _)| e)
+        .unwrap_or_default()
+      }
+      MakerNoteValueConvDecode::Leica {
+        data,
+        mn_offset,
+        mn_len,
+        variant,
+        detected,
+        order,
+        parent_base,
+        model,
+      } => {
+        // The `-n` recompute is the isolated walk with `print_conv = false` and
+        // the typed slot discarded (the `-n` path needs only the ValueConv
+        // emissions), mirroring the other vendors (#259). A blob that walked in
+        // PrintConv walks the SAME way in ValueConv (the `detected` modes +
+        // variant are PrintConv-independent), so `Some` always holds;
+        // `unwrap_or_default` is the defensive empty `Vec` for the impossible
+        // `None`. `parent_base` replays the eager walk's parent TIFF base so the
+        // Leica7 `-$base` rebase is identical across modes.
+        leica_makernote_isolated(
+          data,
+          *mn_offset,
+          *mn_len,
+          *variant,
+          *detected,
+          *order,
+          *parent_base,
           model.as_deref(),
           false,
         )
@@ -3876,6 +3960,11 @@ impl Walker<'_, '_> {
       // Walker's verbose-only omit) — the deferred Crypt/SubDirectory rows are
       // simply absent from `SAMSUNG_TAGS`.
       TableRef::Samsung => makernotes::vendors::samsung::tags::lookup(tag_id).map(|t| t.name()),
+      // `%Panasonic::Leica2`..`Leica9` (#259). The name resolves against the
+      // ACTIVE variant's own table (the variant rides in the `TableRef::Leica`
+      // payload). An unknown id yields `None` (the deferred SubDirectory /
+      // binary rows are absent from the tables), the verbose-only omit.
+      TableRef::Leica(v) => makernotes::vendors::leica::tags::lookup(v, tag_id).map(|t| t.name()),
       _ => tables::lookup(tag_id).map(|t| t.name),
     }
   }
@@ -4384,6 +4473,12 @@ impl Walker<'_, '_> {
       // active Samsung table exactly as the Sony/Pentax walks do, recomputing
       // the count per `int(size/elemsize)` (`Exif.pm:6743`).
       TableRef::Samsung => makernotes::vendors::samsung::format_override(tag_id),
+      // `%Panasonic::Leica2`..`Leica9` (#259) carry their OWN `Format =>`
+      // directives — the `rational64s` `ExternalSensorBrightnessValue` /
+      // `MeasuredLV` rows (Leica2/6/9 0x311/0x312) + the Leica5 0x040d
+      // `ExposureMode` int8u[4] row. The Walker resolves them off the active
+      // Leica variant table exactly as Sony/Pentax/Samsung do.
+      TableRef::Leica(v) => makernotes::vendors::leica::format_override(v, tag_id),
       // VENDOR tables (Canon, #243 phase 2) inherit NO `%Exif::Main` `Format`
       // override: a Canon MakerNote tag colliding with an EXIF override id (e.g.
       // 0x9286 `UserComment`, `Format => 'undef'`) must keep its ON-DISK format —
@@ -5543,6 +5638,50 @@ impl Walker<'_, '_> {
                   // tags ⇒ bundled emits them under the `Panasonic` family-1
                   // group.
                   emission_group1 = makernotes::Vendor::Panasonic.group1();
+                } else if let Some(variant) =
+                  makernotes::vendors::leica::discriminate_variant(bytes, make, model)
+                {
+                  // The Leica2..Leica9 variant tables (#259). Leica1/Leica10
+                  // (the cross-vendor `%Panasonic::Main` routes) did not match,
+                  // so re-discriminate WHICH variant the dispatcher matched and
+                  // walk its OWN table in a FRESH, ISOLATED `Walker`
+                  // ([`leica_makernote_isolated`]). The dispatched `detected`
+                  // carries the per-variant `Start`/`Base`/`ByteOrder` the helper
+                  // threads (Leica2 `$start`, Leica4/5/8 `$start - 8`,
+                  // Leica3/6/9 inherit, Leica7 `-$base` ⇒ `-parent_base`, which
+                  // is `self.base` below — 0 for a standalone TIFF, nonzero for
+                  // an embedded JPEG `APP1`).
+                  // `model` threads `$$self{Model}` for the Leica6 Typ-006
+                  // `Condition`. The walk DISCARDS its `warnings` / `warn_count` /
+                  // `active_ifd_offsets` / `chain_guard`. These tags emit under
+                  // the `Leica` family-1 group (they ARE `%Panasonic::Leica*`
+                  // tags, `GROUPS => { 1 => 'Leica' }`). `print_conv = true`
+                  // yields the cached `-j` emissions + the typed slot; the `-n`
+                  // emissions are recomputed on demand via the SAME helper.
+                  // `self.base` is the parent TIFF base of the IFD that holds
+                  // this 0x927c entry — 0 for a standalone TIFF, NONZERO for an
+                  // embedded JPEG `APP1` Exif block (sliced at its file offset
+                  // and walked with that base). Leica7's `Base => '-$base'`
+                  // rebases absolute value pointers to the slice via
+                  // `-self.base`; the other variants ignore it.
+                  if let Some((emi_pc, typed_pc)) = leica_makernote_isolated(
+                    self.data, mn_offset, mn_len, variant, detected, self.order, self.base, model,
+                    true,
+                  ) {
+                    meta.set_leica(typed_pc);
+                    cached_pc = emi_pc;
+                    value_conv_decode = MakerNoteValueConvDecode::Leica {
+                      data: self.data,
+                      mn_offset,
+                      mn_len,
+                      variant,
+                      detected,
+                      order: self.order,
+                      parent_base: self.base,
+                      model: model.map(smol_str::SmolStr::new),
+                    };
+                    emission_group1 = variant.group1();
+                  }
                 }
               }
               makernotes::Vendor::Dji => {
@@ -5958,6 +6097,15 @@ impl Walker<'_, '_> {
       // `next unless $tagInfo` skip.
       TableRef::Samsung => match makernotes::vendors::samsung::tags::lookup(tag_id) {
         Some(t) => (t.name(), ResolvedConv::Samsung(t)),
+        None => return,
+      },
+      // `%Panasonic::Leica2`..`Leica9` (#259). The resolved [`LeicaTag`] rides in
+      // `ResolvedConv::Leica` WITH its variant so the emit ([`emit_leica_value`])
+      // reapplies its `LeicaPrintConv` + evaluates the row `Condition`. An unknown
+      // Leica tag is skipped here (the deferred SubDirectory/binary rows), matching
+      // `ProcessExif`'s `next unless $tagInfo` skip.
+      TableRef::Leica(v) => match makernotes::vendors::leica::tags::lookup(v, tag_id) {
+        Some(t) => (t.name(), ResolvedConv::Leica(v, t)),
         None => return,
       },
       _ => match tables::lookup(tag_id) {
@@ -7084,6 +7232,22 @@ fn emit_entry<S: ExifSink>(
       let group1 = entry.conv.vendor_group1().unwrap_or(group);
       emit_samsung_value(group1, entry, samsung_tag, print_conv, None, out)
     }
+    // `%Panasonic::Leica2`..`Leica9` (#259). Like Pentax/Samsung, the production
+    // Leica capture runs in the dedicated isolated walker
+    // ([`leica_makernote_isolated`]), and no core-IFD walk produces a
+    // `ResolvedConv::Leica` entry (Leica leaves exist only under
+    // `active_table == TableRef::Leica(_)`). This arm keeps the match exhaustive:
+    // a plain LEAF renders via `emit_leica_value` (which also evaluates the row
+    // `Condition`).
+    ResolvedConv::Leica(variant, leica_tag) => {
+      let group1 = entry.conv.vendor_group1().unwrap_or(group);
+      // The defensive `emit_entry` arm never carries the Leica Typ-006 model
+      // (the production Leica capture is the isolated walker, which threads it);
+      // pass `None` here (a core-IFD walk never produces a Leica entry anyway).
+      emit_leica_value(
+        group1, entry, variant, leica_tag, None, print_conv, None, out,
+      )
+    }
   }
 }
 
@@ -7228,6 +7392,67 @@ fn emit_samsung_value<S: ExifSink>(
     value,
     samsung_tag.is_unknown(),
   )
+}
+
+/// Render ONE Leica maker-note LEAF into the sink — the emit-time reproduction
+/// of `%Panasonic::Leica2`..`Leica9`'s per-tag emit through the shared `Walker`
+/// (#259).
+///
+/// Leica is a SIMPLE vendor like Pentax/Samsung, with ONE wrinkle: some rows
+/// carry a `Condition` that gates emission (the faithful port of ExifTool's
+/// `GetTagInfo` returning no tag when the `Condition` fails). This emit:
+///
+/// 1. Evaluates the row `Condition` against the entry — the Leica5 0x0303
+///    `LensType` `$format eq "string"` gate (read off [`ExifEntry::on_disk_format`])
+///    and the Leica6 Typ-006 rows (`$$self{Model} =~ /Typ 006/`, threaded as
+///    `model`). A failing `Condition` writes NOTHING (no emission, no typed
+///    populate) — the absent-tag behaviour.
+/// 2. Applies the resolved tag's
+///    [`LeicaPrintConv`](makernotes::vendors::leica::printconv::LeicaPrintConv)
+///    (taken BY VALUE — the conv is `Copy`) on the entry's RAW value.
+/// 3. Writes the already-rendered [`TagValue`] under `("MakerNotes", group1)`.
+///    No Leica leaf is `Unknown => 1`, so the flag is always `false`.
+///
+/// `typed` is the optional sink for the typed `MakerNotesLeica` populate (lens +
+/// serial) — `Some` only for the production capture; `populate_typed` runs only
+/// where the leaf emits (gate-passing), mirroring the other vendors.
+///
+/// `model` is the parent `$$self{Model}`, consumed only by the Leica6 Typ-006
+/// `Condition`; every other Leica row ignores it.
+#[cfg(feature = "alloc")]
+#[allow(clippy::too_many_arguments)]
+fn emit_leica_value<S: ExifSink>(
+  group1: &str,
+  entry: &ExifEntry,
+  variant: makernotes::vendors::leica::tags::LeicaVariant,
+  leica_tag: &makernotes::vendors::leica::tags::LeicaTag,
+  model: Option<&str>,
+  print_conv: bool,
+  typed: Option<&mut makernotes::vendors::leica::MakerNotesLeica>,
+  out: &mut S,
+) -> Result<(), core::convert::Infallible> {
+  use makernotes::vendors::leica::tags::LeicaCondition;
+  // Row `Condition` gate. A failing Condition ⇒ `GetTagInfo` returns no tag ⇒
+  // emit NOTHING and populate NO typed field (the absent-tag behaviour).
+  if let Some(cond) = leica_tag.condition() {
+    let holds = match cond {
+      // `$format eq "string"` — the entry's ON-DISK format is `string` (ASCII).
+      LeicaCondition::FormatIsString => entry.on_disk_format == crate::exif::ifd::Format::Ascii,
+      // `$$self{Model} =~ /Typ 006/` — the captured Model contains "Typ 006".
+      LeicaCondition::ModelTyp006 => model.is_some_and(|m| m.contains("Typ 006")),
+    };
+    if !holds {
+      return Ok(());
+    }
+  }
+  let raw = entry.value.raw();
+  let value = leica_tag.conv.apply(raw, print_conv);
+  // Populate the typed surface (gate-passing only, exactly where the leaf emits).
+  if let Some(typed) = typed {
+    makernotes::vendors::leica::populate_typed(typed, variant, entry.tag_id, &value, raw);
+  }
+  // No Leica leaf is `Unknown => 1`.
+  out.write_vendor_value("MakerNotes", group1, leica_tag.name(), value, false)
 }
 
 /// Render ONE Sony maker-note leaf into the sink — the emit-time reproduction of
@@ -9274,6 +9499,197 @@ pub(in crate::exif) fn samsung_makernote_isolated(
         g1,
         entry,
         samsung_tag,
+        print_conv,
+        Some(&mut typed),
+        &mut sink,
+      );
+    }
+  }
+  Some((emissions, typed))
+}
+
+/// Walk a Leica MakerNote variant IFD (`%Panasonic::Leica2`..`Leica9`) in a
+/// FRESH, ISOLATED [`Walker`] and capture its emissions + the typed
+/// [`MakerNotesLeica`](makernotes::vendors::leica::MakerNotesLeica) — the single
+/// entry point BOTH the `-j` production dispatch and the `-n` recompute drive
+/// (#259, structural isolation, mirroring [`samsung_makernote_isolated`]).
+///
+/// `variant` selects which of the SIX Leica tables the walk resolves against
+/// (the dispatcher fanned the EIGHT detected signatures onto the table-bearing
+/// [`LeicaVariant`](makernotes::vendors::leica::tags::LeicaVariant), with
+/// Leica7→Leica6 and Leica8→Leica5). `detected` carries the dispatched
+/// `Start`/`Base`/`ByteOrder` the Walker applies.
+///
+/// ## Base-rule mapping (the Leica7 `NegativeOfBase` note)
+///
+/// The Leica variants use four base rules:
+/// - **Leica2** `Base => '$start'` ([`StartItself`](makernotes::BaseRule::StartItself))
+///   — out-of-line offsets are BLOB-body-relative ⇒ `value_offset_base =
+///   mn_offset + body_offset` (the file offset of the child IFD start).
+/// - **Leica4/Leica5/Leica8** `Base => '$start - 8'`
+///   ([`RelativeToStart(-8)`](makernotes::BaseRule::RelativeToStart)) — with
+///   `body_offset == 8` the child base is `mn_offset` ⇒ `value_offset_base =
+///   mn_offset` (blob-start-relative, the M9 fixup).
+/// - **Leica3/Leica6/Leica9** no `Base` ([`Inherit`](makernotes::BaseRule::Inherit))
+///   — offsets are parent-TIFF-relative against `data` ⇒ `value_offset_base = 0`.
+/// - **Leica7** `Base => '-$base'`
+///   ([`NegativeOfBase`](makernotes::BaseRule::NegativeOfBase)) — the child's
+///   out-of-line value pointers are ABSOLUTE FILE offsets, so they must be
+///   rebased to the slice `data` by SUBTRACTING the parent TIFF base ⇒
+///   `value_offset_base = -parent_base` (`parent_base` = the base of the IFD
+///   that contains this MakerNote entry). For a standalone / base-0 TIFF
+///   `parent_base == 0` ⇒ `-0`, identical to `Inherit` (an absolute pointer
+///   resolves directly against `data`). But a real JPEG `APP1` Exif block is
+///   SLICED at its NONZERO file offset and walked with that base retained, so an
+///   absolute Leica7 pointer `P` resolves at `data[P - parent_base]` — the
+///   slice-relative index. `value_offset_base` is SIGNED, so the negated base is
+///   expressible directly; the resolution site range-checks `off_signed >= 0`
+///   AND `off + size <= len`, so a pointer landing outside the slice is dropped
+///   (never wrapped). (The Leica7 *trailer* layout some JPEGs use — a
+///   `ProcessLeicaTrailer` blob with its own absolute base — is a separate,
+///   deferred case; the inline-IFD path here is byte-exact vs the `perl
+///   exiftool` oracle on the crafted standalone + nonzero-base Leica7 fixtures.)
+///
+/// A degenerate too-short blob (no room for the IFD count word) returns
+/// `Some(empty)` (vendor identified, nothing decoded), never `None`.
+#[allow(clippy::too_many_arguments)]
+#[cfg(feature = "alloc")]
+pub(in crate::exif) fn leica_makernote_isolated(
+  data: &[u8],
+  mn_offset: usize,
+  mn_len: usize,
+  variant: makernotes::vendors::leica::tags::LeicaVariant,
+  detected: makernotes::DetectedMakerNote,
+  parent_order: ByteOrder,
+  parent_base: u32,
+  model: Option<&str>,
+  print_conv: bool,
+) -> Option<(
+  std::vec::Vec<makernotes::VendorEmission>,
+  makernotes::vendors::leica::MakerNotesLeica,
+)> {
+  use makernotes::vendors::leica::MakerNotesLeica;
+  // The captured MakerNote bytes the dispatcher classified
+  // (`data[mn_offset .. mn_offset + mn_len]`, saturating end clamped).
+  let mn_end = mn_offset.saturating_add(mn_len).min(data.len());
+  let _blob = data.get(mn_offset..mn_end)?;
+  // The child IFD start: the MakerNote value offset + the dispatched body offset
+  // (8 for every Leica2..Leica9 variant). The IFD count word must sit inside the
+  // declared value, else a truncated `mn_len` lets the Walker read its count word
+  // from the UNRELATED following parent-TIFF bytes — spurious tags.
+  let body_offset = detected.body_offset() as usize;
+  let ifd_offset = mn_offset.saturating_add(body_offset);
+  match body_offset.checked_add(2) {
+    Some(min) if mn_len >= min => {}
+    _ => return Some((std::vec::Vec::new(), MakerNotesLeica::new())),
+  }
+  // Translate the dispatched `Base` rule into the `value_offset_base` shift (see
+  // the doc comment). `StartItself` ⇒ the child IFD start file offset; `$start -
+  // 8` (RelativeToStart, body_offset 8) ⇒ `mn_offset`; `Inherit` ⇒ 0; Leica7's
+  // `NegativeOfBase` ⇒ `-parent_base` (an absolute child pointer rebased to the
+  // slice; see below).
+  let value_offset_base: i64 = match detected.base_rule() {
+    makernotes::BaseRule::Inherit => 0,
+    // `Base => '$start'` — out-of-line offsets are relative to the child IFD
+    // start file offset (`mn_offset + body_offset`, ExifTool's `$start`).
+    makernotes::BaseRule::StartItself => i64::try_from(ifd_offset).unwrap_or(i64::MAX),
+    // `Base => '$start + delta'` — the child base is `$start + delta` =
+    // `mn_offset + body_offset + delta` (for Leica4/5/8 with delta -8 and
+    // body_offset 8 this is `mn_offset`, the blob start). Computed in i64;
+    // clamped non-negative (a degenerate negative result lands past EOF).
+    makernotes::BaseRule::RelativeToStart(delta) => {
+      (i64::try_from(ifd_offset).unwrap_or(i64::MAX) + i64::from(delta)).max(0)
+    }
+    // `Base => '-$base'` — Leica7. Out-of-line value pointers are ABSOLUTE FILE
+    // offsets, so they must be rebased to the slice `data` by subtracting the
+    // parent TIFF base: an absolute pointer `P` resolves at `data[P -
+    // parent_base] = data[P + value_offset_base]` with `value_offset_base =
+    // -parent_base` (`value_offset_base` is SIGNED; the resolution site
+    // range-checks `off_signed >= 0 && off + size <= len`, so a pointer landing
+    // before/after the slice is dropped, never wrapped). `parent_base` is the
+    // base of the IFD that CONTAINS this 0x927c entry — 0 for a standalone /
+    // base-0 TIFF (⇒ `-0`, identical to `Inherit`), but NONZERO for a real JPEG
+    // `APP1` Exif block (sliced at its file offset, walked with that base). The
+    // OLD code hardcoded 0 here and read embedded-APP1 Leica7 out-of-line values
+    // from the wrong offset / out of bounds.
+    makernotes::BaseRule::NegativeOfBase => -i64::from(parent_base),
+    makernotes::BaseRule::Literal(n) if n >= 0 => n,
+    _ => 0,
+  };
+  // `ByteOrder => Unknown` ⇒ probe the entry-count word; `Explicit(o)` ⇒ fixed.
+  let byte_order_rule = match detected.byte_order() {
+    makernotes::ChildByteOrder::Unknown => ByteOrderRule::Unknown,
+    makernotes::ChildByteOrder::Explicit(o) => ByteOrderRule::Fixed(o),
+  };
+  // No Leica2..Leica9 variant sets `FixBase` (`MakerNotes.pm:611-721`).
+  let fix_base_mode = if detected.fix_base() {
+    FixBaseMode::Heuristic
+  } else {
+    FixBaseMode::No
+  };
+  let mut w = Walker {
+    data,
+    order: parent_order,
+    base: 0,
+    value_offset_base,
+    entries: Vec::new(),
+    // FRESH warning channels: a malformed Leica entry warns into THESE, dropped
+    // on return — never the parent's `ExifTool:Warning` stream.
+    warnings: Vec::new(),
+    warnings_ignorable: Vec::new(),
+    maker_note: None,
+    // The Leica6 Typ-006 `Condition` reads `$$self{Model}`; thread it. No Leica
+    // leaf reads Make.
+    captured_make: None,
+    captured_model: model.map(String::from),
+    chain_guard: ChainGuard::Owned(std::collections::HashSet::new()),
+    cycle_guard_warnings: Vec::new(),
+    // EMPTY active path: the fresh walker has NO ancestor on its recursion stack.
+    active_ifd_offsets: Vec::new(),
+    page_count: 0,
+    multi_page: false,
+    dng_version: false,
+    file_type: None,
+    no_raf: false,
+    warn_count: 0,
+    // Starts on the Exif table; `process_subdir(TableRef::Leica(variant))` swaps
+    // it to the Leica variant table for the sub-walk and restores it.
+    active_table: TableRef::Exif,
+    canon_focal_units: None,
+    canon_lens_type: None,
+    canon_focal_length_blob: None,
+  };
+  // The Leica variant IFD walk — `ProcessProc::Exif` directly (the Leica2..Leica9
+  // tables carry no `PROCESS_PROC`; only their deferred binary sub-tables do). The
+  // probed order is resolved inside `process_subdir`. It appends the Leica leaves
+  // to `w.entries` from index 0, isolating every core side effect from the parent.
+  w.process_subdir(
+    ifd_offset,
+    IfdKind::ExifIfd,
+    TableRef::Leica(variant),
+    byte_order_rule,
+    fix_base_mode,
+    ProcessProc::Exif,
+  );
+  // Capture the walked `ResolvedConv::Leica` leaves into the vendor-emission
+  // `Vec`; build the typed `MakerNotesLeica` from the SAME gate-passing entries.
+  let g1 = vendor_group1_of(TableRef::Leica(variant)).unwrap_or("Leica");
+  let mut emissions = std::vec::Vec::new();
+  let mut typed = MakerNotesLeica::new();
+  {
+    let mut sink = VendorEmissionSink::new(&mut emissions);
+    for entry in &w.entries {
+      // Only `ResolvedConv::Leica` entries live in this run; a defensive
+      // non-Leica conv (never produced under `TableRef::Leica`) is skipped.
+      let ResolvedConv::Leica(entry_variant, leica_tag) = entry.conv else {
+        continue;
+      };
+      let Ok(()) = emit_leica_value(
+        g1,
+        entry,
+        entry_variant,
+        leica_tag,
+        model,
         print_conv,
         Some(&mut typed),
         &mut sink,

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -4258,3 +4258,514 @@ fn real_fixture_samsung_nx500_type2() {
     );
   }
 }
+
+// ===========================================================================
+// MakerNoteLeica2..Leica9 — the per-variant `%Panasonic::Leica*` table port (#259)
+// ===========================================================================
+//
+// Crafted standalone-TIFF fixtures (one per dispatched signature variant). Each
+// carries a `Leica Camera AG`/`LEICA CAMERA AG` Make + the variant's signature
+// header + a small child IFD with representative leaves, AND exercises the
+// variant's BASE RULE via an out-of-line value where the rule is non-trivial
+// (Leica2 `$start`, Leica3/6/7/9 inherit/`-$base`, Leica5 `$start - 8`). Every
+// fixture's byte array + the expected Leica `-j`/`-n` output were VERIFIED
+// against bundled `perl exiftool 13.59` (`-G1 -j [-n] -a -u`); the
+// `*_matches_bundled_exiftool` test re-runs that oracle when the binary is on
+// PATH / `$EXIFTOOL`.
+
+/// Crafted leica2 standalone TIFF (`Leica2` table, base rule `StartItself`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA2_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 3, 0, 0, 0,
+  77, 56, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 69, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67,
+  97, 109, 101, 114, 97, 32, 65, 71, 0, 77, 56, 0, 1, 0, 124, 146, 7, 0, 62, 0, 0, 0, 87, 0, 0, 0,
+  0, 0, 0, 0, 76, 69, 73, 67, 65, 0, 0, 0, 3, 0, 3, 3, 4, 0, 1, 0, 0, 0, 135, 214, 18, 0, 16, 3, 4,
+  0, 1, 0, 0, 0, 20, 0, 0, 0, 64, 3, 4, 0, 3, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 22, 0,
+  0, 0, 33, 0, 0, 0,
+];
+
+/// Crafted leica3 standalone TIFF (`Leica3` table, base rule `Inherit`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA3_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 3, 0, 0, 0,
+  82, 57, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 69, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67,
+  97, 109, 101, 114, 97, 32, 65, 71, 0, 82, 57, 0, 1, 0, 124, 146, 7, 0, 24, 0, 0, 0, 87, 0, 0, 0,
+  0, 0, 0, 0, 1, 0, 13, 0, 3, 0, 3, 0, 0, 0, 105, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 1,
+];
+
+/// Crafted leica4 standalone TIFF (`Leica4` table, base rule `RelativeToStart(-8)`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA4_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 3, 0, 0, 0,
+  77, 57, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 69, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67,
+  97, 109, 101, 114, 97, 32, 65, 71, 0, 77, 57, 0, 1, 0, 124, 146, 7, 0, 26, 0, 0, 0, 87, 0, 0, 0,
+  0, 0, 0, 0, 76, 69, 73, 67, 65, 48, 3, 0, 1, 0, 0, 48, 4, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+/// Crafted leica5 standalone TIFF (`Leica5` table, base rule `RelativeToStart(-8)`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA5_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 9, 0, 0, 0,
+  66, 0, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 75, 0, 0, 0, 0, 0, 0, 0, 76, 69, 73, 67, 65, 32, 67, 65,
+  77, 69, 82, 65, 32, 65, 71, 0, 76, 101, 105, 99, 97, 32, 88, 49, 0, 1, 0, 124, 146, 7, 0, 52, 0,
+  0, 0, 93, 0, 0, 0, 0, 0, 0, 0, 76, 69, 73, 67, 65, 0, 1, 0, 2, 0, 5, 3, 4, 0, 1, 0, 0, 0, 6, 18,
+  15, 0, 8, 4, 2, 0, 14, 0, 0, 0, 38, 0, 0, 0, 0, 0, 0, 0, 68, 67, 73, 77, 47, 49, 48, 48, 76, 69,
+  73, 67, 65, 0,
+];
+
+/// Crafted leica6 standalone TIFF (`Leica6` table, base rule `Inherit`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA6_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 18, 0, 0, 0,
+  66, 0, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67,
+  97, 109, 101, 114, 97, 32, 65, 71, 0, 76, 69, 73, 67, 65, 32, 77, 32, 40, 84, 121, 112, 32, 50,
+  52, 48, 41, 0, 1, 0, 124, 146, 7, 0, 42, 0, 0, 0, 102, 0, 0, 0, 0, 0, 0, 0, 76, 69, 73, 67, 65,
+  0, 2, 255, 1, 0, 3, 3, 2, 0, 16, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 83, 117, 109, 109, 105, 108,
+  117, 120, 45, 77, 32, 53, 48, 32, 32, 0,
+];
+
+/// Crafted leica7 standalone TIFF (`Leica6` table, base rule `NegativeOfBase`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA7_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 28, 0, 0, 0,
+  66, 0, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 94, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67,
+  97, 109, 101, 114, 97, 32, 65, 71, 0, 76, 69, 73, 67, 65, 32, 77, 32, 77, 111, 110, 111, 99, 104,
+  114, 111, 109, 32, 40, 84, 121, 112, 32, 50, 52, 54, 41, 0, 1, 0, 124, 146, 7, 0, 40, 0, 0, 0,
+  112, 0, 0, 0, 0, 0, 0, 0, 76, 69, 73, 67, 65, 0, 2, 255, 1, 0, 3, 3, 2, 0, 14, 0, 0, 0, 138, 0,
+  0, 0, 0, 0, 0, 0, 84, 101, 115, 116, 76, 101, 105, 99, 97, 76, 101, 110, 115, 0,
+];
+
+/// Crafted leica8 standalone TIFF (`Leica5` table, base rule `RelativeToStart(-8)`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA8_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 18, 0, 0, 0,
+  66, 0, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 76, 69, 73, 67, 65, 32, 67, 65,
+  77, 69, 82, 65, 32, 65, 71, 0, 76, 69, 73, 67, 65, 32, 81, 32, 40, 84, 121, 112, 32, 49, 49, 54,
+  41, 0, 1, 0, 124, 146, 7, 0, 26, 0, 0, 0, 102, 0, 0, 0, 0, 0, 0, 0, 76, 69, 73, 67, 65, 0, 8, 0,
+  1, 0, 5, 3, 4, 0, 1, 0, 0, 0, 180, 121, 8, 0, 0, 0, 0, 0,
+];
+
+/// Crafted leica9 standalone TIFF (`Leica9` table, base rule `Inherit`), verified
+/// byte-exact against bundled `perl exiftool`.
+const LEICA9_TIFF: &[u8] = &[
+  73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2, 0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 10, 0, 0, 0,
+  66, 0, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0, 76, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67,
+  97, 109, 101, 114, 97, 32, 65, 71, 0, 76, 69, 73, 67, 65, 32, 77, 49, 48, 0, 1, 0, 124, 146, 7,
+  0, 51, 0, 0, 0, 94, 0, 0, 0, 0, 0, 0, 0, 76, 69, 73, 67, 65, 0, 2, 0, 2, 0, 90, 3, 9, 0, 1, 0, 0,
+  0, 240, 10, 0, 0, 112, 3, 2, 0, 13, 0, 0, 0, 132, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32,
+  65, 80, 79, 32, 53, 48, 0,
+];
+
+/// One Leica variant fixture's expected (key, -j value, -n value) Leica leaves.
+struct LeicaCase {
+  name: &'static str,
+  tiff: &'static [u8],
+  variant: exifast::exif::makernotes::vendors::leica::tags::LeicaVariant,
+  base_rule: exifast::exif::makernotes::BaseRule,
+  print_conv: &'static [(&'static str, fn() -> serde_json::Value)],
+  value_conv: &'static [(&'static str, fn() -> serde_json::Value)],
+}
+
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+fn leica_cases() -> Vec<LeicaCase> {
+  use exifast::exif::makernotes::BaseRule;
+  use exifast::exif::makernotes::vendors::leica::tags::LeicaVariant;
+  std::vec![
+    LeicaCase {
+      name: "leica2",
+      tiff: LEICA2_TIFF,
+      variant: LeicaVariant::Leica2,
+      base_rule: BaseRule::StartItself,
+      print_conv: &[
+        (
+          "Leica:ImageIDNumber",
+          (|| serde_json::json!("11 22 33")) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:LensType",
+          (|| serde_json::json!("Summilux-M 50mm f/1.4 (II)")) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:SerialNumber",
+          (|| serde_json::json!(1234567)) as fn() -> serde_json::Value
+        )
+      ],
+      value_conv: &[
+        (
+          "Leica:ImageIDNumber",
+          (|| serde_json::json!("11 22 33")) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:LensType",
+          (|| serde_json::json!("5 0")) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:SerialNumber",
+          (|| serde_json::json!(1234567)) as fn() -> serde_json::Value
+        )
+      ],
+    },
+    LeicaCase {
+      name: "leica3",
+      tiff: LEICA3_TIFF,
+      variant: LeicaVariant::Leica3,
+      base_rule: BaseRule::Inherit,
+      print_conv: &[(
+        "Leica:WB_RGBLevels",
+        (|| serde_json::json!("256 257 258")) as fn() -> serde_json::Value
+      )],
+      value_conv: &[(
+        "Leica:WB_RGBLevels",
+        (|| serde_json::json!("256 257 258")) as fn() -> serde_json::Value
+      )],
+    },
+    LeicaCase {
+      name: "leica4",
+      tiff: LEICA4_TIFF,
+      variant: LeicaVariant::Leica4,
+      base_rule: BaseRule::RelativeToStart(-8),
+      print_conv: &[],
+      value_conv: &[],
+    },
+    LeicaCase {
+      name: "leica5",
+      tiff: LEICA5_TIFF,
+      variant: LeicaVariant::Leica5,
+      base_rule: BaseRule::RelativeToStart(-8),
+      print_conv: &[
+        (
+          "Leica:OriginalDirectory",
+          (|| serde_json::json!("DCIM/100LEICA")) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:SerialNumber",
+          (|| serde_json::json!(987654)) as fn() -> serde_json::Value
+        )
+      ],
+      value_conv: &[
+        (
+          "Leica:OriginalDirectory",
+          (|| serde_json::json!("DCIM/100LEICA")) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:SerialNumber",
+          (|| serde_json::json!(987654)) as fn() -> serde_json::Value
+        )
+      ],
+    },
+    LeicaCase {
+      name: "leica6",
+      tiff: LEICA6_TIFF,
+      variant: LeicaVariant::Leica6,
+      base_rule: BaseRule::Inherit,
+      print_conv: &[(
+        "Leica:LensType",
+        (|| serde_json::json!("Summilux-M 50")) as fn() -> serde_json::Value
+      )],
+      value_conv: &[(
+        "Leica:LensType",
+        (|| serde_json::json!("Summilux-M 50")) as fn() -> serde_json::Value
+      )],
+    },
+    LeicaCase {
+      name: "leica7",
+      tiff: LEICA7_TIFF,
+      variant: LeicaVariant::Leica6,
+      base_rule: BaseRule::NegativeOfBase,
+      print_conv: &[(
+        "Leica:LensType",
+        (|| serde_json::json!("TestLeicaLens")) as fn() -> serde_json::Value
+      )],
+      value_conv: &[(
+        "Leica:LensType",
+        (|| serde_json::json!("TestLeicaLens")) as fn() -> serde_json::Value
+      )],
+    },
+    LeicaCase {
+      name: "leica8",
+      tiff: LEICA8_TIFF,
+      variant: LeicaVariant::Leica5,
+      base_rule: BaseRule::Inherit,
+      print_conv: &[(
+        "Leica:SerialNumber",
+        (|| serde_json::json!(555444)) as fn() -> serde_json::Value
+      )],
+      value_conv: &[(
+        "Leica:SerialNumber",
+        (|| serde_json::json!(555444)) as fn() -> serde_json::Value
+      )],
+    },
+    LeicaCase {
+      name: "leica9",
+      tiff: LEICA9_TIFF,
+      variant: LeicaVariant::Leica9,
+      base_rule: BaseRule::Inherit,
+      print_conv: &[
+        (
+          "Leica:FNumber",
+          (|| serde_json::json!(2.8)) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:LensProfileName",
+          (|| serde_json::json!("Leica APO 50")) as fn() -> serde_json::Value
+        )
+      ],
+      value_conv: &[
+        (
+          "Leica:FNumber",
+          (|| serde_json::json!(2.8)) as fn() -> serde_json::Value
+        ),
+        (
+          "Leica:LensProfileName",
+          (|| serde_json::json!("Leica APO 50")) as fn() -> serde_json::Value
+        )
+      ],
+    },
+  ]
+}
+
+/// Each Leica2..Leica9 fixture dispatches to `Vendor::Leica` with the EXPECTED
+/// base rule, routes to its OWN variant table, and the full serializer emits the
+/// `Leica:*` leaves byte-identically to bundled in BOTH `-j` and `-n` modes.
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+#[test]
+fn leica_variants_dispatch_and_emit() {
+  for case in leica_cases() {
+    let meta =
+      exifast::parse_exif(case.tiff).unwrap_or_else(|| panic!("{}: TIFF recognized", case.name));
+    let mn = meta
+      .maker_note()
+      .unwrap_or_else(|| panic!("{}: MakerNote captured", case.name));
+    assert!(mn.vendor().is_leica(), "{}: vendor = Leica", case.name);
+    assert_eq!(
+      mn.detected().base_rule(),
+      case.base_rule,
+      "{}: dispatched base rule",
+      case.name
+    );
+    // The Leica variant table populated the typed Leica slot (Leica4 has no
+    // plain leaf, so its slot is the empty default but PRESENT).
+    assert!(
+      mn.meta().leica().is_some(),
+      "{}: Leica typed slot populated (variant {:?})",
+      case.name,
+      case.variant
+    );
+    // The emission group is `Leica` (NOT `Panasonic`, the Leica1/Leica10 route),
+    // unless the variant has no leaf at all (Leica4 — then no emission carries a
+    // group; the default stays whatever the dispatch left, so only assert when
+    // there IS a leaf).
+    if !case.print_conv.is_empty() {
+      assert_eq!(
+        mn.emission_group1(),
+        "Leica",
+        "{}: emission group1 = Leica",
+        case.name
+      );
+    }
+    for (print_on, expected) in [(true, case.print_conv), (false, case.value_conv)] {
+      let mode = if print_on { "-j" } else { "-n" };
+      let json =
+        exifast::parser::extract_info(&std::format!("{}.tif", case.name), case.tiff, print_on);
+      let doc: serde_json::Value = serde_json::from_str(&json)
+        .unwrap_or_else(|e| panic!("{} {}: invalid JSON ({e})", case.name, mode));
+      let obj = doc
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|o| o.as_object())
+        .unwrap_or_else(|| panic!("{} {}: doc is [{{…}}]", case.name, mode));
+      for (key, val_fn) in expected {
+        let got = obj.get(*key).cloned();
+        let want = val_fn();
+        assert_eq!(
+          got.as_ref(),
+          Some(&want),
+          "{} {}: {} mismatch (keys: {:?})",
+          case.name,
+          mode,
+          key,
+          obj.keys().collect::<Vec<_>>()
+        );
+      }
+    }
+  }
+}
+
+/// Cross-check every Leica variant fixture against the bundled `perl exiftool`
+/// binary (`$EXIFTOOL` / PATH): each `Leica:*` leaf the Rust port emits must
+/// match `exiftool -G1 -j -n -a -u`, proving the per-variant table reads +
+/// base-rule offset math are byte-faithful. Skipped (not failed) when the
+/// binary is absent.
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+#[test]
+fn leica_variants_match_bundled_exiftool() {
+  use std::process::Command;
+  let tool = std::env::var("EXIFTOOL").unwrap_or_else(|_| "exiftool".to_string());
+  if Command::new(&tool).arg("-ver").output().is_err() {
+    eprintln!("SKIP: exiftool binary not available; Leica variant cross-check skipped");
+    return;
+  }
+  let dir = std::env::temp_dir();
+  for case in leica_cases() {
+    let path = dir.join(std::format!("exifast_{}.tif", case.name));
+    std::fs::write(&path, case.tiff).expect("write temp Leica tif");
+    for (print_on, expected) in [(true, case.print_conv), (false, case.value_conv)] {
+      let mut args = std::vec!["-G1", "-j", "-a", "-u"];
+      if !print_on {
+        args.push("-n");
+      }
+      let out = Command::new(&tool)
+        .args(&args)
+        .arg(&path)
+        .output()
+        .expect("run exiftool");
+      assert!(out.status.success(), "{}: exiftool failed", case.name);
+      let json = String::from_utf8(out.stdout).expect("utf8");
+      let doc: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+      let obj = doc
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|o| o.as_object())
+        .expect("doc is [{…}]");
+      for (key, val_fn) in expected {
+        assert_eq!(
+          obj.get(*key).cloned().as_ref(),
+          Some(&val_fn()),
+          "{} {}: bundled {} mismatch",
+          case.name,
+          if print_on { "-j" } else { "-n" },
+          key
+        );
+      }
+    }
+    let _ = std::fs::remove_file(&path);
+  }
+}
+
+/// A NONZERO-base regression for Leica7 `Base => '-$base'`
+/// ([`NegativeOfBase`](exifast::exif::makernotes::BaseRule::NegativeOfBase)) —
+/// the production failure mode the standalone (base-0) `LEICA7_TIFF` fixture
+/// misses.
+///
+/// The Leica7 `LEICA\0\x02\xff` MakerNote's out-of-line `LensType` (tag 0x0303)
+/// value pointer is an ABSOLUTE FILE offset. Here the Exif TIFF block is
+/// embedded in a JPEG `APP1` segment, so the container SLICES it at its NONZERO
+/// file offset (12 = SOI 2 + APP1 marker 2 + length 2 + `Exif\0\0` 6) and walks
+/// that slice with `base = 12` retained. The absolute pointer is `12 + 138 =
+/// 150` (the `"TestLeicaLens\0"` bytes sit at block offset 138). ExifTool's
+/// `Base => '-$base'` rebases it to the slice as `data[150 - 12] = data[138]`.
+///
+/// With the OLD `value_offset_base = 0` (assuming the parent base is always 0)
+/// the walker reads `data[150]`, whose `+14`-byte value runs PAST the 152-byte
+/// slice end => the value is dropped and NO `Leica:LensType` is emitted — the
+/// assertion below FAILS. The `-parent_base` (= `-12`) fix resolves it to
+/// `data[138]` => `"TestLeicaLens"`, byte-exact vs the `perl exiftool` oracle on
+/// the same JPEG (cross-checked when the binary is present).
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+#[test]
+fn leica7_embedded_app1_nonzero_base_reads_absolute_out_of_line_value() {
+  // JPEG: SOI + APP1[`Exif\0\0` + Leica7 TIFF block] + EOI. The Leica7 LensType
+  // value pointer is the ABSOLUTE file offset 150 (block offset 138 + base 12).
+  const LEICA7_APP1_JPEG: &[u8] = &[
+    255, 216, 255, 225, 0, 160, 69, 120, 105, 102, 0, 0, 73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2,
+    0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 28, 0, 0, 0, 66, 0, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0,
+    94, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67, 97, 109, 101, 114, 97, 32, 65, 71, 0,
+    76, 69, 73, 67, 65, 32, 77, 32, 77, 111, 110, 111, 99, 104, 114, 111, 109, 32, 40, 84, 121,
+    112, 32, 50, 52, 54, 41, 0, 1, 0, 124, 146, 7, 0, 40, 0, 0, 0, 112, 0, 0, 0, 0, 0, 0, 0, 76,
+    69, 73, 67, 65, 0, 2, 255, 1, 0, 3, 3, 2, 0, 14, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 84, 101,
+    115, 116, 76, 101, 105, 99, 97, 76, 101, 110, 115, 0, 255, 217,
+  ];
+
+  let meta =
+    exifast::exif::jpeg::parse_jpeg_exif(LEICA7_APP1_JPEG).expect("Leica7 APP1 JPEG parsed");
+  let mn = meta.maker_note().expect("MakerNote captured");
+  assert!(mn.vendor().is_leica(), "vendor = Leica (Leica7 signature)");
+  assert_eq!(
+    mn.detected().base_rule(),
+    exifast::exif::makernotes::BaseRule::NegativeOfBase,
+    "Leica7 dispatched base rule = NegativeOfBase"
+  );
+
+  // The typed slot resolves the absolute-pointer LensType — these are the bytes
+  // the `-parent_base` rebase reads; with the old `value_offset_base = 0` the
+  // out-of-line read runs past the sliced block and the slot stays empty.
+  let leica = mn.meta().leica().expect("Leica typed slot populated");
+  assert_eq!(
+    leica.lens_name(),
+    Some("TestLeicaLens"),
+    "Leica7 out-of-line LensType (absolute ptr) must rebase to the slice"
+  );
+
+  // The full serializer emits `Leica:LensType = "TestLeicaLens"` in BOTH modes
+  // (a plain string => identical under -j and -n).
+  for print_on in [true, false] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let json = exifast::parser::extract_info("leica7_app1.jpg", LEICA7_APP1_JPEG, print_on);
+    let doc: serde_json::Value =
+      serde_json::from_str(&json).unwrap_or_else(|e| panic!("{mode}: invalid JSON ({e})"));
+    let obj = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .unwrap_or_else(|| panic!("{mode}: doc is [{{…}}]"));
+    assert_eq!(
+      obj.get("Leica:LensType").and_then(|v| v.as_str()),
+      Some("TestLeicaLens"),
+      "{mode}: embedded-APP1 Leica7 LensType from the absolute out-of-line pointer (keys: {:?})",
+      obj.keys().collect::<Vec<_>>()
+    );
+  }
+}
+
+/// Cross-check the nonzero-base embedded-APP1 Leica7 JPEG against the bundled
+/// `perl exiftool` binary — `Leica:LensType` must match `exiftool -G1 -j -a -u`
+/// (`-n` too), proving the `-$base` absolute-pointer rebase is byte-faithful in
+/// a real container. Skipped (not failed) when the binary is absent.
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+#[test]
+fn leica7_embedded_app1_nonzero_base_matches_bundled_exiftool() {
+  use std::process::Command;
+  // Same JPEG as the test above (absolute value pointer 150).
+  const LEICA7_APP1_JPEG: &[u8] = &[
+    255, 216, 255, 225, 0, 160, 69, 120, 105, 102, 0, 0, 73, 73, 42, 0, 8, 0, 0, 0, 3, 0, 15, 1, 2,
+    0, 16, 0, 0, 0, 50, 0, 0, 0, 16, 1, 2, 0, 28, 0, 0, 0, 66, 0, 0, 0, 105, 135, 4, 0, 1, 0, 0, 0,
+    94, 0, 0, 0, 0, 0, 0, 0, 76, 101, 105, 99, 97, 32, 67, 97, 109, 101, 114, 97, 32, 65, 71, 0,
+    76, 69, 73, 67, 65, 32, 77, 32, 77, 111, 110, 111, 99, 104, 114, 111, 109, 32, 40, 84, 121,
+    112, 32, 50, 52, 54, 41, 0, 1, 0, 124, 146, 7, 0, 40, 0, 0, 0, 112, 0, 0, 0, 0, 0, 0, 0, 76,
+    69, 73, 67, 65, 0, 2, 255, 1, 0, 3, 3, 2, 0, 14, 0, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 84, 101,
+    115, 116, 76, 101, 105, 99, 97, 76, 101, 110, 115, 0, 255, 217,
+  ];
+  let tool = std::env::var("EXIFTOOL").unwrap_or_else(|_| "exiftool".to_string());
+  if Command::new(&tool).arg("-ver").output().is_err() {
+    eprintln!("SKIP: exiftool binary not available; Leica7 APP1 cross-check skipped");
+    return;
+  }
+  let path = std::env::temp_dir().join("exifast_leica7_app1.jpg");
+  std::fs::write(&path, LEICA7_APP1_JPEG).expect("write temp Leica7 APP1 jpg");
+  for print_on in [true, false] {
+    let mut args = std::vec!["-G1", "-j", "-a", "-u"];
+    if !print_on {
+      args.push("-n");
+    }
+    let out = Command::new(&tool)
+      .args(&args)
+      .arg(&path)
+      .output()
+      .expect("run exiftool");
+    assert!(out.status.success(), "exiftool failed");
+    let json = String::from_utf8(out.stdout).expect("utf8");
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+    let obj = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .expect("doc is [{…}]");
+    assert_eq!(
+      obj.get("Leica:LensType").and_then(|v| v.as_str()),
+      Some("TestLeicaLens"),
+      "bundled {}: Leica7 APP1 LensType",
+      if print_on { "-j" } else { "-n" }
+    );
+  }
+  let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
## Summary

Port the **Leica2–Leica9 MakerNote variant tables** + wire them through the shared Walker. **Closes #259.**

The dispatcher already *detected* Leica2 through Leica9 with their base rules (from #255's no-per-vendor-walker work), but they routed to tables the port lacked and so emitted nothing. This adds the tables + emit.

## What's ported

New `src/exif/makernotes/vendors/leica/` module porting the six own tables from ExifTool `Panasonic.pm`:
- **Leica2** (~34 tags — M8: LensType 0x310 split, SerialNumber 0x303 sprintf, WhiteBalance 0x304 with the `>0x8000` Kelvin OTHER), **Leica3**, **Leica4** (M9), **Leica5** (InternalSerialNumber 0x0500 date-decode, ExposureMode 0x040d), **Leica6** (LensType 0x303 trailing-space trim, FirmwareVersion 0x320), **Leica9** (FNumber 0x35a `/1000`).
- **Leica7 reuses `%Leica6`**, **Leica8 reuses `%Leica5`**.

Wired via the per-vendor recipe (`ResolvedConv::Leica` + `leica_makernote_isolated` + `vendor_group1_of` + `lookup_name_in` + `emit_leica_value` + `from_blob` routing). Leica1/Leica10 (which reuse the Panasonic Main table) are unchanged.

## Leica7 `Base => -$base` (NegativeOfBase) — the tricky one

Leica7 is the only `NegativeOfBase` in the module: its out-of-line value pointers are **absolute file offsets**. In a JPEG APP1 the Exif TIFF block is sliced at a nonzero file base, so an absolute pointer must be rebased to the slice by subtracting the parent base. This maps to `value_offset_base = -(parent_base)` — expressible directly via the Walker's signed-`i64` `value_offset_base` (no new base mode). The parent base is threaded through the eager walk, the `-n` recompute replay, and `from_blob` (base 0). A crafted **JPEG APP1 with the TIFF block at a nonzero file offset** and an absolute Leica7 pointer proves it (fails with the old `value_offset_base=0`, passes with `-(parent_base)`).

## Tests (crafted-input + Perl oracle — no real Leica fixtures exist, same as Samsung Type2)

Per-variant crafted MakerNote blobs proven **byte-exact vs bundled ExifTool 13.59** (`leica_variants_match_bundled_exiftool`), each exercising its base rule (Leica2 StartItself, Leica4 RelativeMinus8, Leica7 NegativeOfBase, …) + 15 module unit tests for the conv logic.

## Verify

`fmt=0  build(-Dwarnings, --all-targets)=0  conformance=425/0 (byte-identical — no existing golden changed)  exif_makernotes_dispatch=72/0 (incl the per-variant + Leica7 nonzero-base tests)  typed_serde_parity=green(530)  lib=3146/0`

**Codex adversarial review: APPROVE (R2).** R1 caught that the initial Leica7 `value_offset_base=0` mishandled a nonzero JPEG-APP1 base; R2 confirmed the `-(parent_base)` fix.
