### PR TITLE
feat(exif/makernotes/samsung): port Samsung::Crypt decryption — 16 encrypted Type2 tags (#242)

### DIFF
--- a/src/exif/makernotes/vendors/samsung/crypt.rs
+++ b/src/exif/makernotes/vendors/samsung/crypt.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Samsung Type2 encryption — `Image::ExifTool::Samsung::Crypt`
+//! (`Samsung.pm:1579-1605`) and the `%formatMinMax` range table
+//! (`Samsung.pm:60-65`).
+//!
+//! The `0xa021`..`0xa057` block stores raw-processing arrays (white-balance,
+//! colour, tone-curve, …) encrypted with a per-file int32u[11] key carried in
+//! `0xa020 EncryptionKey`. Each tag's winning `%Samsung::Type2` row has a
+//! `RawConv => Image::ExifTool::Samsung::Crypt($self,$val,$tagInfo,SALT…)`; the
+//! salt arguments select the key-index phase (and, for ARRAY tags, mark that
+//! `$a[0]` is the array length to skip). A salt string beginning with `-`
+//! REVERSES the cipher (the decrypt direction the extractor takes).
+//!
+//! This is a faithful 1:1 port: the loop structure, the
+//! `($salt + $i - $start) % 11` key index, and the `min`/`max` integer
+//! wrap-around all mirror the Perl verbatim. Proven byte-exact against bundled
+//! ExifTool 13.59 on `tests/fixtures/SamsungNX500.srw` (all 16 decrypted Crypt
+//! tags — see [`tests`]).
+
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::Format;
+use std::string::String;
+use std::vec::Vec;
+
+/// One Crypt salt argument (`Samsung.pm` `Crypt(...,SALT…)`): a signed key-index
+/// phase. The Perl salt is a string whose optional leading `-` sets the
+/// direction (`$sign = ($salt =~ s/^-//) ? -1 : 1`) and whose remaining digits
+/// give the phase (`"-0"` ⇒ sign −1, magnitude 0). The extractor (RawConv) salts
+/// are all NEGATIVE-or-zero-sign (decrypt); the never-ported RawConvInv (write)
+/// would use the positive complements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Salt {
+  /// `-1` when the salt string began with `-` (reverse/decrypt), else `+1`.
+  sign: i64,
+  /// The magnitude (the digits after the optional `-`).
+  magnitude: i64,
+}
+
+impl Salt {
+  /// A decrypt salt `"-N"` (`$sign = -1`, magnitude `n`) — the leading-`-`
+  /// form every `%Samsung::Type2` RawConv uses for a single-array tag's phase
+  /// and for the second (Y-coordinate) array of the tone curves.
+  #[must_use]
+  #[inline(always)]
+  pub const fn neg(magnitude: i64) -> Self {
+    Self {
+      sign: -1,
+      magnitude,
+    }
+  }
+
+  /// A `"N"` salt (`$sign = +1`, magnitude `n`) — the leading phase of the
+  /// `int32s` colour matrices / `CbCrMatrix` and the X-coordinate array of the
+  /// tone curves (`Crypt($self,$val,$tagInfo,0,"-0")`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn pos(magnitude: i64) -> Self {
+    Self { sign: 1, magnitude }
+  }
+}
+
+/// `%formatMinMax` (`Samsung.pm:60-65`) — the `[min, max]` value range for the
+/// integer formats Crypt wraps within. `None` for a non-integer format (the
+/// Perl `return undef unless $formatMinMax{$format}` guard — no Crypt row uses
+/// a float/rational `Writable`, so this is never hit in practice).
+#[must_use]
+#[inline]
+fn format_min_max(format: Format) -> Option<(i64, i64)> {
+  match format {
+    Format::Int16u => Some((0, 65535)),
+    Format::Int32u => Some((0, 4_294_967_295)),
+    Format::Int16s => Some((-32768, 32767)),
+    Format::Int32s => Some((-2_147_483_648, 2_147_483_647)),
+    _ => None,
+  }
+}
+
+/// Decrypt (or encrypt) one Samsung Type2 value — the 1:1 port of
+/// `Image::ExifTool::Samsung::Crypt` (`Samsung.pm:1579-1605`).
+///
+/// `vals` are the raw on-disk integers (`ReadValue`'s `@a = split ' ', $val`):
+/// an int32u entry arrives via [`RawValue::U64`](crate::exif::ifd::RawValue) and
+/// an int32s entry via `RawValue::I64`, both already widened to `i64` (an
+/// int32u up to `4_294_967_295` is exact). `key` is the int32u[11]
+/// `$$et{EncryptionKey}` captured at `0xa020`; `format` is the tag's `Writable`
+/// (selecting `%formatMinMax`); `salts` are the row's `SALT…` arguments.
+///
+/// Returns the space-joined decrypted integers (ExifTool's `return "@a"`), or
+/// `None` when the key is empty (`$key or return undef`) or the format has no
+/// `%formatMinMax` entry (`return undef unless $formatMinMax{$format}`).
+///
+/// ## Algorithm (verbatim)
+///
+/// `$newSalt = (@salt > 1) ? 1 : 0` — skip the leading length entry `$a[0]` for
+/// the two-array tone-curve tags. Then for each `$i` from `$newSalt`: at a
+/// salt boundary (`$i == $newSalt`) record `$start = $i`, pop the next salt
+/// (its sign + magnitude), and — if another salt remains — advance the next
+/// boundary by the array length `$a[0]`. Each element is offset by
+/// `$sign * $key[($salt + $i - $start) % 11]` and wrapped back into
+/// `[min, max]` (subtract the span when a positive offset overflows `max`, add
+/// it when a negative offset underflows `min`).
+#[must_use]
+pub fn crypt(vals: &[i64], key: &[i64], format: Format, salts: &[Salt]) -> Option<String> {
+  if key.is_empty() {
+    return None; // $key or return undef
+  }
+  let (min, max) = format_min_max(format)?;
+  let span = (max - min) + 1;
+  let key_len = key.len() as i64;
+
+  let mut a: Vec<i64> = vals.to_vec();
+  // $newSalt = (@salt > 1) ? 1 : 0 — skip the array-length entry for ARRAY tags.
+  let mut new_salt: usize = usize::from(salts.len() > 1);
+  let mut salt_iter = salts.iter();
+  // The length entry $a[0] — read ONCE up front (the loop never mutates it,
+  // since the boundary advance happens before $a[0] would be re-offset).
+  let len_entry: i64 = a.first().copied().unwrap_or(0);
+
+  let mut sign: i64 = 1;
+  let mut salt: i64 = 0;
+  let mut start: usize = 0;
+  let mut i: usize = new_salt;
+  while i < a.len() {
+    if i == new_salt {
+      start = i;
+      // shift @salt — a missing salt leaves $salt/$sign undef in Perl, but the
+      // ported tables always provide exactly enough salts, so a None here is a
+      // table bug; fall back to the prior values rather than panic.
+      if let Some(s) = salt_iter.next() {
+        sign = s.sign;
+        salt = s.magnitude;
+      }
+      // $newSalt += $a[0] if @salt — only when a further salt remains.
+      if salt_iter.len() > 0 {
+        new_salt = new_salt.saturating_add(usize::try_from(len_entry).unwrap_or(0));
+      }
+    }
+    // $a[$i] += $sign * $$key[($salt + $i - $start) % scalar(@$key)]
+    // ($i - $start) is non-negative (i >= start); ($salt + …) is non-negative
+    // for these tables (salt >= 0), so the Perl `%` (which here acts on a
+    // non-negative numerator) maps cleanly onto Rust's `rem_euclid`.
+    let phase = salt + (i as i64 - start as i64);
+    let k = key
+      .get(phase.rem_euclid(key_len) as usize)
+      .copied()
+      .unwrap_or(0);
+    if let Some(slot) = a.get_mut(i) {
+      *slot += sign * k;
+      // handle integer wrap-around
+      if sign > 0 {
+        if *slot > max {
+          *slot -= span;
+        }
+      } else if *slot < min {
+        *slot += span;
+      }
+    }
+    i += 1;
+  }
+
+  // return "@a" — space-joined.
+  let mut out = String::new();
+  for (idx, v) in a.iter().enumerate() {
+    if idx != 0 {
+      out.push(' ');
+    }
+    use core::fmt::Write as _;
+    let _ = write!(out, "{v}");
+  }
+  Some(out)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/exif/makernotes/vendors/samsung/crypt/tests.rs
+++ b/src/exif/makernotes/vendors/samsung/crypt/tests.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `Image::ExifTool::Samsung::Crypt` port tests — REAL-input vectors captured
+//! from bundled ExifTool 13.59 decrypting `tests/fixtures/SamsungNX500.srw`
+//! (the `0xa020 EncryptionKey` = `305 72 737 456 282 307 519 724 13 505 193`).
+//! Each `(raw, format, salts) -> decrypted` triple is the exact RawConv input
+//! and output bundled produces — the proof the cipher port is byte-faithful.
+
+use super::{Salt, crypt};
+use crate::exif::ifd::Format;
+
+/// The NX500 `0xa020 EncryptionKey` (int32u[11]).
+const KEY: &[i64] = &[305, 72, 737, 456, 282, 307, 519, 724, 13, 505, 193];
+
+#[test]
+fn wb_rggb_levels_uncorrected_0xa021() {
+  // SALT "-0", int32u[4].
+  let raw = [6881, 4168, 4833, 9064];
+  let got = crypt(&raw, KEY, Format::Int32u, &[Salt::neg(0)]).unwrap();
+  assert_eq!(got, "6576 4096 4096 8608");
+}
+
+#[test]
+fn wb_rggb_levels_auto_0xa022() {
+  // SALT -4, int32u[4].
+  let raw = [6858, 4403, 4615, 9332];
+  let got = crypt(&raw, KEY, Format::Int32u, &[Salt::neg(4)]).unwrap();
+  assert_eq!(got, "6576 4096 4096 8608");
+}
+
+#[test]
+fn wb_rggb_levels_illuminator1_0xa023() {
+  let raw = [5293, 4601, 4289, 10113];
+  let got = crypt(&raw, KEY, Format::Int32u, &[Salt::neg(8)]).unwrap();
+  assert_eq!(got, "5280 4096 4096 9808");
+}
+
+#[test]
+fn wb_rggb_levels_illuminator2_0xa024() {
+  let raw = [7384, 4833, 4552, 6250];
+  let got = crypt(&raw, KEY, Format::Int32u, &[Salt::neg(1)]).unwrap();
+  assert_eq!(got, "7312 4096 4096 5968");
+}
+
+#[test]
+fn wb_rggb_levels_black_0xa028() {
+  // int32s[4], SALT "-0". Raw on-disk are signed.
+  let raw = [433, 200, 865, 584];
+  let got = crypt(&raw, KEY, Format::Int32s, &[Salt::neg(0)]).unwrap();
+  assert_eq!(got, "128 128 128 128");
+}
+
+#[test]
+fn color_matrix_0xa030() {
+  // int32s[9], SALT 0 (positive sign).
+  let raw = [131, -192, -797, -498, 30, -321, -517, -818, 335];
+  let got = crypt(&raw, KEY, Format::Int32s, &[Salt::pos(0)]).unwrap();
+  assert_eq!(got, "436 -120 -60 -42 312 -14 2 -94 348");
+}
+
+#[test]
+fn color_matrix_srgb_0xa031() {
+  let raw = [73, -174, -757, -484, 46, -351, -511, -824, 335];
+  let got = crypt(&raw, KEY, Format::Int32s, &[Salt::pos(0)]).unwrap();
+  assert_eq!(got, "378 -102 -20 -28 328 -44 8 -100 348");
+}
+
+#[test]
+fn color_matrix_adobe_rgb_0xa032() {
+  let raw = [-61, -36, -761, -482, 38, -345, -511, -796, 307];
+  let got = crypt(&raw, KEY, Format::Int32s, &[Salt::pos(0)]).unwrap();
+  assert_eq!(got, "244 36 -24 -26 320 -38 8 -72 320");
+}
+
+#[test]
+fn cbcr_matrix_default_0xa033() {
+  // int32s[4], SALT 0.
+  let raw = [-49, -72, -737, -200];
+  let got = crypt(&raw, KEY, Format::Int32s, &[Salt::pos(0)]).unwrap();
+  assert_eq!(got, "256 0 0 256");
+}
+
+#[test]
+fn cbcr_matrix_0xa034() {
+  // Same raw bytes as CbCrMatrixDefault but SALT 4 (different phase) ⇒ different output.
+  let raw = [-49, -72, -737, -200];
+  let got = crypt(&raw, KEY, Format::Int32s, &[Salt::pos(4)]).unwrap();
+  assert_eq!(got, "233 235 -218 524");
+}
+
+#[test]
+fn cbcr_gain_default_0xa035() {
+  // int32u[2], SALT "-0".
+  let raw = [4096, 4096];
+  let got = crypt(&raw, KEY, Format::Int32u, &[Salt::neg(0)]).unwrap();
+  assert_eq!(got, "3791 4024");
+}
+
+#[test]
+fn cbcr_gain_0xa036() {
+  // Same raw as CbCrGainDefault but SALT -2 ⇒ different output.
+  let raw = [4096, 4096];
+  let got = crypt(&raw, KEY, Format::Int32u, &[Salt::neg(2)]).unwrap();
+  assert_eq!(got, "3359 3640");
+}
+
+#[test]
+fn tone_curve_srgb_default_0xa040() {
+  // int32u[23], TWO salts (0,"-0"): a[0]=11 is the array length (skipped); the
+  // first 11 entries (X coords) use salt 0 (+sign), the next 11 (Y coords) use
+  // salt "-0" (-sign). The on-disk negative deltas appear as large int32u.
+  let raw = [
+    11, 4294966991, 4294967240, 4294966591, 4294966904, 4294967142, 4294967245, 4294967289, 300,
+    2035, 2567, 3902, 305, 79, 751, 484, 334, 397, 659, 914, 243, 750, 448,
+  ];
+  let got = crypt(&raw, KEY, Format::Int32u, &[Salt::pos(0), Salt::neg(0)]).unwrap();
+  assert_eq!(
+    got,
+    "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255"
+  );
+}
+
+#[test]
+fn empty_key_returns_none() {
+  // $key or return undef — no EncryptionKey captured ⇒ no decryption.
+  let raw = [6881, 4168, 4833, 9064];
+  assert!(crypt(&raw, &[], Format::Int32u, &[Salt::neg(0)]).is_none());
+}
+
+#[test]
+fn non_int_format_returns_none() {
+  // return undef unless $formatMinMax{$format}.
+  let raw = [1, 2];
+  assert!(crypt(&raw, KEY, Format::Rational64u, &[Salt::pos(0)]).is_none());
+}

--- a/src/exif/makernotes/vendors/samsung/mod.rs
+++ b/src/exif/makernotes/vendors/samsung/mod.rs
@@ -10,7 +10,7 @@
 //! hashes, and the `%Samsung::PictureWizard` `ProcessBinaryData` sub-table
 //! (`Samsung.pm:650-705`).
 //!
-//! ## Phase 1 scope
+//! ## Scope
 //!
 //! - The Samsung Type2 body walk runs through the shared `Walker` isolated
 //!   helper [`crate::exif::samsung_makernote_isolated`] — the dispatcher
@@ -18,25 +18,32 @@
 //!   inherit base, `ByteOrder => Unknown` (probed) and `FixBase => 1`, all
 //!   threaded into `process_subdir(TableRef::Samsung)`.
 //! - The faithful tag table ([`tags::SAMSUNG_TAGS`]) — the Type2 plain
-//!   scalar/enum/string/lookup LEAVES.
+//!   scalar/enum/string/lookup LEAVES + the 16 Crypt-encrypted leaves.
 //! - Per-tag conversions ([`printconv::SamsungPrintConv`]).
 //! - [`lens_types::SAMSUNG_LENS_TYPES`] / [`model_ids::SAMSUNG_MODEL_IDS`].
 //! - The `0x0021 PictureWizard` `ProcessBinaryData` SubDirectory, surfaced by
 //!   [`emit_picture_wizard`].
+//! - The `Image::ExifTool::Samsung::Crypt` decryption ([`crypt`], #242): the
+//!   isolated walker captures the `0xa020 EncryptionKey` DataMember
+//!   ([`encryption_key_from_raw`]) and decrypts the 16 `0xa021`..`0xa043`
+//!   `RawConv => Samsung::Crypt(...)` leaves ([`emit_crypt`]) — WB_RGGBLevels*,
+//!   ColorMatrix*, CbCr*, ToneCurve* — byte-exactly to bundled ExifTool.
 //! - A typed [`MakerNotesSamsung`] struct with D8 accessors over the parsed
 //!   camera-identity fields (DeviceType + SamsungModelID + name, LensType +
 //!   name, FirmwareName).
 //!
 //! ## Deferred (see [`tags`])
 //!
-//! The Crypt-encrypted `0xa021`..`0xa057` block (EXCEPT the plain `0xa025`)
-//! and the `0x0011 OrientationInfo` / `0x0035 PreviewIFD` SubDirectory rows.
-//! Three plain leaves in/near that range ARE ported: the `$$valPt`-gated
+//! The `Unknown => 1` Crypt rows (`0xa048 RawData`, `0xa050`-`0xa057`
+//! Distortion/ChromaticAberration/Vignetting*) — `Unknown` suppresses them from
+//! default `-j` output — and the `0x0011 OrientationInfo` / `0x0035 PreviewIFD`
+//! SubDirectory rows (absent from the NX500 fixture; crafted-input only).
+//! Three plain leaves in/near the Crypt range ARE ported: the `$$valPt`-gated
 //! `0xa002 SerialNumber` (value-`Condition` gate in
 //! [`SamsungPrintConv::condition_holds`]), `0xa020 EncryptionKey` (its RawConv
-//! returns `$val` unchanged — a plain int32u[11] passthrough), and
-//! `0xa025 HighlightLinearityLimit` (the plain int32u row wins the duplicate-id
-//! last-wins over the `0xa025 DigitalGain` Crypt row).
+//! returns `$val` unchanged — a plain int32u[11] passthrough — AND seeds the
+//! Crypt key), and `0xa025 HighlightLinearityLimit` (the plain int32u row wins
+//! the duplicate-id last-wins over the `0xa025 DigitalGain` Crypt row).
 //!
 //! ## D8 compliance
 //!
@@ -46,6 +53,7 @@
 
 #![deny(clippy::indexing_slicing)]
 
+pub mod crypt;
 pub mod lens_types;
 pub mod model_ids;
 pub mod printconv;
@@ -56,10 +64,11 @@ use crate::exif::makernotes::VendorEmission;
 use smol_str::SmolStr;
 use std::vec::Vec;
 
+pub use crypt::{Salt, crypt};
 pub use lens_types::{SAMSUNG_LENS_TYPES, SamsungLensType};
 pub use model_ids::{SAMSUNG_MODEL_IDS, SamsungModelEntry};
 pub use printconv::SamsungPrintConv;
-pub use tags::{SAMSUNG_TAGS, SamsungTag, SubTable, format_override, lookup};
+pub use tags::{CryptTag, SAMSUNG_TAGS, SamsungTag, SubTable, format_override, lookup};
 
 /// Decoded Samsung Type2 MakerNotes data — populated by
 /// [`crate::exif::samsung_makernote_isolated`] when the dispatcher resolved
@@ -239,6 +248,89 @@ pub(crate) fn emit_picture_wizard(
     let value = conv.apply(&raw, print_conv);
     out.push(VendorEmission::new(SmolStr::from(name), value, false));
   }
+}
+
+/// Render a decoded [`RawValue`] to the `i64` integer vector ExifTool's
+/// `split(" ",$val)` produces — the SHARED domain both the `0xa020`
+/// `EncryptionKey` DataMember capture and the `Samsung::Crypt` value path
+/// operate on.
+///
+/// Samsung.pm never inspects the TIFF type: the `EncryptionKey` DataMember is
+/// `$$self{EncryptionKey} = [ split(" ",$val) ]` (`Samsung.pm:489-490`) and the
+/// cipher opens with `@a = split ' ', $val` (`Samsung.pm:1582`) — both split the
+/// RENDERED value string. So this splitter is format-agnostic: an int32u entry
+/// arrives as [`RawValue::U64`] (widened to `i64`, exact for `0..=u32::MAX`) and
+/// an int32s entry as [`RawValue::I64`] — either way the elements ARE the
+/// space-separated integer tokens of `$val`, for any arity, signed or unsigned.
+///
+/// Returns `None` for a shape that does NOT render to a clean integer vector
+/// (`F64`/`Rational`/`Text`/`Bytes` — never produced for an `int32u`/`int32s`
+/// Crypt row, but reachable on a parseable wrong-format input). The two callers
+/// take the faithful `Crypt`-returns-`undef` path on `None`: the key capture
+/// leaves the key empty, and [`emit_crypt`] emits NOTHING (it does NOT decrypt
+/// an artificial empty vector to `Some("")`).
+#[must_use]
+fn split_val_to_ints(raw: &RawValue) -> Option<Vec<i64>> {
+  match raw {
+    RawValue::U64(v) => Some(v.iter().map(|&n| n as i64).collect()),
+    RawValue::I64(v) => Some(v.clone()),
+    _ => None,
+  }
+}
+
+/// Capture the `0xa020 EncryptionKey` as the `i64` key vector the [`crypt`]
+/// cipher indexes — the DataMember `$$self{EncryptionKey} = [ split(" ",$val) ]`
+/// (`Samsung.pm:489-490`). Renders `$val` through [`split_val_to_ints`], so the
+/// key is captured for ANY integer encoding (int32u → [`RawValue::U64`], or a
+/// parseable wrong-format int32s → [`RawValue::I64`]), matching ExifTool's
+/// type-agnostic `split(" ",$val)`. A shape that does not render to integers
+/// yields an empty key ⇒ later Crypt tags emit nothing (the faithful
+/// `$key or return undef`).
+#[must_use]
+pub(crate) fn encryption_key_from_raw(raw: &RawValue) -> Vec<i64> {
+  split_val_to_ints(raw).unwrap_or_default()
+}
+
+/// Decrypt one `%Samsung::Type2` Crypt leaf (`0xa021`..`0xa043` of the emitted
+/// 16) and push the plaintext emission — the emit-time port of the row's
+/// `RawConv => Image::ExifTool::Samsung::Crypt($self,$val,$tagInfo,SALT…)`.
+///
+/// `raw` is the entry's decoded value; `key` the captured `EncryptionKey`. The
+/// raw value is rendered to integers through [`split_val_to_ints`] (the
+/// type-agnostic `split(" ",$val)`), then the cipher ([`crypt`]) runs over those
+/// integers with the tag's `Writable` format + salts, returning the space-joined
+/// plaintext (the FINAL value — a Crypt row has no further PrintConv, so `-j` and
+/// `-n` render identically). NOTHING is emitted — exactly as ExifTool's RawConv
+/// `return undef` drops the tag — in three cases: the raw value does not render
+/// to integers ([`split_val_to_ints`] is `None`, a parseable wrong-format entry,
+/// so no artificial empty vector is decrypted to `Some("")`); the key is empty
+/// (`EncryptionKey` absent/malformed); or the format has no `%formatMinMax`
+/// entry. The emission carries the row's `Unknown=>1` flag (only the deferred
+/// `0xa048`/`0xa05x` rows are Unknown; none of the 16 emitted are, so this is
+/// `false` for them).
+pub(crate) fn emit_crypt(
+  name: &str,
+  crypt_tag: tags::CryptTag,
+  raw: &RawValue,
+  key: &[i64],
+  unknown: bool,
+  out: &mut Vec<VendorEmission>,
+) {
+  // `split(" ",$val)` over the RENDERED value — `None` for a shape that does not
+  // render to integers (a parseable wrong-format Crypt entry). ExifTool's RawConv
+  // would still operate, but the faithful target is `Crypt`-returns-`undef`: emit
+  // NOTHING rather than decrypt an artificial empty vector to `Some("")`.
+  let Some(ints) = split_val_to_ints(raw) else {
+    return;
+  };
+  let Some(plain) = crypt(&ints, key, crypt_tag.format(), crypt_tag.salts()) else {
+    return;
+  };
+  out.push(VendorEmission::new(
+    SmolStr::from(name),
+    crate::value::TagValue::Str(SmolStr::from(plain.as_str())),
+    unknown,
+  ));
 }
 
 #[cfg(test)]

