### PR TITLE
fix(tests): repair the #297 merge — restore 417 clobbered conformance tests + NOT_ACTIVE 2 fixtures

### DIFF
--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -63,14 +63,12 @@ fn pin_utc() {
 }
 
 #[test]
-#[ignore]
 fn aac_conformance() {
   check("AAC.aac", "AAC.aac.json", true);
   check("AAC.aac", "AAC.aac.n.json", false);
 }
 
 #[test]
-#[ignore]
 fn crw_conformance() {
   // Canon CRW (CIFF) container — Phase 1. `tests/fixtures/CanonRaw_min.crw` is
   // a HAND-CRAFTED minimal CIFF heap (the REAL bundled `t/images/CanonRaw.crw`
@@ -135,7 +133,6 @@ fn crw_conformance() {
 }
 
 #[test]
-#[ignore]
 fn crw_scalars_conformance() {
   // The LAST coverage gap in `%CanonRaw::Main` — the remaining scalar tags plus
   // the previously-omitted NAMED no-conv records. `tests/fixtures/
@@ -167,7 +164,6 @@ fn crw_scalars_conformance() {
 }
 
 #[test]
-#[ignore]
 fn crw_omitted_records_conformance() {
   // The three previously-omitted `CanonRaw::Main` binary sub-tables (the Codex
   // CRW finding) — `ExposureInfo` (0x1818), `FlashInfo` (0x1813), `WhiteSample`
@@ -207,7 +203,6 @@ fn crw_omitted_records_conformance() {
 }
 
 #[test]
-#[ignore]
 fn crw_whitesample_big_conformance() {
   // The SubDirectory read-gate fix (`CanonRaw.pm:707-709`: a record whose tag
   // has a `SubDirectory` is read REGARDLESS of size). `WhiteSample` (0x1030) is
@@ -238,7 +233,6 @@ fn crw_whitesample_big_conformance() {
 }
 
 #[test]
-#[ignore]
 fn crw_value_in_directory_conformance() {
   // The `valueInDir` branch (`CanonRaw.pm:692-699`): a record's value lives in
   // the entry's 8-byte size+ptr fields (`$size = 8`, `$value = substr($buff,
@@ -266,7 +260,6 @@ fn crw_value_in_directory_conformance() {
 }
 
 #[test]
-#[ignore]
 fn crw_zero_length_records_conformance() {
   // The ZERO-LENGTH (`size == 0`) record edge (`ReadValue` `$count == 0` ⇒ the
   // EMPTY STRING `''`, `ExifTool.pm:6296-6298`). `tests/fixtures/
@@ -285,7 +278,6 @@ fn crw_zero_length_records_conformance() {
 }
 
 #[test]
-#[ignore]
 fn riff_avi_conformance() {
   // FORMATS.md row 26 — bundled `lib/Image/ExifTool/t/images/RIFF.avi`
   // (1262 bytes, Canon MotionJPEG Camera AVI from 2003). Exercises the
@@ -305,7 +297,6 @@ fn riff_avi_conformance() {
 }
 
 #[test]
-#[ignore]
 fn riff_wav_extensible_encoding_conformance() {
   // Finding 1 (full `%audioEncoding`, RIFF.pm:90-335). A crafted WAV whose
   // `fmt ` Encoding is `0xfffe` = `WAVE_FORMAT_EXTENSIBLE` (RIFF.pm:333) —
@@ -324,7 +315,6 @@ fn riff_wav_extensible_encoding_conformance() {
 }
 
 #[test]
-#[ignore]
 fn riff_info_latin1_charset_conformance() {
   // Finding 2 (CSET/charset). A WAV with `LIST_INFO` `IART` carrying cp1252
   // high bytes (`0xe9`→é, `0x80`→€). The DEFAULT RIFF charset is `'Latin'`
@@ -336,7 +326,6 @@ fn riff_info_latin1_charset_conformance() {
 }
 
 #[test]
-#[ignore]
 fn riff_info_casio_valueconv_conformance() {
   // Finding 2 (INFO ValueConvs). `ISFT` "EXILIM\0CASIO" → "EXILIM, CASIO"
   // (the Casio embedded-NUL ValueConv, RIFF.pm:873); `ICRD` "2003-03-10" →
@@ -347,7 +336,6 @@ fn riff_info_casio_valueconv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn riff_truncated_fmt_conformance() {
   // Finding 4 (truncated-chunk guard). A WAV whose `fmt ` chunk declares 16
   // payload bytes but only 12 are present (runs past EOF). Bundled does NOT
@@ -366,7 +354,6 @@ fn riff_truncated_fmt_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp1_conformance() {
   // QuickTime port Sub-Port 1 (the box/atom walker + core structural
   // atoms). `tests/fixtures/QuickTime_sp1.mov` is a SYNTHETIC minimal
@@ -391,7 +378,6 @@ fn quicktime_sp1_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_v1_tkhd_conformance() {
   // PR #38 Codex R1/F2: a SYNTHETIC `.mov` with a VERSION-1 tkhd. The v1
   // Hook widens only the three time/duration fields (create/modify/duration,
@@ -404,7 +390,6 @@ fn quicktime_v1_tkhd_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_moov_order_conformance() {
   // PR #38 Codex R1/F4 (REFUTED): a SYNTHETIC `.mov` whose `trak` precedes
   // `mvhd` inside `moov`. The `TrackDuration` durationInfo is a ValueConv
@@ -425,7 +410,6 @@ fn quicktime_moov_order_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_conformance() {
   // QuickTime port Sub-Port 2 — the `udta` camera atoms + `moov/meta`
   // Keys/ItemList metadata (make + model + software + capture-date + GPS).
@@ -446,7 +430,6 @@ fn quicktime_sp2_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_badgps_conformance() {
   // QuickTime SP2 — the `ConvertISO6709` raw-string PASS-THROUGH (the high
   // Codex finding). `tests/fixtures/QuickTime_sp2_badgps.mov` is the SP2 fixture
@@ -477,7 +460,6 @@ fn quicktime_sp2_badgps_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_iso6709long_conformance() {
   // QuickTime SP2 — `ConvertISO6709` DECIMAL-form numification fidelity (a
   // verified Codex [medium]). `tests/fixtures/QuickTime_sp2_iso6709long.mov` is
@@ -508,7 +490,6 @@ fn quicktime_sp2_iso6709long_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_infgps_conformance() {
   // QuickTime SP2 — `PrintGPSCoordinates`/`GPS::ToDMS` non-finite fidelity (a
   // verified Codex [medium]). `tests/fixtures/QuickTime_sp2_infgps.mov` is the
@@ -537,7 +518,6 @@ fn quicktime_sp2_infgps_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_ilst_before_keys_conformance() {
   // QuickTime SP2 — `ProcessKeys` SINGLE-PASS, file-order key resolution (a
   // verified Codex [high]). `tests/fixtures/QuickTime_sp2_ilst_before_keys.mov`
@@ -568,7 +548,6 @@ fn quicktime_sp2_ilst_before_keys_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_macroman_conformance() {
   // QuickTime SP2 — default-language (`lang 0`) `udta` text is MacRoman by
   // default (a verified Codex [medium]). `tests/fixtures/QuickTime_sp2_macroman
@@ -598,7 +577,6 @@ fn quicktime_sp2_macroman_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_meta_handlerclass_conformance() {
   // QuickTime SP2 — `moov/meta/hdlr` HandlerClass / ComponentType emission (a
   // verified Codex [medium]). `tests/fixtures/QuickTime_sp2_meta_handlerclass
@@ -627,7 +605,6 @@ fn quicktime_sp2_meta_handlerclass_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_udta_camid_conformance() {
   // QuickTime SP2 camera-identity sweep — the NON-copyright-symbol `udta`
   // camera atoms plus the new copyright-symbol identity atoms.
@@ -666,7 +643,6 @@ fn quicktime_sp2_udta_camid_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_android_conformance() {
   // QuickTime SP2 camera-identity sweep — the `com.android.*` Keys full-key
   // FALLBACK (a verified Codex [medium]). `tests/fixtures/QuickTime_sp2_android
@@ -696,7 +672,6 @@ fn quicktime_sp2_android_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_gopro_conformance() {
   // QuickTime SP2 Part-2 — the conv-less `%QuickTime::UserData` camera atoms
   // (the xtask `--kind quicktime` generated `4cc → Name` map) PLUS the two
@@ -730,7 +705,6 @@ fn quicktime_sp2_gopro_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_keys_direction_conformance() {
   // QuickTime SP2 Part-2 — the conv-less `%QuickTime::Keys` atoms (generated
   // `key → Name` map) PLUS the two code-valued Keys atoms hand-ported in the
@@ -762,7 +736,6 @@ fn quicktime_sp2_keys_direction_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_ilst_binary_conformance() {
   // QuickTime SP2 — the conv-less Keys `data`-atom BINARY branch
   // (QuickTime.pm:10411-10414 `elsif (not $$tagInfo{ValueConv}) { $value =
@@ -789,7 +762,6 @@ fn quicktime_sp2_ilst_binary_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_ilst_numeric_conformance() {
   // QuickTime SP2 — the conv-less Keys `data`-atom NUMERIC branch
   // (QuickTime.pm:10402-10409 `$format = QuickTimeFormat($flags,$len); ... $value
@@ -813,7 +785,6 @@ fn quicktime_sp2_ilst_numeric_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_itext_empty_first_conformance() {
   // QuickTime SP2 — the international-text empty-entry CONTINUATION
   // (QuickTime.pm:10483 `next if not $len and $pos`). `tests/fixtures/
@@ -838,7 +809,6 @@ fn quicktime_sp2_itext_empty_first_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_sp2_itext_empty_only_conformance() {
   // QuickTime SP2 — an international-text atom whose ONLY entry is empty emits
   // NO tag. `tests/fixtures/QuickTime_sp2_itext_empty_only.mov` holds a `©nam`
@@ -860,7 +830,6 @@ fn quicktime_sp2_itext_empty_only_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mxf_conformance() {
   // FORMATS.md row 24 (Engine-only). `tests/fixtures/MXF.mxf` is the
   // bundled `lib/Image/ExifTool/t/images/MXF.mxf` (7510 bytes — header
@@ -881,7 +850,6 @@ fn mxf_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mxf_bad_array_conformance() {
   // Golden-v2 Phase B.1.5 — the `Bad array or batch size` warning
   // (MXF.pm:2525-2528). An `(Array|Batch)` value with `len > 16` whose
@@ -902,7 +870,6 @@ fn mxf_bad_array_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mxf_multidescriptor_conformance() {
   // Codex R1/F1 regression: a multi-essence MXF whose audio descriptors are
   // reachable from the `Preface` root ONLY through the HIDDEN structural
@@ -932,7 +899,6 @@ fn mxf_multidescriptor_conformance() {
 }
 
 #[test]
-#[ignore]
 fn m2ts_conformance() {
   // FORMATS.md row 25 (M2TS / AVCHD camcorder container).
   // `tests/fixtures/M2TS.mts` is the bundled `lib/Image/ExifTool/t/images/
@@ -967,7 +933,6 @@ fn m2ts_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_nested_size0_conformance() {
   // PR #38 Codex R1/F5: a SYNTHETIC `.mov` whose `moov` contains a size-0
   // `free` atom (a CONTAINED zero-size = terminator, QuickTime.pm:10036-
@@ -988,7 +953,6 @@ fn quicktime_nested_size0_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_zerodate_conformance() {
   // PR #38 Codex R2/F1: a SYNTHETIC `.mov` whose mvhd/tkhd/mdhd carry RAW-ZERO
   // CreateDate/ModifyDate/Track*Date/Media*Date. The timeInfo RawConv only
@@ -1010,7 +974,6 @@ fn quicktime_zerodate_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_m4a_conformance() {
   // PR #38 Codex R2/F2: a SYNTHETIC `.mov` with an `M4A ` major brand. The
   // QuickTime parser derives `File:FileType=M4A` AND `File:MIMEType=audio/mp4`
@@ -1023,7 +986,6 @@ fn quicktime_m4a_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_m4a_isom_override_conformance() {
   // PR #38 Codex R10/F1: a SYNTHETIC `.mov` with an `isom` MAJOR brand whose
   // brands resolve to MP4, plus a single `soun`-handler track and NO `vide`
@@ -1048,7 +1010,6 @@ fn quicktime_m4a_isom_override_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_useext_glv_conformance() {
   // PR #38 Codex R11/F1: the `%useExt` rule (QuickTime.pm:240
   // `%useExt = ( GLV => 'MP4' )`, applied at QuickTime.pm:10006-10007). This
@@ -1077,7 +1038,6 @@ fn quicktime_useext_glv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_m4v_conformance() {
   // PR #38 Codex R2/F2: a SYNTHETIC `.mov` with an `M4V ` major brand ⇒
   // `File:FileType=M4V`, `File:MIMEType=video/x-m4v` (QuickTime.pm:10008 +
@@ -1088,7 +1048,6 @@ fn quicktime_m4v_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_zerotimescale_conformance() {
   // PR #38 Codex R2/F3: a SYNTHETIC `.mov` with movie TimeScale=0 and
   // Duration=1200. The durationInfo PrintConv gates on TimeScale TRUTHINESS
@@ -1109,7 +1068,6 @@ fn quicktime_zerotimescale_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_maclang_conformance() {
   // PR #38 Codex R2/F4: a SYNTHETIC `.mov` whose mdhd MediaLanguageCode is a
   // MACINTOSH numeric code (12, < 0x400). The ValueConv keeps the bare number
@@ -1126,7 +1084,6 @@ fn quicktime_maclang_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_matrixfrac_conformance() {
   // PR #38 Codex R3/F1: a SYNTHETIC `.mov` whose mvhd MatrixStructure carries
   // raw 1 in the a/d/w slots. The `Format => 'fixed32s[9]'` reads each entry
@@ -1151,7 +1108,6 @@ fn quicktime_matrixfrac_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_multimoov_conformance() {
   // PR #38 Codex R3/F2: a SYNTHETIC `.mov` with TWO top-level `moov` atoms.
   // The first carries the track (tkhd Duration=1200) under mvhd TimeScale=600;
@@ -1175,7 +1131,6 @@ fn quicktime_multimoov_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_size0_moov_conformance() {
   // PR #38 Codex R4/F1: a SYNTHETIC `.mov` = ftyp + a TOP-LEVEL size-0 `moov`
   // containing a real `mvhd`. For a top-level size-0 atom ExifTool prints
@@ -1198,7 +1153,6 @@ fn quicktime_size0_moov_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_multimoov_tracks_conformance() {
   // PR #38 Codex R4/F2: a SYNTHETIC `.mov` with TWO top-level `moov` atoms,
   // each holding ONE (byte-identical) `trak`. ExifTool's `$track` counter is a
@@ -1222,7 +1176,6 @@ fn quicktime_multimoov_tracks_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_multimoov_tracksdistinct_conformance() {
   // PR #38 Codex R5/F1: a SYNTHETIC `.mov` with TWO top-level `moov` atoms,
   // BOTH numbering their lone `trak` as `Track1`, but carrying DISTINCT tags:
@@ -1249,7 +1202,6 @@ fn quicktime_multimoov_tracksdistinct_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_size0_mdat_first_conformance() {
   // PR #38 Codex R5/F2: a SYNTHETIC `.mov` whose VERY FIRST top-level atom is
   // `size == 0, type = mdat` (extends to EOF). ExifTool's first-atom recognition
@@ -1275,7 +1227,6 @@ fn quicktime_size0_mdat_first_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_multimoov_movdur_conformance() {
   // PR #38 Codex R6/F1: a SYNTHETIC `.mov` with TWO top-level `moov` atoms.
   // moov1's `mvhd` has TimeScale=600 + Duration=3000; moov2's `mvhd` is a
@@ -1302,7 +1253,6 @@ fn quicktime_multimoov_movdur_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_multimoov_gpmf_conformance() {
   // GoPro Codex R7/F1: a SYNTHETIC `.mov` with TWO top-level `moov` atoms where
   // ONLY the LATER `moov` carries `udta/GPMF` (a GoPro DEVC container holding
@@ -1331,7 +1281,6 @@ fn quicktime_multimoov_gpmf_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_gopro_gpmf_conformance() {
   // GoPro Codex R12-A: the FULL default-visible `%GoPro::GPMF` tag set. A
   // SYNTHETIC `.mov` whose `moov/udta/GPMF` (QuickTime.pm:2132-2135 →
@@ -1448,22 +1397,6 @@ fn quicktime_gopro_scen_conformance() {
 }
 
 #[test]
-#[ignore]
-#[ignore = "port gap: QuickTime track-level / freeGPS Rove decrypt; see #100"]
-fn quicktime_rove_r2_4k_conformance() {
-  // Rove R2-4K dashcam MP4 with encrypted freeGPS GPS data.
-  // Source: ExifTool forum topic 5095 (Dropbox link, 23 MB, 9.5 s).
-  // Contains `freeGPS` atoms with XOR-encrypted text GPS records
-  // (gpmd_Rove handler, `\xf2\xe1\xf0\xeeTT` = "Rove" ^ 0xAA).
-  // Unblocks #100 (one of 6 freeGPS variants).
-  check(
-    "QuickTime_rove_r2_4k.MP4",
-    "QuickTime_rove_r2_4k.MP4.json",
-    true,
-  );
-  check(
-    "QuickTime_rove_r2_4k.MP4",
-    "QuickTime_rove_r2_4k.MP4.n.json",
 #[ignore = "port gap: track-level + -ee gating; see #211"]
 fn quicktime_gopro_hero8_gpmf_conformance() {
   // Real GoPro HERO8 Black MP4 (from GoPro's official gpmf-parser repo,
@@ -1510,7 +1443,6 @@ fn quicktime_trunc_ftyp_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_overrun_mdat_conformance() {
   // PR #38 Codex R6/F2: a 12-byte file whose first atom is `mdat` with a
   // DECLARED size of 100. ExifTool records the synthetic `mdat-size` /
@@ -1533,7 +1465,6 @@ fn quicktime_overrun_mdat_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_mdat64_moov_conformance() {
   // PR #38 Codex R12/F1 [REAL-INPUT]: `ftyp` + a `size == 1` 64-bit `mdat`
   // (declared total 48, FITS) + a trailing `moov`. With the DEFAULT
@@ -1559,7 +1490,6 @@ fn quicktime_mdat64_moov_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_mdat64_large_conformance() {
   // PR #38 Codex R12/F1 [REAL-INPUT]: a `size == 1` 64-bit `mdat` declaring a
   // total of 0x80000010 — i.e. `lo > 0x7fffffff` (hi == 0), the real >2GB
@@ -1586,7 +1516,6 @@ fn quicktime_mdat64_large_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_dupmdhd_conformance() {
   // PR #38 Codex R7/F1: a SYNTHETIC `.mov` whose `moov/trak/mdia` holds TWO
   // `mdhd` atoms — a FULL mdhd (TimeScale=600, Duration=1200) followed by a
@@ -1607,7 +1536,6 @@ fn quicktime_dupmdhd_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_nested_trunc_mvhd_conformance() {
   // PR #38 Codex R7/F2: a SYNTHETIC `.mov` with a truncated `mvhd` CONTAINED
   // inside `moov` — the mvhd header is intact but its declared 92-byte payload
@@ -1629,7 +1557,6 @@ fn quicktime_nested_trunc_mvhd_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_nested_trunc_tkhd_conformance() {
   // PR #38 Codex R7/F2: a truncated `tkhd` inside `moov/trak` (declared
   // 90-byte payload, 4 bytes present). ExifTool attaches the truncation
@@ -1649,7 +1576,6 @@ fn quicktime_nested_trunc_tkhd_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_nested_trunc_mdhd_conformance() {
   // PR #38 Codex R7/F2: a truncated `mdhd` nested THREE levels deep inside
   // `moov/trak/mdia` (declared 40-byte payload, 4 bytes present). The
@@ -1669,7 +1595,6 @@ fn quicktime_nested_trunc_mdhd_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_invalid_size_conformance() {
   // PR #38 Codex R8/F1: an 8-byte file `00000004 66747970` — the first atom's
   // 4-byte type `ftyp` is a recognized magic atom but its declared `size == 4`
@@ -1693,7 +1618,6 @@ fn quicktime_invalid_size_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_trunc_ext_hdr_conformance() {
   // PR #38 Codex R8/F1: a 12-byte file whose first atom is `size == 1 ftyp`
   // but whose 8-byte extended-size header is truncated (only 4 of 8 bytes).
@@ -1715,7 +1639,6 @@ fn quicktime_trunc_ext_hdr_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_short_ftyp_conformance() {
   // PR #38 Codex R8/F1: an 8-byte file `00000008 66747970` — a `ftyp` first
   // atom whose RAW 32-bit `size` is `8`, i.e. `< 12`. ExifTool's file-type
@@ -1737,7 +1660,6 @@ fn quicktime_short_ftyp_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_ext_ftyp_conformance() {
   // PR #38 Codex R8/F1: a 24-byte file whose first atom is an EXTENDED-size
   // `ftyp` (`size32 == 1`, 64-bit size 24) with the `isom` major brand.
@@ -1762,7 +1684,6 @@ fn quicktime_ext_ftyp_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_ftyp_first_qt_conformance() {
   // PR #38 Codex R9/F1: a `ftyp` whose major brand is `isom`, minor version 0,
   // and FIRST compatible brand is `qt  `. ExifTool's compatible-brand regex
@@ -1786,7 +1707,6 @@ fn quicktime_ftyp_first_qt_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_nested_invalid_mvhd_conformance() {
   // PR #38 Codex R9/F2: a `moov` containing an `mvhd` whose declared
   // `size == 4` is structurally invalid (`< 8`). ExifTool runs the same
@@ -1809,7 +1729,6 @@ fn quicktime_nested_invalid_mvhd_conformance() {
 }
 
 #[test]
-#[ignore]
 fn quicktime_nested_invalid_tkhd_conformance() {
   // PR #38 Codex R9/F2: a `tkhd` with an invalid declared `size == 4` inside
   // `moov/trak`. ExifTool attaches the `Invalid atom size` warning to the
@@ -1937,7 +1856,6 @@ fn iso5_brand_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mxf_utf16_bom_conformance() {
   // Codex R2/F1 regression: `MXF.mxf` with every UTF-16 `ApplicationName` /
   // `TrackName` value rewritten to carry a byte-order mark (byte-length
@@ -1958,7 +1876,6 @@ fn mxf_utf16_bom_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mxf_dup_duration_all_ff_conformance() {
   // Codex R3/F1 regression: two same-InstanceUID `TimecodeComponent` sets, the
   // EARLIER carrying a VALID `Duration` (100) and the LATER (footer-style)
@@ -1982,7 +1899,6 @@ fn mxf_dup_duration_all_ff_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mxf_utf16_embedded_nul_conformance() {
   // Codex R4/F1 regression: `MXF.mxf` with the UTF-16 `ApplicationName` value
   // changed from `ExifTool` to `E\0ifTool` — the second code unit `00 78`
@@ -2010,7 +1926,6 @@ fn mxf_utf16_embedded_nul_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_conformance() {
   // FORMATS.md row 23. `tests/fixtures/Matroska.mkv` is the bundled
   // `lib/Image/ExifTool/t/images/Matroska.mkv` (507 bytes, video+audio
@@ -2024,7 +1939,6 @@ fn matroska_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_simpletag_conformance() {
   // PR #31 R1 finding F1 — Tags → SimpleTag → TagName/TagString
   // mapping via `Image::ExifTool::Matroska::StdTag` (Matroska.pm:750-
@@ -2048,7 +1962,6 @@ fn matroska_simpletag_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_unknown_segment_conformance() {
   // PR #31 R1 finding F2 — unknown-size master element handling
   // (Matroska.pm:1073-1085, 1114). Synthetic fixture: EBMLHeader +
@@ -2071,7 +1984,6 @@ fn matroska_unknown_segment_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_cluster_skip_conformance() {
   // PR #31 R1 finding F3 — Cluster default-skip (Matroska.pm:1096-
   // 1105). Synthetic fixture: EBMLHeader + Segment[Info + Cluster
@@ -2095,7 +2007,6 @@ fn matroska_cluster_skip_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_negative_subsecond_date_conformance() {
   // PR #31 R2 finding companion fixture — pre-2001 DateUTC (signed
   // nanoseconds < 0) exercises BOTH (a) the EBML 8-byte signed-decode
@@ -2123,7 +2034,6 @@ fn matroska_negative_subsecond_date_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_subsecond_date_conformance() {
   // PR #31 R2 finding — `Value::Date` rendering used `as i64` casting on
   // `secs_unix` (f64), silently dropping the subsecond component that
@@ -2157,7 +2067,6 @@ fn matroska_subsecond_date_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_attachment_conformance() {
   // PR #31 R1 finding F5 — Binary elements (Matroska.pm:552
   // `AttachedFileData`, 695 `TagBinary`). Synthetic fixture:
@@ -2181,7 +2090,6 @@ fn matroska_attachment_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_duration_before_scale_conformance() {
   // PR #31 R3 finding — Duration ValueConv (Matroska.pm:170-171)
   // `'$$self{TimecodeScale} ? $val * $$self{TimecodeScale} / 1e9 :
@@ -2212,7 +2120,6 @@ fn matroska_duration_before_scale_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_duration_no_scale_conformance() {
   // PR #31 R3 — Duration FALSY branch (NO TimecodeScale in the file).
   // ValueConv: `$$self{TimecodeScale} ? ... : $val / 1000` — when
@@ -2236,7 +2143,6 @@ fn matroska_duration_no_scale_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_track_targeted_tag_conformance() {
   // PR #31 R4 finding F2 — Track-targeted SimpleTag misattribution
   // (Matroska.pm:1207-1216). Bundled records every `TrackUID` inside a
@@ -2272,7 +2178,6 @@ fn matroska_track_targeted_tag_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_simpletag_duplicates_conformance() {
   // PR #31 R5 finding — SimpleTag accumulator semantics. Matroska.pm:1224-
   // 1226 is `if ($$tagInfo{NoSave} or $struct) { ... $$struct{$tagName} =
@@ -2318,7 +2223,6 @@ fn matroska_simpletag_duplicates_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_chapters_conformance() {
   // PR #31 R4 finding F1 — ChapterTimeStart (0x11) + ChapterTimeEnd (0x12)
   // were `Kind::Skip` (silent drop). Bundled extracts both as
@@ -2353,7 +2257,6 @@ fn matroska_chapters_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_duration_zero_scale_conformance() {
   // PR #31 R3 finding — the ACTUAL pre-fix bug. ValueConv:
   // `$$self{TimecodeScale} ? $val * $$self{TimecodeScale} / 1e9 :
@@ -2381,7 +2284,6 @@ fn matroska_duration_zero_scale_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_illegal_float_size_conformance() {
   // Golden-v2 Phase B.1.5 — the `Illegal float size` warning + the
   // undef→ValueConv leaf VALUE fix (Matroska.pm:1178-1180). A `Format =>
@@ -2411,7 +2313,6 @@ fn matroska_illegal_float_size_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_warning_collision_conformance() {
   // Golden-v2 Phase B R1 — a group-scoped `$et->Warn` `Warning` TAG colliding
   // with a REAL same-group SimpleTag `Warning` on the `-G1` output key
@@ -2446,7 +2347,6 @@ fn matroska_warning_collision_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_warning_collision_rev_conformance() {
   // Golden-v2 Phase B R1 (the bug-exercising direction) — same `Info:Warning`
   // collision as `matroska_warning_collision`, but the REAL SimpleTag
@@ -2478,7 +2378,6 @@ fn matroska_warning_collision_rev_conformance() {
 }
 
 #[test]
-#[ignore]
 fn matroska_truncated_header_conformance() {
   // Golden-v2 Phase B.1.5 — the `Truncated Matroska header` warning + NO
   // `File:*` (Matroska.pm:1003-1006). When the EBML header's declared body
@@ -2504,7 +2403,6 @@ fn matroska_truncated_header_conformance() {
 }
 
 #[test]
-#[ignore]
 fn plist_bin_conformance() {
   // FORMATS.md row 12b. `tests/fixtures/PLIST-bin.plist` is the bundled
   // `lib/Image/ExifTool/t/images/PLIST-bin.plist` (351 bytes — a binary
@@ -2538,7 +2436,6 @@ fn plist_bin_conformance() {
 /// This exercises the engine surface (`extract_info` via `check`). The typed
 /// `parse_bytes` surface is asserted in `plist_trunc_bin_parse_bytes_recognized`.
 #[test]
-#[ignore]
 fn plist_trunc_bin_conformance() {
   check("plist_trunc_bin.plist", "plist_trunc_bin.plist.json", true);
   check(
@@ -2557,7 +2454,6 @@ fn plist_trunc_bin_conformance() {
 /// PLIST` + `File:MIMEType = application/x-plist` (PLIST.pm:483) — the
 /// observability bundled emits and the pre-fix `Ok(None)` lost.
 #[test]
-#[ignore]
 fn plist_trunc_bin_parse_bytes_recognized() {
   let trunc: &[u8] = b"bplist00";
   // Typed public dispatch must recognize it (not `Ok(None)`).
@@ -2603,7 +2499,6 @@ fn plist_trunc_bin_parse_bytes_recognized() {
 }
 
 #[test]
-#[ignore]
 fn plist_xml_conformance() {
   // FORMATS.md row 12b. `tests/fixtures/PLIST-xml.plist` is the bundled
   // `lib/Image/ExifTool/t/images/PLIST-xml.plist` (795 bytes — the same
@@ -2624,7 +2519,6 @@ fn plist_xml_conformance() {
 /// `plainstr` string array confirms the verified string-array last-wins
 /// behavior is unchanged. Bundled `exiftool -j -G1 -struct` is the golden.
 #[test]
-#[ignore]
 fn plist_xml_array_of_dict_conformance() {
   check(
     "plist_synth_xml_array_of_dict.plist",
@@ -2646,7 +2540,6 @@ fn plist_xml_array_of_dict_conformance() {
 /// `application/xml` (MODD has no `%mimeType` entry). Bundled
 /// `exiftool -j -G1 -struct` is the golden.
 #[test]
-#[ignore]
 fn plist_xml_modd_content_conformance() {
   check(
     "plist_synth_xml_modd_content.xml",
@@ -2669,7 +2562,6 @@ fn plist_xml_modd_content_conformance() {
 /// collides while the override does not. The old port checked the generated
 /// name and would have wrongly typed this `MODD`.
 #[test]
-#[ignore]
 fn plist_xml_xmlfiletype_collide_conformance() {
   check(
     "plist_synth_xml_xmlfiletype_collide.xml",
@@ -2693,7 +2585,6 @@ fn plist_xml_xmlfiletype_collide_conformance() {
 /// `plist_aae_compressed.aae` (which is typed AAE by its `.aae` extension, not
 /// by content). Bundled `exiftool -j -G1 -struct` is the golden.
 #[test]
-#[ignore]
 fn plist_xml_aae_override_conformance() {
   check(
     "plist_synth_xml_aae_override.xml",
@@ -2723,7 +2614,6 @@ fn plist_xml_aae_override_conformance() {
 /// XMP) to `ProcessPlist`; nested-dict key flattening (`TestDictAuthor`) still
 /// works. Bundled `exiftool -j -G1 -struct` is the golden.
 #[test]
-#[ignore]
 fn plist_xml_utf8bom_conformance() {
   check(
     "plist_synth_xml_utf8bom.plist",
@@ -2743,7 +2633,6 @@ fn plist_xml_utf8bom_conformance() {
 /// is stored under the bare `outer` key ID ⇒ `XML:Outer="Deep"`. The prior
 /// pass dropped nested arrays (the wildcard arm + `scalar_to_leaf`→None).
 #[test]
-#[ignore]
 fn plist_xml_nested_scalar_array_conformance() {
   check(
     "plist_synth_xml_nested_scalar_array.plist",
@@ -2763,7 +2652,6 @@ fn plist_xml_nested_scalar_array_conformance() {
 /// `XML:TopInner="Val"`. Confirms the empty-slot accounting recurses through
 /// nested arrays, not just the single-array-of-dict case.
 #[test]
-#[ignore]
 fn plist_xml_nested_array_of_dict_conformance() {
   check(
     "plist_synth_xml_nested_array_of_dict.plist",
@@ -2788,7 +2676,6 @@ fn plist_xml_nested_array_of_dict_conformance() {
 /// before the sibling scalar (`Top="B"` / `TopFoo="A"`); the event-stream
 /// rework reproduces the sticky state. Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_mixed_array_conformance() {
   check(
     "plist_synth_xml_mixed_array.plist",
@@ -2808,7 +2695,6 @@ fn plist_xml_mixed_array_conformance() {
 /// the XMP parser's no-child-elements value path), rather than being treated as
 /// pure structure and dropped. Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_empty_containers_conformance() {
   check(
     "plist_synth_xml_empty_containers.plist",
@@ -2832,7 +2718,6 @@ fn plist_xml_empty_containers_conformance() {
 /// root string; the override is now derived from the event-stream emission.
 /// Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_modd_array_conformance() {
   check(
     "plist_synth_xml_modd_array.xml",
@@ -2852,7 +2737,6 @@ fn plist_xml_modd_array_conformance() {
 /// TYPE (`[42,3.5,"hi",false,"(Binary data …)"]`) — not the prior
 /// `Vec<String>` flattening that dropped `real` / `data`.
 #[test]
-#[ignore]
 fn plist_bin_mixed_array_conformance() {
   check(
     "plist_synth_bin_mixed_array.plist",
@@ -2872,7 +2756,6 @@ fn plist_bin_mixed_array_conformance() {
 /// `Tag9Abc`, `Tag-Foo`), while a normal key (`Good`) is not. The XML-only
 /// `MetaDataList//` / `//name` strips do NOT apply on the binary path.
 #[test]
-#[ignore]
 fn plist_bin_tag_prefix_conformance() {
   check(
     "plist_synth_bin_tag_prefix.plist",
@@ -2895,7 +2778,6 @@ fn plist_bin_tag_prefix_conformance() {
 /// hard-coded `+00:00` regardless of OS TZ; this fixture pins the localtime
 /// code path's UTC-host output.
 #[test]
-#[ignore]
 fn plist_bin_date_conformance() {
   pin_utc();
   check(
@@ -2918,7 +2800,6 @@ fn plist_bin_date_conformance() {
 /// (`XML:Good`). R1 F3 had added the guard to the binary path only; bundled
 /// `exiftool -j -G1 -struct` is the golden.
 #[test]
-#[ignore]
 fn plist_xml_short_keys_conformance() {
   check(
     "plist_synth_xml_short_keys.plist",
@@ -2942,7 +2823,6 @@ fn plist_xml_short_keys_conformance() {
 /// bundled `exiftool -j -G1 -struct` is the golden — emits BOTH
 /// `PLIST:CastName` and `PLIST:Cast`.
 #[test]
-#[ignore]
 fn plist_bin_array_of_dict_conformance() {
   check(
     "plist_synth_bin_array_of_dict.plist",
@@ -2969,7 +2849,6 @@ fn plist_bin_array_of_dict_conformance() {
 /// and missed every conversion; bundled `exiftool -j/-n -G1 -struct` is the
 /// golden.
 #[test]
-#[ignore]
 fn plist_xml_static_table_conformance() {
   check(
     "plist_synth_xml_static_table.plist",
@@ -2990,7 +2869,6 @@ fn plist_xml_static_table_conformance() {
 /// module's no-`%Composite` scope) does not fire. `-j` ⇒ `122 deg 25' 9.84"
 /// W`, `-n` ⇒ raw `-122.4194`.
 #[test]
-#[ignore]
 fn plist_xml_gps_longitude_conformance() {
   check(
     "plist_synth_xml_gps_longitude.plist",
@@ -3010,7 +2888,6 @@ fn plist_xml_gps_longitude_conformance() {
 /// scalar `9223372036854775808`; the prior `as i64` cast wrapped it to
 /// `-9223372036854775808`. Bundled `exiftool` is the golden.
 #[test]
-#[ignore]
 fn plist_bin_uint64_conformance() {
   check(
     "plist_synth_bin_uint64.plist",
@@ -3034,7 +2911,6 @@ fn plist_bin_uint64_conformance() {
 /// deeper was dropped by `value_to_list_leaf`. Bundled emits BOTH
 /// `PLIST:CastName="Ann"` and `PLIST:Cast=[[]]`.
 #[test]
-#[ignore]
 fn plist_bin_nested_array_dict_conformance() {
   check(
     "plist_synth_bin_nested_array_dict.plist",
@@ -3055,7 +2931,6 @@ fn plist_bin_nested_array_dict_conformance() {
 /// `trunc()`'d ⇒ `…00:00:00`. `TZ=UTC`-pinned (`pin_utc`) for a
 /// host-independent `+00:00` offset. Bundled `exiftool` is the golden.
 #[test]
-#[ignore]
 fn plist_bin_frac_date_conformance() {
   pin_utc();
   check(
@@ -3077,7 +2952,6 @@ fn plist_bin_frac_date_conformance() {
 /// `…00:00:01`. `TZ=UTC`-pinned; bundled `exiftool` is the golden
 /// (`ConvertUnixTime(0.5 + 11323*24*3600, 1)` ⇒ `2001:01:01 00:00:00+00:00`).
 #[test]
-#[ignore]
 fn plist_bin_halfeven_date_half_conformance() {
   pin_utc();
   check(
@@ -3096,7 +2970,6 @@ fn plist_bin_halfeven_date_half_conformance() {
 /// (`apple=0.5000001`), which DOES round up to `2001:01:01 00:00:01`. Pairs
 /// with the exact-tie case to pin both sides of the half-to-even boundary.
 #[test]
-#[ignore]
 fn plist_bin_halfeven_date_halfup_conformance() {
   pin_utc();
   check(
@@ -3116,7 +2989,6 @@ fn plist_bin_halfeven_date_halfup_conformance() {
 /// by borrowing a second (true floor), then half-to-even leaves `…:00` (no
 /// carry) ⇒ one second before the epoch, `2000:12:31 23:59:59`.
 #[test]
-#[ignore]
 fn plist_bin_halfeven_date_neghalf_conformance() {
   pin_utc();
   check(
@@ -3137,7 +3009,6 @@ fn plist_bin_halfeven_date_neghalf_conformance() {
 /// first, dropping the fraction (and mis-firing the `$time == 0` sentinel for
 /// sub-second values). Bundled `exiftool` ⇒ `1970:01:01 00:00:01`.
 #[test]
-#[ignore]
 fn plist_xml_frac_dto_pos_conformance() {
   pin_utc();
   check(
@@ -3156,7 +3027,6 @@ fn plist_xml_frac_dto_pos_conformance() {
 /// the half-second (`25569 + 0.5/86400`; the IEEE-754 value is ~0.5000001 s,
 /// not a true tie, so it rounds UP) ⇒ `1970:01:01 00:00:01`.
 #[test]
-#[ignore]
 fn plist_xml_frac_dto_half_conformance() {
   pin_utc();
   check(
@@ -3175,7 +3045,6 @@ fn plist_xml_frac_dto_half_conformance() {
 /// day (`25569 - 0.6/86400`). The float is `-0.5999998888` s; ExifTool floors
 /// to `$itime = -1` and rounds the folded fraction ⇒ `1969:12:31 23:59:59`.
 #[test]
-#[ignore]
 fn plist_xml_frac_dto_neg_conformance() {
   pin_utc();
   check(
@@ -3212,7 +3081,6 @@ fn plist_xml_frac_dto_neg_conformance() {
 /// `CompressedPLIST => 1` entry in `%PLIST::Main`
 /// (`rg -n 'CompressedPLIST' PLIST.pm` = 2 matches, both this entry).
 #[test]
-#[ignore]
 fn plist_aae_compressed_conformance() {
   check(
     "plist_aae_compressed.aae",
@@ -3245,7 +3113,6 @@ fn plist_aae_compressed_conformance() {
 /// decode at :186 + the UCS-2BE-string binary type-6 at :308-311 + this
 /// recognition arm; JSON branch is separate, handled at PLIST.pm:490-493).
 #[test]
-#[ignore]
 fn plist_ucs2be_legacy_conformance() {
   check(
     "plist_synth_ucs2be_legacy.plist",
@@ -3269,7 +3136,6 @@ fn plist_ucs2be_legacy_conformance() {
 /// _lists`, so a root binary dict `{ a: v1, a: v2, b: v3 }` emits
 /// `PLIST:TagA=[v1, v2], PLIST:TagB=v3` (matches the oracle).
 #[test]
-#[ignore]
 fn plist_bin_dup_consec_conformance() {
   check(
     "plist_synth_bin_dup_consec.plist",
@@ -3293,7 +3159,6 @@ fn plist_bin_dup_consec_conformance() {
 /// the array branch's `child_scratch` (Codex R2 F4), so the class is fully
 /// covered.
 #[test]
-#[ignore]
 fn plist_bin_dup_nested_conformance() {
   check(
     "plist_synth_bin_dup_nested.plist",
@@ -3318,7 +3183,6 @@ fn plist_bin_dup_nested_conformance() {
 /// is a no-op for non-adjacent same-name pairs, so the second `TagA`
 /// emission overwrites the first.
 #[test]
-#[ignore]
 fn plist_bin_dup_nonconsec_conformance() {
   check(
     "plist_synth_bin_dup_nonconsec.plist",
@@ -3338,7 +3202,6 @@ fn plist_bin_dup_nonconsec_conformance() {
 /// 5-byte UID `11 22 33 44 55` ⇒ `PLIST:Uid="0x1122334455"` and a 9-byte UID
 /// `11..99` ⇒ `"0x112233445566778899"`.
 #[test]
-#[ignore]
 fn plist_bin_uid5_conformance() {
   check(
     "plist_synth_bin_uid5.plist",
@@ -3353,7 +3216,6 @@ fn plist_bin_uid5_conformance() {
 }
 
 #[test]
-#[ignore]
 fn plist_bin_uid9_conformance() {
   check(
     "plist_synth_bin_uid9.plist",
@@ -3373,7 +3235,6 @@ fn plist_bin_uid9_conformance() {
 /// is hex-formatted `8-4-4-4-12` upper-case. The fixture's UID bytes
 /// `00 11 22 … FF` ⇒ `PLIST:Uid="33221100-5544-7766-8899-AABBCCDDEEFF"`.
 #[test]
-#[ignore]
 fn plist_bin_uid16_conformance() {
   check(
     "plist_synth_bin_uid16.plist",
@@ -3393,7 +3254,6 @@ fn plist_bin_uid16_conformance() {
 /// `<key>Real</key>` is extracted (`XML:Real="RealValue"`; the `Fake` tag
 /// never appears).
 #[test]
-#[ignore]
 fn plist_xml_comment_fake_root_conformance() {
   check(
     "plist_synth_xml_comment_fake_root.plist",
@@ -3413,7 +3273,6 @@ fn plist_xml_comment_fake_root_conformance() {
 /// `<key>After</key>` is still parsed (`XML:Items="beta"`,
 /// `XML:After="tail"`).
 #[test]
-#[ignore]
 fn plist_xml_comment_in_container_conformance() {
   check(
     "plist_synth_xml_comment_in_container.plist",
@@ -3434,7 +3293,6 @@ fn plist_xml_comment_in_container_conformance() {
 /// `foobar` (the comment text is dropped). Bundled `exiftool -j -G1 -struct`
 /// golden — `XML:Title="foobar"`.
 #[test]
-#[ignore]
 fn plist_xml_scalar_comment_conformance() {
   check(
     "plist_synth_xml_scalar_comment.plist",
@@ -3455,7 +3313,6 @@ fn plist_xml_scalar_comment_conformance() {
 /// `DecodeBase64` (PLIST.pm:177-178) — yielding a 7-byte payload, NOT the
 /// 5-byte hex decode of `Hello`. Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_data_ws_hex_conformance() {
   check(
     "plist_synth_xml_data_ws_hex.plist",
@@ -3476,7 +3333,6 @@ fn plist_xml_data_ws_hex_conformance() {
 /// `Valid`; `flags=3` ⇒ `Valid, Has been rounded`. The `-n` snapshot shows
 /// the raw integers. Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_slowmotion_flags_conformance() {
   check(
     "plist_synth_xml_slowmotion_flags.plist",
@@ -3500,7 +3356,6 @@ fn plist_xml_slowmotion_flags_conformance() {
 /// drops the illegal `<`/`!`/`>`/`\n` ⇒ `K--Mlkey--Ey`). Bundled
 /// `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_multiline_comment_conformance() {
   check(
     "plist_synth_xml_multiline_comment.plist",
@@ -3522,7 +3377,6 @@ fn plist_xml_multiline_comment_conformance() {
 /// `(none)`. The `-n` snapshot keeps the raw leaf (`3` / `abc`). Bundled
 /// `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_slowmotion_flags_string_conformance() {
   check(
     "plist_synth_xml_slowmotion_flags_string.plist",
@@ -3545,7 +3399,6 @@ fn plist_xml_slowmotion_flags_string_conformance() {
 /// (PLIST.pm:188 Tag-prefix normalization) and `XML:Title` ⇒ `foobar`.
 /// Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_comment_non_ascii_conformance() {
   check(
     "plist_synth_xml_comment_non_ascii.plist",
@@ -3567,7 +3420,6 @@ fn plist_xml_comment_non_ascii_conformance() {
 /// `0xFFFFFF9C`. The `-n` snapshot keeps the raw leaf (`1e2` / `-1e2`).
 /// Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_slowmotion_flags_exponent_conformance() {
   check(
     "plist_synth_xml_slowmotion_flags_exponent.plist",
@@ -3589,7 +3441,6 @@ fn plist_xml_slowmotion_flags_exponent_conformance() {
 /// saturates the UV high to all-ones — same all-bits decode. The `-n`
 /// snapshot keeps the raw leaf. Bundled `exiftool -j -G1 -struct` golden.
 #[test]
-#[ignore]
 fn plist_xml_slowmotion_flags_overflow_conformance() {
   check(
     "plist_synth_xml_slowmotion_flags_overflow.plist",
@@ -3616,7 +3467,6 @@ fn plist_xml_slowmotion_flags_overflow_conformance() {
 /// — never copying the multi-MB payload. Bundled `exiftool -j -G1 -struct`
 /// golden; identical in `-n`.
 #[test]
-#[ignore]
 fn plist_bin_data_boundary_conformance() {
   check(
     "plist_synth_bin_data_boundary.plist",
@@ -3641,7 +3491,6 @@ fn plist_bin_data_boundary_conformance() {
 /// use -b option to extract)`. Bundled `exiftool -j -G1 -struct` golden;
 /// identical in `-n`.
 #[test]
-#[ignore]
 fn plist_bin_data_oversize_conformance() {
   check(
     "plist_synth_bin_data_oversize.plist",
@@ -3669,7 +3518,6 @@ fn plist_bin_data_oversize_conformance() {
 /// identical for `-j` and `-n`. Bundled `exiftool -j -G1 -struct` is the
 /// golden.
 #[test]
-#[ignore]
 fn plist_xml_real_nonfinite_conformance() {
   check(
     "plist_synth_xml_real_nonfinite.plist",
@@ -3699,7 +3547,6 @@ fn plist_xml_real_nonfinite_conformance() {
 /// non-JSON-numeric value (`"007"`, `"0x10"`, `" 3.0 "`) stays a quoted string
 /// both sides. Bundled `exiftool -j -G1 -struct` is the golden.
 #[test]
-#[ignore]
 fn plist_xml_integer_real_raw_conformance() {
   check(
     "plist_synth_xml_integer_real_raw.plist",
@@ -3730,7 +3577,6 @@ fn plist_xml_integer_real_raw_conformance() {
 /// only `XML:DateClean` is rewritten. Bundled `exiftool -j -G1 -struct` is the
 /// golden.
 #[test]
-#[ignore]
 fn plist_xml_date_raw_conformance() {
   check(
     "plist_synth_xml_date_raw.plist",
@@ -3745,7 +3591,6 @@ fn plist_xml_date_raw_conformance() {
 }
 
 #[test]
-#[ignore]
 fn wavpack_conformance() {
   // FORMATS.md row 6. Native `wvpk....` 32-byte header (no RIFF wrapper,
   // no ID3, no APE) ⇒ ProcessWV runs the WavPack::Main ProcessBinaryData
@@ -3758,7 +3603,6 @@ fn wavpack_conformance() {
 }
 
 #[test]
-#[ignore]
 fn wavpack_adversarial_conformance() {
   // Flags = 0xFFFFFFFF: every mask saturates ⇒ exercises the off-end of
   // every PrintConv hash (SampleRate index 15 = 'Custom' is the only
@@ -3778,7 +3622,6 @@ fn wavpack_adversarial_conformance() {
 }
 
 #[test]
-#[ignore]
 fn dsf_conformance() {
   // FORMATS.md row 7. Faithful DSF.pm port (1:1 of ExifTool 13.58
   // lib/Image/ExifTool/DSF.pm:55-99). The fixture is a synthesized minimal
@@ -3788,7 +3631,6 @@ fn dsf_conformance() {
 }
 
 #[test]
-#[ignore]
 fn dsf_short_fmt_warning_conformance() {
   // Pins DSF.pm:71-72 Warn + `return 1`: a DSF whose `fmtLen` violates the
   // `>12 && <1000` guard (here `fmtLen=8`) still emits File:* via
@@ -3799,7 +3641,6 @@ fn dsf_short_fmt_warning_conformance() {
 }
 
 #[test]
-#[ignore]
 fn dv_conformance() {
   // FORMATS.md row 11. `tests/fixtures/DV.dv` is the bundled
   // `lib/Image/ExifTool/t/images/DV.dv` (4400 bytes, PAL 25Mbps 4:2:0,
@@ -3813,7 +3654,6 @@ fn dv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_rm_conformance() {
   // FORMATS.md row 19. `tests/fixtures/Real.rm` is the bundled
   // `lib/Image/ExifTool/t/images/Real.rm` (1915 bytes). Exercises the
@@ -3829,7 +3669,6 @@ fn real_rm_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_ra_conformance() {
   // FORMATS.md row 19. `tests/fixtures/Real.ra` is the bundled
   // `lib/Image/ExifTool/t/images/Real.ra` (130 bytes, RealAudio V4).
@@ -3842,7 +3681,6 @@ fn real_ra_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_1audio_conformance() {
   // Codex R1 F1 adversarial — pinpoints the bundled `File:MIMEType`
   // override (Real.pm:653-657) for a 1-stream RM whose sole MDPR
@@ -3856,7 +3694,6 @@ fn real_synth_1audio_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_2_audio_audio_conformance() {
   // Codex R1 F1 adversarial — 2-stream RM with BOTH MIMEs populated
   // (`audio/x-pn-realaudio` each). Bundled @mimeTypes has 2 entries, so
@@ -3876,7 +3713,6 @@ fn real_synth_2_audio_audio_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_id3v1_empty_title_conformance() {
   // Codex R1 F2 adversarial — RM + RJMD footer + ID3v1 trailer whose
   // Title slot is ALL NULL (faithful bundled `"ID3v1:Title": ""`). The
@@ -3899,7 +3735,6 @@ fn real_synth_id3v1_empty_title_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_embedded_nul_mime_conformance() {
   // Codex R2 adversarial — RM whose 1 MDPR carries a StreamMimeType with
   // an EMBEDDED NUL byte (`audio/x\0pn-realaudio`). Bundled Real.pm:643
@@ -3924,7 +3759,6 @@ fn real_synth_embedded_nul_mime_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_id3v1_sparse_genre_conformance() {
   // Codex R1 F2 adversarial — RM + RJMD footer + ID3v1 trailer whose
   // Genre byte is 192 (SPARSE — outside the GENRE_ENTRIES named-genre
@@ -3950,7 +3784,6 @@ fn real_synth_id3v1_sparse_genre_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_ram_pnm_conformance() {
   // PR #33 Copilot finding — the RAM/RPM Metafile branch (Real.pm:533-555).
   // `tests/fixtures/real_synth_ram_pnm.ram` is a synthetic RAM playlist:
@@ -3975,7 +3808,6 @@ fn real_synth_ram_pnm_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_rpm_pnm_conformance() {
   // PR #33 Copilot finding — RAM-vs-RPM is decided ONLY by the file
   // extension (Real.pm:535-536 `$$et{FILE_EXT} eq 'RPM'`). Same kind of
@@ -3998,7 +3830,6 @@ fn real_synth_rpm_pnm_conformance() {
 }
 
 #[test]
-#[ignore]
 fn real_synth_metafile_http_accept_conformance() {
   // PR #33 Copilot finding — the `http`-line acceptance gate (Real.pm:546:
   // `return 0 if $buff =~ /^http/ and $buff !~ /\.(ra|rm|rv|rmvb|smil)$/i`).
@@ -4022,7 +3853,6 @@ fn real_synth_metafile_http_accept_conformance() {
 }
 
 #[test]
-#[ignore]
 fn dv_unknown_profile_conformance() {
   // Adversarial: 480-byte synthetic with the primary `\x1f\x07\0\x3f`
   // magic and `stype=0x1f` at offset 451 — never present in
@@ -4039,7 +3869,6 @@ fn dv_unknown_profile_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ogg_conformance() {
   // FORMATS.md row 9 (Ogg + Vorbis-comments): a real Ogg-Vorbis fixture
   // from the bundled-ExifTool corpus. The committed golden is bundled
@@ -4056,7 +3885,6 @@ fn ogg_conformance() {
 }
 
 #[test]
-#[ignore]
 fn malformed_ogg_error_conformance() {
   // Adversarial: a 16-byte file starting with `OggS` magic but truncated
   // before the page-header is even 27 bytes long. `.ogg` is a known
@@ -4069,7 +3897,6 @@ fn malformed_ogg_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ogg_truncated_error_conformance() {
   // R1 regression pin: a 27-byte file with valid `OggS` magic but exactly
   // ONE byte short of the page-header minimum read. Bundled `Ogg.pm:94`
@@ -4083,7 +3910,6 @@ fn ogg_truncated_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ogg_vorbis_trailing_garbage_conformance() {
   // R2 regression pin (Codex round-2 [medium] disposition: finding rejected
   // as misframed — see commit message + `src/formats/ogg.rs::process_vorbis_comments`).
@@ -4130,7 +3956,6 @@ fn ogg_vorbis_trailing_garbage_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ogg_vorbis_interleaved_list_conformance() {
   // R1-F2 regression pin: an Ogg-Vorbis comment block with INTERLEAVED
   // `List => 1` and non-List keys: vendor + ARTIST=Alice, TITLE=Song,
@@ -4162,7 +3987,6 @@ fn ogg_vorbis_interleaved_list_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mp3_conformance() {
   // ID3-free MPEG-1 Layer III audio frame at 128 kbps / 44.1 kHz / Joint
   // Stereo (a single 417-byte frame: 4-byte header 0xfffb904c + 413 zero
@@ -4177,7 +4001,6 @@ fn mp3_conformance() {
 }
 
 #[test]
-#[ignore]
 fn vbr_xing_lame_mp3_conformance() {
   // Synthesized 504-byte VBR Xing+LAME MP3. Pins the MPEG.pm:501-578 tail:
   // `%MPEG::Xing` (VBRFrames=1000, VBRBytes=200_000, VBRScale=78, Encoder=
@@ -4195,7 +4018,6 @@ fn vbr_xing_lame_mp3_conformance() {
 }
 
 #[test]
-#[ignore]
 fn vbr_no_vbrscale_mp3_conformance() {
   // F2 (Codex R2): Xing+LAME MP3 with flags = 0x13 — VBRFrames | VBRBytes |
   // LAME, deliberately OMITTING the VBRScale flag bit (0x08). MPEG.pm:510
@@ -4215,7 +4037,6 @@ fn vbr_no_vbrscale_mp3_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mus_layer2_conformance() {
   // Codex R3: 5-byte MUS fixture (`\xff\xfd\x90\x4c\x00`) = MPEG-1 Layer II
   // sync at 160 kbps / 44.1 kHz / Joint Stereo. Bundled `ID3::ProcessMP3`
@@ -4233,7 +4054,6 @@ fn mus_layer2_conformance() {
 }
 
 #[test]
-#[ignore]
 fn junk_past_8k_mp3_conformance() {
   // F1 (Codex R1): 8200 bytes of pseudo-random non-`\xff` filler followed
   // by a valid Layer III header at offset 8200. Bundled ExifTool's
@@ -4249,7 +4069,6 @@ fn junk_past_8k_mp3_conformance() {
 }
 
 #[test]
-#[ignore]
 fn malformed_mp3_error_conformance() {
   // `.mp3` extension + 144 bytes that all fail the audio-frame header
   // validation (either sync-bit reject or bad bitrate). `MP3` is a known
@@ -4262,7 +4081,6 @@ fn malformed_mp3_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ogg_vorbis_specialkeys_conformance() {
   // R3 regression pin (Codex round-3 [medium] dispositions F1+F2).
   //
@@ -4315,7 +4133,6 @@ fn ogg_vorbis_specialkeys_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ogg_id3_prefixed_conformance() {
   // R3 F1 regression pin (Codex round-3 [high] disposition).
   //
@@ -4342,7 +4159,6 @@ fn ogg_id3_prefixed_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ogg_metadata_block_picture_conformance() {
   // R3 F2 regression pin (Codex round-3 [high] disposition).
   //
@@ -4375,7 +4191,6 @@ fn ogg_metadata_block_picture_conformance() {
 }
 
 #[test]
-#[ignore]
 #[ignore = "Ogg-FLAC transport (Ogg.pm:176-179, 190-195): \\x7fFLAC packet → \
   ProcessFLAC on substr(buff,9). FORMALLY ACCEPT-DEFERRED — see docs/tracking.md \
   (R3 F2 fallback). The METADATA_BLOCK_PICTURE half of R3 F2 IS fixed (see \
@@ -4414,7 +4229,6 @@ fn ogg_flac_transport_deferred() {
 }
 
 #[test]
-#[ignore]
 fn ogg_opus_synthetic_conformance() {
   // A synthetic minimal Ogg-Opus stream (BOS page wrapping `OpusHead` +
   // EOS page wrapping `OpusTags` with vendor + 2 KEY=VALUE comments —
@@ -4440,7 +4254,6 @@ fn ogg_opus_synthetic_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_aa_conformance() {
   // FORMATS.md row 10. Bundled fixture
   // `exiftool/t/images/Audible.aa`; goldens captured from `LC_ALL=C
@@ -4452,7 +4265,6 @@ fn audible_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_chapters_aa_conformance() {
   // Adversarial synthesized fixture: minimal valid AA exercising the
   // type-6 ChapterCount path (Audible.pm:221-225, absent from the
@@ -4464,7 +4276,6 @@ fn audible_chapters_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_eof_aa_conformance() {
   // Adversarial: TOC has a type-6 entry whose offset is past EOF (the
   // 0xFFFFFFFF sentinel). The faithful Perl behavior (Audible.pm:222
@@ -4478,7 +4289,6 @@ fn audible_eof_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_warn_aa_conformance() {
   // Adversarial: malformed AA whose first chunk-2 dictionary has
   // `num > 0x200` ⇒ Audible.pm:240 `Warn('Bad dictionary count'),
@@ -4496,7 +4306,6 @@ fn audible_warn_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_badutf_aa_conformance() {
   // Adversarial: chunk-2 dictionary value contains a raw 0xFF byte
   // (`A\xffB`). Bundled Perl ExifTool's pipeline:
@@ -4518,7 +4327,6 @@ fn audible_badutf_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_surrogate_aa_conformance() {
   // Adversarial: chunk-2 dictionary value `"X&#xD800;Y"`. Bundled Perl:
   //   bytes "X&#xD800;Y" → UnescapeHTML →
@@ -4538,7 +4346,6 @@ fn audible_surrogate_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_dup_aa_conformance() {
   // R5: two `author` entries in chunk-2 dictionary. Bundled Perl
   // `FoundTag` (ExifTool.pm:9504-9577) promotes the first entry to
@@ -4552,7 +4359,6 @@ fn audible_dup_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_bigent_aa_conformance() {
   // R5: chunk-2 dictionary value `"&#x100000000;"` — a numeric entity
   // whose body exceeds u32. Bundled Perl: `hex("100000000")` →
@@ -4565,7 +4371,6 @@ fn audible_bigent_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_dupchap_aa_conformance() {
   // R6: two type-6 ChapterCount chunks in TOC (counts 1, then 2).
   // Bundled Perl `FoundTag` last-wins (ExifTool.pm:9504-9577) +
@@ -4580,7 +4385,6 @@ fn audible_dupchap_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_under_aa_conformance() {
   // R6: dict tag `__foo` exercises Perl `AddTagToTable` (ExifTool.pm:
   // 9217-9266) final name normalization: after MakeTagName +
@@ -4594,7 +4398,6 @@ fn audible_under_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_dictcover_aa_conformance() {
   // R6: dictionary tag `_cover_art` (Audible.pm:43-47, `Binary => 1`)
   // takes the static-table branch but its raw value is binary — the
@@ -4610,7 +4413,6 @@ fn audible_dictcover_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_reserved_aa_conformance() {
   // R7: dict tags `GROUPS` and `FORMAT` are in Perl `%specialTags`
   // (ExifTool.pm:1229-1236, table-internal hash keys). When the dict
@@ -4626,7 +4428,6 @@ fn audible_reserved_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_ftype_aa_conformance() {
   // R7: dict entries `file_type` and `FileType` both resolve to
   // dynamic name `FileType` (after MakeTagName + `s/_(.)/\U$1/g` +
@@ -4647,7 +4448,6 @@ fn audible_ftype_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_ftypeext_aa_conformance() {
   // R8 negative case: dict entries `file_type_extension=FIRST` and
   // `FileTypeExtension=SECOND` both resolve to dynamic name
@@ -4664,7 +4464,6 @@ fn audible_ftypeext_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn audible_etver_aa_conformance() {
   // R8 negative case: dict entries `exif_tool_version=FIRST` and
   // `ExifToolVersion=SECOND` both resolve to dynamic name
@@ -4679,7 +4478,6 @@ fn audible_etver_aa_conformance() {
 }
 
 #[test]
-#[ignore]
 fn unsupported_bz2_conformance() {
   check("Unsupported.bz2", "Unsupported.bz2.json", true);
   check("Unsupported.bz2", "Unsupported.bz2.n.json", false);
@@ -4692,7 +4490,6 @@ fn unsupported_bz2_conformance() {
 // no PrintConv) but BOTH are asserted, mirroring the format conformance.
 
 #[test]
-#[ignore]
 fn empty_file_error_conformance() {
   // 0-byte file ⇒ `$self->Error('File is empty')` (ExifTool.pm:3086).
   check("Empty.dat", "Empty.dat.json", true);
@@ -4700,7 +4497,6 @@ fn empty_file_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn unknown_type_error_conformance() {
   // 8 non-magic bytes, unrecognized extension ⇒ buff < 16, no known type
   // ⇒ 'Unknown file type' (ExifTool.pm:3095).
@@ -4709,7 +4505,6 @@ fn unknown_type_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn malformed_aac_error_conformance() {
   // `\xff\xf1\xf0…` passes the AAC %magicNumber gate but `ProcessAAC`
   // rejects (sampling-freq index > 12, AAC.pm:103); `.aac` is a known
@@ -4719,7 +4514,6 @@ fn malformed_aac_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aac_reserved_profile_error_conformance() {
   // Adversarial: ff f1 c0 00 00 00 00 — byte2=0xC0. Passes the AAC
   // %magicNumber gate; ProcessAAC's faithful >>16/>>12 checks (AAC.pm:
@@ -4732,7 +4526,6 @@ fn aac_reserved_profile_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_conformance() {
   // Real fixture from exiftool/t/images/APE.ape: NewHeader (version 3990)
   // + APETAGEX v2 footer with 14 tags including Cover Art (front).
@@ -4741,7 +4534,6 @@ fn ape_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_old_header_conformance() {
   // Adversarial synthesized fixture: OldHeader (version <= 3970) with no
   // APETAGEX trailer. Exercises the APE.pm:149-151 OldHeader branch +
@@ -4751,7 +4543,6 @@ fn ape_old_header_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_apetagex_only_conformance() {
   // Adversarial synthesized fixture (Codex r5 finding): starts directly
   // with APETAGEX (no MAC header). Exercises the APE.pm:142-144
@@ -4764,7 +4555,6 @@ fn ape_apetagex_only_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_wire_composite_ingredients_conformance() {
   // Adversarial wire-format fixture (Codex r8 follow-up). Carries four
   // APE tag-stream entries whose KEYS spell the four Composite Duration
@@ -4790,7 +4580,6 @@ fn ape_wire_composite_ingredients_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_spaced_composite_conformance() {
   // Adversarial wire-format fixture (Codex r9 finding): four APE tag
   // entries whose KEYS contain SPACES — `Sample Rate`, `Total Frames`,
@@ -4814,7 +4603,6 @@ fn ape_spaced_composite_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_dup_override_conformance() {
   // Adversarial wire-format fixture (Codex r9 finding): MAC NewHeader
   // emits `SampleRate=44100`, then the APETAGEX footer emits a
@@ -4830,7 +4618,6 @@ fn ape_dup_override_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_nonfinite_composite_conformance() {
   // Adversarial wire-format fixture (Codex r9 finding): one ingredient
   // (`Total Frames`) has value `"Inf"` (a string Perl coerces to IEEE
@@ -4855,7 +4642,6 @@ fn ape_nonfinite_composite_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_huge_composite_conformance() {
   // Adversarial wire-format fixture (Codex r10 finding): four APE tag
   // entries where the Composite Duration arithmetic produces a value
@@ -4878,7 +4664,6 @@ fn ape_huge_composite_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_repeated_keys_conformance() {
   // Adversarial wire-format fixture (Codex r13 follow-up): same APE
   // wire key emitted TWICE. Two `Title` entries (`First Title`,
@@ -4893,7 +4678,6 @@ fn ape_repeated_keys_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_dynamic_edge_keys_conformance() {
   // Adversarial wire-format fixture (Codex r13 finding): four edge
   // dynamic APE tag keys exercising AddTagToTable (ExifTool.pm:9243-9255)
@@ -4918,7 +4702,6 @@ fn ape_dynamic_edge_keys_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_two63_boundary_composite_conformance() {
   // Adversarial wire-format fixture (Codex r12 finding): `Sample Rate=1`,
   // `Total Frames=9223372036854775808` (= 2^63), `Blocks Per Frame=86400`,
@@ -4943,7 +4726,6 @@ fn ape_two63_boundary_composite_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_u64_days_composite_conformance() {
   // Adversarial wire-format fixture (Codex r11 finding): four APE tag
   // entries chosen so the Composite Duration arithmetic produces a days
@@ -4963,7 +4745,6 @@ fn ape_u64_days_composite_conformance() {
 }
 
 #[test]
-#[ignore]
 fn all_zero_file_error_conformance() {
   // 32 `\0` ⇒ buff ≥ 16 and all-same ⇒ the all-same-byte insight;
   // whole file is `\0` ⇒ 'Entire file is binary zeros'
@@ -4973,7 +4754,6 @@ fn all_zero_file_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn raw_unsupported_error_conformance() {
   // 8 `\0` named `RAW.raw` ⇒ buff < 16 ⇒ the not-all-same arm; the
   // scalar `GetFileType("RAW.raw")` returns `"RAW"` (the multi row
@@ -4985,7 +4765,6 @@ fn raw_unsupported_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mpc_conformance() {
   // Pure SV7 MPC happy path (32-byte MP+ header, no ID3 leading / APE
   // trailer / ID3v1 — those are deferred to PRs #6 (ID3), the APE PR).
@@ -4998,7 +4777,6 @@ fn mpc_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mpc_sv8_warn_conformance() {
   // MPC.pm:107-109 Warn path: a valid MP+ magic with version != 0x07 still
   // calls SetFileType (MPC.pm:94, before the version dispatch) then emits
@@ -5012,7 +4790,6 @@ fn mpc_sv8_warn_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mpc_with_id3v2_prefix_conformance() {
   // F2 (Codex adversarial) regression pin: MPC.pm:84-87 ID3-prefix
   // dispatch. Pre-fix the `AnyParser::Mpc` arm called the bare
@@ -5038,7 +4815,6 @@ fn mpc_with_id3v2_prefix_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mpc_with_apev2_trailer_conformance() {
   // F2 (Codex adversarial) regression pin: MPC.pm:111-113 APE-trailer
   // dispatch. Pre-fix the `AnyParser::Mpc` arm dropped the APE chain
@@ -5064,7 +4840,6 @@ fn mpc_with_apev2_trailer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn wavpack_with_apev2_trailer_conformance() {
   // F2 (Codex adversarial) regression pin: WavPack.pm:100-103 APE-
   // trailer dispatch (`APE::ProcessAPE` after the wvpk-header
@@ -5091,7 +4866,6 @@ fn wavpack_with_apev2_trailer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn red_r3d_conformance() {
   // FORMATS.md row 12: Image::ExifTool::Red. Bundled fixture
   // `tests/fixtures/Red.r3d` is the real `t/images/Red.r3d` (1160 bytes,
@@ -5103,7 +4877,6 @@ fn red_r3d_conformance() {
 }
 
 #[test]
-#[ignore]
 fn red_bad_magic_error_conformance() {
   // 8 bytes, magic gate `\0\0..RED(1|2)` fails. `.r3d` is a known type but
   // no parser accepted ⇒ post-loop 'File format error' (ExifTool.pm:3093).
@@ -5112,7 +4885,6 @@ fn red_bad_magic_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn red_short_size_error_conformance() {
   // 8 bytes, magic OK, `$size = 4 < 8` ⇒ ProcessR3D returns 0 (Red.pm:228).
   // No parser accepted ⇒ 'File format error'.
@@ -5121,7 +4893,6 @@ fn red_short_size_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn red_truncated_header_conformance() {
   // 8 bytes, magic OK, `$size = 0x40 > 8` but the `Read($size-8)` of the
   // remaining header bytes fails ⇒ SetFileType triplet is emitted then
@@ -5145,7 +4916,6 @@ fn red_truncated_header_conformance() {
 // oracle JSON is captured by hand from `perl exiftool -j -G1 -struct …`.
 
 #[test]
-#[ignore]
 fn id3v2_2_conformance() {
   // Synthetic ID3v2.2 file: TT2/TP1/TCO/TCM/COM/PIC frames; no Composite
   // triggers (no Year). Exercises ProcessID3 + ProcessID3v2 (6-byte
@@ -5156,7 +4926,6 @@ fn id3v2_2_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v1_conformance() {
   // 128-byte ID3v1 TAG trailer + 256 leading null bytes. Year set to
   // `\0\0\0\0` ⇒ ID3v1:Year="" ⇒ Composite:DateTimeOriginal NOT emitted
@@ -5167,7 +4936,6 @@ fn id3v1_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_3_conformance() {
   // Synthetic ID3v2.3 file: TIT2/TPE1/TALB/TCON/COMM/APIC frames. v2.3
   // uses 10-byte frame headers (a4 N n) and standard int32 sizes.
@@ -5176,7 +4944,6 @@ fn id3v2_3_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_4_conformance() {
   // Synthetic ID3v2.4 file: TIT2/TPE1 with sync-safe sizes. Exercises
   // ProcessID3v2 v2.4 sync-safe length detection (the no-iTunes-bug
@@ -5186,7 +4953,6 @@ fn id3v2_4_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_3_extended_header_conformance() {
   // R4-F1 regression — pins the FAITHFUL bundled-Perl behavior:
   //   ID3.pm:1481 `$hBuff = substr($hBuff, $len)` strips EXACTLY $len
@@ -5204,7 +4970,6 @@ fn id3v2_3_extended_header_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_corrupt_with_valid_id3v1_trailer_conformance() {
   // R3-F1 regression: a file with a corrupt ID3v2 header (here `ID3v5`,
   // unsupported) BUT a valid ID3v1 trailer at the end. Bundled ID3.pm
@@ -5218,7 +4983,6 @@ fn id3v2_corrupt_with_valid_id3v1_trailer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_4_big_frame_conformance() {
   // R2 regression — v2.4 single frame with sync-safe size > 127 followed
   // by EOF (no terminator). Bundled `ProcessID3v2` (ID3.pm:1143-1152)
@@ -5231,7 +4995,6 @@ fn id3v2_4_big_frame_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v5_unsupported_conformance() {
   // ID3 magic + version 5.0 ⇒ ExifTool emits Warn "Unsupported ID3
   // version: 2.5.0" (ID3.pm:1460). $rtnVal=1 was set at ID3.pm:1453
@@ -5246,7 +5009,6 @@ fn id3v5_unsupported_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3_with_mpeg_audio_conformance() {
   // R1-F1 regression pin: ID3v2 header + MPEG Layer-III audio frames in
   // the same MP3 file. Bundled `ProcessMP3` (ID3.pm:1684-1727) emits
@@ -5269,7 +5031,6 @@ fn id3_with_mpeg_audio_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mp3_with_large_id3v2_artwork_conformance() {
   // Codex R5 high-severity regression pin: an MP3 with a large ID3v2.3
   // header (9261-byte body, containing a 9216-byte APIC artwork JPEG)
@@ -5309,7 +5070,6 @@ fn mp3_with_large_id3v2_artwork_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_conformance() {
   // FLAC.pm:239-280 + Vorbis.pm:157-210. The fixture's metadata blocks
   // contain a StreamInfo (block 0) AND a VorbisComment (block 4) with
@@ -5320,7 +5080,6 @@ fn flac_conformance() {
 }
 
 #[test]
-#[ignore]
 fn bad_flac_conformance() {
   // Adversarial: `fLaC` + 4-byte StreamInfo header claiming 1 MiB payload
   // (truncated). FLAC.pm:263 sets $err=1, :278 emits 'Format error in
@@ -5333,7 +5092,6 @@ fn bad_flac_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_multi_artist_conformance() {
   // R1-F2 regression pin: Vorbis.pm:85 `ARTIST => { List => 1 }`. Fixture
   // is a synthetic FLAC with StreamInfo + VorbisComment containing two
@@ -5353,7 +5111,6 @@ fn flac_multi_artist_conformance() {
 }
 
 #[test]
-#[ignore]
 fn red2_framerate_div_by_zero_conformance() {
   // Codex round-3 F1 regression: RED2 `int16u[3]` at offset 0x56 is
   // `(0, 0, 24000)` — the first word (`$a[0]`) is zero. Perl ValueConv
@@ -5376,7 +5133,6 @@ fn red2_framerate_div_by_zero_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_id3_prefix_conformance() {
   // R1-F1 regression pin: FLAC.pm:244-247 ID3-prefix dispatch. Fixture is
   // a real FLAC body prefixed with a (10-byte, no-extended-header) empty
@@ -5393,7 +5149,6 @@ fn flac_id3_prefix_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_picture_conformance() {
   // R1-F3 regression pin: FLAC.pm:51-54 Picture block (subdir to
   // %FLAC::Picture). Fixture is a synthetic FLAC carrying a Picture
@@ -5405,7 +5160,6 @@ fn flac_picture_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_coverart_conformance() {
   // R1-F3 regression pin: Vorbis.pm:97-105 `COVERART => { Binary => 1,
   // ValueConv => DecodeBase64 }`. Fixture is a FLAC with a VorbisComment
@@ -5418,7 +5172,6 @@ fn flac_coverart_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_metadata_block_picture_conformance() {
   // R1-F3 regression pin: Vorbis.pm:122-135
   // `METADATA_BLOCK_PICTURE => { RawConv => DecodeBase64, SubDirectory =>
@@ -5433,7 +5186,6 @@ fn flac_metadata_block_picture_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_id3v24_footer_conformance() {
   // R2-F1 regression pin: ID3.pm:1484-1487 — `if ($flags & 0x10) { $raf->
   // Seek(10, 1); }` skips the optional v2.4 footer (10 bytes) AFTER the
@@ -5460,7 +5212,6 @@ fn flac_id3v24_footer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_short_header_conformance() {
   // ID3 magic + only 2 bytes total (5 bytes of header). ID3.pm:1454
   // `$raf->Read($hBuff,7)==7 or $et->Warn('Short ID3 header'), last`.
@@ -5470,7 +5221,6 @@ fn id3v2_short_header_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_truncated_data_conformance() {
   // ID3 magic + declared size 100 but only 3 body bytes. ID3.pm:1464
   // Warn "Truncated ID3 data".
@@ -5479,7 +5229,6 @@ fn id3v2_truncated_data_conformance() {
 }
 
 #[test]
-#[ignore]
 fn no_ext_layer2_mpeg_conformance() {
   // R8-F1 regression. A dotless file whose contents start with the valid
   // MPEG Layer-II frame sync `ff fd 90 4c`. Bundled `ProcessMP3`
@@ -5506,7 +5255,6 @@ fn no_ext_layer2_mpeg_conformance() {
 }
 
 #[test]
-#[ignore]
 fn red2_short_first_block_conformance() {
   // Codex round-2 F2 regression: RED2 declared `$size = 0x40` (< 0x44),
   // file has trailing bytes past the declared first block. Pre-fix this
@@ -5529,7 +5277,6 @@ fn red2_short_first_block_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_picture_truncated_conformance() {
   // R2-F3 regression pin: FLAC.pm:131 `Picture => undef[$val{7}]` ⇒
   // ExifTool.pm:6290-6298 `ReadValue` clamps `count` to the remaining
@@ -5551,7 +5298,6 @@ fn flac_picture_truncated_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_3_with_v2_4_frame_conformance() {
   // R8-F2 regression (v2.3 → v2.4 fallback). A v2.3 file containing
   // a v2.4-only frame (`TMOO` = Mood). Bundled ID3.pm:833-836
@@ -5578,7 +5324,6 @@ fn id3v2_3_with_v2_4_frame_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flac_duration_conformance() {
   // R2-F2 regression pin: FLAC.pm:137-149 `%FLAC::Composite` Duration =
   // `($val[0] and $val[1]) ? $val[1] / $val[0] : undef` (TotalSamples /
@@ -5593,7 +5338,6 @@ fn flac_duration_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_4_with_v2_3_frame_conformance() {
   // R8-F2 regression (v2.4 → v2.3 fallback). A v2.4 file containing
   // a v2.3-only frame (`TSIZ` = Size). Symmetric to the above; bundled
@@ -5615,7 +5359,6 @@ fn id3v2_4_with_v2_3_frame_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3_dup_short_frame_conformance() {
   // Golden-v2 Phase C — the `[x$n]` multi-warning count (ExifTool.pm:3199-3201
   // + the `WAS_WARNED` dedup at :5632-5639). A crafted ID3v2.3 + minimal MP3
@@ -5640,7 +5383,6 @@ fn id3_dup_short_frame_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_3_invalid_apic_conformance() {
   // R8-F3 regression (APIC Latin). A v2.3 file with a malformed APIC
   // frame: MIME + 0 + picType + description WITHOUT the description's
@@ -5664,7 +5406,6 @@ fn id3v2_3_invalid_apic_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_3_invalid_apic_utf16_conformance() {
   // R8-F3 regression (APIC UTF-16). The UTF-16 branch of the bundled
   // regex (ID3.pm:1319 `.(.*?)\0(.)((?:..)*?)\0\0`) requires a word-
@@ -5683,7 +5424,6 @@ fn id3v2_3_invalid_apic_utf16_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v2_2_invalid_pic_conformance() {
   // R8-F3 regression (PIC v2.2). The 3-byte image-format + 1-byte
   // picType + description-without-`\0`. Bundled ID3.pm:1321 PIC regex
@@ -5703,7 +5443,6 @@ fn id3v2_2_invalid_pic_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_conformance() {
   // Synthesized AIFF fixture: FORM <sz> AIFF + COMT (1 comment) + COMM
   // (SampleRate=0 keeps Composite Duration's `Require` from firing) +
@@ -5715,7 +5454,6 @@ fn aiff_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_duplicate_name_chunk_last_wins_conformance() {
   // Codex R11 regression: an AIFF with TWO `NAME` chunks. Perl's FoundTag
   // (`ExifTool.pm:9437-9519`) detects the duplicate and, when both
@@ -5737,7 +5475,6 @@ fn aiff_duplicate_name_chunk_last_wins_conformance() {
 }
 
 #[test]
-#[ignore]
 #[ignore = "Phase-2 defer: ID3 SubDirectory dispatch lives in parallel PR #6 (ID3 port). See module-doc of src/formats/aiff.rs and the `ID3 ` branch of process_aiff. This fixture pins the POST-merge oracle output (File:ID3Size + ID3v2_3:Title) so when ID3 lands the test will auto-pass; today it documents the deliberate divergence."]
 fn aiff_id3_chunk_subdirectory_dispatch_deferred_conformance() {
   // Codex R12 regression: an AIFF containing an `ID3 ` chunk carrying a
@@ -5757,7 +5494,6 @@ fn aiff_id3_chunk_subdirectory_dispatch_deferred_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_duration_composite_conformance() {
   // Codex R4 oracle: an AIFF with nonzero SampleRate AND NumSampleFrames
   // MUST emit `Composite:Duration`. Bundled Perl `Image::ExifTool::AIFF
@@ -5771,7 +5507,6 @@ fn aiff_duration_composite_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_duration_float_sample_rate_conformance() {
   // Codex R6 regression: AIFF SampleRate is 80-bit extended (AIFF.pm:91);
   // `get_extended` returns `TagValue::F64` for non-integer rates and
@@ -5795,7 +5530,6 @@ fn aiff_duration_float_sample_rate_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aifc_noninteger_sample_rate_conformance() {
   // Codex R6 regression (AIFC variant): non-integer 80-bit extended rate
   // 44056.94 Hz (the canonical NTSC pull-down rate 44100 * 1000/1001).
@@ -5817,7 +5551,6 @@ fn aifc_noninteger_sample_rate_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_extended_integer_overflow_conformance() {
   // Codex R7 regression: 80-bit extended `403e8000000000000001` decodes to
   // the EXACT integer 2^63 + 1 = 9223372036854775809, which overflows i64.
@@ -5847,7 +5580,6 @@ fn aiff_extended_integer_overflow_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_extended_integer_negative_overflow_conformance() {
   // Codex R7 follow-up: 80-bit extended `c03e8000000000000001` decodes
   // to -(2^63 + 1) = -9223372036854775809, whose magnitude exceeds i64::MIN.
@@ -5873,7 +5605,6 @@ fn aiff_extended_integer_negative_overflow_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_huge_duration_conformance() {
   // Codex R7 regression: SampleRate extended `3fab8000000000000000` decodes
   // to 2^-84 = 5.16987882845642e-26 (a very small non-integer). With
@@ -5900,7 +5631,6 @@ fn aiff_huge_duration_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_negative_zero_significand_extended_conformance() {
   // Codex R8 regression: an AIFF SampleRate extended with `sig == 0` but
   // a NON-zero biased exponent and the negative sign bit set
@@ -5923,7 +5653,6 @@ fn aiff_negative_zero_significand_extended_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_zero_significand_max_exponent_nan_conformance() {
   // Codex R9 regression: an AIFF SampleRate extended with `sig == 0` AND
   // `biased == 0x7FFF` (the infinity exponent slot, `0x7fff0000000000000000`).
@@ -5950,7 +5679,6 @@ fn aiff_zero_significand_max_exponent_nan_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_infinity_sample_rate_conformance() {
   // Codex R8 regression: an AIFF SampleRate extended with the maximum
   // biased exponent (`7fff8000000000000000`). The 80-bit-extended-to-f64
@@ -5976,7 +5704,6 @@ fn aiff_infinity_sample_rate_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_exp53_integer_fits_i64_routes_via_nv_conformance() {
   // Codex R10 regression: SampleRate extended `40730000000000000001`
   // (biased=0x4073=16499, exp=53, sig=1). Mathematically `1 * 2^53 =
@@ -6007,7 +5734,6 @@ fn aiff_exp53_integer_fits_i64_routes_via_nv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_first_overflow_zero_significand_conformance() {
   // Codex R9 recommendation: pin the "first-overflow zero significand"
   // boundary — SampleRate extended `443e0000000000000000` (biased =
@@ -6031,7 +5757,6 @@ fn aiff_first_overflow_zero_significand_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_first_nv_exponent_conformance() {
   // Codex R9 recommendation: pin the "first NV exponent" boundary —
   // SampleRate extended `40738000000000000000` (biased=0x4073=16499,
@@ -6051,7 +5776,6 @@ fn aiff_first_nv_exponent_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_huge_positive_exponent_overflow_conformance() {
   // Codex R9 regression: SampleRate extended `407f8000000000000000` —
   // biased exp 0x407F = 16511, exp = 16511 - 16383 - 63 = 65, sig =
@@ -6082,7 +5806,6 @@ fn aiff_huge_positive_exponent_overflow_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aifc_conformance() {
   // Synthesized AIFC: FORM <sz> AIFC + FVER + COMM (with CompressionType
   // + CompressorName pstring) + NAME. Exercises the AIFC magic path
@@ -6093,7 +5816,6 @@ fn aifc_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aifc_macroman_high_byte_compressor_name_conformance() {
   // Codex R1 regression: AIFC `CompressorName` pstring carrying MacRoman
   // high bytes 0x80 ("Ä") and 0x81 ("Å"). A prior
@@ -6107,7 +5829,6 @@ fn aifc_macroman_high_byte_compressor_name_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aifc_highbyte_compressiontype_conformance() {
   // Codex R3 regression: AIFC `CompressionType` (a no-ValueConv string[4]
   // with a hash PrintConv) carrying the invalid-UTF-8 lead byte 0x80
@@ -6135,7 +5856,6 @@ fn aifc_highbyte_compressiontype_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aifc_pre1970_format_version_time_conformance() {
   // Codex R4 regression: AIFC `FormatVersionTime` with raw u32 = 0 ⇒
   // pre-Unix-epoch timestamp `-2_082_844_800` after the AIFF.pm:26
@@ -6156,7 +5876,6 @@ fn aifc_pre1970_format_version_time_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aifc_truncated_comm_conformance() {
   // Codex R3 regression: a truncated AIFC COMM chunk that provides only 1
   // byte of `CompressionType` (declared `string[4]`). ExifTool's `ReadValue`
@@ -6181,7 +5900,6 @@ fn aifc_truncated_comm_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_short_header_error_conformance() {
   // Adversarial: 11-byte FORM header (`FORM\0\0\0\x10AIF`) — too short for
   // the 12-byte magic verify (AIFF.pm:191). Reject before SetFileType
@@ -6193,7 +5911,6 @@ fn aiff_short_header_error_conformance() {
 }
 
 #[test]
-#[ignore]
 fn aiff_large_chunk_warn_conformance() {
   // Adversarial: valid AIFF header + COMM chunk with len=0xFFFFFFFF
   // (`len2 = len + (len & 1) > 100 MB`). Default `LargeFileSupport` is
@@ -6207,7 +5924,6 @@ fn aiff_large_chunk_warn_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_id3_prefixed_conformance() {
   // Codex R2-F1 cross-format regression pin: APE.pm:122-127 embedded
   // ID3 dispatch. Fixture is a hand-crafted `.ape` whose first bytes
@@ -6229,7 +5945,6 @@ fn ape_id3_prefixed_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mp3_with_apev2_trailer_conformance() {
   // Codex R2-F2 cross-format regression pin: ID3.pm:1722-1727 MP3 →
   // APE trailer fallback. Fixture is a hand-crafted `.mp3` with an
@@ -6259,7 +5974,6 @@ fn mp3_with_apev2_trailer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn dsf_with_id3v2_trailer_conformance() {
   // Codex R2-F3 cross-format regression pin: DSF.pm:88-97 ID3v2
   // trailer at `metaPos`. Fixture is a hand-crafted `.dsf` with
@@ -6289,7 +6003,6 @@ fn dsf_with_id3v2_trailer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_id3v24_footer_then_mac_conformance() {
   // Codex R3 F1 regression pin: ID3.pm:1443 `$hdrEnd = 0`, :1486
   // `Seek(10, 1)` when `flags & 0x10` (v2.4 footer flag), :1504
@@ -6329,7 +6042,6 @@ fn ape_id3v24_footer_then_mac_conformance() {
 }
 
 #[test]
-#[ignore]
 fn mp3_with_apev2_and_id3v1_trailer_conformance() {
   // Codex R3 F2 regression pin: APE.pm:169 `$footPos -= $$et{DoneID3}
   // if $$et{DoneID3} > 1` — when ID3.pm:1527 stores 128 (ID3v1 trailer
@@ -6364,7 +6076,6 @@ fn mp3_with_apev2_and_id3v1_trailer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_with_id3v1_trailer_conformance() {
   // Codex R3 F2 second regression pin: same DoneID3-shift logic in the
   // MAIN `plan_ape_inner` footer path (not just `plan_apetagex_trailer_
@@ -6399,7 +6110,6 @@ fn ape_with_id3v1_trailer_conformance() {
 }
 
 #[test]
-#[ignore]
 fn ape_with_enhancedtag_and_id3v1_conformance() {
   // Codex R4 F2 regression pin: ID3.pm:1521-1525 — when a standard
   // ID3v1 TAG block is detected at `EOF - 128`, bundled ALSO probes
@@ -6459,7 +6169,6 @@ fn ape_with_enhancedtag_and_id3v1_conformance() {
 }
 
 #[test]
-#[ignore]
 fn id3v24_footer_truncated_then_nothing_conformance() {
   // Codex R4 F1 regression pin: slice panic on truncated v2.4 footer.
   // ID3.pm:1484-1486 — `if ($flags & 0x10) { $raf->Seek(10, 1); }` —
@@ -6499,7 +6208,6 @@ fn id3v24_footer_truncated_then_nothing_conformance() {
 }
 
 #[test]
-#[ignore]
 fn moi_conformance() {
   // FORMATS.md row 12a: Image::ExifTool::MOI. Bundled fixture
   // `tests/fixtures/MOI.moi` is the real `t/images/MOI.moi` (320 bytes,
@@ -6521,7 +6229,6 @@ fn moi_conformance() {
 }
 
 #[test]
-#[ignore]
 #[cfg(all(feature = "h264", feature = "serde"))]
 fn h264_conformance() {
   // FORMATS.md row 16: Image::ExifTool::H264. H264 is ENGINE-ONLY — ExifTool
@@ -6882,7 +6589,6 @@ fn h264_conformance() {
 /// under `-n`, bundled `ParseH264Video` emits `H264:WhiteBalance` as the bare
 /// number `1` (the EscapeJSON number gate, exiftool:3809), NOT `"1"`.
 #[test]
-#[ignore]
 #[cfg(all(feature = "h264", feature = "serde"))]
 fn h264_oos_mdpm_n_emits_json_number() {
   use exifast::{AnyMeta, Rendered};
@@ -6923,7 +6629,6 @@ fn h264_oos_mdpm_n_emits_json_number() {
 /// `$et->Warn('H264 forbidden bit error'), last`). The stream `00 00 00 01 86`
 /// has a single NAL whose header `0x86` (`0b1000_0110`) sets the forbidden bit.
 #[test]
-#[ignore]
 #[cfg(all(feature = "h264", feature = "serde"))]
 fn h264_forbidden_bit_surfaces_warning() {
   use exifast::{AnyMeta, Rendered};
@@ -6944,7 +6649,6 @@ fn h264_forbidden_bit_surfaces_warning() {
 }
 
 #[test]
-#[ignore]
 fn flash_conformance() {
   // FORMATS.md row 18: Image::ExifTool::Flash (FLV side). Bundled fixture
   // `tests/fixtures/Flash.flv` is the real `t/images/Flash.flv` (1358 bytes,
@@ -6981,7 +6685,6 @@ fn flash_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_strict_array_string_conformance() {
   // Codex R1/F1 adversarial fixture: AMF0 strict-array (0x0a) of strings
   // (type 0x02). Bundled Flash.pm:410-426 collects every non-struct child
@@ -7002,7 +6705,6 @@ fn flash_amf_strict_array_string_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_nonfinite_string_conformance() {
   // Codex PR #32 R20/F1 fixtures: numeric `%Flash::Meta` fields encoded as
   // AMF strings carrying the IEEE non-finite spellings. Perl's `Perl_my_atof`
@@ -7044,7 +6746,6 @@ fn flash_amf_nonfinite_string_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_strict_array_creationdate_valueconv_conformance() {
   // Codex PR #32 R15/F1 fixture: AMF0 strict-array (0x0a) of strings under
   // the `creationdate` key, whose elements carry trailing whitespace
@@ -7067,7 +6768,6 @@ fn flash_amf_strict_array_creationdate_valueconv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_strict_array_bool_conformance() {
   // Codex R1/F1 fixture: strict-array of booleans (type 0x01). Bundled
   // Flash.pm:329 converts each `0/1` to `"No"/"Yes"` INSIDE ProcessMeta
@@ -7082,7 +6782,6 @@ fn flash_amf_strict_array_bool_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_strict_array_date_conformance() {
   // Codex R1/F1 fixture: strict-array of dates (type 0x0b). Bundled
   // Flash.pm:316-324 emits each as the `YYYY:MM:DD HH:MM:SS.ssssss±HH:MM`
@@ -7096,7 +6795,6 @@ fn flash_amf_strict_array_date_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_strict_array_mixed_conformance() {
   // Codex R1/F1 fixture: strict-array of heterogeneous AMF types
   // (string + double + boolean + date). Bundled emits a single mixed
@@ -7112,7 +6810,6 @@ fn flash_amf_strict_array_mixed_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_truncated_double_conformance() {
   // Codex R1/F2 fixture: AMF double (type 0x00) truncated mid-payload
   // inside a mixed-array. Bundled Flash.pm:456 emits
@@ -7132,7 +6829,6 @@ fn flash_amf_truncated_double_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_truncated_string_conformance() {
   // Codex R1/F2 fixture: AMF string (type 0x02) with a length field that
   // overruns the buffer. Bundled emits `Truncated AMF record 0x2` +
@@ -7150,7 +6846,6 @@ fn flash_amf_truncated_string_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_truncated_date_conformance() {
   // Codex R1/F2 fixture: AMF date (type 0x0b) — f64 parses cleanly but
   // the 2-byte tz suffix is missing. Bundled has a SUBTLE branch here
@@ -7164,7 +6859,6 @@ fn flash_amf_truncated_date_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_truncated_array_conformance() {
   // Codex R1/F2 fixture: AMF strict-array (type 0x0a) with claimed count
   // > available elements. Bundled emits `Truncated AMF record 0xa`
@@ -7179,7 +6873,6 @@ fn flash_amf_truncated_array_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_rec0_double_walks_past_conformance() {
   // Codex R2/F1 adversarial fixture: rec=0 is a top-level AMF Double
   // (0x00 + 8-byte payload `42.0`), followed by `onMetaData` at rec=1
@@ -7207,7 +6900,6 @@ fn flash_amf_rec0_double_walks_past_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_rec0_struct_walks_inline_conformance() {
   // Codex R2/F1 fixture: rec=0 is a top-level AMF object (`0x03`) with
   // one key/value pair (`Preroll: 1`). Flash.pm:337-440's isStruct
@@ -7233,7 +6925,6 @@ fn flash_amf_rec0_struct_walks_inline_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_nested_strict_array_conformance() {
   // Codex R2/F2 fixture: an `onMetaData` object whose `outerArr` tag is
   // a strict-array (`0x0a`) of two elements — element[0] is itself a
@@ -7265,7 +6956,6 @@ fn flash_amf_nested_strict_array_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_unsupported_after_valid_packet_conformance() {
   // Codex R2/F3 fixture: valid `onMetaData` + Duration object, followed
   // by an unsupported AMF type byte (`0x11` — AMF3 data marker,
@@ -7296,7 +6986,6 @@ fn flash_amf_unsupported_after_valid_packet_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_empty_and_reference_scalars_conformance() {
   // Codex R3/F1 fixture: onMetaData mixed-array holding the five AMF
   // scalar shapes whose emission bundled handles via the
@@ -7319,7 +7008,6 @@ fn flash_amf_empty_and_reference_scalars_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_strict_array_with_empties_conformance() {
   // Codex R3/F2 fixture: onMetaData mixed-array with one key `mixList`
   // holding a strict-array `[null, undef, ref(3), double(4.0)]`.
@@ -7344,7 +7032,6 @@ fn flash_amf_strict_array_with_empties_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_top_level_strict_array_walks_past_conformance() {
   // Codex R3/F3 fixture: onMetaData (rec=0) + top-level strict-array
   // (rec=1, `[1.0, 2.0]`) + mixed-array (rec=2) with `goodKey: 7.5`.
@@ -7375,7 +7062,6 @@ fn flash_amf_top_level_strict_array_walks_past_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_array_abort_propagates_to_sibling_conformance() {
   // Codex R4/F1 fixture: onMetaData mixed-array containing two pairs —
   // `badArr` whose strict-array payload starts with an unsupported AMF
@@ -7409,7 +7095,6 @@ fn flash_amf_array_abort_propagates_to_sibling_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_nested_strict_array_prefix_propagation_conformance() {
   // Codex R4/F2 fixture: onMetaData mixed-array with one key `outerArr`
   // holding a strict-array of TWO nested strict-arrays, each containing
@@ -7444,7 +7129,6 @@ fn flash_amf_nested_strict_array_prefix_propagation_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_array_struct_element_failure_does_not_abort_conformance() {
   // Codex R5 fixture (FALSE POSITIVE — see explanation below).
   // onMetaData mixed-array with key `arr` whose strict-array payload
@@ -7509,7 +7193,6 @@ fn flash_amf_array_struct_element_failure_does_not_abort_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_nested_struct_child_abort_does_not_drop_parent_sibling_conformance() {
   // Codex PR #32 R16/F1 — onMetaData mixed-array with a STRUCT-VALUED
   // child `badChild` (AMF object 0x03) whose object body starts with an
@@ -7555,7 +7238,6 @@ fn flash_nested_struct_child_abort_does_not_drop_parent_sibling_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_struct_child_truncated_intro_preserves_parent_warning_conformance() {
   // Codex PR #32 R17/F1 — a struct-valued child whose struct INTRODUCER
   // is itself truncated must NOT enter the child pair loop.
@@ -7607,7 +7289,6 @@ fn flash_struct_child_truncated_intro_preserves_parent_warning_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_nested_livexml_preserved_conformance() {
   // Codex PR #32 R7 — adversarial fixture for the XMP SubDirectory gate.
   //
@@ -7660,7 +7341,6 @@ fn flash_nested_livexml_preserved_conformance() {
 }
 
 #[test]
-#[ignore]
 #[ignore = "FORMATS.md row 15 XMP infra Phase-3+ deferral (Codex PR #32 R6): \
   Flash.pm:243-246 dispatches the `liveXML` AMF key through \
   `SubDirectory => { TagTable => 'Image::ExifTool::XMP::Main' }`. Bundled \
@@ -7713,7 +7393,6 @@ fn flash_xmp_livexml_subdirectory_deferred_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_empty_key_livexml_preserved_conformance() {
   // Codex PR #32 R8/F1 — adversarial fixture for the
   // `is_xmp_subdirectory_dispatch` gate's Option<&str> distinction.
@@ -7760,7 +7439,6 @@ fn flash_empty_key_livexml_preserved_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_toplevel_array_objects_conformance() {
   // Codex PR #32 R8/F2 — adversarial fixture for the array-index
   // append site's Option<&str> distinction.
@@ -7815,7 +7493,6 @@ fn flash_toplevel_array_objects_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_keyed_array_truncated_count_conformance() {
   // Codex PR #32 R9/F1 — adversarial fixture pinning the keyed-array-
   // truncated-count case. A mixed-array contains a key whose value type
@@ -7858,7 +7535,6 @@ fn flash_keyed_array_truncated_count_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_typed_object_truncated_name_conformance() {
   // Codex PR #32 R9/F2 — adversarial fixture pinning the top-level
   // typed-object (`0x10`) truncated-name case. rec=0 is the packet name
@@ -7896,7 +7572,6 @@ fn flash_typed_object_truncated_name_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_array_typed_object_truncated_name_conformance() {
   // Codex PR #32 R9/F2 — adversarial fixture pinning the nested-inside-
   // strict-array typed-object truncated-name case. A mixed-array
@@ -7937,7 +7612,6 @@ fn flash_array_typed_object_truncated_name_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_array_typed_object_truncated_length_conformance() {
   // Codex PR #32 R10 — adversarial fixture pinning the nested-inside-
   // strict-array typed-object NAME-LENGTH-truncation (silent) path. A
@@ -7987,7 +7661,6 @@ fn flash_array_typed_object_truncated_length_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_array_mixed_array_truncated_top_index_conformance() {
   // Codex PR #32 R10 — adversarial fixture pinning the nested-inside-
   // strict-array mixed-array TOP-INDEX-truncation (silent) path. A
@@ -8028,7 +7701,6 @@ fn flash_array_mixed_array_truncated_top_index_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_array_struct_intro_trunc_continues_conformance() {
   // Codex PR #32 R11/F1 — adversarial fixture pinning that a struct-
   // introducer truncation on a NON-LAST strict-array element does NOT
@@ -8082,7 +7754,6 @@ fn flash_array_struct_intro_trunc_continues_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_date_zero_sentinel_conformance() {
   // Codex PR #32 R11/F2 — adversarial fixture pinning ExifTool's
   // zero-time sentinel for an AMF date (type 0x0b) of 0 milliseconds.
@@ -8117,7 +7788,6 @@ fn flash_amf_date_zero_sentinel_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_strict_array_known_tag_printconv_conformance() {
   // Codex PR #32 R12/F1 — adversarial fixture pinning per-element
   // PrintConv for a KNOWN Flash tag whose AMF value is a strict-array
@@ -8150,7 +7820,6 @@ fn flash_amf_strict_array_known_tag_printconv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_date_pre1000_year_padding_conformance() {
   // Codex PR #32 R12/F2 — adversarial fixture pinning the space-padded
   // year of a pre-1000 AMF date. A mixed-array carries key
@@ -8182,7 +7851,6 @@ fn flash_amf_date_pre1000_year_padding_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_nested_strict_array_known_tag_raw_conformance() {
   // Codex PR #32 R13/F1 — adversarial fixture pinning that a NESTED
   // strict-array element does NOT inherit the owning tag's PrintConv. A
@@ -8218,7 +7886,6 @@ fn flash_amf_nested_strict_array_known_tag_raw_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_mixed_top_level_conversion_conformance() {
   // Codex PR #32 R14/F1 — adversarial fixture pinning that the owning tag
   // conversion is applied ONCE PER TOP-LEVEL element (not disabled
@@ -8260,7 +7927,6 @@ fn flash_amf_mixed_top_level_conversion_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_audio_encoding_reserved_unknown_printconv_conformance() {
   // Codex PR #32 R13/F2 — adversarial fixture pinning the hash-PrintConv
   // MISS idiom. An audio-only FLV (header flags 0x04) with audio config
@@ -8289,7 +7955,6 @@ fn flash_audio_encoding_reserved_unknown_printconv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_audio_tail_truncation_emits_tags_conformance() {
   // Codex PR #32 R13/F3 — adversarial fixture pinning that an audio
   // packet whose DECLARED payload is truncated AFTER the first config
@@ -8328,7 +7993,6 @@ fn flash_audio_tail_truncation_emits_tags_conformance() {
 }
 
 #[test]
-#[ignore]
 fn flash_amf_bad_utf8_fixup_conformance() {
   // Codex PR #32 R18/F1 — adversarial fixture pinning ExifTool's
   // FixUTF8-at-JSON semantics for every AMF string-like kind. The
@@ -8362,7 +8026,6 @@ fn flash_amf_bad_utf8_fixup_conformance() {
 }
 
 #[test]
-#[ignore]
 fn exif_badformat_entry0_conformance() {
   // PR #36 Codex R2 F1 — IFD0 whose FIRST entry (index 0) carries an
   // unrecognized format code (99). ExifTool warns `Bad format (99) for
@@ -8384,7 +8047,6 @@ fn exif_badformat_entry0_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_excessive_count_conformance() {
   // Golden-v2 Phase C — the `[Minor]` (ignorable == 2) prefix path. A crafted
   // big-endian TIFF whose IFD0 carries ONE KNOWN tag (Orientation 0x0112) with
@@ -8408,7 +8070,6 @@ fn exif_excessive_count_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_badformat_ifd1_conformance() {
   // PR #36 Codex R3 F1 — IFD0 whose FIRST entry (index 0) has a bad format
   // code (99) AND a NON-zero next-IFD pointer to a structurally valid IFD1
@@ -8431,7 +8092,6 @@ fn exif_badformat_ifd1_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_badoffset_eof_conformance() {
   // PR #36 Codex R1 F1 — an out-of-line value whose offset is inside the
   // block but `offset + size` runs past EOF. ExifTool would seek in the
@@ -8452,7 +8112,6 @@ fn exif_badoffset_eof_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_badoffset_low_conformance() {
   // PR #36 Codex R1 F1 — an out-of-line value (>4 bytes) whose 32-bit
   // offset points into the 8-byte TIFF header (offset 4). ExifTool's
@@ -8476,7 +8135,6 @@ fn exif_badoffset_low_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_conformance() {
   // FORMATS.md row 13: Image::ExifTool::Exif. A standalone TIFF file IS an
   // Exif/TIFF block — `File:FileType == "TIFF"` dispatches to `ProcessExif`.
@@ -8509,7 +8167,6 @@ fn exif_conformance() {
   check("Exif.tif", "Exif.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_eofoverrun_chain_conformance() {
   // PR #36 Codex R14 F1 — IFD0 entry 1 is an out-of-line value (Software)
   // that overruns EOF, with a VALID entry 2 (Orientation) AFTER it AND a
@@ -8541,7 +8198,6 @@ fn exif_eofoverrun_chain_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_focallength35_conformance() {
   // PR #36 Codex R1 F3 — FocalLengthIn35mmFormat (0xa405) is an `int16u`
   // with PrintConv `"$val mm"` (Exif.pm:2896): Perl interpolates the
@@ -8564,7 +8220,6 @@ fn exif_focallength35_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gap_tags_conformance() {
   // Table-codegen Step B — the binary-EXIF coverage-gap `%Exif::Main` leaf
   // tags the camera-relevant hand subset (`src/exif/tables.rs` `EXIF_TAGS`)
@@ -8586,7 +8241,6 @@ fn exif_gap_tags_conformance() {
   check("Exif_gap_tags.tif", "Exif_gap_tags.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_ambient_multi_conformance() {
   // Codex follow-up to Step B — `AmbientTemperature` (0x9400) `Conv::CelsiusSuffix`
   // with a MALFORMED count>1 `rational64s` value (`235/10`, `-50/10`). The
@@ -8609,7 +8263,6 @@ fn exif_ambient_multi_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_composite_exposure_conformance() {
   // Table-codegen Step B — `CompositeImageExposureTimes` (0xa462), the
   // bespoke `undef`-format `RawConv`/`PrintConv` pair (Exif.pm:3068-3119)
@@ -8633,7 +8286,6 @@ fn exif_composite_exposure_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_composite_exposure_edge_conformance() {
   // Codex follow-up to Step B — `CompositeImageExposureTimes` (0xa462) edge
   // cases for the `RawConv`→`PrintConv` token pipeline (Exif.pm:3068-3119).
@@ -8661,7 +8313,6 @@ fn exif_composite_exposure_edge_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_composite_exposure_wrongfmt_conformance() {
   // #198 — `CompositeImageExposureTimes` (0xa462) written with the WRONG
   // on-disk format (`string`/ASCII, not `undef`). The bespoke `RawConv`
@@ -8685,7 +8336,6 @@ fn exif_composite_exposure_wrongfmt_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_composite_exposure_wrongfmt_highbit_conformance() {
   // #198 R4 — the LOSSY-BYTES case proving A1/A2 retain `$val`'s ORIGINAL
   // bytes. A `string`-typed 0xa462 with INVALID-UTF-8 high-bit bytes
@@ -8708,7 +8358,6 @@ fn exif_composite_exposure_wrongfmt_highbit_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_composite_exposure_single_conformance() {
   // Codex R3 — `CompositeImageExposureTimes` (0xa462) decoding to EXACTLY ONE
   // element, pinning the single-element JSON TYPE per ExifTool. The lone token
@@ -8757,7 +8406,6 @@ fn exif_composite_exposure_single_conformance() {
   }
 }
 #[test]
-#[ignore]
 fn exif_composite_exposure_single_number_is_json_number() {
   // Codex R3 type-masking guard — the §4 conformance `check` uses the
   // value-semantic `json_equivalent`, which treats `"0.5" == 0.5` (string vs
@@ -8822,7 +8470,6 @@ fn exif_composite_exposure_single_number_is_json_number() {
   }
 }
 #[test]
-#[ignore]
 fn exif_ambient_wrongfmt_conformance() {
   // Codex R2 class-sweep — `AmbientTemperature` (0x9400) `Conv::CelsiusSuffix`
   // written with the WRONG on-disk format (`undef`, not `rational64s`). Like
@@ -8847,7 +8494,6 @@ fn exif_ambient_wrongfmt_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_after_interop_conformance() {
   // PR #36 Codex R12 F2 — the Windows Phone 7.5 InteropIFD/GPS pointer
   // collision. IFD0's GPSInfo (0x8825) and ExifIFD's InteropOffset
@@ -8886,7 +8532,6 @@ fn exif_gps_after_interop_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_baddir_conformance() {
   // PR #36 Codex R2 F2 — IFD0 with a GPSInfo pointer to an offset PAST
   // end-of-file: the GPS IFD's 2-byte entry count cannot even be read.
@@ -8898,7 +8543,6 @@ fn exif_gps_baddir_conformance() {
   check("Exif_gps_baddir.tif", "Exif_gps_baddir.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_gps_badoffset_conformance() {
   // PR #36 Codex R2 F3 — a GPS sub-IFD with a GPSLatitude (0x0002) whose
   // out-of-line offset (4) points into the 8-byte TIFF header. ExifTool
@@ -8919,7 +8563,6 @@ fn exif_gps_badoffset_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_datestamp_conformance() {
   // PR #36 Codex R7 F1 — a GPS sub-IFD GPSDateStamp (0x001d) whose ON-DISK
   // format code is `string` (2) but whose bytes use `\0` separators
@@ -8948,7 +8591,6 @@ fn exif_gps_datestamp_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_eofoverrun_conformance() {
   // PR #36 Codex R2 F3 — a GPS sub-IFD with a GPSLatitude (0x0002) whose
   // out-of-line `offset + size` runs past EOF. ExifTool warns `Error
@@ -8968,7 +8610,6 @@ fn exif_gps_eofoverrun_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_int32s_conformance() {
   // PR #36 Codex R9 F1 — an IFD0 GPSInfo pointer (0x8825) encoded as
   // `int32s` (format code 9, a SIGNED integer) with a POSITIVE offset.
@@ -8989,7 +8630,6 @@ fn exif_gps_int32s_conformance() {
   check("Exif_gps_int32s.tif", "Exif_gps_int32s.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_gps_proctext_conformance() {
   // PR #36 Codex R3 F2 — GPS sub-IFD with GPSProcessingMethod (0x001b) and
   // GPSAreaInformation (0x001c), both `undef`-format carrying the 8-byte
@@ -9006,7 +8646,6 @@ fn exif_gps_proctext_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_proctext_wrongfmt_conformance() {
   // Golden-value Contract A (#198 byte-walk class, GPS sibling) — a GPS
   // sub-IFD with GPSProcessingMethod (0x001b) declared `string` (format code
@@ -9036,7 +8675,6 @@ fn exif_gps_proctext_wrongfmt_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_shared_pointer_conformance() {
   // PR #36 Codex R13 F1 — the GENERAL IFD-pointer collision. IFD0's
   // ExifOffset (0x8769) AND GPSInfo (0x8825) BOTH point at one shared
@@ -9083,7 +8721,6 @@ fn exif_gps_shared_pointer_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_gps_unicode_conformance() {
   // PR #36 Codex R4 F1 — a BIG-ENDIAN (MM) TIFF whose GPS sub-IFD carries
   // `UNICODE\0`-prefixed UTF-16 text written LITTLE-ENDIAN. ExifTool's
@@ -9099,7 +8736,6 @@ fn exif_gps_unicode_conformance() {
   check("Exif_gps_unicode.tif", "Exif_gps_unicode.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_gps_wrongfmt_conformance() {
   // PR #36 Codex R8 F1 — an IFD0 GPSInfo pointer (0x8825) mis-encoded as
   // `string` (format code 2) instead of an integer. GPSInfo carries `Flags =>
@@ -9120,7 +8756,6 @@ fn exif_gps_wrongfmt_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_ifd65536_conformance() {
   // PR #36 Codex R12 F1 — a multi-page TIFF whose next-IFD chain runs
   // 65537 IFDs deep: IFD0 -> IFD1 -> ... -> IFD65536. ExifTool numbers each
@@ -9146,7 +8781,6 @@ fn exif_ifd65536_conformance() {
   check("Exif_ifd65536.tif", "Exif_ifd65536.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_illegal_ifd0_size_conformance() {
   // PR #36 Codex R2 F2 — IFD0 whose declared extent leaves only ONE byte
   // after `$dirEnd`. ExifTool reads the IFD body from the file via RAF
@@ -9167,7 +8801,6 @@ fn exif_illegal_ifd0_size_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_illegal_subifd_size_conformance() {
   // PR #36 Codex R2 F2 — the same `$bytesFromEnd` check (Exif.pm:6394-
   // 6399) reached via a sub-IFD: IFD0 carries a GPSInfo pointer to a GPS
@@ -9187,7 +8820,6 @@ fn exif_illegal_subifd_size_conformance() {
   );
 }
 #[test]
-#[ignore]
 #[ignore = "MakerNotes wave not yet landed: 0x927c MakerNote subdirectory tags (MakerNotes:*) are produced only once the MakerNotes port merges; remove #[ignore] then (FORMATS.md row 13 forward item)"]
 fn exif_makernote_subdirectory_deferred_conformance() {
   // FORMATS.md row 13 forward item — when this is un-`#[ignore]`d the
@@ -9198,7 +8830,6 @@ fn exif_makernote_subdirectory_deferred_conformance() {
   check("Exif_makernote.tif", "Exif_makernote.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn makernotes_nikon_d2hs_conformance() {
   // NikonD2Hs.jpg — the riskiest Nikon production path AND the first IFD-
   // MakerNote conformance backstop: the ~66 `Nikon:*` tags (incl. encrypted
@@ -9232,7 +8863,6 @@ fn makernotes_nikon_d2hs_conformance() {
   check("NikonD2Hs.jpg", "NikonD2Hs.jpg.n.json", false);
 }
 #[test]
-#[ignore]
 fn makernotes_pentax_k10d_conformance() {
   // Pentax.jpg (K10D) — the Pentax-MakerNote conformance backstop (#262). The 99
   // ported `Pentax:*` tags emit byte-identically to bundled ExifTool 13.59: the
@@ -9264,7 +8894,6 @@ fn makernotes_pentax_k10d_conformance() {
   check("Pentax.jpg", "Pentax.jpg.n.json", false);
 }
 #[test]
-#[ignore]
 fn pentax_avi_conformance() {
   // Pentax.avi (K-x) — the Pentax AVI MakerNote bridge (#157). The RIFF parser
   // routes the `LIST_hydt` → `hymn` chunk through the shared `%Pentax::Main`
@@ -9419,7 +9048,6 @@ fn exif_manyifd_conformance() {
   check("Exif_manyifd.tif", "Exif_manyifd.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_multipage_conformance() {
   // PR #36 Codex R10 F1 — a multi-page TIFF whose next-IFD chain runs
   // THREE deep: IFD0 -> IFD1 -> IFD2. ExifTool's `Multi` trailing-directory
@@ -9442,7 +9070,6 @@ fn exif_multipage_conformance() {
   check("Exif_multipage.tif", "Exif_multipage.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_pagecount_conformance() {
   // PR #68 (TIFF standalone container) — a two-page TIFF whose IFDs carry
   // `SubfileType` (0x00fe) values that trip the bundled `MultiPage` flag
@@ -9487,7 +9114,6 @@ fn exif_pagecount_conformance() {
   check("Exif_pagecount.dng", "Exif_pagecount.dng.n.json", false);
 }
 #[test]
-#[ignore]
 fn exif_pagecount_suppressed_for_tiff_subtypes() {
   // #162 Codex R1: `File:PageCount` is synthesized ONLY when the outer file
   // type is literally `TIFF` (`$$self{TIFF_TYPE} eq 'TIFF'`, ExifTool.pm:8767).
@@ -9534,7 +9160,6 @@ fn exif_pagecount_suppressed_for_tiff_subtypes() {
   }
 }
 #[test]
-#[ignore]
 fn exif_numeric_emission_json_token_type() {
   // PR #36 Codex R18/F1 — Exif/GPS numeric values must be emitted as bare
   // JSON NUMBER tokens, not quoted strings. The conformance `check`s above
@@ -9613,7 +9238,6 @@ fn exif_numeric_emission_json_token_type() {
   }
 }
 #[test]
-#[ignore]
 fn exif_trailing_space_conformance() {
   // PR #36 Codex R15 F1 — space-padded EXIF `string` fields (normal camera /
   // encoder output for a fixed-width or EXIF-"unknown" ASCII field) carry a
@@ -9651,7 +9275,6 @@ fn exif_trailing_space_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_truncated_ifd_conformance() {
   // PR #36 Codex R1 F2 — IFD0 declares 5 entries but the file ends after
   // 2. The directory's declared extent (`$dirEnd`) runs past the buffer;
@@ -9674,7 +9297,6 @@ fn exif_truncated_ifd_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_usercomment_ascii_conformance() {
   // PR #36 Codex R5 F1 — ExifIFD UserComment (0x9286) is `Format => 'undef'`
   // with `RawConv => ConvertExifText($self,$val,1,$tag)` (Exif.pm:2497-2507),
@@ -9696,7 +9318,6 @@ fn exif_usercomment_ascii_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_usercomment_bom_conformance() {
   // PR #36 Codex R5 F1 — a BIG-ENDIAN (MM) TIFF whose ExifIFD UserComment
   // carries a `UNICODE\0`-prefixed UTF-16LE payload that begins with an LE
@@ -9716,7 +9337,6 @@ fn exif_usercomment_bom_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_usercomment_int8u_conformance() {
   // PR #36 Codex R6 F1 — ExifIFD UserComment (0x9286) whose ON-DISK format
   // code is `int8u` (1), the OTHER documented mis-writer (Exif.pm:2499). The
@@ -9738,7 +9358,6 @@ fn exif_usercomment_int8u_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_usercomment_string_conformance() {
   // PR #36 Codex R6 F1 — ExifIFD UserComment (0x9286) whose ON-DISK format
   // code is `string` (2), the documented mis-writer (Exif.pm:2499 "I have
@@ -9764,7 +9383,6 @@ fn exif_usercomment_string_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn exif_usercomment_unicode_conformance() {
   // PR #36 Codex R5 F1 — a BIG-ENDIAN (MM) TIFF whose ExifIFD UserComment
   // carries a `UNICODE\0`-prefixed UTF-16 payload written LITTLE-ENDIAN with
@@ -9787,7 +9405,6 @@ fn exif_usercomment_unicode_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn gps_conformance() {
   // FORMATS.md row 14: Image::ExifTool::GPS. The GPS IFD is a standard Exif
   // sub-IFD reached through the IFD0 `GPSInfo` tag (0x8825, Exif.pm:2130-
@@ -9819,7 +9436,6 @@ fn gps_conformance() {
   check("ExifGPS.tif", "ExifGPS.tif.n.json", false);
 }
 #[test]
-#[ignore]
 fn jpeg_exif_gps_conformance() {
   // Codex R16/F1 — THE core product capability: a real camera JPEG must read
   // its Exif/GPS. Fixture `tests/fixtures/ExifGPS.jpg` IS the bundled
@@ -9859,7 +9475,6 @@ fn jpeg_exif_gps_conformance() {
   check("ExifGPS.jpg", "ExifGPS.jpg.n.json", false);
 }
 #[test]
-#[ignore]
 fn jpeg_malformed_app1_exif_conformance() {
   // PR #36 Codex R17/F1 — a valid JPEG whose `APP1` `Exif\0\0` segment is NOT
   // a valid TIFF block (`Exif\0\0` + the literal bytes `GARBAGE-not-a-tiff-
@@ -9891,7 +9506,6 @@ fn jpeg_malformed_app1_exif_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn jpeg_two_independent_app1_exif_conformance() {
   // PR #36 Codex R17/F2 — a JPEG carrying TWO independent `APP1` Exif blocks,
   // each a self-contained little-endian TIFF (`Exif\0\0II\x2a\0…`): block 1's
@@ -9921,7 +9535,6 @@ fn jpeg_two_independent_app1_exif_conformance() {
   );
 }
 #[test]
-#[ignore]
 fn jpeg_unknown_header_conformance() {
   // PR #36 Codex R18/F2 — a valid JPEG preceded by a 4-byte unknown header
   // (`JUNK` + `\xff\xd8` + an `APP1` Exif block). Synthetic fixture from
@@ -10018,7 +9631,6 @@ fn xmp_base64_control_byte_split_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_base64_binary_payload_conformance() {
   // Codex R3 F1 regression: a `<=100`-byte non-UTF-8 JPEG header
   // (`FF D8 FF E0`) decodes to LOSSY TEXT `"????"` (no control bytes, length
@@ -10037,7 +9649,6 @@ fn xmp_base64_binary_payload_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_base64_malformed_payload_conformance() {
   // Codex R4 F1 regression: `DecodeBase64` (XMP.pm:2981) NEVER fails — it
   // truncates the input at the first byte outside the allow-list
@@ -10064,7 +9675,6 @@ fn xmp_base64_malformed_payload_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_base64_escaped_payload_conformance() {
   // Codex R5 F1 regression: Perl decodes the RAW (still XML-escaped) value
   // FIRST — `$val = DecodeBase64($val)` (XMP.pm:3645) — and only THEN
@@ -10090,7 +9700,6 @@ fn xmp_base64_escaped_payload_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_multiline_comment_preserved_conformance() {
   // Codex R1 F1: both leaf comment-strip sites run `s/<!--.*?-->//g` with NO
   // `/s` flag (XMP.pm:4180 rdf:Description, :4182 `$wasComment` scalar), so a
@@ -10120,7 +9729,6 @@ fn xmp_multiline_comment_preserved_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_cdata_unclosed_falls_back_to_unescape_conformance() {
   // Codex R1 F2: the CDATA-special un-escape path activates ONLY when a
   // COMPLETE `<![CDATA[ … ]]>` pair exists (XMP.pm:3657
@@ -10147,7 +9755,6 @@ fn xmp_cdata_unclosed_falls_back_to_unescape_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_stray_lt_in_text_conformance() {
   // Codex R3-A: the close-scan regex (XMP.pm:3836
   // `<(?:(/?)\Q$prop\E([-\w:.\x80-\xff]*)(.*?(/?))>|(!\[CDATA\[|!--))`/sg) is
@@ -10163,7 +9770,6 @@ fn xmp_stray_lt_in_text_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_close_extra_name_conformance() {
   // Codex R3-A: `$2` = the name-EXTENSION chars after the exact prop name;
   // `next if $2` (XMP.pm:3853) ignores a token whose name merely STARTS with
@@ -10179,7 +9785,6 @@ fn xmp_close_extra_name_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_nodeid_blank_node_conformance() {
   // Codex R3-B: `rdf:nodeID` blank-node resolution (SaveBlankInfo /
   // ProcessBlankInfo, WriteXMP.pl:433/465). A subject element
@@ -10200,7 +9805,6 @@ fn xmp_nodeid_blank_node_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_noncanonical_prefix_conformance() {
   // Codex R6 F1 regression: `FoundXMP` reads `rdf:datatype`/`et:encoding`
   // (XMP.pm:3644) and `xml:lang` (XMP.pm:3497) from the `%attrs` HASH —
@@ -10221,7 +9825,6 @@ fn xmp_noncanonical_prefix_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_rdf_resource_spaced_conformance() {
   // Codex R7 F1 regression: the empty-value fallback (XMP.pm:4185-4186)
   // matches the RAW `$attrs` string with the literal Perl regexes
@@ -10246,7 +9849,6 @@ fn xmp_rdf_resource_spaced_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_attr_junk_conformance() {
   // Codex R2 finding: the COMMON-branch attribute scanner (XMP.pm:3884-3900,
   // `length($attrs) < 2000`) reads attributes with an UNANCHORED `/g` regex in
@@ -10266,7 +9868,6 @@ fn xmp_attr_junk_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_et_encoding_conformance() {
   // Codex R7 F2 regression: a NON-ignored shorthand attribute is removed
   // from `%attrs` (`delete $attrs{$shortName}`, XMP.pm:4133) once it has
@@ -10284,7 +9885,6 @@ fn xmp_et_encoding_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_li_1000_item_cap_conformance() {
   // Codex R8 F1 regression: `ParseXMPElement` imposes a reasonable maximum
   // on the number of items in a list (XMP.pm:3991-3999). At the 1001st
@@ -10305,7 +9905,6 @@ fn xmp_li_1000_item_cap_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_svg_and_xml_inputs_are_not_misfinalized_as_xmp() {
   // Codex R8 F2 regression: `ProcessXMP` recognizes several XML flavours
   // and `SetFileType`s each separately — `<svg`-rooted / `<?xml`+`<svg`
@@ -10350,7 +9949,6 @@ fn xmp_svg_and_xml_inputs_are_not_misfinalized_as_xmp() {
 }
 
 #[test]
-#[ignore]
 fn xmp_numeric_entity_overflow_and_surrogate_conformance() {
   // Codex R9/F2 regression: `UnescapeChar` (XMP.pm:2919-2936) resolves a
   // numeric reference, then emits it via `pack('C0U', $val)` (XMP.pm:2933) —
@@ -10374,7 +9972,6 @@ fn xmp_numeric_entity_overflow_and_surrogate_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_leading_whitespace_recognition_anchoring() {
   // Codex R9/F1 regression: `ProcessXMP` recognition is a TWO-TIER match.
   // Tier 1 (XMP.pm:4341 `^\s*(<\?xpacket begin=|<x(mp)?:x[ma]pmeta)`) tolerates
@@ -10429,7 +10026,6 @@ fn xmp_leading_whitespace_recognition_anchoring() {
 }
 
 #[test]
-#[ignore]
 fn xmp_double_utf8_encoded_conformance() {
   // Codex R10/F1 regression: a UTF-8-BOM + `<?xpacket begin=` sidecar is the
   // `$double` capture (XMP.pm:4351 `^(\xfe\xff|\xff\xfe|\xef\xbb\xbf)(<\?xpacket
@@ -10449,7 +10045,6 @@ fn xmp_double_utf8_encoded_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_utf16le_non_bmp_conformance() {
   // Codex R10/F2 regression: ProcessXMP transcodes UTF-16 via `pack('C0U*',
   // unpack('v*'/'n*', $$dataPt))` (XMP.pm:4571-4587) — each 16-bit unit is
@@ -10474,7 +10069,6 @@ fn xmp_utf16le_non_bmp_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_nikon_basic_param_nxd_override_conformance() {
   // Codex R11/F1 regression: an `xmlns` URI beginning
   // `http://ns.nikon.com/BASIC_PARAM` (a Nikon NX-D settings sidecar) triggers
@@ -10492,7 +10086,6 @@ fn xmp_nikon_basic_param_nxd_override_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_nikon_nxd_extension_override_guard_conformance() {
   // Codex R11/F1 class-sweep: the SAME Nikon NX-D content as
   // `XMP_nikon_nxd.xmp` but under a `.nxd` EXTENSION. `OverrideFileType` is
@@ -10513,7 +10106,6 @@ fn xmp_nikon_nxd_extension_override_guard_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_base64_literal_x0c_typo_conformance() {
   // Codex R11/F2 regression: the base64 binary-guard regex (XMP.pm:3647 `… or
   // $$val =~ /[\0-\x08\x0b\0x0c\x0e-\x1f]/`) ships a TYPO that ExifTool 13.58
@@ -10530,7 +10122,6 @@ fn xmp_base64_literal_x0c_typo_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_plus_signed_rational_not_converted_conformance() {
   // Codex R12/F1 + class-sweep regression: `ConvertRational` (XMP.pm:3400-
   // 3411) gates the value with the Perl regex `^(-?\d+)/(-?\d+)$` — exactly
@@ -10556,7 +10147,6 @@ fn xmp_plus_signed_rational_not_converted_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_exif_colorspace_value_conv_conformance() {
   // Codex R14/F1 regression: `exif:ColorSpace` (XMP.pm:2000) carries
   // `ValueConv => '$val == 0xffffffff ? 0xffff : $val'` (XMP.pm:2003) — some
@@ -10572,7 +10162,6 @@ fn xmp_exif_colorspace_value_conv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_exif_cross_module_printconv_conformance() {
   // Codex R4-A: XMP tags whose bundled `PrintConv` is a REFERENCE to another
   // module's hash (`\%Image::ExifTool::Exif::compression` / `…::
@@ -10603,7 +10192,6 @@ fn xmp_exif_cross_module_printconv_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_et_qualifier_suppression_conformance() {
   // Codex R4-B: `ParseXMPElement` IGNORES `et:desc` always, and `et:val` when
   // preceded by `et:prt` (XMP.pm:4202 `/^et:(desc|prt|val)$/ and ($count or
@@ -10616,7 +10204,6 @@ fn xmp_et_qualifier_suppression_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_aux_lensinfo_rational_list_conformance() {
   // Codex R14/F1 regression: `aux:LensInfo` (XMP.pm:2596) carries
   // `ValueConv => \&ConvertRationalList` (XMP.pm:2600) +
@@ -10635,7 +10222,6 @@ fn xmp_aux_lensinfo_rational_list_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_aux_lensinfo_prime_zero_upper_focal_conformance() {
   // Codex R14/F1 class-sweep: `PrintLensInfo` (Exif.pm:5800) appends the
   // upper focal/aperture only when it is Perl-truthy AND differs from the
@@ -10659,7 +10245,6 @@ fn xmp_aux_lensinfo_prime_zero_upper_focal_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_aux_approximate_focus_distance_conformance() {
   // Codex R14/F1 regression: `aux:ApproximateFocusDistance` (XMP.pm:2630)
   // carries `Writable => 'rational'` and a PrintConv hash whose only mapped
@@ -10693,7 +10278,6 @@ fn xmp_aux_approximate_focus_distance_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_aux_neutral_density_and_lightroom_tags_conformance() {
   // Codex R5/F1 value-divergence fix: the AUX table stopped at
   // `LensDistortInfo`; the Lightroom LR6+/LR7+/LR11+ tags (XMP.pm:2641-2658)
@@ -10723,7 +10307,6 @@ fn xmp_aux_neutral_density_and_lightroom_tags_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_thumbnails_struct_base64_image_is_binary_conformance() {
   // Codex R5/F2 value-divergence fix: `xmp:Thumbnails` (XMP.pm:1062,
   // `Struct => \%sThumbnail`) and `xmp:PageInfo` (XMP.pm:1068,
@@ -10751,7 +10334,6 @@ fn xmp_thumbnails_struct_base64_image_is_binary_conformance() {
 ///   * `XMP_gps.xmp`: `XMP-exif:GPSLatitude` 45.5, `GPSLongitude` -122.508…
 ///     (already signed decimal degrees in `-n`).
 #[test]
-#[ignore]
 #[cfg(all(feature = "xmp", feature = "gps"))]
 fn xmp_projects_camera_lens_capture_and_gps_domain() {
   use exifast::metadata::Project;
@@ -10798,7 +10380,6 @@ fn xmp_projects_camera_lens_capture_and_gps_domain() {
 /// projection negates. Oracle (`-n`, both fixtures): `GPSAltitude` 35,
 /// `GPSAltitudeRef` 1 (below) / 0 (above).
 #[test]
-#[ignore]
 #[cfg(all(feature = "xmp", feature = "gps"))]
 fn xmp_projects_gps_altitude_signed_by_ref() {
   use exifast::metadata::Project;
@@ -10822,21 +10403,18 @@ fn xmp_projects_gps_altitude_signed_by_ref() {
 }
 
 #[test]
-#[ignore]
 fn xmp_gps_belowsea_conformance() {
   check("XMP_gps_belowsea.xmp", "XMP_gps_belowsea.xmp.json", true);
   check("XMP_gps_belowsea.xmp", "XMP_gps_belowsea.xmp.n.json", false);
 }
 
 #[test]
-#[ignore]
 fn xmp_gps_abovesea_conformance() {
   check("XMP_gps_abovesea.xmp", "XMP_gps_abovesea.xmp.json", true);
   check("XMP_gps_abovesea.xmp", "XMP_gps_abovesea.xmp.n.json", false);
 }
 
 #[test]
-#[ignore]
 fn xmp_no_closing_tag_conformance() {
   // F2 — the close-scan finds no `</dc:title>` before end-of-data, so
   // `find_close` returns `CloseErr::NoClosingTag` and the walker raises
@@ -10862,7 +10440,6 @@ fn xmp_no_closing_tag_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_uri_fixed_conformance() {
   // F2 adjacent Warn-site (XMP.pm:3914-3915): the `dc` URI is given WITHOUT its
   // trailing slash (`…/1.1` vs the canonical `…/1.1/`); the trailing-slash
@@ -10875,7 +10452,6 @@ fn xmp_uri_fixed_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_uri_double_slash_conformance() {
   // R9 [medium]: XMP.pm:3911 `$try =~ s{/$}{} or $try .= '/'` toggles EXACTLY
   // ONE trailing slash. A repairable camera namespace `xmlns:exif=…/exif/1.0//`
@@ -10897,7 +10473,6 @@ fn xmp_uri_double_slash_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_iso_seq_conformance() {
   // R10 [medium] (premise corrected): bundled ExifTool 13.59 emits a single-item
   // `exif:ISOSpeedRatings` RDF `Seq` as the ARRAY `XMP-exif:ISO: [100]`
@@ -10909,7 +10484,6 @@ fn xmp_iso_seq_conformance() {
 }
 
 #[test]
-#[ignore]
 #[cfg(feature = "xmp")]
 fn xmp_projects_iso_from_single_item_seq() {
   // R10 fix: XMP `ISO` (`List => 'Seq'`) is ALWAYS a list, so the JSON tag is
@@ -10949,7 +10523,6 @@ fn xmp_projects_iso_from_single_item_seq() {
 /// emission (the actual fix) is pinned here while the cosmetic count delta is
 /// left as a deliberate, documented divergence.
 #[test]
-#[ignore]
 #[cfg(feature = "xmp")]
 fn xmp_parse_error_warnings_emitted() {
   let root = env!("CARGO_MANIFEST_DIR");
@@ -10988,7 +10561,6 @@ fn xmp_parse_error_warnings_emitted() {
 // ===========================================================================
 
 #[test]
-#[ignore]
 fn xmp_generated_crs_camera_raw_settings_conformance() {
   // `crs` (Lightroom camera-raw-settings) is a GENERATED-ONLY namespace (no
   // hand table). Exercises a plain string (`RawFileName`), a `real` autoconv
@@ -11001,7 +10573,6 @@ fn xmp_generated_crs_camera_raw_settings_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_generated_lightroom_namespace_conformance() {
   // `lr` (Lightroom) GENERATED-ONLY namespace, incl. an ExifTool `Name` remap
   // carried in `-listx` (`lr:hierarchicalSubject` → `HierarchicalSubject`, a
@@ -11011,7 +10582,6 @@ fn xmp_generated_lightroom_namespace_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_generated_xmpmm_media_management_conformance() {
   // `xmpMM` (XMP Media Management) GENERATED-ONLY namespace — a top-level tag
   // (`DocumentID`/`OriginalDocumentID`/`RenditionClass`) plus a `-listx`
@@ -11021,7 +10591,6 @@ fn xmp_generated_xmpmm_media_management_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_generated_nested_struct_field_conformance() {
   // Codex R1 [high]: a NESTED structured `xmpMM:DerivedFrom/stRef:maskMarkers`
   // (vs the flat `DerivedFromMaskMarkers` spelling) must reach the GENERATED
@@ -11045,7 +10614,6 @@ fn xmp_generated_nested_struct_field_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_generated_covered_namespace_extra_tags_conformance() {
   // The ADDITIVE fallback in a HAND-COVERED namespace + Name remaps in a new
   // one: `exif:OECFColumns` / `exif:SpatialFrequencyResponseRows` are flattened
@@ -11067,7 +10635,6 @@ fn xmp_generated_covered_namespace_extra_tags_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_generated_phf_backed_value_map_conformance() {
   // The phf-backed large value-map path (the codegen `PHF_THRESHOLD`): PLUS
   // `MediaSummaryCode` has 2143 string-keyed rows → a `phf::Map`, looked up via
@@ -11078,7 +10645,6 @@ fn xmp_generated_phf_backed_value_map_conformance() {
 }
 
 #[test]
-#[ignore]
 fn xmp_generated_unported_conv_passes_through_raw_conformance() {
   // `P::Unported` faithful raw passthrough: `HDRGainMap:HDRGainMapVersion`
   // (XMP2.pl:1791) carries a CODE `PrintConv`
@@ -11095,7 +10661,6 @@ fn xmp_generated_unported_conv_passes_through_raw_conformance() {
 }
 
 #[test]
-#[ignore]
 #[cfg(all(feature = "png", feature = "xmp"))]
 fn png_rawprofile_xmp_conformance() {
   // Issue #179: an ImageMagick `Raw profile type xmp` tEXt chunk (`PNG.pm:746`)
@@ -11141,22 +10706,34 @@ fn png_rawprofile_xmp_conformance() {
 // asserting both snapshots: check("X.ext","X.ext.json",true) and
 // check("X.ext","X.ext.n.json",false).
 
-// #213 — BlackVue DR770X dashcam (PittaSoft) with GPS, accelerometer, embedded JSON metadata
-
-
-
-// #213 — BlackVue DR770X dashcam (PittaSoft) with GPS, accelerometer, embedded JSON metadata
+// #213 — BlackVue DR770X dashcam (PittaSoft): GPS, accelerometer, embedded JSON.
 #[test]
-#[ignore]
+#[ignore = "port gap: BlackVue PittaSoft GPS / accelerometer / embedded-JSON; see #213"]
 fn mp4_blackvue_dr770x_conformance() {
-    check("MP4_blackvue_dr770x.mp4", "MP4_blackvue_dr770x.mp4.json", true);
-    check("MP4_blackvue_dr770x.mp4", "MP4_blackvue_dr770x.mp4.n.json", false);
+  check(
+    "MP4_blackvue_dr770x.mp4",
+    "MP4_blackvue_dr770x.mp4.json",
+    true,
+  );
+  check(
+    "MP4_blackvue_dr770x.mp4",
+    "MP4_blackvue_dr770x.mp4.n.json",
+    false,
+  );
 }
 
-// #138 — Pruveeo D90 dashcam with LIGOGPSINFO data in MPEG-TS container
+// #138 — Pruveeo D90 dashcam: LIGOGPSINFO data in an MPEG-TS container.
 #[test]
-#[ignore]
+#[ignore = "port gap: Pruveeo D90 LIGOGPSINFO in MPEG-TS; see #138"]
 fn mpeg2_ts_pruveeo_d90_conformance() {
-    check("MPEG2_TS_pruveeo_d90.ts", "MPEG2_TS_pruveeo_d90.ts.json", true);
-    check("MPEG2_TS_pruveeo_d90.ts", "MPEG2_TS_pruveeo_d90.ts.n.json", false);
+  check(
+    "MPEG2_TS_pruveeo_d90.ts",
+    "MPEG2_TS_pruveeo_d90.ts.json",
+    true,
+  );
+  check(
+    "MPEG2_TS_pruveeo_d90.ts",
+    "MPEG2_TS_pruveeo_d90.ts.n.json",
+    false,
+  );
 }

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -159,6 +159,12 @@ const NOT_ACTIVE: &[&str] = &[
   "DJI_Matrice30T.jpg",
   "Insta360ONE_equirectangular.jpg",
   "QuickTime_rove_r2_4k.MP4",
+  // The BlackVue DR770X (#213) + Pruveeo D90 (#138) dashcam fixtures — dropped
+  // with goldens + #[ignore]d conformance tests pending their ports (BlackVue
+  // GPS/accelerometer/embedded-JSON; Pruveeo LIGOGPSINFO in MPEG-TS). Their
+  // no-ee .json carries tags exifast does not yet emit, so accept-deferred here.
+  "MP4_blackvue_dr770x.mp4",
+  "MPEG2_TS_pruveeo_d90.ts",
   // `CanonRaw_ctmd.cr3` (the REAL minimal CRX still-RAW, #81 phase 2) — the
   // Canon CTMD `Priority => 0` dedup fix (the `ExposureInfo` `FNumber 3.5` /
   // `ExposureTime 1/80` win over the `ShotInfo` `Priority => 0` re-dispatch) is


### PR DESCRIPTION
**Main is RED after #297 (#213 BlackVue) merged** — this un-breaks it.

## What #297 broke
#297 was based on a stale main; its squash-merge to tests/conformance.rs was +455/-0 and:
1. **Compile error** — corrupted `quicktime_rove_r2_4k_conformance` (dropped its closing `}` + the hero8 test's `#[test]`) → unclosed delimiter.
2. **417-test coverage regression** — added **422 `#[ignore]` lines**, silently re-ignoring ~417 passing conformance tests (7 → 429 ignores). This does NOT fail CI (ignored tests don't fail) but quietly drops most of the suite.
3. **typed_serde RED** — added MP4_blackvue_dr770x.mp4 + MPEG2_TS_pruveeo_d90.ts (with goldens) but not to NOT_ACTIVE (532 vs 530).

## Fix
- Restore tests/conformance.rs to the correct post-#298 state (7-ignore baseline, all ports running), re-adding ONLY #297's legitimate part: the 2 dashcam tests, #[ignore]d with port-gap reasons.
- Add the 2 dashcam fixtures to typed_serde NOT_ACTIVE.

## Verify
`fmt=0  build(-Dwarnings)=0  conformance=425/0 (10 ignored, coverage restored)  typed_serde=530  dispatch=80  timed=126  lib=3186`

⚠️ Process note: #297 should have been rebased onto current main before merge (it diverged ~417 tests). Worth checking how it was created.