### PR TITLE
feat(exif): port the maker-note directory-size salvage clamp (Exif.pm:6384, #248)

### DIFF
--- a/src/exif/makernotes/vendors/canon/body.rs
+++ b/src/exif/makernotes/vendors/canon/body.rs
@@ -38,11 +38,22 @@ pub(crate) enum CanonDirShape {
   /// `Exif.pm:6391`). Reached for a readable directory whose
   /// `$bytesFromEnd` is `0`, `2`, or `>= 4` (`Exif.pm:6395-6399`).
   Walk { num_entries: usize, dir_end: usize },
+  /// The count word READ cleanly but the directory's declared extent
+  /// (`$dirEnd = $dirStart + 2 + 12*$numEntries`) runs PAST the buffer
+  /// (`$dirEnd > $dataLen` ⇒ `undef $dirSize`, `Exif.pm:6356`). With no RAF to
+  /// re-read the IFD from the file, ExifTool warns `Bad <dir> directory`
+  /// (`Exif.pm:6381`) and then either SALVAGES (maker notes — see
+  /// [`salvage_makernote_overrun`]) or `return 0`s (a core IFD). Split out from
+  /// [`CanonDirShape::AbortBadDirectory`] so a maker-note caller can apply the
+  /// salvage clamp while the CTMD / `$inMakerNotes = 0` caller still aborts.
+  /// `num_entries` is the (over-claimed) READ count, retained only to keep the
+  /// abort path's `Illegal … (<n> entries)`-style diagnostics faithful.
+  Overrun { num_entries: usize },
   /// Abort with NO warning here — the structural path already raised
-  /// `Bad <dir> directory` (`Exif.pm:6383`): the IFD0 count is unreadable, or
-  /// the directory overruns the block (`$dirEnd > $dataLen`,
-  /// `Exif.pm:6356`; for the `$inMakerNotes = 0` framing the generic walker
-  /// reuses, an overrun aborts rather than salvages).
+  /// `Bad <dir> directory` (`Exif.pm:6383`): the IFD0 count is unreadable
+  /// (`$dirStart > $dataLen-2`), or the extent arithmetic overflows `usize`
+  /// (the 32-bit/wasm class — an overflow can never describe an in-range
+  /// directory). A clean-count BUFFER OVERRUN is [`CanonDirShape::Overrun`].
   AbortBadDirectory,
   /// Abort AND raise `Illegal <dir> directory size (<n> entries)`
   /// (`Exif.pm:6397`) — a `$bytesFromEnd` of `1` or `3`. NON-minor (the Perl
@@ -95,10 +106,12 @@ pub(crate) fn classify_canon_directory(
     return CanonDirShape::AbortBadDirectory;
   };
   // `undef $dirSize if $dirEnd > $dataLen` (Exif.pm:6356) ⇒ the no-RAF
-  // `$success = 0` path ⇒ `Bad <dir> directory` + abort (the `$inMakerNotes`
-  // salvage only changes the VERBOSE entry walk, which is not modelled).
+  // `$success = 0` path ⇒ `Bad <dir> directory` (`Exif.pm:6381`). For a maker
+  // note this is the salvage gate (`Exif.pm:6382-6388`, [`salvage_makernote_overrun`]);
+  // for the `$inMakerNotes = 0` / CTMD framing it is a plain abort. Surface it
+  // as the distinct [`CanonDirShape::Overrun`] so the caller decides.
   if dir_end > data_len {
-    return CanonDirShape::AbortBadDirectory;
+    return CanonDirShape::Overrun { num_entries };
   }
   // `my $bytesFromEnd = $dataLen - $dirEnd; if ($bytesFromEnd < 4) { unless
   // ($bytesFromEnd==2 or $bytesFromEnd==0) { Warn("Illegal …"); return 0 } }`
@@ -111,6 +124,63 @@ pub(crate) fn classify_canon_directory(
     num_entries,
     dir_end,
   }
+}
+
+/// The MakerNote directory-size SALVAGE clamp (`Exif.pm:6382-6393`) — the ONE
+/// shared decision driving BOTH the shared `Walker`'s emission walk
+/// (`exif/mod.rs` `walk_one_ifd_body`) AND the Canon `%CameraSettings`
+/// DataMember pre-scan (`exif/mod.rs` `canon_prescan_datamembers`), so a
+/// salvaged directory is walked IDENTICALLY by both passes (the pre-scan must
+/// extract `FocalUnits`/`LensType` from the SAME clamped entry set the emission
+/// walk renders, or the dependent sub-tables — FocalLength / FileInfo — would
+/// emit defaults).
+///
+/// Applies ONLY when [`classify_canon_directory`] returned
+/// [`CanonDirShape::Overrun`] (a clean-count buffer overrun). Ports:
+///
+/// ```text
+/// return 0 unless $inMakerNotes and $dirLen >= 14 and $dirStart >= 0 and
+///                 $dirStart + $dirLen <= length($$dataPt);
+/// $dirSize = $dirLen;
+/// $numEntries = int(($dirSize - 2) / 12);  # read what we can
+/// $dirSize = 2 + 12 * $numEntries;
+/// $dirEnd = $dirStart + $dirSize;
+/// ```
+///
+/// `in_maker_notes` is ExifTool's `$inMakerNotes` (`$$tagTablePtr{GROUPS}{0} eq
+/// 'MakerNotes'` — exactly `!active_table.is_core_ifd()` at the call site).
+/// `dir_len` is `$$dirInfo{DirLen}` — the declared `0x927c` value window, already
+/// reduced by any `ProcessUnknown` `LocateIFD` relocation delta by the caller.
+///
+/// Returns the CLAMPED `(num_entries, dir_end)` to walk, or `None` to abort the
+/// whole directory (`return 0`) — for a core IFD, a missing/`< 14` `dir_len`, or
+/// a window that does not fit `[dir_start, dir_start + dir_len] <= data_len`.
+///
+/// `dir_len >= 14` guarantees `(dir_len - 2) / 12 >= 1`, and the recomputed
+/// `dir_end = dir_start + 2 + 12*int((dir_len-2)/12) <= dir_start + dir_len <=
+/// data_len` — so the caller's subsequent `bytes_from_end` subtraction cannot
+/// underflow and the entry walk stays in bounds. Every `+` is `checked_*` for the
+/// 32-bit/wasm overflow class (an overflow can never fit the buffer).
+pub(crate) fn salvage_makernote_overrun(
+  dir_start: usize,
+  data_len: usize,
+  in_maker_notes: bool,
+  dir_len: Option<usize>,
+) -> Option<(usize, usize)> {
+  // `return 0 unless $inMakerNotes and $dirLen >= 14 and
+  //                  $dirStart + $dirLen <= length($$dataPt)` (Exif.pm:6382-6385).
+  // `$dirStart >= 0` is implicit (`dir_start: usize`).
+  let dir_len = dir_len.filter(|_| in_maker_notes).filter(|&dir_len| {
+    dir_len >= 14
+      && dir_start
+        .checked_add(dir_len)
+        .is_some_and(|end| end <= data_len)
+  })?;
+  // `$numEntries = int(($dirSize - 2) / 12); $dirEnd = $dirStart + 2 + 12*$numEntries`
+  // (Exif.pm:6386-6393) — "read what we can".
+  let num_entries = (dir_len - 2) / 12;
+  let dir_end = dir_start.checked_add(2 + 12 * num_entries)?;
+  Some((num_entries, dir_end))
 }
 
 /// The per-entry classification shared by the Canon `0x927c` emission walk and

--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -569,7 +569,11 @@ pub fn redispatch_ctmd_makernote_value_offset_diagnostics(
         num_entries,
         dir_end,
       } => (num_entries, dir_end),
-      CanonDirShape::AbortBadDirectory => return out,
+      // The CTMD re-dispatch is the `$inMakerNotes = 0` framing (the diagnostic
+      // walk has no `DirLen` window): a clean-count overrun ABORTS exactly like
+      // `AbortBadDirectory`, NOT salvaged (the maker-note salvage is applied only
+      // at the two emission sites via [`body::salvage_makernote_overrun`]).
+      CanonDirShape::Overrun { .. } | CanonDirShape::AbortBadDirectory => return out,
       CanonDirShape::AbortIllegalSize { num_entries } => {
         out.push(Diagnostic::warn(std::format!(
           "Illegal IFD0 directory size ({num_entries} entries)"

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -2470,6 +2470,8 @@ fn parse_tiff_with_base_no_raf<'a>(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // Top-level walk — no maker-note `DirLen` (the salvage is gated to maker notes).
+    dir_len: None,
   };
   // Walk the IFD0 → IFD1 chain (the next-IFD pointer). ExifIFD/GPS/Interop
   // are reached as SubDirectories from inside the walk. `ifd0_kind` is `Ifd0`
@@ -2608,6 +2610,8 @@ fn parse_bigtiff<'a>(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // BigTIFF top-level walk — no maker-note `DirLen` (salvage gated to maker notes).
+    dir_len: None,
   };
   w.walk_big_ifd_chain(ifd0_offset, ifd0_kind);
   debug_assert!(
@@ -2799,6 +2803,8 @@ fn parse_tiff_with_base_shared<'a>(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // Top-level walk — no maker-note `DirLen` (the salvage is gated to maker notes).
+    dir_len: None,
   };
   w.walk_ifd_chain(ifd0_offset, IfdKind::Ifd0);
 
@@ -3115,6 +3121,20 @@ struct Walker<'a, 'g> {
   /// by [`emit_canon_subtable`]'s FocalLength arm. `None` when no readable 0x02
   /// exists ⇒ that arm (and the oracle) emit nothing for FocalLength.
   canon_focal_length_blob: Option<std::vec::Vec<u8>>,
+  /// `$$dirInfo{DirLen}` — the DECLARED byte length of the (sub-)directory being
+  /// walked (`Exif.pm:6285` `$dirLen = $$dirInfo{DirLen} || $dataLen - $dirStart`).
+  /// For a MakerNote SubDirectory this is the `0x927c` value size (`DirLen => $size`,
+  /// `Exif.pm:7126`); it gates the maker-note directory-size SALVAGE clamp in
+  /// [`walk_one_ifd_body`] (`Exif.pm:6384-6388`): when the IFD count word claims a
+  /// directory bigger than the buffer, an in-maker-note walk with `dir_len >= 14`
+  /// (and `[ifd_start, ifd_start+dir_len]` in range) reads `(dir_len-2)/12` entries
+  /// instead of aborting. `Some(mn_len)` only on the isolated vendor walkers; `None`
+  /// for every core IFD / top-level walk — where the salvage never fires (it is also
+  /// gated on `!active_table.is_core_ifd()`, i.e. ExifTool's `$inMakerNotes`), so the
+  /// field's value there is irrelevant. [`process_subdir`] reduces it by the
+  /// `ProcessUnknown` `LocateIFD` relocation delta (`DirLen -= offset`,
+  /// `MakerNotes.pm:1589`/`:1658`) for the duration of that sub-walk.
+  dir_len: Option<usize>,
 }
 
 impl Walker<'_, '_> {
@@ -3351,11 +3371,12 @@ impl Walker<'_, '_> {
       self.warn(std::format!("Bad {} directory", kind.as_str()));
       return None;
     }
-    let num_entries = get_u16(data, ifd_start, self.order)? as usize;
+    let mut num_entries = get_u16(data, ifd_start, self.order)? as usize;
     // `$dirSize = 2 + 12 * $numEntries; $dirEnd = $dirStart + $dirSize`,
     // each step checked (see the overflow note above) — overflow ⇒ the
-    // Bad-directory abort.
-    let Some(dir_end) = num_entries
+    // Bad-directory abort. (`mut`: the maker-note salvage below re-clamps both
+    // `num_entries` and `dir_end` to the declared `dir_len`.)
+    let Some(mut dir_end) = num_entries
       .checked_mul(12)
       .and_then(|body| body.checked_add(2))
       .and_then(|dir_size| ifd_start.checked_add(dir_size))
@@ -3368,20 +3389,62 @@ impl Walker<'_, '_> {
     // (Exif.pm:6389-6395). If the IFD overruns the buffer entirely we
     // cannot read its entries — abort.
     if dir_end > data.len() {
-      // The IFD's declared extent runs past the EXIF block. ExifTool's
-      // "read what we can" salvage (`$numEntries = int(($dirSize-2)/12)`,
-      // Exif.pm:6386-6388) is GATED to MakerNotes: `return 0 unless
-      // $inMakerNotes and $dirLen >= 14 …` (Exif.pm:6381-6385). For a
-      // normal IFD0/IFD1/ExifIFD/GPS/InteropIFD the count cannot be read
-      // reliably (the file-seek fallback at Exif.pm:6362-6374 fails its
-      // `Read` and yields `$success = 0`), so ExifTool warns
-      // "Bad $dir directory" and aborts the WHOLE directory — no partial
-      // tags. The exifast walker never recurses into a MakerNote IFD
-      // (vendor parsing is deferred — see [`SubDirKind::MakerNote`]), so
-      // every directory kind it handles takes the abort branch.
-      // `$et->Warn("Bad $dir directory")` — Exif.pm:6381.
+      // The IFD's declared extent runs past the buffer (`$dirEnd > $dataLen` ⇒
+      // `undef $dirSize`, Exif.pm:6356). With no RAF to re-read the IFD from the
+      // file (`$success = 0`), ExifTool warns `Bad $dir directory` — MINOR while
+      // `$inMakerNotes` (`$et->Warn("Bad $dir directory", $inMakerNotes)`,
+      // Exif.pm:6381) — and then SALVAGES for maker notes (`Exif.pm:6382-6388`):
+      //
+      //   return 0 unless $inMakerNotes and $dirLen >= 14 and $dirStart >= 0 and
+      //                   $dirStart + $dirLen <= length($$dataPt);
+      //   $dirSize = $dirLen;
+      //   $numEntries = int(($dirSize - 2) / 12);  # read what we can
+      //
+      // i.e. when the count word claims more entries than fit the buffer BUT the
+      // walk is in a maker note (`$$tagTablePtr{GROUPS}{0} eq 'MakerNotes'` —
+      // exactly `!active_table.is_core_ifd()`) AND the declared maker-note length
+      // `$dirLen` is a valid minimal IFD (`>= 14` = 2 count + one 12-byte entry)
+      // whose `[dirStart, dirStart+dirLen]` window fits the buffer, CLAMP
+      // `numEntries` to `(dirLen - 2) / 12` and walk that many entries (from the
+      // declared maker-note region) instead of aborting. A core IFD
+      // (IFD0/IFD1/ExifIFD/GPS/InteropIFD — `is_core_ifd()`, `$inMakerNotes == 0`)
+      // or a maker note whose `$dirLen < 14` / out-of-range window still `return
+      // 0`s the WHOLE directory.
+      //
+      // The warning is recorded on THIS walk's channel via `warn` (NOT
+      // `warn_counted` — ExifTool's `Warn` here is not followed by `++$warnCount`);
+      // for a maker-note sub-walk the isolated `Walker` discards its `warnings`
+      // (every other maker-note `$et->Warn` is dropped the same way), so the
+      // observable salvage effect is the EMITTED tags from the clamped entries.
       self.warn(std::format!("Bad {} directory", kind.as_str()));
-      return None;
+      // The salvage decision is the SHARED [`salvage_makernote_overrun`]
+      // (`body.rs`) — the SAME helper [`canon_prescan_datamembers`] drives, so a
+      // salvaged Canon directory is pre-scanned over the IDENTICAL clamped entry
+      // set this emission walk renders (the DataMembers it extracts therefore feed
+      // the dependent FocalLength / FileInfo sub-tables). `$inMakerNotes` is
+      // `!self.active_table.is_core_ifd()`; `self.dir_len` is `$$dirInfo{DirLen}`
+      // (already reduced by any `ProcessUnknown` `LocateIFD` delta in
+      // [`process_subdir`]). `None` ⇒ abort the whole directory (`return 0`,
+      // Exif.pm:6382): a core IFD, a missing/`< 14` `dir_len`, or an out-of-range
+      // window. (ExifTool also `Set16u`s the clamped count back into the buffer;
+      // the port reads the count once into `num_entries`, so the clamped value
+      // drives `walk_entries` directly — re-storing it is unnecessary.) The warning
+      // is recorded on THIS walk's channel via `warn` (not `warn_counted` —
+      // ExifTool's `Warn` here is not followed by `++$warnCount`); a maker-note
+      // sub-walk's isolated `Walker` discards its `warnings`, so the observable
+      // salvage effect is the EMITTED tags from the clamped entries.
+      let Some((salvaged_entries, salvaged_end)) =
+        makernotes::vendors::canon::body::salvage_makernote_overrun(
+          ifd_start,
+          data.len(),
+          !self.active_table.is_core_ifd(),
+          self.dir_len,
+        )
+      else {
+        return None;
+      };
+      num_entries = salvaged_entries;
+      dir_end = salvaged_end;
     }
 
     // `my $bytesFromEnd = $dataLen - $dirEnd; if ($bytesFromEnd < 4) {
@@ -4835,29 +4898,67 @@ impl Walker<'_, '_> {
 
     // ---- Pre-walk hook 2: ProcessUnknown's `LocateIFD` (`MakerNotes.pm:1816-
     // 1837`). Only `ProcessProc::Unknown` relocates the IFD start + order; the
-    // other processors keep `ifd_start`/`resolved_order` as derived. A failed
-    // locate leaves them unchanged (the walk then bounds-rejects, mirroring
-    // `ProcessUnknown`'s `Unrecognized` warn arm). Inert for `Exif`/`Canon`.
+    // other processors keep `ifd_start`/`resolved_order` as derived. Inert for
+    // `Exif`/`Canon`/`BinaryData`.
     //
     // `locate_ifd` returns the located IFD offset RELATIVE to the `ifd_start` it
     // was handed (its scan runs `0..=32` from `dir_start`), so the ABSOLUTE
     // position in `self.data` is `ifd_start + located`. Adding it back is
-    // essential for any maker note whose blob begins at a non-zero TIFF offset;
-    // a `checked_add` overflow (degenerate input) falls back to the unrelocated
-    // start, which the walk then bounds-rejects.
-    let (ifd_start, resolved_order) = match process {
-      ProcessProc::Unknown => makernotes::fixbase::locate_ifd(
-        self.data,
-        ifd_start,
-        None,
-        resolved_order,
-        self.captured_make.as_deref(),
-        self.captured_model.as_deref(),
-      )
-      .and_then(|(located, order)| ifd_start.checked_add(located).map(|abs| (abs, order)))
-      .unwrap_or((ifd_start, resolved_order)),
+    // essential for any maker note whose blob begins at a non-zero TIFF offset.
+    //
+    // ABORT on no candidate (`MakerNotes.pm:1834`). `LocateIFD` returning `undef`
+    // is ExifTool's `Unrecognized MakerNotes` arm — `ProcessUnknown` then `return
+    // 0` WITHOUT walking the directory (it processes NOTHING). So a `None` here
+    // (no plausible IFD within the declared window) ABORTS the whole sub-directory
+    // — `return` BEFORE FixBase, the Canon pre-scan, and `walk_one_ifd`, emitting no
+    // tags. This is load-bearing now that `walk_one_ifd_body` SALVAGES a non-core
+    // count-word overrun (clamping `num_entries` by the same `dir_len`): without
+    // the abort, the `None` would fall back to `ifd_start` and the salvage could
+    // emit spurious vendor tags from a count word at the UNRELOCATED start whose
+    // first clamped entry happens to be a valid vendor tag — even though `LocateIFD`
+    // legitimately found no in-window IFD. A post-`Some` `checked_add` overflow
+    // (degenerate input that can't yield an absolute start) aborts for the same
+    // reason: there is no walkable relocated IFD.
+    //
+    // `self.dir_len` is threaded as `LocateIFD`'s `$$dirInfo{DirLen}`
+    // (`MakerNotes.pm:1501` `my $dirLen = defined $$dirInfo{DirLen} ? … : $size`):
+    // it BOUNDS the relocation-candidate scan — the `$offset + 14 > $dirLen` IFD_TRY
+    // cutoff (`:1573`) and the TIFF-header `$ptr + $offset + 14 <= $dirLen` window
+    // (`:1586`) — so a relocated IFD candidate must fit the DECLARED maker-note
+    // window, not the whole trailing buffer. Without it (`None` ⇒ `$dirLen = $size`)
+    // a TRUNCATED MakerNote could relocate onto IFD-shaped bytes that lie AFTER the
+    // declared `0x927c` value and emit spurious vendor tags. `None` for a `dir_len`-
+    // less caller keeps the prior full-buffer scan. (The standard-IFD arm's
+    // `$bytesFromEnd` still uses `$size`, `:1613` — unchanged.)
+    let (ifd_start, resolved_order, locate_delta) = match process {
+      ProcessProc::Unknown => {
+        let Some(relocated) = makernotes::fixbase::locate_ifd(
+          self.data,
+          ifd_start,
+          self.dir_len,
+          resolved_order,
+          self.captured_make.as_deref(),
+          self.captured_model.as_deref(),
+        )
+        .and_then(|(located, order)| {
+          // `LocateIFD` returns the IFD start RELATIVE to the handed `ifd_start`, so
+          // the relocation delta is exactly `located` — ExifTool advances
+          // `$$dirInfo{DirStart} += $offset` and shrinks `$$dirInfo{DirLen} -= $offset`
+          // by the SAME amount (`MakerNotes.pm:1657-1658`), keeping `DirStart+DirLen`
+          // invariant. Carry `located` so the `dir_len` (the salvage gate) tracks it.
+          ifd_start
+            .checked_add(located)
+            .map(|abs| (abs, order, located))
+        }) else {
+          // `Unrecognized MakerNotes` ⇒ `ProcessUnknown` processes nothing
+          // (`MakerNotes.pm:1834`). Abort the sub-directory: emit no tags, leaving
+          // every saved field untouched (none were mutated yet).
+          return;
+        };
+        relocated
+      }
       ProcessProc::Exif | ProcessProc::Canon | ProcessProc::BinaryData => {
-        (ifd_start, resolved_order)
+        (ifd_start, resolved_order, 0)
       }
     };
 
@@ -4955,9 +5056,18 @@ impl Walker<'_, '_> {
     let saved_table = self.active_table;
     let saved_order = self.order;
     let saved_warn_count = self.warn_count;
+    // `$$dirInfo{DirLen}` is per-`ProcessExif`-call (`Exif.pm:6285`); scope it like
+    // the table/order/warn-count fields. `ProcessUnknown`'s `LocateIFD` advanced
+    // `ifd_start` by `locate_delta`, so the remaining declared length shrinks by the
+    // same amount (`$$dirInfo{DirLen} -= $offset`, `MakerNotes.pm:1658`) — keeping
+    // the salvage window `[ifd_start, ifd_start+dir_len]` correct for the relocated
+    // IFD. `None` (a core sub-IFD / a `dir_len`-less caller) stays `None`.
+    let saved_dir_len = self.dir_len;
+    self.dir_len = self.dir_len.map(|d| d.saturating_sub(locate_delta));
     self.active_table = table;
     self.order = resolved_order;
     let _ = self.walk_one_ifd(ifd_start, kind);
+    self.dir_len = saved_dir_len;
     self.warn_count = saved_warn_count;
     self.order = saved_order;
     self.active_table = saved_table;
@@ -5005,6 +5115,7 @@ impl Walker<'_, '_> {
   fn canon_prescan_datamembers(&mut self, ifd_start: usize, order: ByteOrder) {
     use makernotes::vendors::canon::body::{
       CanonDirShape, CanonEntryClass, classify_canon_directory, classify_canon_entry,
+      salvage_makernote_overrun,
     };
     use makernotes::vendors::canon::{camera_settings, read_focal_units};
     // Reset first: the members are only meaningful for THIS Canon walk.
@@ -5013,14 +5124,34 @@ impl Walker<'_, '_> {
     self.canon_focal_length_blob = None;
     let data = self.data;
     // Directory shape — the SHARED `ProcessExif` gate (`Exif.pm:6343-6400`) the
-    // emission walk uses. A degenerate/overrunning/`1`/`3`-byte-tail directory
-    // walks no entries (so both members stay `None`); only the `Walk` arm walks.
-    let CanonDirShape::Walk {
-      num_entries,
-      dir_end,
-    } = classify_canon_directory(data, ifd_start, data.len(), order)
-    else {
-      return;
+    // emission walk uses. A degenerate/`1`/`3`-byte-tail directory walks no
+    // entries (so both members stay `None`); only the `Walk` arm — or a SALVAGED
+    // `Overrun` — walks.
+    let (num_entries, dir_end) = match classify_canon_directory(data, ifd_start, data.len(), order)
+    {
+      CanonDirShape::Walk {
+        num_entries,
+        dir_end,
+      } => (num_entries, dir_end),
+      // A clean-count buffer overrun: apply the SAME maker-note salvage clamp
+      // the emission walk does (`walk_one_ifd_body` → [`salvage_makernote_overrun`]),
+      // so the pre-scan extracts `FocalUnits`/`LensType` from the IDENTICAL
+      // clamped entry set the emission walk renders — otherwise a salvaged
+      // Canon directory's dependent FocalLength / FileInfo sub-tables would emit
+      // defaults. The Canon Main IFD is always a maker note (this pre-scan runs
+      // ONLY under `TableRef::Canon`, `!is_core_ifd`), so `$inMakerNotes` is
+      // unconditionally `true`; `self.dir_len` is `$$dirInfo{DirLen}` (Canon uses
+      // `ProcessProc::Canon`, so no `LocateIFD` delta — it is unadjusted here).
+      // `None` (a missing/`< 14`/out-of-range `dir_len`) ⇒ walk no entries, like
+      // the emission walk's abort.
+      CanonDirShape::Overrun { .. } => {
+        let Some(salvaged) = salvage_makernote_overrun(ifd_start, data.len(), true, self.dir_len)
+        else {
+          return;
+        };
+        salvaged
+      }
+      CanonDirShape::AbortBadDirectory | CanonDirShape::AbortIllegalSize { .. } => return,
     };
     let entries_start = ifd_start + 2;
     // `$warnCount` — the SAME per-entry abort cap the emission walk honors
@@ -8185,6 +8316,8 @@ pub(in crate::exif) fn apple_makernote_isolated(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Apple IFD's declared length: the captured value (`blob`) end minus the `14 + header` body offset (`Exif.pm:6385` salvage gate).
+    dir_len: Some(blob.len().saturating_sub(ifd_offset)),
   };
   // The Apple Main IFD walk — the SAME `process_subdir` entry the Canon walk uses,
   // but with `ProcessProc::Exif` (Apple needs NO Canon DataMember pre-scan; the
@@ -8378,6 +8511,8 @@ pub(in crate::exif) fn sony_makernote_isolated(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Sony IFD's declared length: the `0x927c` value size minus the body offset (the salvage gate, `Exif.pm:6383`).
+    dir_len: Some(mn_len.saturating_sub(body_offset)),
   };
   // The Sony Main IFD walk — `ProcessProc::Exif` (Sony needs NO Canon DataMember
   // pre-scan; the `if table == TableRef::Canon` hook is inert). `Fixed(order)` is
@@ -8662,6 +8797,8 @@ pub(in crate::exif) fn panasonic_makernote_isolated_with_offset(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Panasonic IFD's declared length: the `0x927c` value size minus the body offset (the salvage gate, `Exif.pm:6383`).
+    dir_len: Some(mn_len.saturating_sub(body_offset)),
   };
   // The Panasonic Main IFD walk — `ProcessProc::Exif` (Panasonic needs NO Canon
   // DataMember pre-scan; the `if table == TableRef::Canon` hook is inert).
@@ -8925,6 +9062,8 @@ pub(in crate::exif) fn nikon_makernote_isolated(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Nikon IFD's declared length: the `0x927c` value size minus the layout's body offset (equal in both the blob and parent-TIFF layouts; the salvage gate, `Exif.pm:6383`).
+    dir_len: Some(mn_len.saturating_sub(layout.ifd_offset())),
   };
   // The Nikon Main/Type2 IFD walk — `ProcessProc::Exif` (Nikon needs NO Canon
   // DataMember pre-scan; the `if table == TableRef::Canon` hook is inert).
@@ -9209,6 +9348,8 @@ pub(in crate::exif) fn pentax_makernote_isolated(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Pentax IFD's declared length: the `0x927c` value size minus the body offset; `process_subdir` further subtracts the `LocateIFD` relocation (the salvage gate, `Exif.pm:6383`).
+    dir_len: Some(mn_len.saturating_sub(body_offset)),
   };
   // The Pentax Main IFD walk — `ProcessProc::Unknown` runs `LocateIFD` (Pentax's
   // offsets are inconsistent, `MakerNotes.pm:1816` / `subdir.rs`) then
@@ -9473,6 +9614,8 @@ pub(in crate::exif) fn samsung_makernote_isolated(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Samsung IFD's declared length: the `0x927c` value size minus the body offset; `process_subdir` further subtracts the `LocateIFD` relocation (the salvage gate, `Exif.pm:6383`).
+    dir_len: Some(mn_len.saturating_sub(body_offset)),
   };
   // The Samsung Type2 IFD walk — `ProcessProc::Unknown` runs `LocateIFD`
   // (Samsung's offsets are inconsistent, `MakerNotes.pm:976`) then `ProcessExif`.
@@ -9713,6 +9856,8 @@ pub(in crate::exif) fn leica_makernote_isolated(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Leica IFD's declared length: the `0x927c` value size minus the body offset (the salvage gate, `Exif.pm:6383`).
+    dir_len: Some(mn_len.saturating_sub(body_offset)),
   };
   // The Leica variant IFD walk — `ProcessProc::Exif` directly (the Leica2..Leica9
   // tables carry no `PROCESS_PROC`; only their deferred binary sub-tables do). The
@@ -9893,6 +10038,8 @@ pub(in crate::exif) fn canon_makernote_isolated(
     canon_focal_units: None,
     canon_lens_type: None,
     canon_focal_length_blob: None,
+    // `$$dirInfo{DirLen}` — the Canon MakerNote's declared length (`DirLen => $size`, the `0x927c` value size; Canon's body offset is 0). Gates the directory-size salvage clamp (`Exif.pm:6383-6388`, #248).
+    dir_len: Some(mn_len),
   };
   // The Canon Main IFD walk — the SAME `process_subdir` entry the recompute used
   // (`IfdKind::ExifIfd` directory kind, fixed parent order, no FixBase, the Canon
@@ -12662,6 +12809,8 @@ mod tests {
       canon_focal_units: None,
       canon_lens_type: None,
       canon_focal_length_blob: None,
+      // Test walk — no maker-note `DirLen`.
+      dir_len: None,
     }
   }
 

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -4787,3 +4787,882 @@ fn leica7_embedded_app1_nonzero_base_matches_bundled_exiftool() {
   }
   let _ = std::fs::remove_file(&path);
 }
+
+// ===========================================================================
+// MakerNote directory-size SALVAGE clamp (Exif.pm:6384-6388, #248)
+// ===========================================================================
+
+/// Craft a big-endian JPEG (`Exif` APP1) whose Canon MakerNote (`0x927c`) IFD
+/// count word CLAIMS `claimed_count` entries (so `2 + 12*claimed_count` overruns
+/// the buffer) while the BLOB physically holds only two real Canon leaves —
+/// `OwnerName` (0x0009) and `CanonImageType` (0x0006), both ASCII out-of-line.
+/// `mn_len` is the declared `0x927c` value length: defaults to `2 + 12*N` (exactly
+/// covering the `N=2` real entries, so the salvage clamp `(mn_len-2)/12 == 2`); a
+/// `mn_len_override` lets a caller force the sub-14 / out-of-range gate-fail cases.
+/// The two string values sit AFTER the (salvaged) directory end, so the salvaged
+/// entries decode WITHOUT a Suspicious-offset skip.
+#[cfg(all(feature = "exif", feature = "std"))]
+fn craft_canon_overrun_jpeg(claimed_count: u16, mn_len_override: Option<u32>) -> Vec<u8> {
+  let be16 = |v: u16| v.to_be_bytes();
+  let be32 = |v: u32| v.to_be_bytes();
+  let make = b"Canon\x00";
+  let model = b"Canon EOS 5D\x00";
+  let hdr = 8usize;
+  let ifd0_start = hdr;
+  let ifd0_size = 2 + 12 * 3 + 4;
+  let make_off = ifd0_start + ifd0_size;
+  let model_off = make_off + make.len();
+  let exif_start = model_off + model.len();
+  let exif_size = 2 + 12 + 4;
+  let canon_start = exif_start + exif_size;
+  let n_real = 2usize;
+  // The next-IFD pointer sits exactly at the SALVAGED directory end
+  // (canon_start + 2 + 12*N), so the two string values that follow are at an
+  // offset >= dir_end (no Suspicious-offset skip).
+  let nextptr_off = canon_start + 2 + 12 * n_real;
+  let owner = b"OwnerX\x00";
+  let imgtype = b"CanonImg\x00";
+  let owner_off = nextptr_off + 4;
+  let imgtype_off = owner_off + owner.len();
+  let mn_len = mn_len_override.unwrap_or((2 + 12 * n_real) as u32);
+
+  let mut t: Vec<u8> = Vec::new();
+  t.extend_from_slice(b"MM");
+  t.extend_from_slice(&be16(0x2a));
+  t.extend_from_slice(&be32(ifd0_start as u32));
+  // IFD0: Make, Model, ExifIFD.
+  t.extend_from_slice(&be16(3));
+  t.extend_from_slice(&be16(0x010f));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(make.len() as u32));
+  t.extend_from_slice(&be32(make_off as u32));
+  t.extend_from_slice(&be16(0x0110));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(model.len() as u32));
+  t.extend_from_slice(&be32(model_off as u32));
+  t.extend_from_slice(&be16(0x8769));
+  t.extend_from_slice(&be16(4));
+  t.extend_from_slice(&be32(1));
+  t.extend_from_slice(&be32(exif_start as u32));
+  t.extend_from_slice(&be32(0));
+  t.extend_from_slice(make);
+  t.extend_from_slice(model);
+  // ExifIFD: MakerNote.
+  t.extend_from_slice(&be16(1));
+  t.extend_from_slice(&be16(0x927c));
+  t.extend_from_slice(&be16(7)); // UNDEF
+  t.extend_from_slice(&be32(mn_len));
+  t.extend_from_slice(&be32(canon_start as u32));
+  t.extend_from_slice(&be32(0));
+  // Canon Main IFD: the count word CLAIMS an overrun, then two real entries.
+  t.extend_from_slice(&be16(claimed_count));
+  t.extend_from_slice(&be16(0x0009)); // OwnerName
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(owner.len() as u32));
+  t.extend_from_slice(&be32(owner_off as u32));
+  t.extend_from_slice(&be16(0x0006)); // CanonImageType
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(imgtype.len() as u32));
+  t.extend_from_slice(&be32(imgtype_off as u32));
+  t.extend_from_slice(&be32(0)); // next-IFD ptr at the salvaged dir_end
+  t.extend_from_slice(owner);
+  t.extend_from_slice(imgtype);
+
+  // Wrap in a JPEG: SOI + APP1(Exif\0\0 + tiff) + EOI.
+  let mut app1: Vec<u8> = Vec::new();
+  app1.extend_from_slice(b"Exif\x00\x00");
+  app1.extend_from_slice(&t);
+  let mut jpeg: Vec<u8> = Vec::new();
+  jpeg.extend_from_slice(&[0xff, 0xd8]);
+  jpeg.extend_from_slice(&[0xff, 0xe1]);
+  jpeg.extend_from_slice(&((app1.len() + 2) as u16).to_be_bytes());
+  jpeg.extend_from_slice(&app1);
+  jpeg.extend_from_slice(&[0xff, 0xd9]);
+  jpeg
+}
+
+/// SALVAGE (`Exif.pm:6384-6388`, #248): a crafted Canon MakerNote whose IFD count
+/// word claims 1000 entries (`2 + 12*1000` overruns the buffer) but whose declared
+/// `mn_len` (26 ≥ 14) is a valid in-range region ⇒ exifast CLAMPS to
+/// `(26-2)/12 == 2` entries and emits BOTH salvaged Canon leaves, instead of
+/// aborting the whole directory (which would emit zero Canon tags).
+///
+/// Oracle (`perl exiftool -G1 -j` on the SAME crafted bytes):
+///
+/// ```text
+/// "ExifTool:Warning": "[minor] Bad MakerNotes directory",
+/// "IFD0:Make": "Canon",
+/// "IFD0:Model": "Canon EOS 5D",
+/// "Canon:OwnerName": "OwnerX",
+/// "Canon:CanonImageType": "CanonImg"
+/// ```
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_makernote_dirsize_overrun_salvages_clamped_entries() {
+  let data = craft_canon_overrun_jpeg(1000, None);
+  let meta = exifast::exif::jpeg::parse_jpeg_exif(&data).expect("crafted Canon JPEG parsed");
+  let mn = meta.maker_note().expect("MakerNote captured");
+  assert!(mn.vendor().is_canon(), "vendor = Canon");
+  let emissions = mn.emissions_print_conv();
+  // BOTH salvaged Canon leaves emit (the clamp walked the 2 real entries).
+  let owner = emissions
+    .iter()
+    .find(|e| e.name() == "OwnerName")
+    .map(|e| e.value().clone());
+  assert_eq!(
+    owner,
+    Some(exifast::TagValue::Str("OwnerX".into())),
+    "the salvage must walk the clamped entries and emit OwnerName (NOT abort)"
+  );
+  let imgtype = emissions
+    .iter()
+    .find(|e| e.name() == "CanonImageType")
+    .map(|e| e.value().clone());
+  assert_eq!(
+    imgtype,
+    Some(exifast::TagValue::Str("CanonImg".into())),
+    "the second salvaged entry (CanonImageType) must emit too"
+  );
+}
+
+/// NEGATIVE (the `$dirLen >= 14` gate, `Exif.pm:6383`): the SAME overrun Canon
+/// MakerNote but with a declared `mn_len` of 8 (< 14) ⇒ the salvage condition
+/// FAILS, so exifast aborts the whole directory and emits ZERO Canon leaves
+/// (Make/Model still resolve). Bundled `perl exiftool -G1 -j` likewise emits the
+/// `[minor] Bad MakerNotes directory` warning and NO `Canon:*` tags.
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_makernote_dirsize_overrun_short_dirlen_aborts() {
+  let data = craft_canon_overrun_jpeg(1000, Some(8));
+  let meta = exifast::exif::jpeg::parse_jpeg_exif(&data).expect("crafted Canon JPEG parsed");
+  // Make/Model from IFD0 still resolve.
+  assert_eq!(
+    meta.entry("Model").map(|e| match e.value_ref().raw() {
+      exifast::exif::ifd::RawValue::Text { text: s, .. } => s.as_str(),
+      _ => "<not-text>",
+    }),
+    Some("Canon EOS 5D")
+  );
+  let mn = meta.maker_note().expect("MakerNote captured");
+  assert!(mn.vendor().is_canon(), "vendor = Canon");
+  // `dirLen < 14` ⇒ NO salvage ⇒ the directory aborts ⇒ zero Canon leaves.
+  assert!(
+    mn.emissions_print_conv().is_empty(),
+    "a sub-14 declared MakerNote length must NOT salvage — abort, emit no Canon tags"
+  );
+}
+
+/// NEGATIVE (the `$inMakerNotes` gate, `Exif.pm:6382`): a CORE IFD (ExifIFD) whose
+/// count word overruns the buffer is NOT salvaged — ExifTool warns `Bad ExifIFD
+/// directory` (NON-minor, `$inMakerNotes == 0`) and `return 0`s the directory. The
+/// salvage clamp must fire for maker notes ONLY (`!active_table.is_core_ifd()`); a
+/// core IFD overrun still aborts. Assert the overrunning ExifIFD yields NO Exif
+/// tags from it (its single real entry is NOT read).
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn core_ifd_dirsize_overrun_aborts_no_salvage() {
+  let be16 = |v: u16| v.to_be_bytes();
+  let be32 = |v: u32| v.to_be_bytes();
+  let hdr = 8usize;
+  let ifd0_start = hdr;
+  let ifd0_size = 2 + 12 + 4;
+  let exif_start = ifd0_start + ifd0_size;
+  let mut t: Vec<u8> = Vec::new();
+  t.extend_from_slice(b"MM");
+  t.extend_from_slice(&be16(0x2a));
+  t.extend_from_slice(&be32(ifd0_start as u32));
+  // IFD0: ExifIFD pointer only.
+  t.extend_from_slice(&be16(1));
+  t.extend_from_slice(&be16(0x8769));
+  t.extend_from_slice(&be16(4));
+  t.extend_from_slice(&be32(1));
+  t.extend_from_slice(&be32(exif_start as u32));
+  t.extend_from_slice(&be32(0));
+  // ExifIFD: count word CLAIMS 1000 (overrun), then one real ExposureProgram
+  // (0x8822, SHORT, inline) the walk would emit IF it did not abort.
+  t.extend_from_slice(&be16(1000));
+  t.extend_from_slice(&be16(0x8822)); // ExposureProgram
+  t.extend_from_slice(&be16(3)); // int16u
+  t.extend_from_slice(&be32(1));
+  t.extend_from_slice(&be16(2)); // value 2 (= "Program AE")
+  t.extend_from_slice(&be16(0)); // inline padding
+  t.extend_from_slice(&be32(0)); // next-IFD ptr
+
+  let meta = exifast::parse_exif_block(&t).expect("valid TIFF");
+  // A core ExifIFD overrun aborts (no salvage): ExposureProgram is NOT emitted.
+  assert!(
+    meta.entry("ExposureProgram").is_none(),
+    "a CORE IFD overrun must abort (no maker-note salvage): ExposureProgram dropped"
+  );
+}
+
+/// Cross-check the SALVAGE against the bundled ExifTool binary (when `$EXIFTOOL`
+/// is set / on PATH): `perl exiftool -G1 -j` on the crafted overrun Canon JPEG
+/// must emit BOTH salvaged Canon leaves + the `[minor] Bad MakerNotes directory`
+/// warning, proving the clamp is byte-faithful. Skipped (not failed) when the
+/// binary is unavailable.
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+#[test]
+fn canon_dirsize_salvage_matches_bundled_exiftool() {
+  use std::process::Command;
+  let tool = std::env::var("EXIFTOOL").unwrap_or_else(|_| "exiftool".to_string());
+  if Command::new(&tool).arg("-ver").output().is_err() {
+    eprintln!("SKIP: exiftool binary not available; Canon salvage cross-check skipped");
+    return;
+  }
+  let data = craft_canon_overrun_jpeg(1000, None);
+  let dir = std::env::temp_dir();
+  let path = dir.join("exifast_canon_dirsize_salvage.jpg");
+  std::fs::write(&path, &data).expect("write temp salvage jpg");
+  let out = Command::new(&tool)
+    .args([
+      "-G1",
+      "-j",
+      "-Make",
+      "-Model",
+      "-OwnerName",
+      "-CanonImageType",
+      "-Warning",
+    ])
+    .arg(&path)
+    .output()
+    .expect("run exiftool");
+  let _ = std::fs::remove_file(&path);
+  assert!(out.status.success(), "exiftool failed");
+  let json = String::from_utf8(out.stdout).expect("utf8");
+  let doc: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+  let obj = doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .expect("doc is [{…}]");
+  // The bundled binary salvages the SAME two Canon leaves.
+  assert_eq!(
+    obj.get("Canon:OwnerName").and_then(|v| v.as_str()),
+    Some("OwnerX"),
+    "bundled exiftool must salvage Canon:OwnerName"
+  );
+  assert_eq!(
+    obj.get("Canon:CanonImageType").and_then(|v| v.as_str()),
+    Some("CanonImg"),
+    "bundled exiftool must salvage Canon:CanonImageType"
+  );
+  // And raises the minor Bad-MakerNotes-directory warning.
+  assert_eq!(
+    obj.get("ExifTool:Warning").and_then(|v| v.as_str()),
+    Some("[minor] Bad MakerNotes directory"),
+    "bundled exiftool must warn [minor] Bad MakerNotes directory"
+  );
+}
+
+// ===========================================================================
+// #248 R1 finding 1 — the Canon `%CameraSettings` DataMember pre-scan must
+// apply the SAME maker-note salvage clamp as the emission walk, so a SALVAGED
+// Canon directory's dependent sub-tables (FocalLength / FileInfo) read the
+// pre-scanned `FocalUnits` / `LensType` instead of defaulting.
+// ===========================================================================
+
+/// Craft a big-endian JPEG (`Exif` APP1) whose Canon MakerNote (`0x927c`) IFD
+/// count word CLAIMS an OVERRUN (`claimed_count`, so `2 + 12*claimed_count`
+/// exceeds the buffer) while the declared `0x927c` value length is exactly
+/// `2 + 12*2 == 26` (>= 14) ⇒ the salvage clamps to TWO real entries:
+///
+///   - `0x0001` `CanonCameraSettings` — `int16u[26]`, out-of-line, carrying
+///     `LensType` (position 22) and `FocalUnits` (position 25 = 2); the
+///     DataMembers the pre-scan must extract from the SALVAGED entry set.
+///   - `0x0002` `CanonFocalLength` — `int16u[2]`, out-of-line: `FocalType` = 2
+///     (Zoom), raw `FocalLength` = 100. The sub-table renders
+///     `FocalLength = 100 / FocalUnits` mm — `"50 mm"` WITH the pre-scanned
+///     `FocalUnits = 2`, but the default `"100 mm"` if the pre-scan aborts the
+///     salvaged directory (the bug this finding fixes).
+///
+/// Both out-of-line values sit AFTER the salvaged directory end (`canon_start +
+/// 26`), so neither is dropped by the Suspicious-offset rule. `lens_type` and
+/// `focal_units` are caller-chosen so the test can vary the lens word.
+#[cfg(all(feature = "exif", feature = "std"))]
+fn craft_canon_focal_salvage_jpeg(claimed_count: u16, lens_type: u16, focal_units: u16) -> Vec<u8> {
+  let be16 = |v: u16| v.to_be_bytes();
+  let be32 = |v: u32| v.to_be_bytes();
+  let make = b"Canon\x00";
+  // A non-EOS PowerShot model: keeps the typed focal RANGE off the EOS path and
+  // does not perturb the FocalLength sub-table (its FocalPlane words are absent).
+  let model = b"Canon PowerShot S100\x00";
+  let hdr = 8usize;
+  let ifd0_start = hdr;
+  let ifd0_size = 2 + 12 * 3 + 4;
+  let make_off = ifd0_start + ifd0_size;
+  let model_off = make_off + make.len();
+  let exif_start = model_off + model.len();
+  let exif_size = 2 + 12 + 4;
+  let canon_start = exif_start + exif_size;
+  let n_real = 2usize;
+  // The next-IFD pointer sits at the SALVAGED directory end; the CameraSettings
+  // out-of-line value (52 bytes > 4) follows it (offset >= dir_end ⇒ no
+  // Suspicious-offset skip). The FocalLength value (4 bytes == size <= 4) is
+  // INLINE in its 12-byte entry's value field (`Exif.pm:6517` — Canon reads a
+  // `<= 4`-byte value from `$entry + 8`), so it needs no out-of-line slot.
+  let nextptr_off = canon_start + 2 + 12 * n_real;
+  let cs_off = nextptr_off + 4; // CanonCameraSettings value (52 bytes, out-of-line)
+  // The declared `0x927c` length: exactly the salvaged-directory extent (26),
+  // which is >= 14 ⇒ the salvage clamps to `(26 - 2) / 12 == 2` entries.
+  let mn_len = (2 + 12 * n_real) as u32;
+
+  // CanonCameraSettings: int16u[26]. word0 = blob byte-length (52); word22 =
+  // LensType; word25 = FocalUnits. All other words 0 (RawConv-dropped / benign).
+  let mut cs = vec![0u8; 52];
+  let put = |buf: &mut [u8], word_idx: usize, v: u16| {
+    let off = 2 * word_idx;
+    buf[off..off + 2].copy_from_slice(&v.to_be_bytes());
+  };
+  put(&mut cs, 0, 52);
+  put(&mut cs, 22, lens_type);
+  put(&mut cs, 25, focal_units);
+
+  // CanonFocalLength: int16u[2]. word0 = FocalType (2 = Zoom); word1 = raw
+  // FocalLength (100 ⇒ 100/FocalUnits mm).
+  let mut fl = vec![0u8; 4];
+  put(&mut fl, 0, 2);
+  put(&mut fl, 1, 100);
+
+  let mut t: Vec<u8> = Vec::new();
+  t.extend_from_slice(b"MM");
+  t.extend_from_slice(&be16(0x2a));
+  t.extend_from_slice(&be32(ifd0_start as u32));
+  // IFD0: Make, Model, ExifIFD.
+  t.extend_from_slice(&be16(3));
+  t.extend_from_slice(&be16(0x010f));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(make.len() as u32));
+  t.extend_from_slice(&be32(make_off as u32));
+  t.extend_from_slice(&be16(0x0110));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(model.len() as u32));
+  t.extend_from_slice(&be32(model_off as u32));
+  t.extend_from_slice(&be16(0x8769));
+  t.extend_from_slice(&be16(4));
+  t.extend_from_slice(&be32(1));
+  t.extend_from_slice(&be32(exif_start as u32));
+  t.extend_from_slice(&be32(0));
+  t.extend_from_slice(make);
+  t.extend_from_slice(model);
+  // ExifIFD: MakerNote.
+  t.extend_from_slice(&be16(1));
+  t.extend_from_slice(&be16(0x927c));
+  t.extend_from_slice(&be16(7)); // UNDEF
+  t.extend_from_slice(&be32(mn_len));
+  t.extend_from_slice(&be32(canon_start as u32));
+  t.extend_from_slice(&be32(0));
+  // Canon Main IFD: the count word CLAIMS an overrun, then two real entries.
+  t.extend_from_slice(&be16(claimed_count));
+  t.extend_from_slice(&be16(0x0001)); // CanonCameraSettings
+  t.extend_from_slice(&be16(3)); // int16u
+  t.extend_from_slice(&be32(26)); // count = 26 words
+  t.extend_from_slice(&be32(cs_off as u32));
+  t.extend_from_slice(&be16(0x0002)); // CanonFocalLength
+  t.extend_from_slice(&be16(3)); // int16u
+  t.extend_from_slice(&be32(2)); // count = 2 words (size 4 ⇒ INLINE value)
+  t.extend_from_slice(&fl); // inline FocalType + raw FocalLength (4 bytes)
+  t.extend_from_slice(&be32(0)); // next-IFD ptr at the salvaged dir_end
+  t.extend_from_slice(&cs);
+
+  // Wrap in a JPEG: SOI + APP1(Exif\0\0 + tiff) + EOI.
+  let mut app1: Vec<u8> = Vec::new();
+  app1.extend_from_slice(b"Exif\x00\x00");
+  app1.extend_from_slice(&t);
+  let mut jpeg: Vec<u8> = Vec::new();
+  jpeg.extend_from_slice(&[0xff, 0xd8]);
+  jpeg.extend_from_slice(&[0xff, 0xe1]);
+  jpeg.extend_from_slice(&((app1.len() + 2) as u16).to_be_bytes());
+  jpeg.extend_from_slice(&app1);
+  jpeg.extend_from_slice(&[0xff, 0xd9]);
+  jpeg
+}
+
+/// #248 R1 finding 1 — a SALVAGED Canon directory must be PRE-SCANNED over the
+/// SAME clamped entry set, so the `0x02` FocalLength sub-table reads the
+/// pre-scanned `FocalUnits` (`= 2`) and renders `100 / 2 == "50 mm"`, NOT the
+/// default-unit `"100 mm"`. WITHOUT the finding-1 fix the pre-scan aborts the
+/// overclaimed directory, leaving `FocalUnits` unset ⇒ the FocalLength would
+/// render `"100 mm"` (the regression). The `LensType` DataMember (position 22)
+/// likewise emits only because the pre-scan walked the salvaged CameraSettings.
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn canon_salvaged_dir_prescan_drives_focallength_and_lenstype() {
+  // LensType 1 = "Canon EF 50mm f/1.8" (`%canonLensTypes`); FocalUnits 2.
+  let data = craft_canon_focal_salvage_jpeg(1000, 1, 2);
+  let meta = exifast::exif::jpeg::parse_jpeg_exif(&data).expect("crafted Canon JPEG parsed");
+  let mn = meta.maker_note().expect("MakerNote captured");
+  assert!(mn.vendor().is_canon(), "vendor = Canon");
+  let emissions = mn.emissions_print_conv();
+  let find = |name: &str| {
+    emissions
+      .iter()
+      .find(|e| e.name() == name)
+      .map(|e| e.value().clone())
+  };
+  // The dependent FocalLength sub-table emission scaled by the pre-scanned
+  // FocalUnits = 2 ⇒ 100/2 = "50 mm" (the salvage drove the pre-scan).
+  assert_eq!(
+    find("FocalLength"),
+    Some(exifast::TagValue::Str("50 mm".into())),
+    "the salvaged dir's FocalLength must use the pre-scanned FocalUnits=2 (50 mm), \
+     NOT the default unit (100 mm) — the finding-1 fix"
+  );
+  assert_eq!(
+    find("FocalType"),
+    Some(exifast::TagValue::Str("Zoom".into())),
+    "FocalType from the salvaged 0x02 entry"
+  );
+  // LensType emits ONLY because the pre-scan walked the salvaged CameraSettings.
+  assert_eq!(
+    find("LensType"),
+    Some(exifast::TagValue::Str("Canon EF 50mm f/1.8".into())),
+    "LensType resolved from the salvaged CameraSettings position 22"
+  );
+}
+
+/// Cross-check the SALVAGED-directory sub-table output against the bundled
+/// ExifTool binary (`perl exiftool -G1 -j`): the SAME crafted bytes must emit
+/// `Canon:FocalLength = "50 mm"` and `Canon:LensType = "Canon EF 50mm f/1.8"`
+/// — proving the pre-scan salvage is byte-faithful. Skipped (not failed) when
+/// the binary is unavailable.
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+#[test]
+fn canon_salvaged_dir_prescan_matches_bundled_exiftool() {
+  use std::process::Command;
+  let tool = std::env::var("EXIFTOOL").unwrap_or_else(|_| "exiftool".to_string());
+  if Command::new(&tool).arg("-ver").output().is_err() {
+    eprintln!("SKIP: exiftool binary not available; Canon salvage pre-scan cross-check skipped");
+    return;
+  }
+  let data = craft_canon_focal_salvage_jpeg(1000, 1, 2);
+  let dir = std::env::temp_dir();
+  let path = dir.join("exifast_canon_salvage_prescan.jpg");
+  std::fs::write(&path, &data).expect("write temp salvage-prescan jpg");
+  let out = Command::new(&tool)
+    .args(["-G1", "-j", "-FocalLength", "-FocalType", "-LensType"])
+    .arg(&path)
+    .output()
+    .expect("run exiftool");
+  let _ = std::fs::remove_file(&path);
+  assert!(out.status.success(), "exiftool failed");
+  let json = String::from_utf8(out.stdout).expect("utf8");
+  let doc: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+  let obj = doc
+    .as_array()
+    .and_then(|a| a.first())
+    .and_then(|o| o.as_object())
+    .expect("doc is [{…}]");
+  // Bundled renders the FocalLength scaled by the salvaged FocalUnits = 2.
+  assert_eq!(
+    obj.get("Canon:FocalLength").and_then(|v| v.as_str()),
+    Some("50 mm"),
+    "bundled exiftool must render the salvaged FocalLength as 50 mm (FocalUnits=2)"
+  );
+  assert_eq!(
+    obj.get("Canon:LensType").and_then(|v| v.as_str()),
+    Some("Canon EF 50mm f/1.8"),
+    "bundled exiftool must render the salvaged LensType"
+  );
+}
+
+// ===========================================================================
+// #248 R1 finding 2 — `ProcessUnknown`'s `LocateIFD` must bound its
+// relocation-candidate scan by the threaded `DirLen` (`MakerNotes.pm:1501`),
+// NOT by `data.len() - dir_start`. A truncated MakerNote whose declared `0x927c`
+// length stops BEFORE an IFD-shaped run that physically follows in the buffer
+// must NOT relocate onto it and emit spurious vendor tags.
+// ===========================================================================
+
+/// Craft a big-endian JPEG (`Exif` APP1) carrying a Pentax `AOC\0` MakerNote
+/// (`MakerNotePentax`, `ProcessUnknown` + `FixBase => 1`) whose value region is
+/// `"AOC\0"` + 4 zero bytes + a little-endian 1-entry IFD (`Quality` 0x0008 =
+/// 1) at value-offset 8 — i.e. `LocateIFD` would relocate `+8` and the walk
+/// would emit `Pentax:Quality`. The DECLARED `0x927c` length is `mn_len`; the
+/// IFD bytes [8, 26) physically EXTEND PAST a truncated `mn_len` but stay inside
+/// the captured TIFF buffer (the "truncated MakerNote" case). `mn_len` < 22
+/// (`8 + 14`) ⇒ a DirLen-bounded `LocateIFD` rejects the `+8` candidate; a
+/// `mn_len` >= 22 lets it through.
+#[cfg(all(feature = "exif", feature = "std"))]
+fn craft_pentax_aoc_truncated_jpeg(mn_len: u32) -> Vec<u8> {
+  let be16 = |v: u16| v.to_be_bytes();
+  let be32 = |v: u32| v.to_be_bytes();
+  let make = b"PENTAX\x00";
+  let model = b"PENTAX K10D\x00";
+  let hdr = 8usize;
+  let ifd0_start = hdr;
+  let ifd0_size = 2 + 12 * 3 + 4;
+  let make_off = ifd0_start + ifd0_size;
+  let model_off = make_off + make.len();
+  let exif_start = model_off + model.len();
+  let exif_size = 2 + 12 + 4;
+  let mn_start = exif_start + exif_size;
+
+  // The MakerNote value: "AOC\0" + 4 zero bytes + a LE 1-entry IFD at offset 8.
+  let mut mn: Vec<u8> = Vec::new();
+  mn.extend_from_slice(b"AOC\x00"); // offset 0..4 — Pentax primary signature
+  mn.extend_from_slice(&[0u8; 4]); // offset 4..8 — zero count words ⇒ LocateIFD skips 4/6
+  // IFD at offset 8 (little-endian): count=1, Quality(0x0008) int16u=1, next=0.
+  mn.extend_from_slice(&1u16.to_le_bytes()); // entry count = 1
+  mn.extend_from_slice(&0x0008u16.to_le_bytes()); // tag 0x0008 = Quality
+  mn.extend_from_slice(&3u16.to_le_bytes()); // format = int16u
+  mn.extend_from_slice(&1u32.to_le_bytes()); // count = 1
+  mn.extend_from_slice(&1u16.to_le_bytes()); // value 1 inline
+  mn.extend_from_slice(&0u16.to_le_bytes()); // value padding
+  mn.extend_from_slice(&0u32.to_le_bytes()); // next-IFD = 0
+  mn.extend_from_slice(&[0u8; 8]); // trailing slack so LocateIFD's size checks pass
+  // The IFD reaches offset 26; the value region is 34 bytes — but the 0x927c tag
+  // DECLARES only `mn_len` of it.
+
+  let mut t: Vec<u8> = Vec::new();
+  t.extend_from_slice(b"MM");
+  t.extend_from_slice(&be16(0x2a));
+  t.extend_from_slice(&be32(ifd0_start as u32));
+  // IFD0: Make, Model, ExifIFD.
+  t.extend_from_slice(&be16(3));
+  t.extend_from_slice(&be16(0x010f));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(make.len() as u32));
+  t.extend_from_slice(&be32(make_off as u32));
+  t.extend_from_slice(&be16(0x0110));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(model.len() as u32));
+  t.extend_from_slice(&be32(model_off as u32));
+  t.extend_from_slice(&be16(0x8769));
+  t.extend_from_slice(&be16(4));
+  t.extend_from_slice(&be32(1));
+  t.extend_from_slice(&be32(exif_start as u32));
+  t.extend_from_slice(&be32(0));
+  t.extend_from_slice(make);
+  t.extend_from_slice(model);
+  // ExifIFD: MakerNote — DECLARES `mn_len` (possibly < the IFD's physical reach).
+  t.extend_from_slice(&be16(1));
+  t.extend_from_slice(&be16(0x927c));
+  t.extend_from_slice(&be16(7)); // UNDEF
+  t.extend_from_slice(&be32(mn_len));
+  t.extend_from_slice(&be32(mn_start as u32));
+  t.extend_from_slice(&be32(0));
+  t.extend_from_slice(&mn); // the full 34-byte region (IFD bytes stay in the buffer)
+
+  // Wrap in a JPEG: SOI + APP1(Exif\0\0 + tiff) + EOI.
+  let mut app1: Vec<u8> = Vec::new();
+  app1.extend_from_slice(b"Exif\x00\x00");
+  app1.extend_from_slice(&t);
+  let mut jpeg: Vec<u8> = Vec::new();
+  jpeg.extend_from_slice(&[0xff, 0xd8]);
+  jpeg.extend_from_slice(&[0xff, 0xe1]);
+  jpeg.extend_from_slice(&((app1.len() + 2) as u16).to_be_bytes());
+  jpeg.extend_from_slice(&app1);
+  jpeg.extend_from_slice(&[0xff, 0xd9]);
+  jpeg
+}
+
+/// #248 R1 finding 2 — `LocateIFD` bounds its relocation scan by `DirLen`: a
+/// Pentax `AOC\0` MakerNote whose IFD is at value-offset 8 but whose DECLARED
+/// `0x927c` length is 20 (< `8 + 14`) must emit NO Pentax tags, even though the
+/// IFD-shaped bytes physically follow in the buffer. The CONTROL (declared
+/// length 30 >= 22) proves the SAME bytes DO emit `Pentax:Quality` when the
+/// window admits the relocation — so the suppression is the DirLen bound, not a
+/// parse failure.
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn pentax_locate_ifd_respects_dirlen_window() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::fixbase;
+
+  // NON-VACUOUS: the value region IS IFD-shaped — `LocateIFD` with NO DirLen
+  // (the pre-fix behaviour, scanning the whole buffer) locks onto the IFD at
+  // value-offset 8, so WITHOUT the DirLen bound `ProcessUnknown` would walk it.
+  let region = {
+    let mut r: Vec<u8> = Vec::new();
+    r.extend_from_slice(b"AOC\x00");
+    r.extend_from_slice(&[0u8; 4]);
+    r.extend_from_slice(&1u16.to_le_bytes());
+    r.extend_from_slice(&0x0008u16.to_le_bytes());
+    r.extend_from_slice(&3u16.to_le_bytes());
+    r.extend_from_slice(&1u32.to_le_bytes());
+    r.extend_from_slice(&1u16.to_le_bytes());
+    r.extend_from_slice(&0u16.to_le_bytes());
+    r.extend_from_slice(&0u32.to_le_bytes());
+    r.extend_from_slice(&[0u8; 8]);
+    r
+  };
+  assert_eq!(
+    fixbase::locate_ifd(&region, 0, None, ByteOrder::Big, Some("PENTAX"), None).map(|(off, _)| off),
+    Some(8),
+    "the crafted Pentax AOC region IS IFD-shaped at offset 8 (LocateIFD locks \
+     there with NO DirLen) — so the DirLen bound, not a parse failure, suppresses \
+     the tags"
+  );
+  // And with the DECLARED window (20 < 8 + 14) the SAME scan finds NOTHING — the
+  // finding-2 fix, asserted directly on `locate_ifd`.
+  assert_eq!(
+    fixbase::locate_ifd(&region, 0, Some(20), ByteOrder::Big, Some("PENTAX"), None),
+    None,
+    "a DirLen of 20 must bound the scan SHORT of the offset-8 IFD"
+  );
+
+  // End-to-end: declared `mn_len` 20 ⇒ NO Pentax tags (the relocation is bounded).
+  let truncated = craft_pentax_aoc_truncated_jpeg(20);
+  let meta = exifast::exif::jpeg::parse_jpeg_exif(&truncated).expect("crafted Pentax JPEG parsed");
+  let mn = meta.maker_note().expect("MakerNote captured");
+  assert!(
+    mn.vendor().is_pentax(),
+    "vendor = Pentax (AOC primary dispatched)"
+  );
+  assert!(
+    mn.emissions_print_conv().is_empty(),
+    "a truncated DirLen must bound LocateIFD: NO Pentax tags from the out-of-window IFD"
+  );
+  assert_eq!(
+    mn.meta().pentax().and_then(|p| p.quality()),
+    None,
+    "no bogus Quality from an IFD that lies past the declared MakerNote window"
+  );
+
+  // CONTROL: declared `mn_len` 30 (>= 22) ⇒ the SAME bytes DO emit Pentax:Quality
+  // — proving the difference is the DirLen bound, not the byte content.
+  let admitted = craft_pentax_aoc_truncated_jpeg(30);
+  let meta2 = exifast::exif::jpeg::parse_jpeg_exif(&admitted).expect("crafted Pentax JPEG parsed");
+  let mn2 = meta2.maker_note().expect("MakerNote captured");
+  assert_eq!(
+    mn2.meta().pentax().and_then(|p| p.quality()),
+    Some(1),
+    "a DirLen wide enough to admit the offset-8 IFD DOES emit Quality (control)"
+  );
+}
+
+/// Craft a big-endian JPEG (`Exif` APP1) whose Pentax `AOC\0` MakerNote (`0x927c`)
+/// is shaped so that — for the DECLARED `mn_len` window — `LocateIFD` finds NO
+/// plausible IFD (`return undef` ⇒ `ProcessUnknown` processes nothing), YET the
+/// count word AT the unrelocated `ifd_start` (the `AOC` bytes, `0x414F` big-endian
+/// = 16719) is an OVERCLAIM whose `walk_one_ifd_body` salvage clamp
+/// (`(mn_len - 2) / 12` entries) would walk a VALID `Pentax:Quality` (`0x0008`)
+/// entry. With `mn_len == 26` the clamp keeps TWO entries:
+///
+///   - entry 0 @ blob offset 2 — tag id `0x4300` (the `"C\0"` of `AOC\0`, an
+///     UNKNOWN Pentax tag), `int16u[1]` (a VALID format so it is a normal-but-
+///     skipped entry, NOT a first-entry `Bad format` abort);
+///   - entry 1 @ blob offset 14 — `Quality` (`0x0008`), `int16u[1]`, inline value
+///     `1` ⇒ `Pentax:Quality` would emit on the salvage walk.
+///
+/// Every `LocateIFD` scan offset within the 26-byte window (0,2,4,6,8,10,12)
+/// rejects (see the per-offset reasoning in the test) so `locate_ifd` is `None`;
+/// the Quality entry sits at offset 14, BEYOND the `$offset + 14 > $dirLen` scan
+/// cutoff, so it is reachable ONLY by the count-word salvage. The DECLARED `0x927c`
+/// length is `mn_len`; the physical blob is longer (the IFD bytes stay inside the
+/// captured TIFF buffer) — the "truncated MakerNote" shape.
+#[cfg(all(feature = "exif", feature = "std"))]
+fn craft_pentax_aoc_overrun_jpeg(mn_len: u32) -> Vec<u8> {
+  let be16 = |v: u16| v.to_be_bytes();
+  let be32 = |v: u32| v.to_be_bytes();
+  let make = b"PENTAX\x00";
+  let model = b"PENTAX K10D\x00";
+  let hdr = 8usize;
+  let ifd0_start = hdr;
+  let ifd0_size = 2 + 12 * 3 + 4;
+  let make_off = ifd0_start + ifd0_size;
+  let model_off = make_off + make.len();
+  let exif_start = model_off + model.len();
+  let exif_size = 2 + 12 + 4;
+  let mn_start = exif_start + exif_size;
+
+  // The MakerNote value (big-endian throughout — the salvage walk's resolved
+  // order). Offset 0..4 is the forced `AOC\0` signature; its first two bytes ARE
+  // the IFD count word (`0x414F` = an overclaim ⇒ the salvage clamp fires).
+  let mut mn: Vec<u8> = Vec::new();
+  mn.extend_from_slice(b"AOC\x00"); // 0..4 — signature; count word = 0x414F (overrun)
+  // entry 0 @ offset 2 (tag id = the "C\0" of the signature = 0x4300, UNKNOWN):
+  // its format/count/value live at offsets 4.. (ours to control).
+  mn.extend_from_slice(&be16(0x0003)); // 4..6  — entry0 format = int16u (VALID ⇒ no entry-0 abort)
+  mn.extend_from_slice(&be32(1)); // 6..10 — entry0 count = 1
+  mn.extend_from_slice(&be16(1)); // 10..12 — entry0 inline value = 1
+  mn.extend_from_slice(&be16(0)); // 12..14 — entry0 inline value padding (= 0)
+  // entry 1 @ offset 14 — Pentax Quality (0x0008), int16u[1], inline value 1.
+  mn.extend_from_slice(&be16(0x0008)); // 14..16 — entry1 tag id = Quality
+  mn.extend_from_slice(&be16(0x0003)); // 16..18 — entry1 format = int16u
+  mn.extend_from_slice(&be32(1)); // 18..22 — entry1 count = 1
+  mn.extend_from_slice(&be16(1)); // 22..24 — entry1 inline value = 1 (Quality = "Better")
+  mn.extend_from_slice(&be16(0)); // 24..26 — entry1 inline value padding
+  mn.extend_from_slice(&be32(0)); // 26..30 — next-IFD pointer = 0 (bytes_from_end = 4)
+  // The blob physically reaches offset 30; the 0x927c tag DECLARES only `mn_len`.
+
+  let mut t: Vec<u8> = Vec::new();
+  t.extend_from_slice(b"MM");
+  t.extend_from_slice(&be16(0x2a));
+  t.extend_from_slice(&be32(ifd0_start as u32));
+  // IFD0: Make, Model, ExifIFD.
+  t.extend_from_slice(&be16(3));
+  t.extend_from_slice(&be16(0x010f));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(make.len() as u32));
+  t.extend_from_slice(&be32(make_off as u32));
+  t.extend_from_slice(&be16(0x0110));
+  t.extend_from_slice(&be16(2));
+  t.extend_from_slice(&be32(model.len() as u32));
+  t.extend_from_slice(&be32(model_off as u32));
+  t.extend_from_slice(&be16(0x8769));
+  t.extend_from_slice(&be16(4));
+  t.extend_from_slice(&be32(1));
+  t.extend_from_slice(&be32(exif_start as u32));
+  t.extend_from_slice(&be32(0));
+  t.extend_from_slice(make);
+  t.extend_from_slice(model);
+  // ExifIFD: MakerNote — DECLARES `mn_len` (< the IFD's physical reach).
+  t.extend_from_slice(&be16(1));
+  t.extend_from_slice(&be16(0x927c));
+  t.extend_from_slice(&be16(7)); // UNDEF
+  t.extend_from_slice(&be32(mn_len));
+  t.extend_from_slice(&be32(mn_start as u32));
+  t.extend_from_slice(&be32(0));
+  t.extend_from_slice(&mn); // the full 30-byte region (IFD bytes stay in the buffer)
+
+  // Wrap in a JPEG: SOI + APP1(Exif\0\0 + tiff) + EOI.
+  let mut app1: Vec<u8> = Vec::new();
+  app1.extend_from_slice(b"Exif\x00\x00");
+  app1.extend_from_slice(&t);
+  let mut jpeg: Vec<u8> = Vec::new();
+  jpeg.extend_from_slice(&[0xff, 0xd8]);
+  jpeg.extend_from_slice(&[0xff, 0xe1]);
+  jpeg.extend_from_slice(&((app1.len() + 2) as u16).to_be_bytes());
+  jpeg.extend_from_slice(&app1);
+  jpeg.extend_from_slice(&[0xff, 0xd9]);
+  jpeg
+}
+
+/// #248 R3 finding — `ProcessUnknown`'s `LocateIFD`-returns-`undef` arm
+/// (`MakerNotes.pm:1834`) must ABORT the sub-directory (ExifTool `return 0`s
+/// WITHOUT processing it), NOT fall back to the unrelocated `ifd_start`. This is
+/// load-bearing now that `walk_one_ifd_body` SALVAGES a non-core count-word
+/// overrun: a Pentax `AOC\0` MakerNote whose declared `0x927c` window holds NO
+/// plausible IFD (`locate_ifd == None`) but whose `AOC`-byte count word is an
+/// overclaim WOULD, on the pre-fix fallback, salvage-clamp to entries that include
+/// a valid `Pentax:Quality` (`0x0008`). The abort suppresses it.
+///
+/// This is the case the existing `pentax_locate_ifd_respects_dirlen_window` does
+/// NOT cover: there the clamped first entry has a zero format code ⇒ a first-entry
+/// abort ⇒ no tags regardless of the R3 fix. HERE the salvage WOULD emit a tag, so
+/// the test fails WITHOUT the abort (verified by reverting the fix) and passes WITH
+/// it. Cross-checked against bundled `perl exiftool -G1 -j`: ExifTool's `LocateIFD`
+/// finds no in-window IFD ⇒ `ProcessUnknown` processes nothing ⇒ no `Pentax:Quality`.
+#[cfg(all(feature = "exif", feature = "std"))]
+#[test]
+fn pentax_locate_ifd_none_aborts_before_overrun_salvage() {
+  use exifast::exif::ifd::ByteOrder;
+  use exifast::exif::makernotes::fixbase;
+
+  // The bare MakerNote value (the `0x927c` payload) — the same bytes the dispatch
+  // hands the Pentax walk at `ifd_start`.
+  let region = {
+    let be16 = |v: u16| v.to_be_bytes();
+    let be32 = |v: u32| v.to_be_bytes();
+    let mut r: Vec<u8> = Vec::new();
+    r.extend_from_slice(b"AOC\x00");
+    r.extend_from_slice(&be16(0x0003));
+    r.extend_from_slice(&be32(1));
+    r.extend_from_slice(&be16(1));
+    r.extend_from_slice(&be16(0));
+    r.extend_from_slice(&be16(0x0008));
+    r.extend_from_slice(&be16(0x0003));
+    r.extend_from_slice(&be32(1));
+    r.extend_from_slice(&be16(1));
+    r.extend_from_slice(&be16(0));
+    r.extend_from_slice(&be32(0));
+    r
+  };
+  // PRECONDITION 1 — `LocateIFD` finds NO IFD within the DECLARED 26-byte window.
+  // The scan tries offsets 0,2,4,6,8,10,12 (offset 14 ⇒ `14 + 14 > 26` breaks):
+  //   @0  count 0x414F — upper byte nonzero ⇒ "not an IFD", skip;
+  //   @2  count 0x4300 — low byte 0 ⇒ toggle, num 0x43 = 67 entries overrun, skip;
+  //   @4  count 0x0003 = 3 — 3 entries overrun the 30-byte blob, skip;
+  //   @6  count 0x0000 = 0 — `next unless $num`, skip;
+  //   @8  count 0x0001 = 1 — the sole entry's format word (@12) is 0 ⇒ reject;
+  //   @10 count 0x0001 = 1 — the sole entry's value-size (format @14 = 8, count
+  //       @16 huge) exceeds the blob ⇒ reject;
+  //   @12 count 0x0000 = 0 — skip.
+  // ⇒ `None`, the R3 precondition (the same `$dirLen`-bounded scan ExifTool runs).
+  assert_eq!(
+    fixbase::locate_ifd(&region, 0, Some(26), ByteOrder::Big, Some("PENTAX"), None),
+    None,
+    "LocateIFD must find NO plausible IFD within the declared 26-byte Pentax window"
+  );
+
+  // PRECONDITION 2 — the count word AT ifd_start (the `AOC` bytes, 0x414F = 16719)
+  // is an overclaim that overruns the buffer ⇒ `walk_one_ifd_body` reaches its
+  // maker-note salvage clamp on the pre-fix `None`-fallback. `(26 - 2) / 12 == 2`
+  // entries are kept; entry 1 (offset 14) is the VALID `Pentax:Quality`.
+  assert_eq!(
+    (26 - 2) / 12,
+    2,
+    "the declared window clamps the overrun to 2 entries"
+  );
+
+  // END-TO-END — declared `mn_len` 26 ⇒ the abort fires: NO Pentax tags. WITHOUT
+  // the R3 abort the salvage would clamp + walk entry 1 and emit `Pentax:Quality`.
+  let data = craft_pentax_aoc_overrun_jpeg(26);
+  let meta = exifast::exif::jpeg::parse_jpeg_exif(&data).expect("crafted Pentax JPEG parsed");
+  let mn = meta.maker_note().expect("MakerNote captured");
+  assert!(
+    mn.vendor().is_pentax(),
+    "vendor = Pentax (AOC primary dispatched)"
+  );
+  assert!(
+    mn.emissions_print_conv().is_empty(),
+    "R3: a None LocateIFD must ABORT the sub-directory — the count-word overrun \
+     salvage must NOT run, so NO Pentax tags emit"
+  );
+  assert_eq!(
+    mn.meta().pentax().and_then(|p| p.quality()),
+    None,
+    "R3: the salvageable Quality entry must be suppressed by the LocateIFD abort"
+  );
+
+  // CROSS-CHECK against bundled ExifTool (when available): `LocateIFD` finds no
+  // in-window IFD ⇒ `ProcessUnknown` processes nothing ⇒ no `Pentax:Quality`.
+  // Skipped (not failed) when the binary is unavailable.
+  #[cfg(feature = "json")]
+  {
+    use std::process::Command;
+    let tool = std::env::var("EXIFTOOL").unwrap_or_else(|_| "exiftool".to_string());
+    if Command::new(&tool).arg("-ver").output().is_ok() {
+      let dir = std::env::temp_dir();
+      let path = dir.join("exifast_pentax_locate_none_abort.jpg");
+      std::fs::write(&path, &data).expect("write temp jpg");
+      let out = Command::new(&tool)
+        .args([
+          "-G1",
+          "-j",
+          "-Make",
+          "-Model",
+          "-Pentax:Quality",
+          "-Quality",
+        ])
+        .arg(&path)
+        .output()
+        .expect("run exiftool");
+      let _ = std::fs::remove_file(&path);
+      assert!(out.status.success(), "exiftool failed");
+      let json = String::from_utf8(out.stdout).expect("utf8");
+      let doc: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+      let obj = doc
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|o| o.as_object())
+        .expect("doc is [{…}]");
+      // The AOC primary dispatch is confirmed by Make; ExifTool emits NO Pentax
+      // Quality (LocateIFD found no in-window IFD ⇒ the directory is not processed).
+      assert_eq!(
+        obj.get("IFD0:Make").and_then(|v| v.as_str()),
+        Some("PENTAX"),
+        "bundled exiftool reads the PENTAX make (AOC primary dispatch)"
+      );
+      assert!(
+        !obj.contains_key("Pentax:Quality"),
+        "bundled exiftool emits NO Pentax:Quality (LocateIFD found no in-window IFD \
+         ⇒ ProcessUnknown processes nothing) — parity with the R3 abort"
+      );
+    } else {
+      eprintln!("SKIP: exiftool binary not available; Pentax LocateIFD-None cross-check skipped");
+    }
+  }
+}