--- a/src/exif/makernotes/vendors/samsung/tags.rs
+++ b/src/exif/makernotes/vendors/samsung/tags.rs
@@ -4,9 +4,10 @@
 //! `%Image::ExifTool::Samsung::Type2` IFD tag table (`Samsung.pm:129-648`).
 //!
 //! Faithful 1:1 port against bundled ExifTool 13.59 (Samsung.pm `$VERSION`
-//! 1.51). Phase 1 ports the PLAIN scalar/enum/string/lookup LEAVES plus the
+//! 1.51). Ports the PLAIN scalar/enum/string/lookup LEAVES, the
 //! `0x0021 PictureWizard` `ProcessBinaryData` SubDirectory (whose five members
-//! are surfaced by the capture loop, [`super::emit_picture_wizard`]).
+//! are surfaced by the capture loop, [`super::emit_picture_wizard`]), and the
+//! 16 Crypt-encrypted leaves (#242, see below).
 //!
 //! A "plain" leaf is one whose WINNING `%Samsung::Type2` row has NO
 //! `RawConv => Image::ExifTool::Samsung::Crypt(...)` (and no `SubDirectory`).
@@ -16,24 +17,35 @@
 //! - **`0xa020 EncryptionKey`** (`Samsung.pm:484-493`) — int32u Count 11. Its
 //!   `RawConv` stores a split key in a DataMember but RETURNS `$val` unchanged,
 //!   so the value is the RAW int32u[11] (the cleartext key); it is NOT a Crypt
