### PR TITLE
feat(exif/makernotes): mark Sony/Nikon/Panasonic/Samsung/Pentax/PanasonicRaw Priority=>0 tags (#284)

### DIFF
--- a/src/exif/makernotes/vendors/nikon/mod.rs
+++ b/src/exif/makernotes/vendors/nikon/mod.rs
@@ -617,6 +617,7 @@ pub(crate) fn emit_flash_info(
     "FlashOutput",
     "FlashCompensation",
     NikonConv::FlashCompensation,
+    0,
     emissions,
   );
 
@@ -678,6 +679,7 @@ pub(crate) fn emit_flash_info(
     "FlashGroupAOutput",
     "FlashGroupACompensation",
     NikonConv::FlashGroupCompensation,
+    1,
     emissions,
   );
   // offset 18 CONDITIONAL on FlashGroupBControlMode (same as 17, group B).
@@ -690,6 +692,7 @@ pub(crate) fn emit_flash_info(
     "FlashGroupBOutput",
     "FlashGroupBCompensation",
     NikonConv::FlashGroupCompensation,
+    1,
     emissions,
   );
 }
@@ -863,10 +866,15 @@ pub(crate) fn emit_shot_info(
       && let Some(record) = body.get(0x157..0x157 + 2)
     {
       let n = u16::from_be_bytes([*record.first().unwrap_or(&0), *record.get(1).unwrap_or(&0)]);
-      emissions.push(VendorEmission::new(
+      // `%Nikon::ShotInfo` 0205 `0x157 ShutterCount` is `Priority => 0`
+      // (`Nikon.pm:6058`) — mark it so a duplicate never overrides a
+      // higher-priority same-name tag (`ExifTool.pm:9544-9560`); the
+      // `any(name == "ShutterCount")` guard above pre-applies the same rule.
+      emissions.push(VendorEmission::new_with_priority(
         "ShutterCount".into(),
         TagValue::I64(i64::from(n)),
         false,
+        0,
       ));
     }
     // 0x1ae `VibrationReduction` (int8u, PrintHex, `{0x00=>'n/a',0x0c=>'Off',
@@ -961,10 +969,20 @@ fn emit_shot_info_int(
   let Some(raw) = read_value(body, offset, format, 1, avail, order) else {
     return;
   };
-  // No PrintConv (Priority 0 raw integer) ⇒ the default `ReadValue` render.
+  // No PrintConv (Priority 0 raw integer) ⇒ the default `ReadValue` render. The
+  // base `%Nikon::ShotInfo` counts are `Priority => 0`
+  // (`Nikon.pm:6019/6026/6081`) — mark the emission so a duplicate never
+  // overrides a higher-priority same-`(doc, family1, name)` tag
+  // (`ExifTool.pm:9544-9560`); the early-return guard above is the same rule
+  // pre-applied on the walk path.
   let parsed = ParsedValue::new(raw);
   if let Some(value) = NikonConv::Raw.apply(&parsed, false, None, order) {
-    emissions.push(VendorEmission::new(name.into(), value, false));
+    emissions.push(VendorEmission::new_with_priority(
+      name.into(),
+      value,
+      false,
+      0,
+    ));
   }
 }
 
@@ -1031,6 +1049,11 @@ fn emit_flash_output_or_comp(
   output_name: &'static str,
   comp_name: &'static str,
   comp_conv: NikonConv,
+  // The COMP-arm member's ExifTool `Priority => N` (`0` for the offset-10
+  // `FlashCompensation`, `%Nikon::FlashInfo0100`, `Nikon.pm:10875`; `1` for the
+  // offset-17/18 `FlashGroup{A,B}Compensation`). The `FlashOutput` arm is never
+  // `Priority => 0`.
+  comp_priority: u8,
   emissions: &mut Vec<VendorEmission>,
 ) {
   let Some(&byte) = sub.get(offset) else {
@@ -1046,7 +1069,12 @@ fn emit_flash_output_or_comp(
     // The `Compensation`-arm (int8s `Format` override — the byte is signed).
     let parsed = ParsedValue::new(RawValue::I64(std::vec![i64::from(byte as i8)]));
     if let Some(value) = comp_conv.apply(&parsed, print_conv, None, order) {
-      emissions.push(VendorEmission::new(comp_name.into(), value, false));
+      emissions.push(VendorEmission::new_with_priority(
+        comp_name.into(),
+        value,
+        false,
+        comp_priority,
+      ));
     }
   }
 }
@@ -1392,7 +1420,18 @@ pub(crate) fn emit_lens_data(
           let Some(value) = pos.conv.apply(&parsed, print_conv, None, order) else {
             continue;
           };
-          emissions.push(VendorEmission::new(pos.name.into(), value, false));
+          // The legacy `FocalLength` row (`%Nikon::LensData01`/`0204`/`0800`,
+          // `Nikon.pm:5544/5630/5764`) is `Priority => 0` — a duplicate never
+          // overrides a higher-priority same-name tag (`ExifTool.pm:9544-9560`).
+          // The sibling `MinFocalLength`/`MaxFocalLength` rows are NOT, so key on
+          // the exact name (the ONLY `Priority => 0` legacy LensData byte member).
+          let priority = u8::from(pos.name != "FocalLength");
+          emissions.push(VendorEmission::new_with_priority(
+            pos.name.into(),
+            value,
+            false,
+            priority,
+          ));
         }
         // `LensModel`, `Format => 'string[len]'`: `len` ASCII bytes, NUL-truncated
         // (`ReadValue`'s `s/\0.*//s`). An entirely-empty (all-NUL) field yields the
@@ -1502,6 +1541,7 @@ fn emit_lens_data_0800_new(
       NikonConv::LensFirmwareZ,
       false,
       "LensFirmwareVersion",
+      1,
       emissions,
     );
   }
@@ -1516,6 +1556,7 @@ fn emit_lens_data_0800_new(
       NikonConv::LensApertureZ,
       false,
       "MaxAperture",
+      0,
       emissions,
     );
     emit_z_int16u(
@@ -1526,6 +1567,7 @@ fn emit_lens_data_0800_new(
       NikonConv::LensApertureZ,
       false,
       "FNumber",
+      0,
       emissions,
     );
     emit_z_int16u(
@@ -1536,6 +1578,7 @@ fn emit_lens_data_0800_new(
       NikonConv::FocalLengthZ,
       false,
       "FocalLength",
+      0,
       emissions,
     );
   }
@@ -1567,6 +1610,7 @@ fn emit_lens_data_0800_new(
       NikonConv::FocusDistanceZ,
       false,
       "FocusDistance",
+      1,
       emissions,
     );
   }
@@ -1666,6 +1710,10 @@ fn emit_z_int16u(
   conv: NikonConv,
   unknown: bool,
   name: &'static str,
+  // The member's ExifTool `Priority => N` (`0` for the `%Nikon::LensData0800`
+  // NEW-block `MaxAperture`/`FNumber`/`FocalLength` rows,
+  // `Nikon.pm:5891/5901/5911`; `1` for the firmware/focus members).
+  priority: u8,
   emissions: &mut Vec<VendorEmission>,
 ) {
   let Some(n) = read_z_int16u(body, offset, order) else {
@@ -1674,7 +1722,12 @@ fn emit_z_int16u(
   let raw = RawValue::U64(std::vec![u64::from(n)]);
   let parsed = ParsedValue::new(raw);
   if let Some(value) = conv.apply(&parsed, print_conv, None, order) {
-    emissions.push(VendorEmission::new(name.into(), value, unknown));
+    emissions.push(VendorEmission::new_with_priority(
+      name.into(),
+      value,
+      unknown,
+      priority,
+    ));
   }
 }
 
@@ -2674,6 +2727,17 @@ mod tests {
     assert_eq!(lens_get(&em, "MaxApertureAtMaxFocal"), Some(str_val("4.0")));
     assert_eq!(lens_get(&em, "MCUVersion"), Some(TagValue::I64(7)));
     assert_eq!(lens_get(&em, "EffectiveMaxAperture"), Some(str_val("6.7")));
+    // #284: the legacy `FocalLength` row is `Priority => 0` (`Nikon.pm:5630`);
+    // the sibling `MinFocalLength`/`MaxFocalLength` keep the default priority 1.
+    let prio = |name: &str| em.iter().find(|e| e.name() == name).map(|e| e.priority());
+    assert_eq!(
+      prio("FocalLength"),
+      Some(0),
+      "legacy FocalLength Priority=>0"
+    );
+    assert_eq!(prio("MinFocalLength"), Some(1));
+    assert_eq!(prio("MaxFocalLength"), Some(1));
+    assert_eq!(prio("LensIDNumber"), Some(1));
   }
 
   #[test]
@@ -2969,6 +3033,15 @@ mod tests {
     // — here 0x4c FocusDistanceRangeWidth=0x05 (non-zero) and 0x56=0x02
     // (non-zero) ⇒ "CFD" (still unknown-flagged, so output-suppressed).
     assert_eq!(lens_get(&em, "LensDriveEnd"), Some(str_val("CFD")));
+    // #284: the NEW Z-block `MaxAperture`/`FNumber`/`FocalLength` rows are
+    // `Priority => 0` (`Nikon.pm:5891/5901/5911`); the `LensFirmwareVersion`/
+    // `FocusDistance` members keep the default priority 1.
+    let prio = |name: &str| em.iter().find(|e| e.name() == name).map(|e| e.priority());
+    assert_eq!(prio("MaxAperture"), Some(0), "Z MaxAperture Priority=>0");
+    assert_eq!(prio("FNumber"), Some(0), "Z FNumber Priority=>0");
+    assert_eq!(prio("FocalLength"), Some(0), "Z FocalLength Priority=>0");
+    assert_eq!(prio("LensFirmwareVersion"), Some(1));
+    assert_eq!(prio("FocusDistance"), Some(1));
   }
 
   /// The `0x56` `LensDriveEnd` stateful RawConv (`Nikon.pm:5933-5939`): `Inf`
@@ -3530,6 +3603,15 @@ mod tests {
     // contract), which the JSON layer serializes as the BARE number 0 — matching
     // the oracle `"Nikon:FlashCompensation": 0`.
     assert_eq!(get("FlashCompensation"), Some(str_val("0")));
+    // #284: the offset-10 `FlashCompensation` row is `Priority => 0`
+    // (`Nikon.pm:10875`); the offset-14 `FlashGNDistance` is the default 1.
+    let prio = |n: &str| em.iter().find(|e| e.name() == n).map(|e| e.priority());
+    assert_eq!(
+      prio("FlashCompensation"),
+      Some(0),
+      "FlashCompensation Priority=>0"
+    );
+    assert_eq!(prio("FlashGNDistance"), Some(1));
     assert!(get("FlashOutput").is_none());
     assert_eq!(get("FlashGNDistance"), Some(str_val("0")));
     assert_eq!(get("FlashGroupAControlMode"), Some(str_val("Off")));
@@ -3886,6 +3968,20 @@ mod tests {
     assert_eq!(lens_get(&em, "ShotInfoVersion"), Some(str_val("0204")));
     assert_eq!(lens_get(&em, "ShutterCount"), Some(TagValue::I64(12345)));
     assert_eq!(lens_get(&em, "DeletedImageCount"), Some(TagValue::I64(7)));
+    // #284: 0x6a ShutterCount / 0x6e DeletedImageCount are `Priority => 0`
+    // (`Nikon.pm:6019/6026`); 0x82 VibrationReduction keeps the default 1.
+    let prio = |n: &str| em.iter().find(|e| e.name() == n).map(|e| e.priority());
+    assert_eq!(
+      prio("ShutterCount"),
+      Some(0),
+      "0204 ShutterCount Priority=>0"
+    );
+    assert_eq!(
+      prio("DeletedImageCount"),
+      Some(0),
+      "0204 DeletedImageCount Priority=>0"
+    );
+    assert_eq!(prio("VibrationReduction"), Some(1));
     assert_eq!(lens_get(&em, "VibrationReduction"), Some(str_val("On")));
     // VR_0x66 (0x66, `Unknown => 1`) is never implemented/emitted.
     assert!(
@@ -3963,6 +4059,14 @@ mod tests {
     );
     assert_eq!(lens_get(&em, "ShotInfoVersion"), Some(str_val("0211")));
     assert_eq!(lens_get(&em, "ShutterCount"), Some(TagValue::I64(999)));
+    // #284: 0x24d ShutterCount is `Priority => 0` (`Nikon.pm:6081`).
+    assert_eq!(
+      em.iter()
+        .find(|e| e.name() == "ShutterCount")
+        .map(|e| e.priority()),
+      Some(0),
+      "0211 ShutterCount Priority=>0"
+    );
   }
 
   /// An ENCRYPTED `0206` ShotInfo with VALID keys (serial/count present)

--- a/src/exif/makernotes/vendors/nikon/tags.rs
+++ b/src/exif/makernotes/vendors/nikon/tags.rs
@@ -99,6 +99,23 @@ impl NikonTag {
     self.id
   }
 
+  /// The ExifTool `Priority => N` of this `%Nikon::Main` leaf — `0` for a
+  /// `Priority => 0` row (never overrides an earlier same-`(doc, family1, name)`
+  /// tag, `ExifTool.pm:9544-9560`), `1` (the default) otherwise. The sole walked
+  /// `%Nikon::Main` `Priority => 0` leaf is `0x0002 ISO` (`Nikon.pm:1803` — "the
+  /// EXIF ISO is more reliable"). The `Priority => 0` rows in walked SUB-tables
+  /// (`LensData` FocalLength/FNumber/MaxAperture, `ShotInfo` ShutterCount/
+  /// DeletedImageCount, `FlashInfo0100` FlashCompensation) are marked at their
+  /// own emit sites, not here.
+  #[must_use]
+  #[inline(always)]
+  pub const fn tag_priority(&self) -> u8 {
+    match self.id {
+      0x0002 => 0,
+      _ => 1,
+    }
+  }
+
   /// Tag `Name`.
   #[must_use]
   #[inline(always)]
@@ -1008,5 +1025,21 @@ mod tests {
     for p in LENS_DATA_0204.iter().chain(LENS_DATA_0800_OLD) {
       assert_eq!(p.read, LensRead::Byte, "{} must be int8u", p.name);
     }
+  }
+
+  /// The sole walked `%Nikon::Main` `Priority => 0` leaf (`0x0002 ISO`,
+  /// `Nikon.pm:1803`) reports priority 0; a non-marked sibling reports the
+  /// default 1 (#284). The walked sub-table `Priority => 0` rows (LensData/
+  /// ShotInfo/FlashInfo) are pinned at their own emit sites, not on `NikonTag`.
+  #[test]
+  fn tag_priority_marks_main_iso() {
+    assert_eq!(lookup(0x0002).unwrap().tag_priority(), 0, "ISO");
+    // A non-`Priority => 0` Main leaf keeps the default priority 1.
+    assert_eq!(
+      lookup(0x0001).unwrap().tag_priority(),
+      1,
+      "MakerNoteVersion"
+    );
+    assert_eq!(lookup(0x0004).unwrap().tag_priority(), 1, "Quality");
   }
 }

--- a/src/exif/makernotes/vendors/pentax/mod.rs
+++ b/src/exif/makernotes/vendors/pentax/mod.rs
@@ -235,7 +235,15 @@ pub(crate) fn emit_lens_rec(
     // ValueConv: the default space-joined int8u[2] pair, e.g. `"3 44"`.
     crate::value::TagValue::Str(SmolStr::from(std::format!("{series} {model}")))
   };
-  emissions.push(super::VendorEmission::new("LensType".into(), value, false));
+  // `%Pentax::LensRec` `LensType` (pos 0) is `Priority => 0` (`Pentax.pm:4202`):
+  // a duplicate never overrides an earlier same-`(doc, family1, name)` tag
+  // (`ExifTool.pm:9544-9560`).
+  emissions.push(super::VendorEmission::new_with_priority(
+    "LensType".into(),
+    value,
+    false,
+    0,
+  ));
 }
 
 /// Populate the typed lens identity from the LensRec byte pair — the typed-slot

--- a/src/exif/makernotes/vendors/pentax/subtables.rs
+++ b/src/exif/makernotes/vendors/pentax/subtables.rs
@@ -754,15 +754,19 @@ pub(crate) fn emit_lens_info(
     if model.is_none_or(|m| !m.contains("645Z")) {
       let raw = i64::from(v);
       let f = 10.0 * ((raw >> 2) as f64) * 4.0_f64.powi(((raw & 0x03) - 2) as i32);
-      push(
-        out,
-        "LensFocalLength",
+      // `%Pentax::LensData` `LensFocalLength` (pos 9) is `Priority => 0`
+      // (`Pentax.pm:4506`): a duplicate never overrides an earlier same-`(doc,
+      // family1, name)` tag (`ExifTool.pm:9544-9560`).
+      out.push(VendorEmission::new_with_priority(
+        SmolStr::new_static("LensFocalLength"),
         if print_conv {
           TagValue::Str(SmolStr::from(std::format!("{f:.1} mm")))
         } else {
           TagValue::F64(f)
         },
-      );
+        false,
+        0,
+      ));
     }
   }
   // 10: NominalMaxAperture — `Mask => 0xf0` (>>4); `ValueConv => '2**($val/4)'`;

--- a/src/exif/makernotes/vendors/pentax/subtables/tests.rs
+++ b/src/exif/makernotes/vendors/pentax/subtables/tests.rs
@@ -748,3 +748,24 @@ fn camera_info_truncated_block_partial_emit_no_panic() {
   emit_camera_info(&[], true, &mut em0);
   assert!(em0.is_empty());
 }
+
+/// #284: `%Pentax::LensData` `LensFocalLength` (offset 9) is `Priority => 0`
+/// (`Pentax.pm:4506`) — the marking is carried on the emission so a duplicate
+/// never overrides a higher-priority same-name tag. A sibling LensData leaf
+/// (`LensFStops`) keeps the default priority 1.
+#[test]
+fn lens_data_focal_length_is_priority_zero() {
+  let mut em = Vec::new();
+  emit_lens_info(LENSINFO2_K10D, 69, Some("PENTAX K10D"), true, &mut em);
+  let prio = |n: &str| {
+    em.iter()
+      .find(|e| e.name() == n)
+      .map(VendorEmission::priority)
+  };
+  assert_eq!(
+    prio("LensFocalLength"),
+    Some(0),
+    "LensData LensFocalLength Priority=>0"
+  );
+  assert_eq!(prio("LensFStops"), Some(1));
+}

--- a/src/exif/makernotes/vendors/pentax/tags.rs
+++ b/src/exif/makernotes/vendors/pentax/tags.rs
@@ -66,6 +66,22 @@ impl PentaxTag {
     self.name
   }
 
+  /// The ExifTool `Priority => N` of this `%Pentax::Main` leaf — `0` for a
+  /// `Priority => 0` row (never overrides an earlier same-`(doc, family1, name)`
+  /// tag, `ExifTool.pm:9544-9560`), `1` (the default) otherwise. The two walked
+  /// `%Pentax::Main` `Priority => 0` rows are `0x0012 ExposureTime`
+  /// (`Pentax.pm:1474`) and `0x0013 FNumber` (`Pentax.pm:1484`). The
+  /// `Priority => 0` rows in walked SUB-tables (`LensRec` `LensType`,
+  /// `LensData` `LensFocalLength`) are marked at their own emit sites.
+  #[must_use]
+  #[inline(always)]
+  pub const fn tag_priority(&self) -> u8 {
+    match self.id {
+      0x0012 | 0x0013 => 0,
+      _ => 1,
+    }
+  }
+
   /// `true` when bundled marks the tag `Unknown => 1`.
   #[must_use]
   #[inline(always)]

--- a/src/exif/makernotes/vendors/pentax/tags/tests.rs
+++ b/src/exif/makernotes/vendors/pentax/tags/tests.rs
@@ -55,3 +55,16 @@ fn quality_hash_k10d_better() {
     Some("Better")
   );
 }
+
+/// The two walked `%Pentax::Main` `Priority => 0` rows (`0x0012 ExposureTime`
+/// `Pentax.pm:1474`, `0x0013 FNumber` `Pentax.pm:1484`) report priority 0; a
+/// non-marked sibling reports the default 1 (#284). The walked sub-table
+/// `Priority => 0` rows (`LensRec` LensType, `LensData` LensFocalLength) are
+/// pinned at their own emit sites, not on `PentaxTag`.
+#[test]
+fn tag_priority_marks_priority0_main_rows() {
+  assert_eq!(lookup(0x0012).unwrap().tag_priority(), 0, "ExposureTime");
+  assert_eq!(lookup(0x0013).unwrap().tag_priority(), 0, "FNumber");
+  // A non-`Priority => 0` Main leaf keeps the default priority 1.
+  assert_eq!(lookup(0x0005).unwrap().tag_priority(), 1, "PentaxModelID");
+}

--- a/src/exif/makernotes/vendors/pentax/tests.rs
+++ b/src/exif/makernotes/vendors/pentax/tests.rs
@@ -22,6 +22,8 @@ fn emit_lens_rec_pentax_jpg_pair() {
   emit_lens_rec(&block, true, &mut em);
   assert_eq!(em.len(), 1);
   assert_eq!(em[0].name(), "LensType");
+  // #284: `%Pentax::LensRec` `LensType` is `Priority => 0` (`Pentax.pm:4202`).
+  assert_eq!(em[0].priority(), 0, "LensRec LensType Priority=>0");
   assert_eq!(
     em[0].value(),
     &crate::value::TagValue::Str("Sigma or Tamron Lens (3 44)".into())

--- a/src/exif/makernotes/vendors/samsung/tags.rs
+++ b/src/exif/makernotes/vendors/samsung/tags.rs
@@ -82,6 +82,20 @@ impl SamsungTag {
     self.name
   }
 
+  /// The ExifTool `Priority => N` of this `%Samsung::Main` leaf — `0` for a
+  /// `Priority => 0` row (never overrides an earlier same-`(doc, family1, name)`
+  /// tag, `ExifTool.pm:9544-9560`), `1` (the default) otherwise. The two walked
+  /// `Priority => 0` rows are `0xa019 FNumber` (`Samsung.pm:465`) and `0xa01a
+  /// FocalLengthIn35mmFormat` (`Samsung.pm:475`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn tag_priority(&self) -> u8 {
+    match self.id {
+      0xa019 | 0xa01a => 0,
+      _ => 1,
+    }
+  }
+
   /// The tag's optional `Format =>` directive (`Exif.pm:6728-6745`).
   #[must_use]
   #[inline(always)]

--- a/src/exif/makernotes/vendors/samsung/tags/tests.rs
+++ b/src/exif/makernotes/vendors/samsung/tags/tests.rs
@@ -84,3 +84,19 @@ fn focal_length_35_carries_int32u_format_override() {
   // A plain leaf has no override.
   assert_eq!(format_override(0x0002), None);
 }
+
+/// The two walked `%Samsung::Main` `Priority => 0` rows (`0xa019 FNumber`
+/// `Samsung.pm:465`, `0xa01a FocalLengthIn35mmFormat` `Samsung.pm:475`) report
+/// priority 0; a non-marked sibling reports the default 1 (#284).
+#[test]
+fn tag_priority_marks_priority0_rows() {
+  assert_eq!(lookup(0xa019).unwrap().tag_priority(), 0, "FNumber");
+  assert_eq!(
+    lookup(0xa01a).unwrap().tag_priority(),
+    0,
+    "FocalLengthIn35mmFormat"
+  );
+  // A non-`Priority => 0` Main leaf keeps the default priority 1.
+  assert_eq!(lookup(0xa018).unwrap().tag_priority(), 1, "ExposureTime");
+  assert_eq!(lookup(0x0002).unwrap().tag_priority(), 1, "DeviceType");
+}

--- a/src/exif/makernotes/vendors/sony/tags.rs
+++ b/src/exif/makernotes/vendors/sony/tags.rs
@@ -98,6 +98,23 @@ impl SonyTag {
   pub const fn is_unknown(&self) -> bool {
     self.unknown
   }
+
+  /// The ExifTool `Priority => N` of this `%Sony::Main` leaf — `0` for a
+  /// `Priority => 0` row (a duplicate that never overrides an earlier same-`(doc,
+  /// family1, name)` tag, `ExifTool.pm:9544-9560`), `1` (the default,
+  /// `:9553`) otherwise. The two `Priority => 0` rows the port WALKS+emits are
+  /// `0x201b FocusMode` (`Sony.pm:1246`) and `0xb04f DynamicRangeOptimizer`
+  /// (`Sony.pm:2652`); every other `Priority => 0` Sony row lives in a deferred
+  /// sub-table (CameraInfo*/Tag2010*/Tag90xx/AFInfo/SR2DataIFD) that emits no
+  /// leaf, so it never reaches here.
+  #[must_use]
+  #[inline(always)]
+  pub const fn tag_priority(&self) -> u8 {
+    match self.id {
+      0x201b | 0xb04f => 0,
+      _ => 1,
+    }
+  }
 }
 
 /// The `Format =>` directive's FORMAT for tag `id` under `%Sony::Main`, if any —
@@ -1352,5 +1369,21 @@ mod tests {
   #[test]
   fn unknown_count_is_17() {
     assert_eq!(SONY_TAGS.iter().filter(|t| t.unknown).count(), 17);
+  }
+
+  /// The two walked `%Sony::Main` `Priority => 0` rows (`0x201b FocusMode`
+  /// `Sony.pm:1246`, `0xb04f DynamicRangeOptimizer` `Sony.pm:2652`) report
+  /// priority 0; a non-marked sibling reports the default 1 (#284).
+  #[test]
+  fn tag_priority_marks_priority0_rows() {
+    assert_eq!(lookup(0x201b).unwrap().tag_priority(), 0, "FocusMode");
+    assert_eq!(
+      lookup(0xb04f).unwrap().tag_priority(),
+      0,
+      "DynamicRangeOptimizer"
+    );
+    // A non-`Priority => 0` Main leaf keeps the default priority 1.
+    assert_eq!(lookup(0x0102).unwrap().tag_priority(), 1, "Quality");
+    assert_eq!(lookup(0xb027).unwrap().tag_priority(), 1, "LensType");
   }
 }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -7331,7 +7331,18 @@ fn emit_pentax_value<S: ExifSink>(
   out: &mut S,
 ) -> Result<(), core::convert::Infallible> {
   let value = pentax_tag.conv.apply(raw, print_conv);
-  out.write_vendor_value("MakerNotes", group1, name, value, pentax_tag.is_unknown())
+  // Thread the row's ExifTool `Priority => N` (`0` for the walked `0x0012
+  // ExposureTime` / `0x0013 FNumber` rows, `1` otherwise) so a `Priority => 0`
+  // leaf never overrides an earlier same-`(doc, family1, name)` value
+  // (`ExifTool.pm:9544-9560`).
+  out.write_vendor_value_with_priority(
+    "MakerNotes",
+    group1,
+    name,
+    value,
+    pentax_tag.is_unknown(),
+    pentax_tag.tag_priority(),
+  )
 }
 
 /// Render ONE Samsung Type2 maker-note LEAF into the sink — the emit-time
@@ -7385,12 +7396,17 @@ fn emit_samsung_value<S: ExifSink>(
   if let Some(typed) = typed {
     populate_typed(typed, entry.tag_id, raw);
   }
-  out.write_vendor_value(
+  // Thread the row's ExifTool `Priority => N` (`0` for the walked `0xa019
+  // FNumber` / `0xa01a FocalLengthIn35mmFormat` rows, `1` otherwise) so a
+  // `Priority => 0` leaf never overrides an earlier same-`(doc, family1, name)`
+  // value (`ExifTool.pm:9544-9560`).
+  out.write_vendor_value_with_priority(
     "MakerNotes",
     group1,
     samsung_tag.name(),
     value,
     samsung_tag.is_unknown(),
+    samsung_tag.tag_priority(),
   )
 }
 
@@ -7550,12 +7566,17 @@ fn emit_sony_value<S: ExifSink>(
   if let Some(typed) = typed {
     populate_typed(typed, tag_id, raw, &value);
   }
-  out.write_vendor_value(
+  // Thread the row's ExifTool `Priority => N` (`0` for the walked `0x201b
+  // FocusMode` / `0xb04f DynamicRangeOptimizer` rows, `1` otherwise) so the
+  // sink's priority-aware dedup keeps an EARLIER same-`(doc, family1, name)`
+  // value over a `Priority => 0` leaf (`ExifTool.pm:9544-9560`).
+  out.write_vendor_value_with_priority(
     "MakerNotes",
     group1,
     sony_tag.name(),
     value,
     sony_tag.is_unknown(),
+    sony_tag.tag_priority(),
   )
 }
 
@@ -7614,12 +7635,17 @@ fn emit_nikon_value<S: ExifSink>(
   if let Some(typed) = typed {
     populate_typed(typed, entry.tag_id, &value, nikon_tag.name());
   }
-  out.write_vendor_value(
+  // Thread the row's ExifTool `Priority => N` (`0` for the walked `%Nikon::Main`
+  // `0x0002 ISO` row, `1` otherwise) so a `Priority => 0` leaf never overrides an
+  // earlier same-`(doc, family1, name)` value (`ExifTool.pm:9544-9560`) — the EXIF
+  // ISO is the more reliable duplicate (`Nikon.pm:1803`).
+  out.write_vendor_value_with_priority(
     "MakerNotes",
     group1,
     nikon_tag.name(),
     value,
     nikon_tag.is_unknown(),
+    nikon_tag.tag_priority(),
   )
 }
 


### PR DESCRIPTION
Faithful-completeness follow-up to #283 (the general ExifTool Priority=>0 dedup mechanism + the 4 Canon marks). Extends the same `tag_priority` marking to the other 6 vendors. **Closes #284.**

**20 tags marked** — only the `Priority => 0` rows that are in tables exifast actually walks+emits (a Priority-0 row in a deferred/non-walked table is a no-op and is correctly skipped):
- **Sony** 2 (Main: FocusMode 0x201b, DynamicRangeOptimizer 0xb04f)
- **Nikon** 12 (Main ISO; LensData FocalLengths legacy + the 0800 Z-block MaxAperture/FNumber/FocalLength; base ShotInfo ShutterCount/DeletedImageCount; FlashInfo0100 FlashCompensation)
- **Samsung** 2 (Main: FNumber 0xa019, FocalLengthIn35mm 0xa01a)
- **Pentax** 4 (Main ExposureTime/FNumber; LensRec LensType; LensData LensFocalLength)
- **Panasonic** 0, **PanasonicRaw** 0 (their Priority-0 rows are all in deferred Leica sub-tables / unparsed RW2)

Mirrors Canon's `SubTable::tag_priority` → `write_vendor_value_with_priority`. The Nikon/Pentax sub-table emits mark *exactly* the Priority-0 positions (e.g. legacy LensData marks the bare FocalLength but not Min/MaxFocalLength; FlashInfo marks the offset-10 FlashCompensation but not the group-comp arms).

**No colliding fixtures exist**, so conformance is byte-identical — the marks are transcribed from the ExifTool source and pinned by 14 unit tests (priority 0 for marked ids, 1 for siblings).

`fmt=0  build(-Dwarnings)=0  conformance=425/0 (byte-identical)  exif_makernotes_dispatch=72/0  typed_serde=green(530)  lib=3151/0`

**Codex adversarial review: APPROVE (R1)** — the marked rows match bundled ExifTool Priority=>0 entries, priority threads through the emit paths, skipped rows are deferred or non-emitted.