### PR DESCRIPTION
Ports ExifTool's ProcessExif maker-note overrun **salvage clamp** (Exif.pm:6384-6393) into the post-#243 shared Walker: when a maker-note IFD's claimed count overruns the buffer, ExifTool does not abort — if in-maker-notes and dir_len>=14 and in-bounds, it clamps num_entries to (dir_len-2)/12 and walks what fits. A core IFD overrun still aborts.

## Through 3 review rounds
- **R1** — the salvage clamp in walk_one_ifd_body, gated to maker-notes (a shared dir-framing helper), with 4 crafted tests + a bundled exiftool cross-check.
- **R2** — two interaction fixes: the Canon DataMember pre-scan now shares the same salvage clamp (so a salvaged dir's FocalUnits/LensType reach the FocalLength/FileInfo sub-tables — proven via FocalLength '50 mm' not the default); and locate_ifd is now bounded by the declared DirLen window for ProcessUnknown.
- **R3** — when locate_ifd finds no in-window IFD (None), ProcessUnknown now aborts the subdirectory instead of falling back to ifd_start (which, with the new salvage, could emit spurious Pentax/Samsung tags). Regression test + perl cross-check + revert-check.

## Verify
`fmt=0  build(-Dwarnings)=0  conformance=425/0 byte-identical (real Canon/Pentax/Samsung unchanged)  exif_makernotes_dispatch=80/0  typed_serde=530 green`

**Codex adversarial review: APPROVE (R3).**