-//!   tag. `Protected => 1` gates writing only, not extraction.
+//!   tag. `Protected => 1` gates writing only, not extraction. The isolated
+//!   Samsung walker ALSO captures this raw key as the [`super::crypt::crypt`]
+//!   key for the rows below.
 //! - **`0xa025 HighlightLinearityLimit`** (`Samsung.pm:529-532`) — int32u, no
 //!   conv. `0xa025` is the table's ONLY duplicate id: the earlier `DigitalGain`
 //!   (`Samsung.pm:523`, a Crypt row) is OVERWRITTEN by this later plain row
 //!   (Perl hash LAST-WINS), so the winning leaf is the raw int32u.
 //!
-//! ## Deferred (Phase 1+ follow-ups)
+//! ## The Crypt-encrypted block (#242)
 //!
-//! - **The Crypt-encrypted block** `0xa021`..`0xa057` EXCEPT `0xa025` (i.e.
-//!   `WB_RGGBLevels*`, `ColorMatrix*`, `CbCr*`, `ToneCurve*`,
-//!   `RawData`/`Distortion`/`ChromaticAberration`/`Vignetting*`) — every one has
-//!   a `RawConv => Image::ExifTool::Samsung::Crypt(...)` winning row
-//!   (raw-processing data, not camera-indexing). These tag IDs are simply ABSENT
-//!   from the table, so the shared `Walker` drops them (unknown-tag skip),
-//!   exactly as Phase 1 intends; the conformance golden `-x`es them.
+//! The 16 EMITTED encrypted leaves carry a [`CryptTag`] directive (the row's
+//! `Writable` format + `Crypt(...,SALT…)` salts): `WB_RGGBLevels*`
+//! (`0xa021`-`0xa024`, `0xa028`), `ColorMatrix*` (`0xa030`-`0xa032`), `CbCr*`
+//! (`0xa033`-`0xa036`), `ToneCurve*` (`0xa040`-`0xa043`). The isolated Samsung
+//! walker decrypts each with the captured `EncryptionKey` ([`super::crypt`]),
+//! emitting the plaintext space-joined integers byte-exactly to bundled
+//! ExifTool (proven on `tests/fixtures/SamsungNX500.srw`).
+//!
+//! ## Deferred
+//!
+//! - **The `Unknown => 1` Crypt rows** `0xa048 RawData`, `0xa050 Distortion`,
+//!   `0xa051 ChromaticAberration`, `0xa052`-`0xa054 Vignetting*`, and the
+//!   `Hidden` `0xa055`-`0xa057` — every one is `Unknown => 1`, which
+//!   ExifTool suppresses from default `-j` output (`ExifTool.pm:9179-9185`), so
+//!   they are NOT among the 16 emitted and are simply ABSENT from the table.
 //! - **The remaining SubDirectory rows** `0x0011 OrientationInfo` (Gear 360
 //!   only) and `0x0035 PreviewIFD` (a Nikon-PreviewIFD sub-IFD that emits under
-//!   its own `PreviewIFD:` group) — deferred.
+//!   its own `PreviewIFD:` group) — deferred (neither is present in the NX500
+//!   fixture, so neither is camera-indexing-proven; crafted-input only).
 //!
 //! ## The `0xa002 SerialNumber` value-`Condition`
 //!
@@ -50,6 +62,7 @@
 
 #![deny(clippy::indexing_slicing)]
 
+use super::crypt::Salt;
 use super::printconv::SamsungPrintConv;
 use crate::exif::ifd::Format;
 use crate::exif::makernotes::vendors::FormatOverride;
@@ -72,6 +85,43 @@ pub struct SamsungTag {
   /// `Some(FormatOverride)` when bundled carries a `Format => '…'` directive
   /// that RE-INTERPRETS the entry's on-disk bytes (`Exif.pm:6728-6745`).
   pub format: Option<FormatOverride>,
+  /// `Some(CryptTag)` when the winning row has a
+  /// `RawConv => Image::ExifTool::Samsung::Crypt($self,$val,$tagInfo,SALT…)`
+  /// (`Samsung.pm:1579-1605`). The isolated Samsung walker decrypts the raw
+  /// integers with the captured `0xa020 EncryptionKey` + these salts + the
+  /// tag's `Writable` format, emitting the space-joined plaintext. `None` for a
+  /// plain leaf.
+  pub crypt: Option<CryptTag>,
+}
+
+/// The `Image::ExifTool::Samsung::Crypt` directive carried by an encrypted
+/// `%Samsung::Type2` row (`0xa021`..`0xa057`): the `Writable` format (selecting
+/// `%formatMinMax`) and the `SALT…` arguments. Decrypted by
+/// [`super::crypt::crypt`] with the per-file `EncryptionKey`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CryptTag {
+  /// The tag's `Writable => '…'` integer format — selects the `%formatMinMax`
+  /// `[min, max]` wrap range.
+  format: Format,
+  /// The row's `Crypt(...,SALT…)` salt arguments (one per stored array; the
+  /// tone curves carry two).
+  salts: &'static [Salt],
+}
+
+impl CryptTag {
+  /// The `Writable` format selecting the `%formatMinMax` wrap range.
+  #[must_use]
+  #[inline(always)]
+  pub const fn format(&self) -> Format {
+    self.format
+  }
+
+  /// The `Crypt(...,SALT…)` salt arguments.
+  #[must_use]
+  #[inline(always)]
+  pub const fn salts(&self) -> &'static [Salt] {
+    self.salts
+  }
 }
 
 impl SamsungTag {
@@ -116,6 +166,13 @@ impl SamsungTag {
   pub const fn is_unknown(&self) -> bool {
     self.unknown
   }
+
+  /// The tag's `Samsung::Crypt` directive, if its winning row carries one.
+  #[must_use]
+  #[inline(always)]
+  pub const fn crypt(&self) -> Option<CryptTag> {
+    self.crypt
+  }
 }
 
 /// Samsung Type2 SubDirectory targets.
@@ -139,6 +196,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0002 DeviceType (Samsung.pm:140-152) — int32u, PrintHex label hash.
   SamsungTag {
@@ -148,6 +206,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0003 SamsungModelID (Samsung.pm:153-245) — int32u, PrintHex lookup.
   SamsungTag {
@@ -157,6 +216,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0020 SmartAlbumColor (Samsung.pm:256-278) — int16u[2]. Branch 1 (the \0{4} "0 0"=>n/a) ported; branch 2's per-element color array is deferred (raw passthrough).
   SamsungTag {
@@ -166,6 +226,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0021 PictureWizard (Samsung.pm:279-283) — int16u SubDirectory → %Samsung::PictureWizard ProcessBinaryData (descended in the capture loop).
   SamsungTag {
@@ -175,6 +236,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: Some(SubTable::PictureWizard),
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0030 LocalLocationName (Samsung.pm:291-298) — Format 'undef', Writable 'string', no PrintConv; ValueConv truncates at the first double-NUL and turns each NUL+spaces separator into a newline.
   SamsungTag {
@@ -184,6 +246,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: Some(FormatOverride::new(Format::Undef, None)),
+    crypt: None,
   },
   // 0x0031 LocationName (Samsung.pm:299-303) — string.
   SamsungTag {
@@ -193,6 +256,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0040 RawDataByteOrder (Samsung.pm:334-340) — label hash.
   SamsungTag {
@@ -202,6 +266,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0041 WhiteBalanceSetup (Samsung.pm:341-348) — int32u, 0=>Auto 1=>Manual.
   SamsungTag {
@@ -211,6 +276,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0043 CameraTemperature (Samsung.pm:349-356) — rational64s, "$val C" when numeric.
   SamsungTag {
@@ -220,6 +286,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0050 RawDataCFAPattern (Samsung.pm:361-368) — label hash.
   SamsungTag {
@@ -229,6 +296,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0100 FaceDetect (Samsung.pm:381-385) — int16u, 0=>Off 1=>On.
   SamsungTag {
@@ -238,6 +306,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0120 FaceRecognition (Samsung.pm:388-392) — int32u, 0=>Off 1=>On.
   SamsungTag {
@@ -247,6 +316,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0x0123 FaceName (Samsung.pm:393) — string.
   SamsungTag {
@@ -256,6 +326,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa001 FirmwareName (Samsung.pm:399-403) — string.
   SamsungTag {
@@ -265,6 +336,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa002 SerialNumber (Samsung.pm:404-409) — string, no PrintConv. Gated by a
   // `Condition => '$$valPt =~ /^\w{5}/'` value-Condition (emit only when the
@@ -277,6 +349,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa003 LensType (Samsung.pm:410-416) — int16u Count -1, %samsungLensTypes lookup.
   SamsungTag {
@@ -286,6 +359,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa004 LensFirmware (Samsung.pm:417-421) — string.
   SamsungTag {
@@ -295,6 +369,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa005 InternalLensSerialNumber (Samsung.pm:422-426) — string.
   SamsungTag {
@@ -304,6 +379,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa010 SensorAreas (Samsung.pm:427-433) — int32u[8], raw space-joined.
   SamsungTag {
@@ -313,6 +389,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa011 ColorSpace (Samsung.pm:434-441) — int16u, 0=>sRGB 1=>Adobe RGB.
   SamsungTag {
@@ -322,6 +399,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa012 SmartRange (Samsung.pm:442-446) — int16u, 0=>Off 1=>On.
   SamsungTag {
@@ -331,6 +409,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa013 ExposureCompensation (Samsung.pm:447-450) — rational64s, raw.
   SamsungTag {
@@ -340,6 +419,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa014 ISO (Samsung.pm:451-454) — int32u, raw.
   SamsungTag {
@@ -349,6 +429,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa018 ExposureTime (Samsung.pm:455-462) — rational64u, first-value ValueConv + PrintExposureTime.
   SamsungTag {
@@ -358,6 +439,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa019 FNumber (Samsung.pm:463-471) — rational64u, Priority 0, first-value ValueConv + %.1f.
   SamsungTag {
@@ -367,6 +449,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
   },
   // 0xa01a FocalLengthIn35mmFormat (Samsung.pm:472-481) — Format int32u, ValueConv /10, "$val mm".
   SamsungTag {
@@ -376,6 +459,7 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: Some(FormatOverride::new(Format::Int32u, None)),
+    crypt: None,
   },
   // 0xa020 EncryptionKey (Samsung.pm:484-493) — int32u Count 11. Its
   // `RawConv => '$$self{EncryptionKey} = [ split(" ",$val) ]; $val'` STORES the
@@ -390,6 +474,59 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
+  },
+  // 0xa021 WB_RGGBLevelsUncorrected (Samsung.pm:494-500) — int32u, Crypt SALT [neg(0)].
+  SamsungTag {
+    id: 0xa021,
+    name: "WB_RGGBLevelsUncorrected",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::neg(0)],
+    }),
+  },
+  // 0xa022 WB_RGGBLevelsAuto (Samsung.pm:501-507) — int32u, Crypt SALT [neg(4)].
+  SamsungTag {
+    id: 0xa022,
+    name: "WB_RGGBLevelsAuto",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::neg(4)],
+    }),
+  },
+  // 0xa023 WB_RGGBLevelsIlluminator1 (Samsung.pm:508-514) — int32u, Crypt SALT [neg(8)].
+  SamsungTag {
+    id: 0xa023,
+    name: "WB_RGGBLevelsIlluminator1",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::neg(8)],
+    }),
+  },
+  // 0xa024 WB_RGGBLevelsIlluminator2 (Samsung.pm:515-521) — int32u, Crypt SALT [neg(1)].
+  SamsungTag {
+    id: 0xa024,
+    name: "WB_RGGBLevelsIlluminator2",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::neg(1)],
+    }),
   },
   // 0xa025 HighlightLinearityLimit (Samsung.pm:529-532) — int32u, NO RawConv =
   // PLAIN. 0xa025 has a DUPLICATE row: Samsung.pm:523 (DigitalGain, RawConv =>
@@ -403,6 +540,163 @@ pub const SAMSUNG_TAGS: &[SamsungTag] = &[
     sub_table: None,
     unknown: false,
     format: None,
+    crypt: None,
+  },
+  // 0xa028 WB_RGGBLevelsBlack (Samsung.pm:533-539) — int32s, Crypt SALT [neg(0)].
+  SamsungTag {
+    id: 0xa028,
+    name: "WB_RGGBLevelsBlack",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32s,
+      salts: &[Salt::neg(0)],
+    }),
+  },
+  // 0xa030 ColorMatrix (Samsung.pm:540-546) — int32s, Crypt SALT [pos(0)].
+  SamsungTag {
+    id: 0xa030,
+    name: "ColorMatrix",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32s,
+      salts: &[Salt::pos(0)],
+    }),
+  },
+  // 0xa031 ColorMatrixSRGB (Samsung.pm:547-553) — int32s, Crypt SALT [pos(0)].
+  SamsungTag {
+    id: 0xa031,
+    name: "ColorMatrixSRGB",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32s,
+      salts: &[Salt::pos(0)],
+    }),
+  },
+  // 0xa032 ColorMatrixAdobeRGB (Samsung.pm:554-560) — int32s, Crypt SALT [pos(0)].
+  SamsungTag {
+    id: 0xa032,
+    name: "ColorMatrixAdobeRGB",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32s,
+      salts: &[Salt::pos(0)],
+    }),
+  },
+  // 0xa033 CbCrMatrixDefault (Samsung.pm:561-567) — int32s, Crypt SALT [pos(0)].
+  SamsungTag {
+    id: 0xa033,
+    name: "CbCrMatrixDefault",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32s,
+      salts: &[Salt::pos(0)],
+    }),
+  },
+  // 0xa034 CbCrMatrix (Samsung.pm:568-574) — int32s, Crypt SALT [pos(4)].
+  SamsungTag {
+    id: 0xa034,
+    name: "CbCrMatrix",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32s,
+      salts: &[Salt::pos(4)],
+    }),
+  },
+  // 0xa035 CbCrGainDefault (Samsung.pm:575-581) — int32u, Crypt SALT [neg(0)].
+  SamsungTag {
+    id: 0xa035,
+    name: "CbCrGainDefault",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::neg(0)],
+    }),
+  },
+  // 0xa036 CbCrGain (Samsung.pm:582-588) — int32u, Crypt SALT [neg(2)].
+  SamsungTag {
+    id: 0xa036,
+    name: "CbCrGain",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::neg(2)],
+    }),
+  },
+  // 0xa040 ToneCurveSRGBDefault (Samsung.pm:589-602) — int32u, Crypt SALT [pos(0), neg(0)].
+  SamsungTag {
+    id: 0xa040,
+    name: "ToneCurveSRGBDefault",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::pos(0), Salt::neg(0)],
+    }),
+  },
+  // 0xa041 ToneCurveAdobeRGBDefault (Samsung.pm:603-609) — int32u, Crypt SALT [pos(0), neg(0)].
+  SamsungTag {
+    id: 0xa041,
+    name: "ToneCurveAdobeRGBDefault",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::pos(0), Salt::neg(0)],
+    }),
+  },
+  // 0xa042 ToneCurveSRGB (Samsung.pm:610-616) — int32u, Crypt SALT [pos(0), neg(0)].
+  SamsungTag {
+    id: 0xa042,
+    name: "ToneCurveSRGB",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::pos(0), Salt::neg(0)],
+    }),
+  },
+  // 0xa043 ToneCurveAdobeRGB (Samsung.pm:617-623) — int32u, Crypt SALT [pos(0), neg(0)].
+  SamsungTag {
+    id: 0xa043,
+    name: "ToneCurveAdobeRGB",
+    conv: SamsungPrintConv::None,
+    sub_table: None,
+    unknown: false,
+    format: None,
+    crypt: Some(CryptTag {
+      format: Format::Int32u,
+      salts: &[Salt::pos(0), Salt::neg(0)],
+    }),
   },
 ];
 

--- a/src/exif/makernotes/vendors/samsung/tags/tests.rs
+++ b/src/exif/makernotes/vendors/samsung/tags/tests.rs
@@ -48,15 +48,29 @@ fn lookup_resolves_key_leaves() {
     Some(SamsungPrintConv::None)
   ));
   assert_eq!(lookup(0xa025).and_then(|t| t.sub_table()), None);
-  // The genuinely-Crypt rows (RawConv => Samsung::Crypt) + the deferred
-  // SubDirectory rows are NOT ported.
-  assert!(
-    lookup(0xa021).is_none(),
-    "WB_RGGBLevelsUncorrected (Crypt) must be deferred"
+  // The 16 emitted Crypt rows (RawConv => Samsung::Crypt, #242) ARE ported and
+  // carry a `crypt` directive; the deferred SubDirectory rows are NOT ported.
+  assert_eq!(
+    lookup(0xa021).map(|t| t.name()),
+    Some("WB_RGGBLevelsUncorrected")
   );
   assert!(
-    lookup(0xa030).is_none(),
-    "ColorMatrix (Crypt) must be deferred"
+    lookup(0xa021).and_then(|t| t.crypt()).is_some(),
+    "WB_RGGBLevelsUncorrected (Crypt) must carry a crypt directive"
+  );
+  assert_eq!(lookup(0xa030).map(|t| t.name()), Some("ColorMatrix"));
+  assert!(
+    lookup(0xa030).and_then(|t| t.crypt()).is_some(),
+    "ColorMatrix (Crypt) must carry a crypt directive"
+  );
+  // A plain leaf carries NO crypt directive.
+  assert!(lookup(0xa020).and_then(|t| t.crypt()).is_none());
+  // The Unknown=>1 Crypt rows (0xa048/0xa05x) stay DEFERRED (suppressed from
+  // default -j output) — not part of the 16.
+  assert!(lookup(0xa048).is_none(), "RawData (Unknown Crypt) deferred");
+  assert!(
+    lookup(0xa050).is_none(),
+    "Distortion (Unknown Crypt) deferred"
   );
   assert!(lookup(0x0011).is_none(), "OrientationInfo must be deferred");
   assert!(lookup(0x0035).is_none(), "PreviewIFD must be deferred");

--- a/src/exif/makernotes/vendors/samsung/tests.rs
+++ b/src/exif/makernotes/vendors/samsung/tests.rs
@@ -59,3 +59,122 @@ fn emit_picture_wizard_short_array_stops() {
   let names: Vec<&str> = out.iter().map(|e| e.name()).collect();
   assert_eq!(names, std::vec!["PictureWizardMode", "PictureWizardColor"]);
 }
+
+// ===========================================================================
+// Crypt wrong-format robustness (#242 Codex R1) — Samsung.pm operates on
+// `split(" ",$val)` (the RENDERED value), TIFF-type-agnostic. The key capture
+// and the Crypt value path therefore handle ANY integer encoding (int32u →
+// `U64`, a parseable wrong-format int32s → `I64`), and a shape that does NOT
+// render to integers emits NOTHING (Crypt returns undef → no tag), never `""`.
+// ===========================================================================
+
+/// The NX500 `0xa020 EncryptionKey` int32u[11] (the real-input key from the
+/// crypt unit tests), reused here to prove the wrong-format paths still decrypt
+/// to the byte-exact NX500 plaintext.
+const NX500_KEY: [i64; 11] = [305, 72, 737, 456, 282, 307, 519, 724, 13, 505, 193];
+
+/// Bug 1: a `0xa020` encoded as SIGNED integers (`RawValue::I64`) — a parseable
+/// wrong-format key the old `U64`-only capture silently dropped — IS captured.
+/// ExifTool's `[ split(" ",$val) ]` does not inspect the TIFF type.
+#[test]
+fn encryption_key_from_raw_captures_signed_key() {
+  let signed = RawValue::I64(NX500_KEY.to_vec());
+  assert_eq!(
+    encryption_key_from_raw(&signed),
+    NX500_KEY.to_vec(),
+    "a signed-encoded 0xa020 must capture the key (not the empty Vec the old U64-only match left)"
+  );
+  // A non-integer shape still yields the empty key (⇒ later Crypt tags drop).
+  assert!(
+    encryption_key_from_raw(&RawValue::Bytes(std::vec![1, 2, 3])).is_empty(),
+    "a non-integer 0xa020 shape renders to no key"
+  );
+}
+
+/// Bug 1, end to end: with the key captured from a SIGNED-encoded `0xa020`, an
+/// encrypted `0xa021` decrypts to the SAME byte-exact NX500 plaintext as the
+/// happy (unsigned) path — proving the capture is format-agnostic, not that the
+/// signed encoding changes the cipher input.
+#[test]
+fn emit_crypt_decrypts_under_signed_encoded_key() {
+  // 0xa020 arrives SIGNED; the key must still come out as the NX500 int32u[11].
+  let key = encryption_key_from_raw(&RawValue::I64(NX500_KEY.to_vec()));
+  assert_eq!(key, NX500_KEY.to_vec());
+
+  let crypt_tag = lookup(0xa021)
+    .and_then(SamsungTag::crypt)
+    .expect("0xa021 WB_RGGBLevelsUncorrected is a Crypt row");
+  // The 0xa021 on-disk raw (int32u[4]) → bundled plaintext "6576 4096 4096 8608".
+  let raw = RawValue::U64(std::vec![6881, 4168, 4833, 9064]);
+  let mut out = Vec::new();
+  emit_crypt(
+    "WB_RGGBLevelsUncorrected",
+    crypt_tag,
+    &raw,
+    &key,
+    false,
+    &mut out,
+  );
+  // Collect (name, value) without indexing (the module `#![deny]`s
+  // indexing_slicing) — the same iterate-then-assert pattern the PictureWizard
+  // tests use.
+  let pairs: Vec<(&str, &TagValue)> = out.iter().map(|e| (e.name(), e.value())).collect();
+  assert_eq!(
+    pairs,
+    std::vec![(
+      "WB_RGGBLevelsUncorrected",
+      &TagValue::Str("6576 4096 4096 8608".into())
+    )],
+    "byte-exact NX500 plaintext regardless of the key's TIFF encoding"
+  );
+}
+
+/// Bug 1, both axes signed: BOTH the key AND the encrypted value arrive as
+/// `RawValue::I64` (the shared `split(" ",$val)` splitter renders either shape
+/// to the same integer tokens) — still the byte-exact NX500 plaintext.
+#[test]
+fn emit_crypt_signed_encoded_key_and_value() {
+  let key = encryption_key_from_raw(&RawValue::I64(NX500_KEY.to_vec()));
+  let crypt_tag = lookup(0xa021).and_then(SamsungTag::crypt).unwrap();
+  // Same magnitudes as the int32u happy path, but encoded signed.
+  let raw = RawValue::I64(std::vec![6881, 4168, 4833, 9064]);
+  let mut out = Vec::new();
+  emit_crypt(
+    "WB_RGGBLevelsUncorrected",
+    crypt_tag,
+    &raw,
+    &key,
+    false,
+    &mut out,
+  );
+  let values: Vec<&TagValue> = out.iter().map(super::VendorEmission::value).collect();
+  assert_eq!(
+    values,
+    std::vec![&TagValue::Str("6576 4096 4096 8608".into())]
+  );
+}
+
+/// Bug 2: an encrypted `0xa021` whose raw is a shape that does NOT render to
+/// integers (`RawValue::Bytes`), with a NONEMPTY key, emits NOTHING — NOT a
+/// `Some("")` from decrypting an artificial empty vector. Faithful to Crypt
+/// returning undef.
+#[test]
+fn emit_crypt_non_integer_raw_emits_nothing() {
+  let crypt_tag = lookup(0xa021).and_then(SamsungTag::crypt).unwrap();
+  let raw = RawValue::Bytes(std::vec![0xde, 0xad, 0xbe, 0xef]);
+  let mut out = Vec::new();
+  // Key is present + nonempty — so the ONLY reason to drop is the un-renderable
+  // raw shape (the old `Vec::new()` path would have decrypted [] to `Some("")`).
+  emit_crypt(
+    "WB_RGGBLevelsUncorrected",
+    crypt_tag,
+    &raw,
+    &NX500_KEY,
+    false,
+    &mut out,
+  );
+  assert!(
+    out.is_empty(),
+    "an un-renderable Crypt raw shape emits NOTHING (not an empty-string tag)"
+  );
+}

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -9497,6 +9497,13 @@ pub(in crate::exif) fn samsung_makernote_isolated(
   let mut typed = MakerNotesSamsung::new();
   {
     let mut sink = VendorEmissionSink::new(&mut emissions);
+    // The `0xa020 EncryptionKey` DataMember (`Samsung.pm:489-490`), captured
+    // DURING the walk: `0xa020` precedes every `0xa021`+ Crypt tag in the
+    // ascending Type2 IFD, so by the time a Crypt entry is reached the key is
+    // set. Empty until captured (and stays empty if `0xa020` is absent/malformed)
+    // ⇒ a Crypt tag with no key emits nothing (`Samsung::Crypt`'s
+    // `$key or return undef`).
+    let mut encryption_key: std::vec::Vec<i64> = std::vec::Vec::new();
     for entry in &w.entries {
       // Only `ResolvedConv::Samsung` entries live in this run; a defensive
       // non-Samsung conv (never produced under `TableRef::Samsung`) is skipped.
@@ -9520,7 +9527,29 @@ pub(in crate::exif) fn samsung_makernote_isolated(
         }
         continue;
       }
-      // Leaf tag — the plain Samsung renderer + the gate-passing typed populate.
+      // Crypt tag (`RawConv => Samsung::Crypt`, `0xa021`..`0xa043` of the 16) —
+      // decrypt with the captured key + the row's salts/format, emitting the
+      // plaintext directly (no PrintConv: `-j` and `-n` render the same string).
+      // The decrypted arrays are raw-processing data, not camera-identity, so
+      // they populate no typed field.
+      if let Some(crypt_tag) = samsung_tag.crypt() {
+        samsung::emit_crypt(
+          samsung_tag.name(),
+          crypt_tag,
+          entry.value.raw(),
+          &encryption_key,
+          samsung_tag.is_unknown(),
+          &mut *sink.emissions,
+        );
+        continue;
+      }
+      // Plain leaf — the Samsung renderer + the gate-passing typed populate. The
+      // `0xa020 EncryptionKey` is one such leaf: it is emitted normally AND its
+      // raw int32u[11] is captured here as the Crypt key for the following rows
+      // (the `$$self{EncryptionKey} = [ split(" ",$val) ]; $val` DataMember tap).
+      if entry.tag_id == 0xa020 {
+        encryption_key = samsung::encryption_key_from_raw(entry.value.raw());
+      }
       let Ok(()) = emit_samsung_value(
         g1,
         entry,

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -8956,8 +8956,9 @@ fn makernotes_samsung_nx500_conformance() {
   // `MakerNoteSamsung2` (`MakerNotes.pm:965-979`, EXIF-format magic) and walks
   // `%Samsung::Type2` through the shared `Walker` (body offset 0, inherit base,
   // `ByteOrder => Unknown` probed to big-endian, `FixBase => 1`, `ProcessProc =>
-  // ProcessUnknown`). exifast emits all 27 plain `Samsung:*` leaves
-  // byte-identically to bundled ExifTool 13.59 — the camera-indexing identity
+  // ProcessUnknown`). exifast emits all 45 `Samsung:*` leaves (29 plain + the
+  // 16 decrypted Crypt leaves, #242) byte-identically to bundled ExifTool 13.59
+  // — the camera-indexing identity
   // (`DeviceType` = "High-end NX Camera", `SamsungModelID` = "Various Models
   // (0x5001038)", `LensType` = "Samsung NX 45mm F1.8" via %samsungLensTypes,
   // `FirmwareName` = "1.10", `LensFirmware` = "01.00_01.10",
@@ -8969,27 +8970,36 @@ fn makernotes_samsung_nx500_conformance() {
   // ASCII-string render), the `CameraTemperature` undef rational, `SensorAreas`,
   // `SmartAlbumColor` = "n/a" (the `\0{4}` branch), and the five
   // `%Samsung::PictureWizard` ProcessBinaryData members (PictureWizardMode =
-  // "Standard", Color = 65535, the -4-shifted Saturation/Sharpness/Contrast).
+  // "Standard", Color = 65535, the -4-shifted Saturation/Sharpness/Contrast),
+  // and the 16 decrypted Crypt leaves (#242, e.g. ColorMatrix =
+  // "436 -120 -60 -42 312 -14 2 -94 348", WB_RGGBLevelsBlack = "128 128 128 128").
   // The "[minor] Unrecognized MakerNotes" warning bundled emitted while Samsung
-  // was undecoded is GONE (the vendor now decodes). All 27 match for BOTH the
-  // `-j` PrintConv and `-n` numeric snapshots.
+  // was undecoded is GONE (the vendor now decodes). All 45 match for BOTH the
+  // `-j` PrintConv and `-n` numeric snapshots (a Crypt row has no PrintConv, so
+  // its plaintext is identical in both).
+  //
+  // #242: the 16 `RawConv => Samsung::Crypt(...)` encrypted leaves are now
+  // DECRYPTED and emitted — WB_RGGBLevels{Uncorrected,Auto,Illuminator1,
+  // Illuminator2,Black}, ColorMatrix{,SRGB,AdobeRGB}, CbCr{MatrixDefault,Matrix,
+  // GainDefault,Gain}, ToneCurve{SRGBDefault,AdobeRGBDefault,SRGB,AdobeRGB}. The
+  // cipher (`Samsung::Crypt`, Samsung.pm:1579-1605) decrypts each with the
+  // `0xa020 EncryptionKey` int32u[11] captured DURING the Type2 walk; exifast's
+  // plaintext space-joined integers match bundled ExifTool 13.59 BYTE-EXACT (the
+  // real-input proof the cipher port is correct).
   //
   // The goldens are generated with `gen_golden.sh EXCLUDE="…"` dropping the tags
   // exifast does NOT emit — every exclusion is a documented deferral (none masks
   // a Samsung-Type2 faithfulness gap; the diff carries NO tag exifast emits that
   // bundled does not):
-  //   -x Samsung:<16 Crypt tags> — the `RawConv => Samsung::Crypt(...)`
-  //                        encrypted block `0xa021`..`0xa057` EXCEPT the plain
-  //                        `0xa025` (WB_RGGBLevels*, ColorMatrix*, CbCr*,
-  //                        ToneCurve*) — raw-processing data, deferred.
-  //                        (`0xa020 EncryptionKey` + `0xa025`
-  //                        HighlightLinearityLimit are plain leaves, EMITTED.)
   //   -x PreviewIFD:all  — the `0x0035 PreviewIFD` Nikon-PreviewIFD sub-IFD
   //                        (PreviewImage + its IFD tags), deferred.
   //   -x SubIFD:all -x SubIFD1:all — the SRW raw/JpgFromRaw sub-IFDs (the raw
   //                        image strips + the embedded JPEG), not walked.
   //   -x Composite:all   — exifast has no EXIF Composite subsystem (drops the
   //                        Composite:LensID/ImageSize/WB_RGGBLevels/… synthesis).
+  // (The deferred `Unknown => 1` Crypt rows 0xa048/0xa05x are NOT excluded here:
+  // ExifTool suppresses them from default `-j` output, so bundled never emits
+  // them either — no `-x` is needed.)
   // (The `0x0011 OrientationInfo` row is absent from this body. The
   // `0xa002 SerialNumber` row IS present, but its value is `"0"` + NULs, which
   // fails the `Condition => '$$valPt =~ /^\w{5}/'` gate (`Samsung.pm:404-409`)

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -4228,6 +4228,25 @@ fn real_fixture_samsung_nx500_type2() {
     // only duplicate id (overwriting the earlier 0xa025 DigitalGain Crypt row);
     // plain int32u ⇒ the raw value 3791 (Codex R3).
     ("Samsung:HighlightLinearityLimit", "3791"),
+    // The decrypted Crypt leaves (#242) — `Samsung::Crypt` decrypts each with
+    // the captured 0xa020 EncryptionKey; the plaintext space-joined integers
+    // match bundled ExifTool byte-exact (real-input proof).
+    (
+      "Samsung:WB_RGGBLevelsUncorrected",
+      r#""6576 4096 4096 8608""#,
+    ),
+    ("Samsung:WB_RGGBLevelsAuto", r#""6576 4096 4096 8608""#),
+    ("Samsung:WB_RGGBLevelsBlack", r#""128 128 128 128""#),
+    (
+      "Samsung:ColorMatrix",
+      r#""436 -120 -60 -42 312 -14 2 -94 348""#,
+    ),
+    ("Samsung:CbCrMatrix", r#""233 235 -218 524""#),
+    ("Samsung:CbCrGain", r#""3359 3640""#),
+    (
+      "Samsung:ToneCurveSRGB",
+      r#""11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255""#,
+    ),
   ] {
     let got = map
       .get(key)
@@ -4240,17 +4259,16 @@ fn real_fixture_samsung_nx500_type2() {
     );
   }
 
-  // The deferred genuinely-Crypt leaves (RawConv => Samsung::Crypt) + the
-  // SubDirectory parent pointer must NOT leak a value. (0xa020 EncryptionKey and
-  // 0xa025 HighlightLinearityLimit are PLAIN leaves and ARE emitted — asserted
+  // The SubDirectory parent pointer must NOT leak a value (its members are
+  // surfaced separately, asserted above), and the still-deferred `Unknown => 1`
+  // Crypt rows (0xa048 RawData, 0xa050 Distortion) must be absent — ExifTool
+  // suppresses Unknown tags from default output. (The 16 emitted Crypt leaves +
+  // 0xa020 EncryptionKey + 0xa025 HighlightLinearityLimit ARE present — asserted
   // above; they are NOT in this absent set.)
   for absent in [
-    "Samsung:WB_RGGBLevelsAuto",
-    "Samsung:WB_RGGBLevelsUncorrected",
-    "Samsung:ColorMatrix",
-    "Samsung:CbCrGain",
-    "Samsung:ToneCurveSRGB",
     "Samsung:PictureWizard",
+    "Samsung:RawData",
+    "Samsung:Distortion",
   ] {
     assert!(
       !map.contains_key(absent),

--- a/tests/golden/SamsungNX500.srw.json
+++ b/tests/golden/SamsungNX500.srw.json
@@ -61,5 +61,21 @@
   "Samsung:FNumber": 8.9,
   "Samsung:FocalLengthIn35mmFormat": "69 mm",
   "Samsung:EncryptionKey": "305 72 737 456 282 307 519 724 13 505 193",
-  "Samsung:HighlightLinearityLimit": 3791
+  "Samsung:WB_RGGBLevelsUncorrected": "6576 4096 4096 8608",
+  "Samsung:WB_RGGBLevelsAuto": "6576 4096 4096 8608",
+  "Samsung:WB_RGGBLevelsIlluminator1": "5280 4096 4096 9808",
+  "Samsung:WB_RGGBLevelsIlluminator2": "7312 4096 4096 5968",
+  "Samsung:HighlightLinearityLimit": 3791,
+  "Samsung:WB_RGGBLevelsBlack": "128 128 128 128",
+  "Samsung:ColorMatrix": "436 -120 -60 -42 312 -14 2 -94 348",
+  "Samsung:ColorMatrixSRGB": "378 -102 -20 -28 328 -44 8 -100 348",
+  "Samsung:ColorMatrixAdobeRGB": "244 36 -24 -26 320 -38 8 -72 320",
+  "Samsung:CbCrMatrixDefault": "256 0 0 256",
+  "Samsung:CbCrMatrix": "233 235 -218 524",
+  "Samsung:CbCrGainDefault": "3791 4024",
+  "Samsung:CbCrGain": "3359 3640",
+  "Samsung:ToneCurveSRGBDefault": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255",
+  "Samsung:ToneCurveAdobeRGBDefault": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255",
+  "Samsung:ToneCurveSRGB": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255",
+  "Samsung:ToneCurveAdobeRGB": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255"
 }]

--- a/tests/golden/SamsungNX500.srw.n.json
+++ b/tests/golden/SamsungNX500.srw.n.json
@@ -61,5 +61,21 @@
   "Samsung:FNumber": 8.9,
   "Samsung:FocalLengthIn35mmFormat": 69,
   "Samsung:EncryptionKey": "305 72 737 456 282 307 519 724 13 505 193",
-  "Samsung:HighlightLinearityLimit": 3791
+  "Samsung:WB_RGGBLevelsUncorrected": "6576 4096 4096 8608",
+  "Samsung:WB_RGGBLevelsAuto": "6576 4096 4096 8608",
+  "Samsung:WB_RGGBLevelsIlluminator1": "5280 4096 4096 9808",
+  "Samsung:WB_RGGBLevelsIlluminator2": "7312 4096 4096 5968",
+  "Samsung:HighlightLinearityLimit": 3791,
+  "Samsung:WB_RGGBLevelsBlack": "128 128 128 128",
+  "Samsung:ColorMatrix": "436 -120 -60 -42 312 -14 2 -94 348",
+  "Samsung:ColorMatrixSRGB": "378 -102 -20 -28 328 -44 8 -100 348",
+  "Samsung:ColorMatrixAdobeRGB": "244 36 -24 -26 320 -38 8 -72 320",
+  "Samsung:CbCrMatrixDefault": "256 0 0 256",
+  "Samsung:CbCrMatrix": "233 235 -218 524",
+  "Samsung:CbCrGainDefault": "3791 4024",
+  "Samsung:CbCrGain": "3359 3640",
+  "Samsung:ToneCurveSRGBDefault": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255",
+  "Samsung:ToneCurveAdobeRGBDefault": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255",
+  "Samsung:ToneCurveSRGB": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255",
+  "Samsung:ToneCurveAdobeRGB": "11 0 16 32 64 128 256 512 1024 2048 3072 4095 0 7 14 28 52 90 140 190 230 245 255"
 }]


### PR DESCRIPTION
Phase-2 core of #242: port `Samsung::Crypt` so the encrypted Samsung Type2 tags decode, **proven real-input byte-exact on the NX500 fixture**.

## The cipher (faithful to Samsung.pm:1579-1605)

A per-element additive cipher: `a[i] += sign * key[(salt+i-start) % 11]` with per-format integer wrap (`max-min+1`), per-tag salt (a leading `-` ⇒ sign −1), and the array length-entry skip. The EncryptionKey (0xa020, int32u[11]) is captured as a DataMember during the ascending Type2 walk (before the encrypted tags), mirroring ExifTool.

## Real-input proof (NX500)

The 16 encrypted tags — WB_RGGBLevels{Uncorrected/Auto/Illuminator1/Illuminator2/Black}, Color{Matrix/MatrixSRGB/MatrixAdobeRGB}, CbCr{MatrixDefault/Matrix/GainDefault/Gain}, ToneCurve{SRGBDefault/AdobeRGBDefault/SRGB/AdobeRGB} — now decrypt **byte-exact vs bundled ExifTool 13.59** (e.g. ColorMatrix `436 -120 -60 -42 312 -14 2 -94 348`, ToneCurveSRGB, WB_RGGBLevelsBlack `128 128 128 128`). The NX500 golden was regenerated to include them.

## Wrong-format robustness (R2)

Both the key capture and the Crypt value drive through one shared `split_val_to_ints` that mirrors ExifTool's `split(" ",$val)` — format-agnostic over signed/unsigned/array shapes, returning `None` (no emission) for un-renderable shapes (so an un-renderable Crypt value emits **nothing**, not `""`, matching `Crypt` returning undef; and a signed-encoded 0xa020 is captured rather than silently dropping all Crypt tags).

## Verify

`fmt=0  build(-Dwarnings)=0  conformance=425/0 (NX500 byte-exact w/ the 16 decrypted)  exif_makernotes_dispatch=72/0 (incl 4 wrong-format tests)  typed_serde=green(530)  lib=3165/0 (15 crypt unit vectors + 4 wrong-format)`

**Codex adversarial review: APPROVE (R2).** R1 flagged the narrow-typing wrong-format gap; R2 confirmed the shared-splitter fix.

## Remaining Phase-2 (follow-on)

The OrientationInfo (0x0011) + PreviewIFD (0x0035→Nikon::PreviewIFD) SubDirectories — both absent from NX500 (crafted-only) — complete #242; PictureWizard (0x0021) already landed in Phase 1.