### PR TITLE
feat(quicktime/gopro): per-sample Doc<N> gpmd timed GPS + -ee gating + Track<N> grouping (#211, #189)

### DIFF
--- a/src/emit.rs
+++ b/src/emit.rs
@@ -238,7 +238,14 @@ pub(crate) fn run_emission<T: Taggable>(
     // rule (`ExifTool.pm:9544-9560`).
     let priority = e.priority();
     let (group, name, value) = e.into_tag().into_parts();
-    let _ = out.write_value_doc(group.doc(), group.family1(), name.as_str(), priority, value);
+    let _ = out.write_value_doc(
+      group.doc(),
+      group.doc_sub(),
+      group.family1(),
+      name.as_str(),
+      priority,
+      value,
+    );
   }
 }
 

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -1718,8 +1718,8 @@ const _: () = {
       // `-G1` collapses the leading `doc`, `-G3` prefixes `Doc<N>:`.
       let group_mode = self.group_mode;
       let mut key = std::string::String::new();
-      for (doc, group, name, _priority, value) in entries {
-        crate::serialize_key::group_key_into(&mut key, *doc, group, name, group_mode);
+      for (doc, doc_sub, group, name, _priority, value) in entries {
+        crate::serialize_key::group_key_into(&mut key, *doc, *doc_sub, group, name, group_mode);
         map.serialize_entry(key.as_str(), value)?;
       }
       if let Some(w) = warning {

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -3611,11 +3611,11 @@ mod tests {
     let desc_idx = tm
       .entries()
       .iter()
-      .position(|(_, g, n, _, _)| g == "APE" && n == "CoverArtFrontDesc");
+      .position(|(_, _, g, n, _, _)| g == "APE" && n == "CoverArtFrontDesc");
     let cover_idx = tm
       .entries()
       .iter()
-      .position(|(_, g, n, _, _)| g == "APE" && n == "CoverArtFront");
+      .position(|(_, _, g, n, _, _)| g == "APE" && n == "CoverArtFront");
     assert!(desc_idx < cover_idx);
   }
 
@@ -3748,7 +3748,7 @@ mod tests {
     let names: Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, g, n, _, _)| (g == "APE").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _)| (g == "APE").then_some(n.as_str()))
       .collect();
     assert_eq!(names, &["Title", "Artist"]);
     assert_eq!(

--- a/src/formats/audible.rs
+++ b/src/formats/audible.rs
@@ -1735,7 +1735,7 @@ mod tests {
     let tm = emit_into_tagmap(&meta, true);
     tm.entries()
       .iter()
-      .filter_map(|(_, g, n, _, v)| (g == "Audible").then(|| (n.to_string(), v.clone())))
+      .filter_map(|(_, _, g, n, _, v)| (g == "Audible").then(|| (n.to_string(), v.clone())))
       .collect()
   }
 

--- a/src/formats/dsf.rs
+++ b/src/formats/dsf.rs
@@ -1904,7 +1904,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, g, n, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
+        .any(|(_, _, g, n, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 trailer tags present in the engine output"
     );
   }

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -2413,7 +2413,7 @@ mod tests {
     let names: Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, g, n, _, _)| (g == "FLAC").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _)| (g == "FLAC").then_some(n.as_str()))
       .filter(|n| n.starts_with("Picture"))
       .collect();
     assert_eq!(
@@ -2822,7 +2822,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, g, n, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
+        .any(|(_, _, g, n, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 tags present in the engine output"
     );
   }

--- a/src/formats/gopro.rs
+++ b/src/formats/gopro.rs
@@ -121,8 +121,8 @@ use alloc::{
 use smol_str::SmolStr;
 
 use crate::metadata::{
-  GoProConv, GoProGlpiSample, GoProGpsSample, GoProIdentity, GoProKbat, GoProMeta, GoProScalar,
-  GoProTag, GoProTagValue,
+  GoProConv, GoProFdscSample, GoProGlpiSample, GoProGpsSample, GoProIdentity, GoProKbat, GoProMeta,
+  GoProScalar, GoProTag, GoProTagValue,
 };
 
 // ===========================================================================
@@ -272,6 +272,40 @@ pub fn process_gopro(data: &[u8], out: &mut GoProMeta) -> bool {
     unit: None,
   };
   walker.walk(data)
+}
+
+/// Decode one GoPro `fdsc` timed-metadata sample — the
+/// `Image::ExifTool::GoPro::fdsc` `ProcessBinaryData` block (GoPro.pm:651-665).
+/// The sample is dispatched only when it starts `GPRO`
+/// (QuickTimeStream.pl:213-218 `Condition => '$$valPt =~ /^GPRO/'`); the four
+/// named fields are fixed-offset NUL-trimmed strings:
+///  - `0x08` `FirmwareVersion` `string[15]`,
+///  - `0x17` `SerialNumber` `string[16]`,
+///  - `0x57` `OtherSerialNumber` `string[15]`,
+///  - `0x66` `Model` `string[16]`.
+///
+/// A field whose `offset + len` runs past the sample is left `None` (ExifTool's
+/// `ProcessBinaryData` simply does not emit a tag whose bytes are out of range).
+/// Returns the decoded [`GoProFdscSample`] (its `track_index`/`doc`/timing are
+/// stamped by the caller). The `GPRO` magic is the caller's gate; this function
+/// trusts it (mirrors `ProcessBinaryData` running after the `Condition` match).
+#[must_use]
+pub fn process_fdsc(data: &[u8]) -> GoProFdscSample {
+  // `ReadValue('string', offset, len)`: read `len` bytes, then NUL-trim at the
+  // first `\0` (the same `read_ascii` shape every GoPro `c`-string field uses).
+  let field = |offset: usize, len: usize| -> Option<SmolStr> {
+    data
+      .get(offset..offset.saturating_add(len))
+      .and_then(read_ascii)
+      .map(SmolStr::from)
+  };
+  let mut sample = GoProFdscSample::new();
+  sample
+    .set_firmware_version(field(0x08, 15))
+    .set_serial_number(field(0x17, 16))
+    .set_other_serial_number(field(0x57, 15))
+    .set_model(field(0x66, 16));
+  sample
 }
 
 /// Container-walk state. ExifTool tracks `$type`, `$scal`, `$unit` per

--- a/src/formats/h264.rs
+++ b/src/formats/h264.rs
@@ -3507,7 +3507,7 @@ mod tests {
     let wb_keys = j
       .entries()
       .iter()
-      .filter(|(_, _, n, _, _)| n.contains("WhiteBalance"))
+      .filter(|(_, _, _, n, _, _)| n.contains("WhiteBalance"))
       .count();
     assert_eq!(wb_keys, 1, "only the priority winner is emitted");
   }

--- a/src/formats/id3/process.rs
+++ b/src/formats/id3/process.rs
@@ -3031,7 +3031,7 @@ mod tests {
     // `(family1, name, value)` shape this comparison helper compares.
     tm.entries()
       .iter()
-      .map(|(_, g, n, _, v)| (g.clone(), n.clone(), v.clone()))
+      .map(|(_, _, g, n, _, v)| (g.clone(), n.clone(), v.clone()))
       .collect()
   }
 
@@ -3086,7 +3086,7 @@ mod tests {
       out
         .entries()
         .iter()
-        .map(|(_, g, n, _, v)| (g.clone(), n.clone(), v.clone()))
+        .map(|(_, _, g, n, _, v)| (g.clone(), n.clone(), v.clone()))
         .collect()
     }
 

--- a/src/formats/moi.rs
+++ b/src/formats/moi.rs
@@ -1326,7 +1326,7 @@ mod tests {
     let format_names: std::vec::Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, g, n, _, _)| (g == "MOI").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _)| (g == "MOI").then_some(n.as_str()))
       .collect();
     assert_eq!(
       format_names,

--- a/src/formats/mpc.rs
+++ b/src/formats/mpc.rs
@@ -1508,7 +1508,7 @@ mod tests {
     // No MPC:* tags emitted (sv7_header is None). The format-tag entries
     // carry the `"<Group1>:<Name>"` keys; warnings live in their own
     // accumulator (`TagMap::warnings`).
-    assert!(w.entries().iter().all(|(_, g, _, _, _)| g != "MPC"));
+    assert!(w.entries().iter().all(|(_, _, g, _, _, _)| g != "MPC"));
     // The warning is pushed through write_warning ⇒ TagMap::warnings.
     assert_eq!(
       w.warnings(),
@@ -1723,7 +1723,7 @@ mod tests {
     let keys: std::vec::Vec<&str> = w
       .entries()
       .iter()
-      .map(|(_, g, _, _, _)| g.as_str())
+      .map(|(_, _, g, _, _, _)| g.as_str())
       .collect();
     let mpc_pos = keys.iter().position(|g| *g == "MPC");
     let ape_pos = keys.iter().position(|g| *g == "APE");

--- a/src/formats/ogg.rs
+++ b/src/formats/ogg.rs
@@ -3443,7 +3443,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, g, n, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3527,7 +3527,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, g, n, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3566,7 +3566,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, g, n, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3607,7 +3607,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, g, n, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3680,7 +3680,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, g, n, _, _)| g == "Vorbis" && n != "Vendor"),
+        .any(|(_, _, g, n, _, _)| g == "Vorbis" && n != "Vendor"),
       "at least one Vorbis comment beyond vendor: {:?}",
       w.entries()
     );
@@ -3970,11 +3970,11 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, g, n, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
+        .any(|(_, _, g, n, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 tags present in the engine output"
     );
     assert!(
-      w.entries().iter().any(|(_, g, _, _, _)| g == "Vorbis"),
+      w.entries().iter().any(|(_, _, g, _, _, _)| g == "Vorbis"),
       "OGG body tags present in the engine output"
     );
   }

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -60,8 +60,9 @@ use crate::{
   },
   metadata::{
     AudioSampleDesc, Bitrate, CammMeta, CanonCtmdMeta, ColorRepresentation, DjiProtobufMeta,
-    GoProConv, GoProMeta, GoProTag, GoProTagValue, Insta360Meta, LigoGpsMeta, MediaTrack,
-    ParrotMeta, QuickTimeGps, QuickTimeMeta, QuickTimeStreamMeta, SonyRtmdMeta, VisualSampleDesc,
+    GoProConv, GoProMeta, GoProTag, GoProTagValue, GoProTimedMeta, Insta360Meta, LigoGpsMeta,
+    MediaTrack, ParrotMeta, QuickTimeGps, QuickTimeMeta, QuickTimeStreamMeta, SonyRtmdMeta,
+    VisualSampleDesc,
   },
   value::{binary_placeholder, format_g},
 };
@@ -4057,6 +4058,13 @@ pub struct Meta<'a> {
   /// scan in `mdat` (see [`crate::formats::gopro`]). Empty
   /// ([`GoProMeta::is_empty`]) for a non-GoPro video.
   gopro: GoProMeta,
+  /// **SP4** — the GoPro `gpmd` + `fdsc` TIMED-metadata per-sample `Doc<N>`
+  /// sources (#211 / #189), decoded through the `gpmd` / `fdsc` MetaFormat
+  /// dispatch in [`quicktime_stream`]. Distinct from [`Self::gopro`] (the
+  /// always-on `moov/udta/GPMF` box emitted under `GoPro:`): these emit under
+  /// `Track<N>:` in `-ee` mode only. Empty ([`GoProTimedMeta::is_empty`]) for a
+  /// GoPro video whose data is only in the `udta/GPMF` box, or a non-GoPro one.
+  gopro_timed: GoProTimedMeta,
   /// **SP4** — Android Google CAMM (Camera Motion Metadata) — decoded
   /// through the `camm` MetaFormat dispatch in [`quicktime_stream`]. Empty
   /// ([`CammMeta::is_empty`]) for a non-Android video (or one whose CAMM
@@ -4228,6 +4236,19 @@ impl Meta<'_> {
     &self.gopro
   }
 
+  /// **SP4** — the GoPro `gpmd` + `fdsc` TIMED-metadata per-sample `Doc<N>`
+  /// sources (#211). Distinct from [`Self::gopro`] (the always-on `moov/udta/GPMF`
+  /// box emitted under `GoPro:`): these per-sample telemetry samples emit under
+  /// `Track<N>:` in `-ee` mode only, but their GPS / camera identity is folded
+  /// into the always-on [`crate::metadata::MediaMetadata`] projection.
+  /// [`GoProTimedMeta::is_empty`] for a GoPro video whose data is only in the
+  /// `udta/GPMF` box, or a non-GoPro one.
+  #[must_use]
+  #[inline(always)]
+  pub const fn gopro_timed(&self) -> &GoProTimedMeta {
+    &self.gopro_timed
+  }
+
   /// **SP4** — Android Google CAMM (Camera Motion Metadata).
   /// [`CammMeta::is_empty`] for a non-Android video (or one whose `camm`
   /// metadata track is absent).
@@ -4396,6 +4417,15 @@ impl Meta<'_> {
     // if a higher-priority source already populated the domain it would
     // write). GoPro on-device GNSS is the HIGHEST GPS tier.
     self.gopro.project_into(&mut md);
+    // **SP4** — the GoPro `gpmd` / `fdsc` TIMED-metadata samples (#211). SAME
+    // on-device-GNSS tier as the always-on `udta/GPMF` box above: a GoPro file
+    // whose GPS lives ONLY in the timed `gpmd` track (e.g. HERO8 — the `GPMF`
+    // box carries identity but no `GPS5`/`GPS9`) surfaces its `GpsLocation` (and
+    // camera identity) HERE. Set-once per domain, so it no-ops whenever the flat
+    // `GoProMeta` above already populated camera / GPS. Always-on (the normalized
+    // projection is the product's output); the per-sample timed TAG stream is
+    // still `-ee`-gated separately (see [`emit_gopro_doc`]).
+    self.gopro_timed.project_into(&mut md);
     // **SP2** — the `udta` / Keys camera identity, capture date and GPS. Sits
     // BELOW GoPro on-device telemetry but ABOVE the SP3 timed-metadata scan: it
     // is explicit container camera metadata. Keys (the iOS `mdta` ItemList) is
@@ -5042,6 +5072,10 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // by the brute-force `GP\x06\0\0` scan (some GoPro firmware writes
   // unreferenced GPMF records in `mdat` outside of a metadata track).
   let mut gopro_meta = GoProMeta::new();
+  // **SP4 — GoPro `gpmd`/`fdsc` timed `Doc<N>`** accumulator (#211/#189),
+  // populated by the `gpmd`/`fdsc` MetaFormat dispatch in [`quicktime_stream`].
+  // Additive to the per-format sample dispatch, like `camm_meta`.
+  let mut gopro_timed_meta = GoProTimedMeta::new();
   // **SP4 — Android CAMM**: the `camm` MetaFormat dispatch in
   // [`quicktime_stream`] populates `camm_meta` for each timed-metadata sample
   // whose track carries Google Camera Motion Metadata. Threaded ALONGSIDE the
@@ -5117,6 +5151,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
     kodak_version,
     &mut stream,
     &mut gopro_meta,
+    &mut gopro_timed_meta,
     &mut camm_meta,
     &mut sony_rtmd_meta,
     &mut canon_ctmd_meta,
@@ -5392,6 +5427,7 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
     qt,
     stream,
     gopro: gopro_meta,
+    gopro_timed: gopro_timed_meta,
     android_camm: camm_meta,
     sony_rtmd: sony_rtmd_meta,
     canon_ctmd: canon_ctmd_meta,
@@ -7491,6 +7527,20 @@ impl crate::emit::Taggable for Meta<'_> {
     // family-1 = `GoPro`; the JPEG `APP6` path reuses [`emit_gopro_tags`] with
     // the `APP6` family-0).
     emit_gopro_tags(&self.gopro, "GoPro", "GoPro", print_conv, &mut tags);
+
+    // ── SP4: GoPro `gpmd` + `fdsc` TIMED-metadata per-sample `Doc<N>` ───────
+    // (#211 / #189) Distinct from the always-on `udta/GPMF` box above: the
+    // `gpmd` track's per-sample GPMF + the `fdsc` track's identity emit under
+    // `Track<N>:` (family-1) in `-ee` mode ONLY — one `Doc<N>` per sample, the
+    // multi-row `GPS5`/`GPS9` rows split into `Doc<N>-<M>` (ProcessString,
+    // GoPro.pm:759-774), collapsed first-wins per `(Track<N>, name)` at `-G1`.
+    emit_gopro_doc(
+      &self.gopro_timed,
+      opts,
+      print_conv,
+      &mut first_seen,
+      &mut tags,
+    );
 
     // ── SP4: Android CAMM cross-kind `-G1` SampleTime/SampleDuration ────────
     // At `-ee -G1` the single `Track<N>:SampleTime`/`SampleDuration` is the timing
@@ -11494,6 +11544,436 @@ fn sony_rtmd_exposure_time_read_value(
   }
 }
 
+/// Emit the GoPro `gpmd` + `fdsc` TIMED-metadata per-sample `Doc<N>` sources
+/// (#211 / #189) under `Track<N>:`, in `-ee` mode ONLY. Each `gpmd`
+/// [`crate::metadata::GoProDocSample`] is one `DEVC` = one `Doc<N>`:
+///  - `Track<N>:SampleTime` / `Track<N>:SampleDuration` (the sample-table
+///    timing `ProcessSamples` emits ahead of the payload);
+///  - the per-`DEVC` [`GoProMeta`]'s main-group leaves (DeviceName, the sensor /
+///    settings streams, the GPS scalars `GPSMeasureMode`/`GPSDateTime`/
+///    `GPSHPositioningError`) via [`emit_gopro_main_group`];
+///  - the `GPS5`/`GPS9` ROWS: row 0 at `Doc<N>`, each subsequent row at the
+///    `ProcessString` two-level sub-document `Doc<N>-<M>` (GoPro.pm:759-774),
+///    each carrying `GPSLatitude`/`GPSLongitude`/`GPSAltitude`/`GPSSpeed`/
+///    `GPSSpeed3D` rendered with the `%GoPro::GPS5`/`GPS9` PrintConvs (lat/lon
+///    `ToDMS` + N/E hemisphere, altitude `"$val m"`, speed `$val * 3.6` km/h).
+///
+/// Each `fdsc` [`crate::metadata::GoProFdscSample`] is one `Doc<N>` carrying
+/// `SampleTime`/`SampleDuration` + the `GoPro::fdsc` identity fields.
+///
+/// At `-ee -G3` every `Doc<N>` / `Doc<N>-<M>` keeps its own group + payload; at
+/// `-ee -G1` the doc axis collapses to ONE row per `(Track<N>, name)`,
+/// first-wins (the shared `first_seen` gate over the doc-ORDERED walk), so the
+/// first sample's first GPS row + first sensor block survive — matching the
+/// `.ee.json` `-G1` golden. NOT gated by `-ee` → emits nothing at the default.
+#[cfg(feature = "alloc")]
+fn emit_gopro_doc<F: FnMut(&str, &str) -> bool>(
+  timed: &GoProTimedMeta,
+  opts: crate::emit::EmitOptions,
+  print_conv: bool,
+  first_seen: &mut F,
+  tags: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::serialize_key::GroupMode;
+  use crate::value::{Group, TagValue};
+  if !opts.extract_embedded {
+    return;
+  }
+  let g3 = matches!(opts.group_mode, GroupMode::G3);
+  // ExifTool's `%noDups` is PER TAG NAME, decided by which document OWNS a tag's
+  // primary key (ExifTool.pm:9514-9566) — NOT a single document-wide rule. Flush
+  // ONE sample's (= one `DEVC` = one `Doc<N>`) collected leaves under that
+  // mechanism, mirroring `HandleTag`/`FoundTag` exactly:
+  //   * The FIRST document to carry a `(family1, name)` key OWNS the primary slot
+  //     (`$$valueHash{$tag}`). Within THAT document a repeated key (the same tag
+  //     `HandleTag`'d once per `STRM` of the `DEVC`) overwrites the primary in
+  //     place — the existing key's `G3` equals the current `DOC_NUM`, so the
+  //     overwrite branch fires (ExifTool.pm:9565) ⇒ WITHIN-doc LAST-wins.
+  //   * A LATER document that repeats an ALREADY-OWNED key cannot overwrite (the
+  //     primary's `G3` is the earlier doc), so each `STRM` spawns a numbered copy
+  //     `$tag (N)` (ExifTool.pm:9514-9517); the FIRST copy is the one a `-G3`
+  //     `Doc<N>:Track<N>:` render keeps ⇒ WITHIN-doc FIRST-wins for that key in
+  //     that document, and at `-G1` the across-doc first-wins drops it entirely.
+  // So the within-doc rule is LAST-wins for a key whose primary THIS document
+  // owns (its FIRST-appearing document) and FIRST-wins for a key an EARLIER
+  // document already owns — tracked per key in `committed`. The prior code used a
+  // single `first_doc_collapsed` boolean (Doc1 last-wins, Doc2..N first-wins),
+  // which only matches when EVERY key first appears in Doc1 (it does for the
+  // hero8 fixture); it WRONGLY gave first-wins to a key that first appears in a
+  // LATER document (absent/truncated in Doc1), losing that document's real last
+  // `STRM` value. `committed` (the per-key owner set, mirroring the
+  // `camm`/`emit_timed_samples` `committed`) fixes that while preserving hero8.
+  //
+  // ACROSS documents (`-G1`): FIRST-document-wins, PER KEY — the file-wide
+  // `first_seen(family1, name)` gate (records each key on first sight, drops a
+  // later document's repeat). At `-G3` each `Doc<N>` is its own group, so the gate
+  // does not apply; the per-key within-doc collapse above is the only dedup and
+  // each `Doc<N>` keeps its own value.
+  let mut committed: std::vec::Vec<(smol_str::SmolStr, smol_str::SmolStr)> = std::vec::Vec::new();
+  let mut flush = |scratch: &mut std::vec::Vec<EmittedTag>,
+                   first_seen: &mut F,
+                   tags: &mut std::vec::Vec<EmittedTag>| {
+    // Collapse this DEVC to ONE value per `(family1, name)`, preserving
+    // first-occurrence ORDER. A key whose primary THIS document owns (not yet in
+    // `committed`) takes the LAST occurrence's value (within-doc last-wins); a key
+    // an EARLIER document already owns keeps its FIRST occurrence here (within-doc
+    // first-wins = the surviving numbered copy). Applied in BOTH modes.
+    let mut doc_vals: std::vec::Vec<((smol_str::SmolStr, smol_str::SmolStr), EmittedTag)> =
+      std::vec::Vec::new();
+    for tag in scratch.drain(..) {
+      let key = (
+        smol_str::SmolStr::new(tag.tag().group_ref().family1()),
+        smol_str::SmolStr::new(tag.tag().name()),
+      );
+      if let Some(slot) = doc_vals.iter_mut().find(|(k, _)| *k == key) {
+        // Repeated key WITHIN this document: overwrite (last-wins) only when this
+        // document owns the key's primary; otherwise keep the first occurrence.
+        if !committed.contains(&key) {
+          slot.1 = tag;
+        }
+      } else {
+        doc_vals.push((key, tag));
+      }
+    }
+    // This document now OWNS every key it first carried — record them so a later
+    // document treats them as earlier-owned (first-wins). Done in BOTH modes (the
+    // `-G3` path has no `first_seen` gate to carry the ownership otherwise).
+    for (key, _) in &doc_vals {
+      if !committed.contains(key) {
+        committed.push(key.clone());
+      }
+    }
+    if g3 {
+      for (_key, tag) in doc_vals {
+        tags.push(tag);
+      }
+    } else {
+      for (_key, tag) in doc_vals {
+        if first_seen(tag.tag().group_ref().family1(), tag.tag().name()) {
+          tags.push(tag);
+        }
+      }
+    }
+  };
+  let mut scratch: std::vec::Vec<EmittedTag> = std::vec::Vec::new();
+  // ── gpmd `DEVC` samples ──────────────────────────────────────────────────
+  for s in timed.doc_samples() {
+    let ti = if s.track_index() == 0 {
+      1
+    } else {
+      s.track_index()
+    };
+    let track = std::format!("Track{ti}");
+    let doc = s.doc();
+    // The parent-`Doc<N>` group for the sample-timing + main-group leaves + the
+    // GPS5/GPS9 ROW 0 (`Doc<N>`); `-G1` collapses the doc to a plain `Track<N>`.
+    let parent = if g3 {
+      Group::with_doc("QuickTime", track.as_str(), doc)
+    } else {
+      Group::new("QuickTime", track.as_str())
+    };
+    scratch.clear();
+    // SampleTime / SampleDuration (`ConvertDuration` at `-j`, raw at `-n`).
+    for (val, name) in [
+      (s.sample_time(), "SampleTime"),
+      (s.sample_duration(), "SampleDuration"),
+    ] {
+      if let Some(secs) = val {
+        let value = if print_conv {
+          TagValue::Str(crate::datetime::convert_duration(secs).into())
+        } else {
+          TagValue::F64(secs)
+        };
+        scratch.push(EmittedTag::new(parent.clone(), name.into(), value, false));
+      }
+    }
+    // The main-group leaves of this DEVC (identity / settings / GPS scalars).
+    emit_gopro_main_group(s.meta(), &parent, print_conv, &mut scratch);
+    // The GPS5/GPS9 ROWS — ExifTool's `ProcessString` (GoPro.pm:749-774) keeps
+    // ROW 0 at the parent `DOC_NUM` (`Doc<N>`) and splits each SUBSEQUENT row
+    // into its OWN sub-document `Doc<N>-<M>`. Row 0's columns join this DEVC's
+    // `scratch` (so they share the within-doc last-wins + the parent `Doc<N>`);
+    // each later row is a DISTINCT document, flushed on its own — at `-G1` the
+    // across-doc `first_seen` then drops it (row 0 already committed
+    // `GPSLatitude`/… for this `Track<N>`, faithful first-doc-wins), at `-G3` it
+    // emits under its `Doc<N>-<M>` group.
+    let mut rows = s.meta().gps_samples().iter();
+    if let Some(row0) = rows.next() {
+      emit_gopro_gps_row(row0, &parent, print_conv, &mut scratch);
+    }
+    // Flush this DEVC's `Doc<N>` (main-group + GPS row 0) under the two-rule
+    // collapse before the sub-document rows (which are later documents).
+    flush(&mut scratch, first_seen, tags);
+    for (row_idx, fix) in rows.enumerate() {
+      // `enumerate()` here starts at 0 for the SECOND row, so the sub-document
+      // index is `row_idx + 1` (`Doc<N>-1`, `Doc<N>-2`, …). `row_idx + 1` fits
+      // u32 for any realistic GPS payload (u16 sample count); saturate for a
+      // pathological one.
+      let sub = u32::try_from(row_idx).unwrap_or(u32::MAX).saturating_add(1);
+      let group = if g3 {
+        Group::with_subdoc("QuickTime", track.as_str(), doc, sub)
+      } else {
+        Group::new("QuickTime", track.as_str())
+      };
+      scratch.clear();
+      emit_gopro_gps_row(fix, &group, print_conv, &mut scratch);
+      flush(&mut scratch, first_seen, tags);
+    }
+  }
+  // ── fdsc samples ─────────────────────────────────────────────────────────
+  for f in timed.fdsc_samples() {
+    let ti = if f.track_index() == 0 {
+      1
+    } else {
+      f.track_index()
+    };
+    let track = std::format!("Track{ti}");
+    let group = if g3 {
+      Group::with_doc("QuickTime", track.as_str(), f.doc())
+    } else {
+      Group::new("QuickTime", track.as_str())
+    };
+    scratch.clear();
+    for (val, name) in [
+      (f.sample_time(), "SampleTime"),
+      (f.sample_duration(), "SampleDuration"),
+    ] {
+      if let Some(secs) = val {
+        let value = if print_conv {
+          TagValue::Str(crate::datetime::convert_duration(secs).into())
+        } else {
+          TagValue::F64(secs)
+        };
+        scratch.push(EmittedTag::new(group.clone(), name.into(), value, false));
+      }
+    }
+    // `GoPro::fdsc` identity fields in table order (GoPro.pm:659-664).
+    for (val, name) in [
+      (f.firmware_version(), "FirmwareVersion"),
+      (f.serial_number(), "SerialNumber"),
+      (f.other_serial_number(), "OtherSerialNumber"),
+      (f.model(), "Model"),
+    ] {
+      if let Some(v) = val {
+        scratch.push(EmittedTag::new(
+          group.clone(),
+          name.into(),
+          TagValue::Str(v.into()),
+          false,
+        ));
+      }
+    }
+    flush(&mut scratch, first_seen, tags);
+  }
+}
+
+/// Emit one GoPro `GPS5`/`GPS9` ROW's value columns under `group` — the
+/// `%GoPro::GPS5`/`GPS9` PrintConvs (GoPro.pm:489-513/543-562): `GPSLatitude`/
+/// `GPSLongitude` via `GPS::ToDMS` + N/E hemisphere at `-j` (raw decimal at
+/// `-n`), `GPSAltitude` `"$val m"`, `GPSSpeed`/`GPSSpeed3D` `$val * 3.6` (km/h,
+/// a `ValueConv` so bare in BOTH modes). The `GPS9`-only `GPSDateTime`/`GPSDOP`/
+/// `GPSMeasureMode` columns are emitted when present (a `GPS5` row leaves them
+/// `None`). The block-level `GPSMeasureMode`/`GPSDateTime`/`GPSHPositioningError`
+/// (GPSF/GPSU/GPSP scalars) ride the main-group block, not here.
+#[cfg(feature = "alloc")]
+fn emit_gopro_gps_row(
+  fix: &crate::metadata::GoProGpsSample,
+  group: &crate::value::Group,
+  print_conv: bool,
+  scratch: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::value::TagValue;
+  if let (Some(lat), Some(lon)) = (fix.latitude(), fix.longitude()) {
+    let lat_v = if print_conv {
+      TagValue::Str(dms_signed(lat, 'N', 'S').into())
+    } else {
+      TagValue::F64(lat)
+    };
+    let lon_v = if print_conv {
+      TagValue::Str(dms_signed(lon, 'E', 'W').into())
+    } else {
+      TagValue::F64(lon)
+    };
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSLatitude".into(),
+      lat_v,
+      false,
+    ));
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSLongitude".into(),
+      lon_v,
+      false,
+    ));
+  }
+  if let Some(alt) = fix.altitude_m() {
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSAltitude".into(),
+      unit_suffix_value(alt, " m", print_conv),
+      false,
+    ));
+  }
+  // `GPSSpeed`/`GPSSpeed3D`: ValueConv `$val * 3.6` (m/s stored → km/h), no
+  // PrintConv ⇒ the same numeric value in `-j` and `-n`.
+  if let Some(spd) = fix.speed_2d_mps() {
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSSpeed".into(),
+      TagValue::F64(spd * 3.6),
+      false,
+    ));
+  }
+  if let Some(s3d) = fix.speed_3d_mps() {
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSSpeed3D".into(),
+      TagValue::F64(s3d * 3.6),
+      false,
+    ));
+  }
+  // GPS9-only columns (a GPS5 row leaves these `None`).
+  if let Some(dt) = fix.date_time() {
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSDateTime".into(),
+      TagValue::Str(dt.into()),
+      false,
+    ));
+  }
+  if let Some(dop) = fix.dop() {
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSDOP".into(),
+      TagValue::F64(dop),
+      false,
+    ));
+  }
+  if let Some(mode) = fix.measure_mode() {
+    scratch.push(EmittedTag::new(
+      group.clone(),
+      "GPSMeasureMode".into(),
+      gps_measure_mode_value(mode, print_conv),
+      false,
+    ));
+  }
+}
+
+/// Emit a [`GoProMeta`]'s MAIN-GROUP tags — the camera-identity fields, the
+/// generic table-driven settings, and the flat GPS / system scalars
+/// (`GPSU`/`GPSF`/`GPSP`/`GPSA`/`SYST`) — under `group`, in GPMF-walk
+/// (first-occurrence) order ([`GoProMeta::main_group_order`]). Shared by the
+/// always-on `moov/udta/GPMF` path ([`emit_gopro_tags`], `group = GoPro:`) and
+/// the per-sample `gpmd` `Doc<N>` path ([`emit_gopro_doc`], `group =
+/// Doc<N>:Track<N>`). The per-sample GPS5/GPS9 ROW columns are NOT emitted here
+/// (they are the caller's `Doc<N>-<M>` ProcessString split) — only the
+/// scalar/identity/settings leaves a `DEVC`/`udta` GPMF directory carries.
+#[cfg(feature = "alloc")]
+fn emit_gopro_main_group(
+  gp: &GoProMeta,
+  group: &crate::value::Group,
+  print_conv: bool,
+  tags: &mut std::vec::Vec<crate::emit::EmittedTag>,
+) {
+  use crate::emit::EmittedTag;
+  use crate::metadata::{GoProIdentity, GoProMainGroupTag, GoProScalar};
+  use crate::value::TagValue;
+  let str_value = |s: &str| TagValue::Str(s.into());
+  let emit_identity = |field: GoProIdentity, tags: &mut std::vec::Vec<EmittedTag>| {
+    let value = match field {
+      GoProIdentity::DeviceName => gp.device_name().map(str_value),
+      GoProIdentity::FirmwareVersion => gp.firmware_version().map(str_value),
+      GoProIdentity::CameraSerialNumber => gp.camera_serial_number().map(str_value),
+      GoProIdentity::Model => gp.model().map(str_value),
+      GoProIdentity::MediaUniqueID => gp.media_uid().map(|raw| media_uid_value(raw, print_conv)),
+    };
+    if let Some(v) = value {
+      tags.push(EmittedTag::new(
+        group.clone(),
+        field.as_str().into(),
+        v,
+        false,
+      ));
+    }
+  };
+  let emit_scalar = |field: GoProScalar, tags: &mut std::vec::Vec<EmittedTag>| {
+    let entry: Option<(&str, TagValue)> = match field {
+      GoProScalar::GpsDateTime => gp
+        .gps_date_time()
+        .map(|dt| ("GPSDateTime", TagValue::Str(dt.into()))),
+      GoProScalar::GpsMeasureMode => gp
+        .gps_measure_mode()
+        .map(|m| ("GPSMeasureMode", gps_measure_mode_value(m, print_conv))),
+      GoProScalar::GpsHPositioningError => gp
+        .gps_h_positioning_error_m()
+        .map(|e| ("GPSHPositioningError", TagValue::F64(e))),
+      GoProScalar::GpsAltitudeSystem => gp
+        .gps_altitude_system()
+        .map(|s| ("GPSAltitudeSystem", TagValue::Str(s.into()))),
+      GoProScalar::SystemTime => gp
+        .system_time()
+        .map(|st| ("SystemTime", TagValue::Str(st.into()))),
+    };
+    if let Some((name, value)) = entry {
+      tags.push(EmittedTag::new(group.clone(), name.into(), value, false));
+    }
+  };
+  let emit_generic = |idx: usize, tags: &mut std::vec::Vec<EmittedTag>| {
+    // A recorded index is always in range, but the `.get()` keeps the access
+    // checked (the file-wide indexing deny is honoured).
+    if let Some(gt) = gp.generic_tags().get(idx) {
+      tags.push(EmittedTag::new(
+        group.clone(),
+        gt.name().into(),
+        gopro_generic_value(gt, print_conv),
+        false,
+      ));
+    }
+  };
+  let recorded = gp.main_group_order();
+  if recorded.is_empty() {
+    // Fallback for an order-less hand-built meta: canonical identity order,
+    // then the GPS / system scalars, then the generic settings in their stored
+    // (push) order.
+    const CANONICAL: [GoProIdentity; 5] = [
+      GoProIdentity::DeviceName,
+      GoProIdentity::FirmwareVersion,
+      GoProIdentity::CameraSerialNumber,
+      GoProIdentity::Model,
+      GoProIdentity::MediaUniqueID,
+    ];
+    for field in CANONICAL {
+      emit_identity(field, tags);
+    }
+    const SCALARS: [GoProScalar; 5] = [
+      GoProScalar::GpsDateTime,
+      GoProScalar::GpsMeasureMode,
+      GoProScalar::GpsHPositioningError,
+      GoProScalar::GpsAltitudeSystem,
+      GoProScalar::SystemTime,
+    ];
+    for field in SCALARS {
+      emit_scalar(field, tags);
+    }
+    for idx in 0..gp.generic_tags().len() {
+      emit_generic(idx, tags);
+    }
+  } else {
+    // The faithful path: emit every main-group tag at its recorded walk
+    // position.
+    for entry in recorded {
+      match entry {
+        GoProMainGroupTag::Identity(field) => emit_identity(*field, tags),
+        GoProMainGroupTag::Scalar(field) => emit_scalar(*field, tags),
+        GoProMainGroupTag::Generic(idx) => emit_generic(*idx, tags),
+      }
+    }
+  }
+}
+
 /// Emit every default-visible `%GoPro::GPMF` tag a [`GoProMeta`] carries, under
 /// the group `(family0, family1)`, into `tags`. The faithful `HandleTag` stream
 /// of `ProcessGoPro` (GoPro.pm:846-896), shared by the QuickTime `GPMF` /
@@ -11559,95 +12039,7 @@ pub(crate) fn emit_gopro_tags(
   //
   // A hand-built [`GoProMeta`] with no recorded order (e.g. a test fixture)
   // falls back to the canonical identity → GPS-scalars → settings sequence.
-  {
-    use crate::metadata::{GoProIdentity, GoProMainGroupTag, GoProScalar};
-    let str_value = |s: &str| TagValue::Str(s.into());
-    let emit_identity = |field: GoProIdentity, tags: &mut std::vec::Vec<EmittedTag>| {
-      let value = match field {
-        GoProIdentity::DeviceName => gp.device_name().map(str_value),
-        GoProIdentity::FirmwareVersion => gp.firmware_version().map(str_value),
-        GoProIdentity::CameraSerialNumber => gp.camera_serial_number().map(str_value),
-        GoProIdentity::Model => gp.model().map(str_value),
-        GoProIdentity::MediaUniqueID => gp.media_uid().map(|raw| media_uid_value(raw, print_conv)),
-      };
-      if let Some(v) = value {
-        tags.push(EmittedTag::new(gpg(), field.as_str().into(), v, false));
-      }
-    };
-    let emit_scalar = |field: GoProScalar, tags: &mut std::vec::Vec<EmittedTag>| {
-      let entry: Option<(&str, TagValue)> = match field {
-        GoProScalar::GpsDateTime => gp
-          .gps_date_time()
-          .map(|dt| ("GPSDateTime", TagValue::Str(dt.into()))),
-        GoProScalar::GpsMeasureMode => gp
-          .gps_measure_mode()
-          .map(|m| ("GPSMeasureMode", gps_measure_mode_value(m, print_conv))),
-        GoProScalar::GpsHPositioningError => gp
-          .gps_h_positioning_error_m()
-          .map(|e| ("GPSHPositioningError", TagValue::F64(e))),
-        GoProScalar::GpsAltitudeSystem => gp
-          .gps_altitude_system()
-          .map(|s| ("GPSAltitudeSystem", TagValue::Str(s.into()))),
-        GoProScalar::SystemTime => gp
-          .system_time()
-          .map(|st| ("SystemTime", TagValue::Str(st.into()))),
-      };
-      if let Some((name, value)) = entry {
-        tags.push(EmittedTag::new(gpg(), name.into(), value, false));
-      }
-    };
-    let emit_generic = |idx: usize, tags: &mut std::vec::Vec<EmittedTag>| {
-      // A recorded index is always in range, but the `.get()` keeps the access
-      // checked (the file-wide indexing deny is honoured).
-      if let Some(gt) = gp.generic_tags().get(idx) {
-        tags.push(EmittedTag::new(
-          gpg(),
-          gt.name().into(),
-          gopro_generic_value(gt, print_conv),
-          false,
-        ));
-      }
-    };
-    let recorded = gp.main_group_order();
-    if recorded.is_empty() {
-      // Fallback for an order-less hand-built meta: canonical identity order,
-      // then the GPS / system scalars, then the generic settings in their stored
-      // (push) order.
-      const CANONICAL: [GoProIdentity; 5] = [
-        GoProIdentity::DeviceName,
-        GoProIdentity::FirmwareVersion,
-        GoProIdentity::CameraSerialNumber,
-        GoProIdentity::Model,
-        GoProIdentity::MediaUniqueID,
-      ];
-      for field in CANONICAL {
-        emit_identity(field, tags);
-      }
-      const SCALARS: [GoProScalar; 5] = [
-        GoProScalar::GpsDateTime,
-        GoProScalar::GpsMeasureMode,
-        GoProScalar::GpsHPositioningError,
-        GoProScalar::GpsAltitudeSystem,
-        GoProScalar::SystemTime,
-      ];
-      for field in SCALARS {
-        emit_scalar(field, tags);
-      }
-      for idx in 0..gp.generic_tags().len() {
-        emit_generic(idx, tags);
-      }
-    } else {
-      // The faithful path: emit every main-group tag at its recorded walk
-      // position.
-      for entry in recorded {
-        match entry {
-          GoProMainGroupTag::Identity(field) => emit_identity(*field, tags),
-          GoProMainGroupTag::Scalar(field) => emit_scalar(*field, tags),
-          GoProMainGroupTag::Generic(idx) => emit_generic(*idx, tags),
-        }
-      }
-    }
-  }
+  emit_gopro_main_group(gp, &gpg(), print_conv, tags);
   // ── first GPS5/GPS9 fix (summarized; full list via `Meta::gopro`) ──
   if let Some(fix) = gp.first_fix() {
     // GPSLatitude/GPSLongitude: the `GPS::ToDMS` PrintConv
@@ -18073,6 +18465,7 @@ mod tests {
       None,
       &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -18112,6 +18505,7 @@ mod tests {
       None,
       &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -18158,6 +18552,7 @@ mod tests {
       None,
       &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta_a,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -18190,6 +18585,7 @@ mod tests {
       None,
       &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta_b,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -18220,6 +18616,7 @@ mod tests {
       None,
       &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -18243,6 +18640,7 @@ mod tests {
       None,
       &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -18266,6 +18664,7 @@ mod tests {
       None,
       &mut crate::metadata::QuickTimeStreamMeta::new(),
       &mut meta2,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut crate::metadata::CammMeta::new(),
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -20844,5 +21243,154 @@ mod tests {
     assert_eq!(acc.audio_format(), Some("lpcm"));
     assert_eq!(acc.channels(), Some(2));
     assert_eq!(acc.sample_rate(), Some(44100.0));
+  }
+
+  /// #211 finding 2 — GoPro `%noDups` is PER `(family1, name)`, decided by which
+  /// document OWNS each key's primary slot, NOT one document-wide rule. A
+  /// multi-`STRM` DEVC repeats a tag under one `Doc<N>`; the WITHIN-document rule
+  /// is LAST-wins for the doc that OWNS the key (its first-appearing document) and
+  /// FIRST-wins for a doc that repeats an already-owned key. The prior
+  /// `first_doc_collapsed` boolean conflated this into "Doc1 last, Doc2..N first",
+  /// which is only right when every key first appears in Doc1; this exercises both
+  /// the bug it caused and the behavior it happened to get right.
+  #[cfg(feature = "alloc")]
+  #[test]
+  fn gopro_doc_nodups_is_per_key_not_document_wide() {
+    use crate::emit::{EmitOptions, EmittedTag};
+    use crate::metadata::{
+      GoProConv, GoProDocSample, GoProMeta, GoProTag, GoProTagValue, GoProTimedMeta,
+    };
+    use crate::value::TagValue;
+
+    let plain = |v: f64| GoProTagValue::Num(v);
+    // Doc1 (Track4): owns "Gamma" (= 10.0), "Alpha", and "Delta" (single STRM,
+    // 7.0) — but NOT "Beta".
+    let mut m1 = GoProMeta::new();
+    m1.push_generic_tag(GoProTag::new("Gamma".into(), plain(10.0), GoProConv::Plain));
+    m1.push_generic_tag(GoProTag::new("Alpha".into(), plain(1.0), GoProConv::Plain));
+    m1.push_generic_tag(GoProTag::new("Delta".into(), plain(7.0), GoProConv::Plain));
+    // Doc2 (Track4): "Beta" is OWNED HERE and appears in TWO STRMs (1.0 then 2.0)
+    // → within-doc last-wins ⇒ 2.0. "Delta" is ALREADY OWNED by Doc1 and repeats
+    // in TWO STRMs (100.0 then 200.0) → within-doc first-wins ⇒ 100.0 (the
+    // surviving numbered copy; the hero8 `PredominantHue` Doc2..N case). "Gamma"
+    // re-states (= 99.0) and must NOT win across docs.
+    let mut m2 = GoProMeta::new();
+    m2.push_generic_tag(GoProTag::new("Beta".into(), plain(1.0), GoProConv::Plain));
+    m2.push_generic_tag(GoProTag::new("Beta".into(), plain(2.0), GoProConv::Plain));
+    m2.push_generic_tag(GoProTag::new(
+      "Delta".into(),
+      plain(100.0),
+      GoProConv::Plain,
+    ));
+    m2.push_generic_tag(GoProTag::new(
+      "Delta".into(),
+      plain(200.0),
+      GoProConv::Plain,
+    ));
+    m2.push_generic_tag(GoProTag::new("Gamma".into(), plain(99.0), GoProConv::Plain));
+
+    let mut timed = GoProTimedMeta::new();
+    timed.push_doc_sample(GoProDocSample::new(m1, 4, 1, None, None));
+    timed.push_doc_sample(GoProDocSample::new(m2, 4, 2, None, None));
+
+    // ── `-G3`: each `Doc<N>` is its own group, so the per-key within-doc collapse
+    // is the only dedup; both Doc1 and Doc2 values survive under their own group.
+    let mut g3_keys: std::vec::Vec<smol_str::SmolStr> = std::vec::Vec::new();
+    let mut g3_seen = |grp: &str, name: &str| -> bool {
+      let key = smol_str::SmolStr::new(std::format!("{grp}:{name}"));
+      if g3_keys.contains(&key) {
+        return false;
+      }
+      g3_keys.push(key);
+      true
+    };
+    let mut g3 = std::vec::Vec::new();
+    emit_gopro_doc(
+      &timed,
+      EmitOptions::with_group_mode(
+        crate::emit::ConvMode::ValueConv,
+        true,
+        crate::serialize_key::GroupMode::G3,
+      ),
+      false,
+      &mut g3_seen,
+      &mut g3,
+    );
+    let g3_at = |doc: u32, name: &str| -> Option<f64> {
+      g3.iter()
+        .find(|t| t.tag().group_ref().doc() == doc && t.tag().name() == name)
+        .and_then(|t| match t.tag().value_ref() {
+          TagValue::F64(v) => Some(*v),
+          _ => None,
+        })
+    };
+    // Doc2 OWNS "Beta" → within-doc LAST-wins (2.0); Doc2 repeats Doc1-owned
+    // "Delta" → within-doc FIRST-wins (100.0, NOT 200.0). The latter is exactly
+    // the hero8 `Doc<N>:Track4:PredominantHue` first-`STRM`-wins behavior that a
+    // naive "always last-wins" would have regressed.
+    assert_eq!(
+      g3_at(2, "Beta"),
+      Some(2.0),
+      "Doc2 owns Beta: within-doc last"
+    );
+    assert_eq!(
+      g3_at(2, "Delta"),
+      Some(100.0),
+      "Doc2 repeats Doc1-owned Delta: within-doc FIRST-wins (numbered copy)"
+    );
+    assert_eq!(g3_at(1, "Delta"), Some(7.0));
+    assert_eq!(g3_at(1, "Gamma"), Some(10.0));
+    assert_eq!(
+      g3_at(2, "Gamma"),
+      Some(99.0),
+      "-G3 keeps each doc's own value"
+    );
+
+    // ── `-G1`: the file-wide first-wins gate collapses to one row per key.
+    let mut emitted_keys: std::vec::Vec<smol_str::SmolStr> = std::vec::Vec::new();
+    let mut first_seen = |grp: &str, name: &str| -> bool {
+      let key = smol_str::SmolStr::new(std::format!("{grp}:{name}"));
+      if emitted_keys.contains(&key) {
+        return false;
+      }
+      emitted_keys.push(key);
+      true
+    };
+    let mut tags: std::vec::Vec<EmittedTag> = std::vec::Vec::new();
+    emit_gopro_doc(
+      &timed,
+      EmitOptions::g1(crate::emit::ConvMode::ValueConv, true),
+      false,
+      &mut first_seen,
+      &mut tags,
+    );
+    let lookup = |name: &str| -> Option<f64> {
+      tags
+        .iter()
+        .find(|t| t.tag().name() == name)
+        .and_then(|t| match t.tag().value_ref() {
+          TagValue::F64(v) => Some(*v),
+          _ => None,
+        })
+    };
+    // "Beta" first appears (and is owned) in Doc2 with two STRMs → within-doc
+    // LAST-wins = 2.0 surfaces (the bug: the old boolean kept Doc2's FIRST = 1.0).
+    assert_eq!(
+      lookup("Beta"),
+      Some(2.0),
+      "a key first owned in Doc2 takes Doc2's within-doc LAST value, not its first"
+    );
+    // "Gamma"/"Delta" are owned by Doc1 → Doc1's value survives (first-doc-wins).
+    assert_eq!(lookup("Gamma"), Some(10.0), "across-doc first-wins per key");
+    assert_eq!(lookup("Delta"), Some(7.0));
+    assert_eq!(lookup("Alpha"), Some(1.0));
+    // Each key emits exactly once at -G1.
+    for name in ["Alpha", "Beta", "Gamma", "Delta"] {
+      assert_eq!(
+        tags.iter().filter(|t| t.tag().name() == name).count(),
+        1,
+        "-G1 collapses {name} to one row"
+      );
+    }
   }
 }

--- a/src/formats/quicktime_stream.rs
+++ b/src/formats/quicktime_stream.rs
@@ -1989,6 +1989,7 @@ fn process_samples(
   free_gps_state: &mut FreeGpsState,
   out: &mut QuickTimeStreamMeta,
   gopro_out: &mut crate::metadata::GoProMeta,
+  gopro_timed_out: &mut crate::metadata::GoProTimedMeta,
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
@@ -2054,6 +2055,7 @@ fn process_samples(
       free_gps_state,
       out,
       gopro_out,
+      gopro_timed_out,
       camm_out,
       sony_rtmd_out,
       canon_ctmd_out,
@@ -2086,7 +2088,12 @@ fn decode_one_sample(
   create_date_raw: Option<u64>,
   free_gps_state: &mut FreeGpsState,
   out: &mut QuickTimeStreamMeta,
-  gopro_out: &mut crate::metadata::GoProMeta,
+  // The `gpmd` GoPro fallback now records per-sample `Doc<N>` into
+  // `gopro_timed_out` (not the flat `gopro_out`, which the `moov/udta/GPMF`
+  // path in `walk_moov` owns), so this sample-level dispatcher no longer
+  // touches the flat meta — kept in the signature for caller symmetry.
+  _gopro_out: &mut crate::metadata::GoProMeta,
+  gopro_timed_out: &mut crate::metadata::GoProTimedMeta,
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
@@ -2223,8 +2230,51 @@ fn decode_one_sample(
     // non-variant `gpmd` sample leave `FoundEmbedded` unset, and the later
     // brute-force `mdat` scan would emit extra GP6/freeGPS tags ExifTool skips.
     // So: extract via the walker, but report `true` UNCONDITIONALLY.
-    let _extracted = crate::formats::gopro::process_gopro(buff, gopro_out);
+    //
+    // **Per-sample `Doc<N>` (#211 / #189).** This `gpmd` sample is ONE `DEVC`
+    // container — ExifTool's `ProcessGP6` / `ProcessSamples` opens ONE
+    // `$$et{DOC_NUM} = ++$$et{DOC_COUNT}` for it (GoPro.pm:794-797) and emits
+    // the decoded GPMF under `Track<N>:` (the `gpmd` `trak`'s `SET_GROUP1`,
+    // GoPro.pm:826-828), in `-ee` mode only. Decode this sample into its OWN
+    // [`GoProMeta`] (one DEVC's worth of leaves) and record it as a
+    // [`crate::metadata::GoProDocSample`] stamped with the global `Doc<N>`
+    // ordinal, the enclosing `Track<N>` index, and the sample-table timing —
+    // the emission ([`crate::formats::quicktime::emit_gopro_doc`]) gates it on
+    // `-ee`. This is SEPARATE from the always-on `moov/udta/GPMF` box (which
+    // stays in the flat `gopro_out` → `GoPro:`, processed without `-ee`); a
+    // `gpmd` track no longer pollutes the `GoPro:` group at the default (no-ee)
+    // output. `open_doc` bumps the SHARED global counter (so a `gpmd` `trak`
+    // after a `camm`/`mebx` `trak` continues the ordinal — #214).
+    let mut sample_meta = crate::metadata::GoProMeta::new();
+    let _extracted = crate::formats::gopro::process_gopro(buff, &mut sample_meta);
+    let doc = out.open_doc();
+    gopro_timed_out.push_doc_sample(crate::metadata::GoProDocSample::new(
+      sample_meta,
+      track_index,
+      doc,
+      sample.time,
+      sample.dur,
+    ));
     return true;
+  }
+  // The `fdsc` MetaFormat (QuickTimeStream.pl:213-218) — GoPro Hero5/6/8
+  // "frame description" timed metadata. ExifTool dispatches `ProcessBinaryData`
+  // on the `Image::ExifTool::GoPro::fdsc` table ONLY when the sample starts
+  // `GPRO` (`Condition => '$$valPt =~ /^GPRO/'`; other `fdsc` shapes `GP\x00` /
+  // `GP\x04` are not yet parsed by bundled). Like `gpmd` it emits under
+  // `Track<N>:` in `-ee` mode (one `Doc<N>` per sample). Returns `false`:
+  // `ProcessBinaryData` does NOT set `$$et{FoundEmbedded}` (only `ProcessGoPro`
+  // / a `gps `-box freeGPS decode do), so an `fdsc` track must not suppress the
+  // brute-force `mdat` scan.
+  if &track.meta_format == b"fdsc" {
+    if !buff.starts_with(b"GPRO") {
+      return false;
+    }
+    let mut fdsc = crate::formats::gopro::process_fdsc(buff);
+    let doc = out.open_doc();
+    fdsc.stamp(track_index, doc, sample.time, sample.dur);
+    gopro_timed_out.push_fdsc_sample(fdsc);
+    return false;
   }
   // The `camm` MetaFormat (QuickTimeStream.pl:251-309) — Google's Camera
   // Motion Metadata. Bundled dispatches by the int16u-LE packet-type at
@@ -2767,6 +2817,7 @@ pub(crate) fn extract_stream(
   kodak_version: Option<&str>,
   out: &mut QuickTimeStreamMeta,
   gopro_out: &mut crate::metadata::GoProMeta,
+  gopro_timed_out: &mut crate::metadata::GoProTimedMeta,
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
@@ -2806,6 +2857,7 @@ pub(crate) fn extract_stream(
           &mut free_gps_state,
           &mut *out,
           gopro_out,
+          gopro_timed_out,
           camm_out,
           sony_rtmd_out,
           canon_ctmd_out,
@@ -3022,6 +3074,7 @@ fn walk_moov(
   free_gps_state: &mut FreeGpsState,
   out: &mut QuickTimeStreamMeta,
   gopro_out: &mut crate::metadata::GoProMeta,
+  gopro_timed_out: &mut crate::metadata::GoProTimedMeta,
   camm_out: &mut crate::metadata::CammMeta,
   sony_rtmd_out: &mut crate::metadata::SonyRtmdMeta,
   canon_ctmd_out: &mut crate::metadata::CanonCtmdMeta,
@@ -3060,6 +3113,7 @@ fn walk_moov(
             free_gps_state,
             out,
             gopro_out,
+            gopro_timed_out,
             camm_out,
             sony_rtmd_out,
             canon_ctmd_out,
@@ -3221,6 +3275,7 @@ mod tests {
         &mut free_gps_state,
         &mut out,
         &mut gopro,
+        &mut crate::metadata::GoProTimedMeta::new(),
         &mut camm,
         &mut sony,
         &mut canon,
@@ -3249,6 +3304,7 @@ mod tests {
         &mut free_gps_state,
         &mut out,
         &mut gopro,
+        &mut crate::metadata::GoProTimedMeta::new(),
         &mut camm,
         &mut sony,
         &mut canon,
@@ -3276,6 +3332,7 @@ mod tests {
         &mut free_gps_state,
         &mut out,
         &mut gopro,
+        &mut crate::metadata::GoProTimedMeta::new(),
         &mut camm,
         &mut sony,
         &mut canon,
@@ -3299,6 +3356,7 @@ mod tests {
         &mut free_gps_state,
         &mut out,
         &mut gopro,
+        &mut crate::metadata::GoProTimedMeta::new(),
         &mut camm,
         &mut sony,
         &mut canon,
@@ -3327,6 +3385,7 @@ mod tests {
         &mut free_gps_state,
         &mut out,
         &mut gopro,
+        &mut crate::metadata::GoProTimedMeta::new(),
         &mut camm,
         &mut sony,
         &mut canon,
@@ -3354,6 +3413,7 @@ mod tests {
         &mut free_gps_state,
         &mut out,
         &mut gopro,
+        &mut crate::metadata::GoProTimedMeta::new(),
         &mut camm,
         &mut sony,
         &mut canon,
@@ -3491,6 +3551,7 @@ mod tests {
         &mut free_gps_state,
         &mut out,
         &mut gopro,
+        &mut crate::metadata::GoProTimedMeta::new(),
         &mut camm,
         &mut sony,
         &mut canon,
@@ -3526,6 +3587,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3588,6 +3650,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3643,6 +3706,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3732,6 +3796,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3799,6 +3864,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3840,6 +3906,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3915,6 +3982,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3934,6 +4002,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -3994,6 +4063,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut camm,
       &mut sony,
       &mut canon,
@@ -4355,6 +4425,7 @@ mod tests {
     let mut out = QuickTimeStreamMeta::new();
     let mut free_gps_state = FreeGpsState::new();
     let mut gopro_out = crate::metadata::GoProMeta::new();
+    let mut gopro_timed_out = crate::metadata::GoProTimedMeta::new();
     let mut camm_out = crate::metadata::CammMeta::new();
     let mut sony_rtmd_out = crate::metadata::SonyRtmdMeta::new();
     let mut canon_ctmd_out = crate::metadata::CanonCtmdMeta::new();
@@ -4369,6 +4440,7 @@ mod tests {
       &mut free_gps_state,
       &mut out,
       &mut gopro_out,
+      &mut gopro_timed_out,
       &mut camm_out,
       &mut sony_rtmd_out,
       &mut canon_ctmd_out,
@@ -4975,7 +5047,18 @@ mod tests {
     let mut lg = crate::metadata::LigoGpsMeta::new();
     let mut meta = QuickTimeStreamMeta::new();
     let found_embedded = extract_stream(
-      &data, None, None, &mut meta, &mut gp, &mut cm, &mut sr, &mut cc, &mut pr, &mut dj, &mut lg,
+      &data,
+      None,
+      None,
+      &mut meta,
+      &mut gp,
+      &mut crate::metadata::GoProTimedMeta::new(),
+      &mut cm,
+      &mut sr,
+      &mut cc,
+      &mut pr,
+      &mut dj,
+      &mut lg,
     );
     assert!(meta.is_empty());
     // No `gps ` box ⇒ ProcessFreeGPS never ran ⇒ FoundEmbedded stays false.
@@ -5134,6 +5217,7 @@ mod tests {
       None,
       &mut meta,
       &mut gp,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut cm,
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),
@@ -5239,6 +5323,7 @@ mod tests {
       None,
       &mut meta,
       &mut gp,
+      &mut crate::metadata::GoProTimedMeta::new(),
       &mut cm,
       &mut crate::metadata::SonyRtmdMeta::new(),
       &mut crate::metadata::CanonCtmdMeta::new(),

--- a/src/formats/real.rs
+++ b/src/formats/real.rs
@@ -3060,7 +3060,7 @@ mod tests {
   fn keys(tm: &crate::tagmap::TagMap) -> Vec<String> {
     tm.entries()
       .iter()
-      .map(|(_, g, n, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _)| std::format!("{g}:{n}"))
       .collect()
   }
 

--- a/src/formats/wavpack.rs
+++ b/src/formats/wavpack.rs
@@ -1469,7 +1469,7 @@ mod tests {
     let names: std::vec::Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, g, n, _, _)| (g == "File").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _)| (g == "File").then_some(n.as_str()))
       .collect();
     assert_eq!(
       names,

--- a/src/metadata/gopro.rs
+++ b/src/metadata/gopro.rs
@@ -1192,6 +1192,29 @@ impl GoProMeta {
       && self.generic_tags.is_empty()
   }
 
+  /// `true` when this meta carries a real CAMERA-IDENTITY field with a
+  /// NON-EMPTY value — a `Model` (`MINF`) or `DeviceName` (`DVNM`, the model
+  /// fallback in [`Self::project_into`]), a `CameraSerialNumber` (`CASN`), or a
+  /// `FirmwareVersion` (`FMWR`). Distinct from [`Self::is_empty`]: a sample that
+  /// carries ONLY GPS / generic telemetry is non-empty yet has NO identity, so
+  /// it must not stamp a make-only `CameraInfo` over a later identity-bearing
+  /// sample (the timed-projection identity selector, GoProTimedMeta).
+  ///
+  /// An identity field is decoded via the GoPro `c`-string path
+  /// ([`crate::formats::gopro`] `read_ascii`), which returns `Some("")` for a
+  /// non-zero-size all-NUL payload (a defined-but-empty record ExifTool still
+  /// `HandleTag`s). Such an EMPTY identity is NOT a real identity and must not
+  /// gate the timed make-only stamp, so each field counts ONLY when present AND
+  /// non-empty.
+  #[inline]
+  #[must_use]
+  pub fn has_camera_identity(&self) -> bool {
+    nonempty(self.model()).is_some()
+      || nonempty(self.device_name()).is_some()
+      || nonempty(self.camera_serial_number()).is_some()
+      || nonempty(self.firmware_version()).is_some()
+  }
+
   /// The FIRST Karma `GLPI` sample carrying a GPS coordinate pair.
   #[inline(always)]
   #[must_use]
@@ -1399,6 +1422,445 @@ impl Default for GoProMeta {
   }
 }
 
+/// One GoPro `gpmd` timed-metadata SAMPLE — one `DEVC` container = one
+/// `$$et{DOC_NUM} = ++$$et{DOC_COUNT}` (GoPro.pm:794-797, ProcessGP6 /
+/// QuickTimeStream.pl ProcessSamples). Each sample's GPMF KLV is decoded into
+/// its OWN [`GoProMeta`] (one DEVC's worth of leaves, in walk order), and is
+/// stamped with the enclosing `gpmd` `trak`'s 1-based `Track<N>` index, the
+/// global `Doc<N>` ordinal off the shared `QuickTimeStreamMeta` counter, and
+/// the sample-table `(SampleTime, SampleDuration)`.
+///
+/// ExifTool emits this under `Track<N>:` (family-1; `ProcessGoPro` keeps the
+/// `Track<N>` `SET_GROUP1`, GoPro.pm:826-828) in `-ee` mode ONLY — the FULL
+/// per-sample sensor/GPS block at `-ee -G3` (one `Doc<N>` per sample, the
+/// multi-row `GPS5`/`GPS9` rows split into `Doc<N>-<M>` by `ProcessString`,
+/// GoPro.pm:749-774), collapsed first-wins to the first `Doc` per `Track` at
+/// `-ee -G1`. Distinct from the `moov/udta/GPMF` box, which is processed
+/// WITHOUT `-ee` and emits under `GoPro:` (the [`GoProMeta`] on `Meta::gopro`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct GoProDocSample {
+  /// The decoded GPMF leaves of this ONE `DEVC` sample (one fresh
+  /// [`GoProMeta`] per gpmd sample). `gps_samples` holds the `GPS5`/`GPS9`
+  /// rows of this sample; `main_group_order` + `generic_tags` the sensor /
+  /// settings / GPS-scalar leaves.
+  meta: GoProMeta,
+  /// The enclosing `gpmd` `trak`'s 1-based `Track<N>` index (family-1).
+  track_index: u32,
+  /// The global `Doc<N>` ordinal (`++DOC_COUNT`), shared across every embedded
+  /// source in the file (so a `gpmd` `trak` after a `camm`/`mebx` `trak`
+  /// continues the ordinal).
+  doc: u32,
+  /// The sample-table `SampleTime` (seconds), emitted ahead of the payload.
+  sample_time: Option<f64>,
+  /// The sample-table `SampleDuration` (seconds).
+  sample_duration: Option<f64>,
+}
+
+impl GoProDocSample {
+  /// Build a gpmd timed sample from its decoded per-DEVC meta and stamping.
+  #[inline]
+  #[must_use]
+  pub fn new(
+    meta: GoProMeta,
+    track_index: u32,
+    doc: u32,
+    sample_time: Option<f64>,
+    sample_duration: Option<f64>,
+  ) -> Self {
+    Self {
+      meta,
+      track_index,
+      doc,
+      sample_time,
+      sample_duration,
+    }
+  }
+
+  /// The decoded GPMF leaves of this DEVC sample.
+  #[inline(always)]
+  #[must_use]
+  pub const fn meta(&self) -> &GoProMeta {
+    &self.meta
+  }
+
+  /// The 1-based `Track<N>` index of the enclosing `gpmd` `trak`.
+  #[inline(always)]
+  #[must_use]
+  pub const fn track_index(&self) -> u32 {
+    self.track_index
+  }
+
+  /// The global `Doc<N>` ordinal.
+  #[inline(always)]
+  #[must_use]
+  pub const fn doc(&self) -> u32 {
+    self.doc
+  }
+
+  /// The sample-table `SampleTime` (seconds).
+  #[inline(always)]
+  #[must_use]
+  pub const fn sample_time(&self) -> Option<f64> {
+    self.sample_time
+  }
+
+  /// The sample-table `SampleDuration` (seconds).
+  #[inline(always)]
+  #[must_use]
+  pub const fn sample_duration(&self) -> Option<f64> {
+    self.sample_duration
+  }
+}
+
+/// One GoPro `fdsc` timed-metadata SAMPLE — the `Image::ExifTool::GoPro::fdsc`
+/// `ProcessBinaryData` block (GoPro.pm:651-665) extracted from an `fdsc`
+/// metadata `trak` whose sample starts `GPRO` (QuickTimeStream.pl:213-218,
+/// `Condition => '$$valPt =~ /^GPRO/'`). Hero5/Hero6/Hero8 write the camera
+/// identity here too. Like [`GoProDocSample`] it emits under `Track<N>:` in
+/// `-ee` mode only (one `Doc<N>` per sample), with the sample-table timing.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GoProFdscSample {
+  /// `FirmwareVersion` (offset 0x08, `string[15]`).
+  firmware_version: Option<SmolStr>,
+  /// `SerialNumber` (offset 0x17, `string[16]`).
+  serial_number: Option<SmolStr>,
+  /// `OtherSerialNumber` (offset 0x57, `string[15]`).
+  other_serial_number: Option<SmolStr>,
+  /// `Model` (offset 0x66, `string[16]`).
+  model: Option<SmolStr>,
+  /// The enclosing `fdsc` `trak`'s 1-based `Track<N>` index (family-1).
+  track_index: u32,
+  /// The global `Doc<N>` ordinal (`++DOC_COUNT`).
+  doc: u32,
+  /// The sample-table `SampleTime` (seconds).
+  sample_time: Option<f64>,
+  /// The sample-table `SampleDuration` (seconds).
+  sample_duration: Option<f64>,
+}
+
+impl GoProFdscSample {
+  /// An empty fdsc sample (every field `None`, unstamped).
+  #[inline]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      firmware_version: None,
+      serial_number: None,
+      other_serial_number: None,
+      model: None,
+      track_index: 0,
+      doc: 0,
+      sample_time: None,
+      sample_duration: None,
+    }
+  }
+
+  /// `FirmwareVersion`.
+  #[inline(always)]
+  #[must_use]
+  pub fn firmware_version(&self) -> Option<&str> {
+    self.firmware_version.as_deref()
+  }
+
+  /// `SerialNumber`.
+  #[inline(always)]
+  #[must_use]
+  pub fn serial_number(&self) -> Option<&str> {
+    self.serial_number.as_deref()
+  }
+
+  /// `OtherSerialNumber`.
+  #[inline(always)]
+  #[must_use]
+  pub fn other_serial_number(&self) -> Option<&str> {
+    self.other_serial_number.as_deref()
+  }
+
+  /// `Model`.
+  #[inline(always)]
+  #[must_use]
+  pub fn model(&self) -> Option<&str> {
+    self.model.as_deref()
+  }
+
+  /// The 1-based `Track<N>` index of the enclosing `fdsc` `trak`.
+  #[inline(always)]
+  #[must_use]
+  pub const fn track_index(&self) -> u32 {
+    self.track_index
+  }
+
+  /// The global `Doc<N>` ordinal.
+  #[inline(always)]
+  #[must_use]
+  pub const fn doc(&self) -> u32 {
+    self.doc
+  }
+
+  /// The sample-table `SampleTime` (seconds).
+  #[inline(always)]
+  #[must_use]
+  pub const fn sample_time(&self) -> Option<f64> {
+    self.sample_time
+  }
+
+  /// The sample-table `SampleDuration` (seconds).
+  #[inline(always)]
+  #[must_use]
+  pub const fn sample_duration(&self) -> Option<f64> {
+    self.sample_duration
+  }
+
+  /// `true` when no identity field was decoded.
+  #[inline(always)]
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.firmware_version.is_none()
+      && self.serial_number.is_none()
+      && self.other_serial_number.is_none()
+      && self.model.is_none()
+  }
+
+  /// `true` when this `fdsc` sample carries a real CAMERA-IDENTITY value — a
+  /// NON-EMPTY `Model` / `SerialNumber` / `FirmwareVersion` (the three fields
+  /// the timed `fdsc` `CameraInfo` projection consumes,
+  /// [`GoProTimedMeta::project_into`]). Mirrors [`GoProMeta::has_camera_identity`]
+  /// so the timed-projection identity selector reads the same predicate shape
+  /// across both sample kinds.
+  ///
+  /// Distinct from [`Self::is_empty`]: an `fdsc` field is decoded via the GoPro
+  /// `c`-string path ([`crate::formats::gopro`] `process_fdsc` / `read_ascii`),
+  /// which returns `Some("")` for a non-zero-size all-NUL payload — so a sample
+  /// whose only set fields are EMPTY strings is non-empty yet carries no real
+  /// identity and must not stamp a make-only `CameraInfo` over a later
+  /// identity-bearing `gpmd` sample or lower-priority container metadata.
+  /// `OtherSerialNumber` is deliberately EXCLUDED: it is not one of the fields
+  /// the projection writes into `CameraInfo`, so it alone cannot justify the
+  /// make-only stamp.
+  #[inline]
+  #[must_use]
+  pub fn has_camera_identity(&self) -> bool {
+    nonempty(self.model()).is_some()
+      || nonempty(self.serial_number()).is_some()
+      || nonempty(self.firmware_version()).is_some()
+  }
+
+  /// Assign `FirmwareVersion`.
+  #[inline(always)]
+  pub fn set_firmware_version(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.firmware_version = v;
+    self
+  }
+
+  /// Assign `SerialNumber`.
+  #[inline(always)]
+  pub fn set_serial_number(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.serial_number = v;
+    self
+  }
+
+  /// Assign `OtherSerialNumber`.
+  #[inline(always)]
+  pub fn set_other_serial_number(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.other_serial_number = v;
+    self
+  }
+
+  /// Assign `Model`.
+  #[inline(always)]
+  pub fn set_model(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.model = v;
+    self
+  }
+
+  /// Stamp the `trak` index / `Doc<N>` ordinal / sample-table timing onto this
+  /// sample (the stream walker calls this after decoding the `GPRO` block).
+  #[inline]
+  pub fn stamp(
+    &mut self,
+    track_index: u32,
+    doc: u32,
+    sample_time: Option<f64>,
+    sample_duration: Option<f64>,
+  ) -> &mut Self {
+    self.track_index = track_index;
+    self.doc = doc;
+    self.sample_time = sample_time;
+    self.sample_duration = sample_duration;
+    self
+  }
+}
+
+impl Default for GoProFdscSample {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+/// The GoPro `gpmd` + `fdsc` TIMED-metadata accumulator — the per-sample
+/// `Doc<N>` sources distinct from the always-on `moov/udta/GPMF` box (which
+/// lives in [`GoProMeta`]). Populated by the `gpmd` / `fdsc` MetaFormat
+/// dispatch in [`crate::formats::quicktime_stream`], emitted under `Track<N>:`
+/// in `-ee` mode only (#211 / #189). Empty for a GoPro file whose data comes
+/// only from the `udta/GPMF` box (the four crafted-minimal fixtures) or for a
+/// non-GoPro video.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct GoProTimedMeta {
+  /// One [`GoProDocSample`] per `gpmd` timed-metadata sample, in walk order.
+  doc_samples: Vec<GoProDocSample>,
+  /// One [`GoProFdscSample`] per `fdsc` (`GPRO`) timed-metadata sample.
+  fdsc_samples: Vec<GoProFdscSample>,
+}
+
+impl GoProTimedMeta {
+  /// An empty accumulator (no timed gpmd / fdsc samples).
+  #[inline(always)]
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      doc_samples: Vec::new(),
+      fdsc_samples: Vec::new(),
+    }
+  }
+
+  /// `true` when neither a `gpmd` nor an `fdsc` timed sample was decoded.
+  #[inline(always)]
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.doc_samples.is_empty() && self.fdsc_samples.is_empty()
+  }
+
+  /// The decoded `gpmd` timed samples in walk order.
+  #[inline(always)]
+  #[must_use]
+  pub fn doc_samples(&self) -> &[GoProDocSample] {
+    self.doc_samples.as_slice()
+  }
+
+  /// The decoded `fdsc` timed samples in walk order.
+  #[inline(always)]
+  #[must_use]
+  pub fn fdsc_samples(&self) -> &[GoProFdscSample] {
+    self.fdsc_samples.as_slice()
+  }
+
+  /// Append a decoded `gpmd` timed sample.
+  #[inline(always)]
+  pub fn push_doc_sample(&mut self, sample: GoProDocSample) -> &mut Self {
+    self.doc_samples.push(sample);
+    self
+  }
+
+  /// Append a decoded `fdsc` timed sample.
+  #[inline(always)]
+  pub fn push_fdsc_sample(&mut self, sample: GoProFdscSample) -> &mut Self {
+    self.fdsc_samples.push(sample);
+    self
+  }
+
+  /// The FIRST timed `gpmd` sample whose decoded GPMF carries a GPS coordinate
+  /// pair — a `GPS5`/`GPS9` fix, or (Karma drone) a `GLPI` fix — the entry that
+  /// feeds the [`MediaMetadata`] GPS projection. Mirrors the per-sample
+  /// `first_fix`/`first_glpi_fix` of [`GoProMeta`] across the timed-sample axis;
+  /// returns the enclosing [`GoProDocSample`] so the caller can reach its
+  /// `Doc<N>`/`Track<N>` stamping if needed.
+  #[inline]
+  #[must_use]
+  pub fn first_fix(&self) -> Option<&GoProDocSample> {
+    self
+      .doc_samples
+      .iter()
+      .find(|s| s.meta().first_fix().is_some() || s.meta().first_glpi_fix().is_some())
+  }
+}
+
+// ===========================================================================
+// GoProTimedMeta projection into MediaMetadata (golden L2)
+// ===========================================================================
+
+impl GoProTimedMeta {
+  /// Project the GoPro `gpmd` / `fdsc` TIMED-metadata camera identity + GPS into
+  /// [`MediaMetadata`].
+  ///
+  /// This is the ALWAYS-ON normalized projection (the product's actual output),
+  /// distinct from the per-sample timed TAG stream emitted only at `-ee`: a GoPro
+  /// file whose GPS lives ONLY in the timed `gpmd` track (e.g. the HERO8 sample —
+  /// the `udta/GPMF` box carries identity but NO `GPS5`/`GPS9`) must still surface
+  /// its [`GpsLocation`] here. Mirrors the CAMM / Sony rtmd / Insta360 timed-GPS
+  /// projections: the FIRST coordinate-bearing sample summarizes the track.
+  ///
+  /// The two domains are projected INDEPENDENTLY (a `gpmd` sample may carry GPS
+  /// telemetry while the real camera identity lives elsewhere):
+  ///
+  /// - **CameraInfo:** the FIRST `gpmd` sample carrying real identity (a
+  ///   `Model`/`DeviceName`/`CameraSerialNumber`/`FirmwareVersion` —
+  ///   [`GoProMeta::has_camera_identity`]) sets it via
+  ///   [`GoProMeta::project_camera_into`]. A GPS-only sample is SKIPPED for
+  ///   identity so it cannot stamp a make-only `CameraInfo` that masks a later
+  ///   identity-bearing sample. When NO `gpmd` sample carries identity (the
+  ///   camera fields live in an `fdsc` `GPRO` block instead — Hero5/6/8), the
+  ///   first identity-bearing [`GoProFdscSample`] fills `CameraInfo` (`fdsc`
+  ///   carries no GPS).
+  /// - **GpsLocation:** the FIRST coordinate-bearing `gpmd` sample
+  ///   ([`Self::first_fix`]) summarizes the track via
+  ///   [`GoProMeta::project_gps_into`] — the "first valid fix" precedent — at
+  ///   the SAME HIGHEST GPS priority tier as the always-on `udta/GPMF` box,
+  ///   regardless of which sample supplied the identity.
+  ///
+  /// Set-once per domain throughout (each step no-ops when a higher-priority
+  /// source already populated the domain it would write), so this composes into
+  /// the QuickTime priority chain at the GoPro on-device-GNSS tier. An inherent
+  /// helper (not the golden [`Project`](crate::metadata::Project) trait) — GoPro
+  /// is reached only through the QuickTime container, whose projection
+  /// ([`crate::formats::quicktime::Meta::media_metadata`]) calls this.
+  pub(crate) fn project_into(&self, md: &mut MediaMetadata) {
+    if self.is_empty() {
+      return;
+    }
+    // ── CameraInfo (identity) ──────────────────────────────────────────
+    // Take identity from the FIRST `gpmd` sample that carries REAL identity —
+    // NOT a GPS-only/make-only sample, which would otherwise stamp a make-only
+    // `CameraInfo` and mask both later identity-bearing `gpmd` samples and the
+    // `fdsc` fallback. Each `gpmd` sample is one `DEVC` with its own decoded
+    // `GoProMeta`; `project_camera_into` is set-once (no-ops when a
+    // higher-priority source already set the camera).
+    if let Some(s) = self
+      .doc_samples
+      .iter()
+      .find(|s| s.meta().has_camera_identity())
+    {
+      s.meta().project_camera_into(md);
+    } else if md.camera().is_none()
+      && let Some(f) = self.fdsc_samples.iter().find(|f| f.has_camera_identity())
+    {
+      // No `gpmd` sample carried identity: fall back to the `fdsc` (`GPRO`)
+      // block (firmware / serial / model — no GPS), when no higher-priority
+      // source already set the camera. `f` passed `has_camera_identity`, so at
+      // least one field is non-empty; each field is still `nonempty`-filtered so
+      // an empty sibling field is never written as an empty string (the same
+      // rule the predicate uses). `fdsc` has no `DeviceName` fallback.
+      let model = nonempty(f.model());
+      let serial = nonempty(f.serial_number());
+      let software = nonempty(f.firmware_version());
+      let mut cam = CameraInfo::new();
+      cam
+        .update_make(Some("GoPro".into()))
+        .update_model(model.map(str::to_string))
+        .update_serial(serial.map(str::to_string))
+        .update_software(software.map(str::to_string));
+      md.set_camera(cam);
+    }
+    // ── GpsLocation ────────────────────────────────────────────────────
+    // Summarize GPS from the FIRST coordinate-bearing `gpmd` sample,
+    // INDEPENDENTLY of which sample supplied the identity above
+    // (`project_gps_into` is set-once at the HIGHEST GPS priority tier).
+    if let Some(s) = self.first_fix() {
+      s.meta().project_gps_into(md);
+    }
+  }
+}
+
 // ===========================================================================
 // GoPro projection into MediaMetadata (golden L2)
 // ===========================================================================
@@ -1432,24 +1894,58 @@ impl GoProMeta {
     if self.is_empty() {
       return;
     }
-    // ── CameraInfo ─────────────────────────────────────────────────────
+    self.project_camera_into(md);
+    self.project_gps_into(md);
+  }
+
+  /// Project ONLY this meta's [`CameraInfo`] (the `Make`/`Model`/`Serial`/
+  /// `Software` half of [`Self::project_into`]) into `md`, set-once. Split out
+  /// so the timed-sample projection ([`GoProTimedMeta::project_into`]) can take
+  /// identity from one sample and GPS from a DIFFERENT sample.
+  ///
+  /// Every identity field is filtered through [`nonempty`] (the SAME non-empty
+  /// rule as [`Self::has_camera_identity`], so predicate and projection agree):
+  /// `Model` (`MINF`) falls back to `DeviceName` (`DVNM`) only when `MINF` is
+  /// empty/absent; `Serial` (`CASN`) and `Software` (`FMWR`) are written only
+  /// when non-empty. The `Make`-only `GoPro` stamp + `set_camera` fire ONLY when
+  /// at least one projected identity field is non-empty — so a GPS-only or an
+  /// empty-identity sample writes NO `CameraInfo`, and a selected sample never
+  /// writes an empty value that would shadow a later real identity in the
+  /// priority chain. The timed path additionally gates the SELECTION of the
+  /// sample on [`Self::has_camera_identity`].
+  fn project_camera_into(&self, md: &mut MediaMetadata) {
     if md.camera().is_none() {
-      let mut cam = CameraInfo::new();
-      cam
-        .update_make(Some("GoPro".into()))
-        .update_model(
-          self
-            .model()
-            .or_else(|| self.device_name())
-            .map(str::to_string),
-        )
-        .update_serial(self.camera_serial_number().map(str::to_string))
-        .update_software(self.firmware_version().map(str::to_string));
-      if !cam.is_empty() {
+      // The GoPro `c`-string decoder yields `Some("")` for a defined-but-empty
+      // (all-NUL) record, so each identity field is filtered through `nonempty`:
+      // `Model` (`MINF`) falls back to `DeviceName` (`DVNM`) only when MINF is
+      // empty/absent, and an empty `DVNM` falls through to absent. Serial /
+      // software are written only when non-empty. This is the SAME non-empty
+      // rule as `has_camera_identity`, so predicate and projection agree — a
+      // selected sample never writes an empty value into `CameraInfo`.
+      let model = nonempty(self.model()).or_else(|| nonempty(self.device_name()));
+      let serial = nonempty(self.camera_serial_number());
+      let software = nonempty(self.firmware_version());
+      // Never stamp make-only `CameraInfo` for a sample whose every projected
+      // identity field is empty/absent (it would otherwise shadow a later real
+      // identity in the priority chain).
+      if model.is_some() || serial.is_some() || software.is_some() {
+        let mut cam = CameraInfo::new();
+        cam
+          .update_make(Some("GoPro".into()))
+          .update_model(model.map(str::to_string))
+          .update_serial(serial.map(str::to_string))
+          .update_software(software.map(str::to_string));
         md.set_camera(cam);
       }
     }
-    // ── GpsLocation (HIGHEST tier of the GPS priority chain) ───────────
+  }
+
+  /// Project ONLY this meta's [`GpsLocation`] (the HIGHEST-tier GPS half of
+  /// [`Self::project_into`]) into `md`, set-once. Split out alongside
+  /// [`Self::project_camera_into`] so the timed-sample projection can summarize
+  /// GPS from the first COORDINATE-bearing sample independently of which sample
+  /// supplied the camera identity.
+  fn project_gps_into(&self, md: &mut MediaMetadata) {
     if md.gps().is_none() {
       if let Some(f) = self.first_fix() {
         // Primary: GPS5/GPS9 hardware GNSS.
@@ -1494,6 +1990,22 @@ impl GoProMeta {
 #[inline]
 fn usable_glpi_time(s: &str) -> bool {
   !s.is_empty() && !s.starts_with('<') && !s.starts_with("0000:")
+}
+
+/// Map an EMPTY string to absent: `Some("")` -> `None`, every other value
+/// unchanged. The single non-empty rule shared by the GoPro camera-identity
+/// predicate ([`GoProMeta::has_camera_identity`] /
+/// [`GoProFdscSample::has_camera_identity`]) AND the identity projection
+/// ([`GoProMeta::project_camera_into`] + the `fdsc` fallback in
+/// [`GoProTimedMeta::project_into`]). The GoPro `c`-string decoder
+/// ([`crate::formats::gopro`] `read_ascii`) returns `Some("")` for a non-zero
+/// all-NUL payload (a defined-but-empty record ExifTool still `HandleTag`s), so
+/// such a field is present yet carries no real value — it must neither gate the
+/// make-only stamp nor be written into [`CameraInfo`], where it would shadow a
+/// later real identity in the priority chain.
+#[inline]
+fn nonempty(s: Option<&str>) -> Option<&str> {
+  s.filter(|v| !v.is_empty())
 }
 
 #[cfg(test)]
@@ -1643,5 +2155,627 @@ mod tests {
     m.project_into(&mut md);
     // The higher-priority Sony Make wins — GoPro doesn't overwrite it.
     assert_eq!(md.camera().expect("camera").make(), Some("Sony"));
+  }
+
+  // ── GoProTimedMeta (gpmd / fdsc) projection — #211 finding 1 ──────────────
+
+  /// A hand-built timed `gpmd` sample carrying a `GPS5`-style fix projects its
+  /// camera identity AND GpsLocation into MediaMetadata — proving the timed
+  /// `gpmd` GPS (which no longer reaches the flat `GoProMeta`) reaches the typed
+  /// projection (the regression the finding flagged). Mirrors the CAMM / rtmd /
+  /// Insta360 first-fix precedent.
+  #[test]
+  fn timed_project_into_surfaces_gpmd_camera_and_gps() {
+    let mut sample_meta = GoProMeta::new();
+    sample_meta
+      .set_device_name(Some("HERO8 Black".into()))
+      .set_camera_serial_number(Some("C347".into()))
+      .set_firmware_version(Some("HD8.01".into()))
+      .set_gps_date_time(Some("2019:11:18 23:42:08.645".into()));
+    let mut fix = GoProGpsSample::new();
+    fix
+      .set_latitude(Some(42.026625))
+      .set_longitude(Some(-129.294339))
+      .set_altitude_m(Some(9540.24));
+    sample_meta.push_gps_sample(fix);
+
+    let mut timed = GoProTimedMeta::new();
+    timed.push_doc_sample(GoProDocSample::new(sample_meta, 4, 1, Some(0.0), Some(1.0)));
+    assert!(!timed.is_empty());
+    assert!(
+      timed.first_fix().is_some(),
+      "first coordinate-bearing sample"
+    );
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    let cam = md.camera().expect("timed gpmd CameraInfo projected");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), Some("HERO8 Black"));
+    assert_eq!(cam.serial(), Some("C347"));
+    let gps = md.gps().expect("timed gpmd GpsLocation projected");
+    assert!((gps.latitude().unwrap() - 42.026625).abs() < 1e-9);
+    assert!((gps.longitude().unwrap() + 129.294339).abs() < 1e-9);
+    assert!((gps.altitude_m().unwrap() - 9540.24).abs() < 1e-6);
+    assert_eq!(gps.timestamp(), Some("2019:11:18 23:42:08.645"));
+  }
+
+  /// The FIRST coordinate-bearing `gpmd` sample wins the GPS summary (later
+  /// samples do not overwrite), mirroring the first-fix-wins precedent; camera
+  /// identity comes from the first sample carrying it.
+  #[test]
+  fn timed_project_into_uses_first_coordinate_bearing_sample() {
+    let mut timed = GoProTimedMeta::new();
+    // Sample 1: identity but NO coordinates (altitude only).
+    let mut m1 = GoProMeta::new();
+    m1.set_model(Some("HERO8 Black".into()));
+    let mut s1 = GoProGpsSample::new();
+    s1.set_altitude_m(Some(10.0));
+    m1.push_gps_sample(s1);
+    timed.push_doc_sample(GoProDocSample::new(m1, 4, 1, None, None));
+    // Sample 2: the first real fix.
+    let mut m2 = GoProMeta::new();
+    let mut s2 = GoProGpsSample::new();
+    s2.set_latitude(Some(1.0)).set_longitude(Some(2.0));
+    m2.push_gps_sample(s2);
+    timed.push_doc_sample(GoProDocSample::new(m2, 4, 2, None, None));
+    // Sample 3: a LATER fix that must NOT win.
+    let mut m3 = GoProMeta::new();
+    let mut s3 = GoProGpsSample::new();
+    s3.set_latitude(Some(9.0)).set_longitude(Some(9.0));
+    m3.push_gps_sample(s3);
+    timed.push_doc_sample(GoProDocSample::new(m3, 4, 3, None, None));
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+    let gps = md.gps().expect("gps from first coordinate-bearing sample");
+    assert_eq!(gps.latitude(), Some(1.0));
+    assert_eq!(gps.longitude(), Some(2.0));
+    assert_eq!(md.camera().expect("camera").model(), Some("HERO8 Black"));
+  }
+
+  /// An `fdsc` (`GPRO`) sample carries camera identity but NO GPS — it fills
+  /// CameraInfo when the `gpmd` samples did not, and leaves GpsLocation unset.
+  #[test]
+  fn timed_project_into_camera_from_fdsc_when_no_gpmd_identity() {
+    let mut fdsc = GoProFdscSample::new();
+    fdsc
+      .set_model(Some("HERO8 Black".into()))
+      .set_serial_number(Some("C347".into()))
+      .set_firmware_version(Some("HD8.01.01.20.00".into()));
+    let mut timed = GoProTimedMeta::new();
+    timed.push_fdsc_sample(fdsc);
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+    let cam = md.camera().expect("fdsc CameraInfo projected");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), Some("HERO8 Black"));
+    assert_eq!(cam.serial(), Some("C347"));
+    assert_eq!(cam.software(), Some("HD8.01.01.20.00"));
+    assert!(md.gps().is_none(), "fdsc carries no GPS");
+  }
+
+  /// An empty timed meta writes nothing, and the projection no-ops when a
+  /// higher-priority source already populated the domain.
+  #[test]
+  fn timed_project_into_empty_and_priority_chain() {
+    let empty = GoProTimedMeta::new();
+    let mut md = MediaMetadata::new();
+    empty.project_into(&mut md);
+    assert!(md.camera().is_none());
+    assert!(md.gps().is_none());
+
+    // A higher-priority GPS already set — the timed gpmd fix must not overwrite.
+    let mut m = GoProMeta::new();
+    let mut s = GoProGpsSample::new();
+    s.set_latitude(Some(5.0)).set_longitude(Some(6.0));
+    m.push_gps_sample(s);
+    let mut timed = GoProTimedMeta::new();
+    timed.push_doc_sample(GoProDocSample::new(m, 4, 1, None, None));
+    let mut md2 = MediaMetadata::new();
+    let mut existing = GpsLocation::new();
+    existing
+      .update_latitude(Some(1.0))
+      .update_longitude(Some(2.0));
+    md2.set_gps(existing);
+    timed.project_into(&mut md2);
+    assert_eq!(md2.gps().expect("gps").latitude(), Some(1.0));
+  }
+
+  /// #211 R2 — a GPS-only `gpmd` sample (coordinates, NO model/serial/firmware)
+  /// followed by an identity-bearing `fdsc` (`GPRO`) sample: the GPS-only
+  /// sample must NOT stamp a make-only `CameraInfo` that blocks the `fdsc`
+  /// fallback. The projection ends with BOTH the GPS (from the `gpmd`
+  /// coordinate sample) AND the real camera identity (from `fdsc`).
+  #[test]
+  fn timed_gps_only_gpmd_does_not_block_fdsc_identity() {
+    let mut timed = GoProTimedMeta::new();
+    // gpmd sample 1: a coordinate fix, but NO identity (GPS-only telemetry).
+    let mut gps_only = GoProMeta::new();
+    let mut fix = GoProGpsSample::new();
+    fix
+      .set_latitude(Some(42.026625))
+      .set_longitude(Some(-129.294339))
+      .set_altitude_m(Some(9540.24));
+    gps_only.push_gps_sample(fix);
+    assert!(!gps_only.is_empty(), "GPS-only meta is non-empty");
+    assert!(
+      !gps_only.has_camera_identity(),
+      "GPS-only meta carries no camera identity"
+    );
+    timed.push_doc_sample(GoProDocSample::new(gps_only, 4, 1, Some(0.0), Some(1.0)));
+    // fdsc (GPRO) sample: the real camera identity (no GPS).
+    let mut fdsc = GoProFdscSample::new();
+    fdsc
+      .set_model(Some("HERO8 Black".into()))
+      .set_serial_number(Some("C347".into()))
+      .set_firmware_version(Some("HD8.01.01.20.00".into()));
+    assert!(fdsc.has_camera_identity());
+    timed.push_fdsc_sample(fdsc);
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    // The GPS-only sample no longer blocks identity: fdsc fills CameraInfo.
+    let cam = md
+      .camera()
+      .expect("fdsc identity projected past the GPS-only gpmd sample");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), Some("HERO8 Black"));
+    assert_eq!(cam.serial(), Some("C347"));
+    assert_eq!(cam.software(), Some("HD8.01.01.20.00"));
+    // ...and the GPS still comes from the gpmd coordinate sample.
+    let gps = md.gps().expect("gps from the GPS-only gpmd sample");
+    assert!((gps.latitude().unwrap() - 42.026625).abs() < 1e-9);
+    assert!((gps.longitude().unwrap() + 129.294339).abs() < 1e-9);
+    assert!((gps.altitude_m().unwrap() - 9540.24).abs() < 1e-6);
+  }
+
+  /// #211 R2 — a GPS-only `gpmd` sample followed by a LATER identity-bearing
+  /// `gpmd` sample: identity is taken from the later sample (not masked by a
+  /// make-only `CameraInfo` from the GPS-only sample), while the GPS still
+  /// summarizes from the FIRST coordinate-bearing sample.
+  #[test]
+  fn timed_gps_only_gpmd_does_not_block_later_gpmd_identity() {
+    let mut timed = GoProTimedMeta::new();
+    // gpmd sample 1: a coordinate fix, but NO identity.
+    let mut gps_only = GoProMeta::new();
+    let mut fix = GoProGpsSample::new();
+    fix.set_latitude(Some(1.0)).set_longitude(Some(2.0));
+    gps_only.push_gps_sample(fix);
+    assert!(!gps_only.has_camera_identity());
+    timed.push_doc_sample(GoProDocSample::new(gps_only, 4, 1, None, None));
+    // gpmd sample 2 (LATER): carries the real identity (and its own later fix
+    // that must NOT win the GPS summary).
+    let mut identity = GoProMeta::new();
+    identity
+      .set_model(Some("HERO8 Black".into()))
+      .set_camera_serial_number(Some("C347".into()))
+      .set_firmware_version(Some("HD8.01".into()));
+    let mut later_fix = GoProGpsSample::new();
+    later_fix.set_latitude(Some(9.0)).set_longitude(Some(9.0));
+    identity.push_gps_sample(later_fix);
+    assert!(identity.has_camera_identity());
+    timed.push_doc_sample(GoProDocSample::new(identity, 4, 2, None, None));
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    // Identity comes from the LATER gpmd sample (the GPS-only sample didn't
+    // mask it with a make-only CameraInfo).
+    let cam = md
+      .camera()
+      .expect("later gpmd identity projected past the GPS-only sample");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), Some("HERO8 Black"));
+    assert_eq!(cam.serial(), Some("C347"));
+    assert_eq!(cam.software(), Some("HD8.01"));
+    // GPS still summarizes from the FIRST coordinate-bearing sample.
+    let gps = md
+      .gps()
+      .expect("gps from the first coordinate-bearing sample");
+    assert_eq!(gps.latitude(), Some(1.0));
+    assert_eq!(gps.longitude(), Some(2.0));
+  }
+
+  /// #211 R3/R4 — the GoPro `c`-string decoder returns `Some("")` for a
+  /// non-zero-size all-NUL payload (`read_ascii`), so an EMPTY identity string
+  /// (`DVNM`/`MINF`/`CASN`/`FMWR` = `Some("")`) is non-empty yet carries NO real
+  /// identity. The non-empty predicate rejects every such field individually,
+  /// in any mix, so an empty-only sample never gates the make-only stamp.
+  #[test]
+  fn timed_empty_identity_strings_are_not_camera_identity() {
+    // Each field present-but-empty does NOT count as identity.
+    for set_one in [
+      GoProMeta::set_device_name as fn(&mut GoProMeta, Option<SmolStr>) -> &mut GoProMeta,
+      GoProMeta::set_model,
+      GoProMeta::set_camera_serial_number,
+      GoProMeta::set_firmware_version,
+    ] {
+      let mut m = GoProMeta::new();
+      set_one(&mut m, Some(SmolStr::default())); // Some("")
+      assert!(
+        !m.has_camera_identity(),
+        "an empty-string identity field is not a real identity"
+      );
+    }
+    // ALL four empty at once: still no identity.
+    let mut all_empty = GoProMeta::new();
+    all_empty
+      .set_device_name(Some(SmolStr::default()))
+      .set_model(Some(SmolStr::default()))
+      .set_camera_serial_number(Some(SmolStr::default()))
+      .set_firmware_version(Some(SmolStr::default()));
+    assert!(!all_empty.has_camera_identity());
+    // A single NON-empty field flips it back on (empties on the rest don't mask).
+    let mut mixed = GoProMeta::new();
+    mixed
+      .set_device_name(Some(SmolStr::default()))
+      .set_model(Some("HERO8 Black".into()))
+      .set_camera_serial_number(Some(SmolStr::default()))
+      .set_firmware_version(Some(SmolStr::default()));
+    assert!(
+      mixed.has_camera_identity(),
+      "one non-empty field is a real identity even amid empties"
+    );
+  }
+
+  /// #211 R3/R4 — the same hole on the `fdsc` (`GPRO`) helper: `process_fdsc`
+  /// uses the same `read_ascii` NUL-trim path, so an `fdsc` sample whose
+  /// identity fields are all `Some("")` is non-empty yet carries no real
+  /// identity. `OtherSerialNumber` is excluded entirely (the projection never
+  /// writes it into `CameraInfo`), so a sample identified ONLY by a non-empty
+  /// `OtherSerialNumber` must NOT pass — it would otherwise stamp a make-only
+  /// `CameraInfo`.
+  #[test]
+  fn timed_empty_fdsc_identity_strings_are_not_camera_identity() {
+    // All projected fields present-but-empty → no identity.
+    let mut empty = GoProFdscSample::new();
+    empty
+      .set_model(Some(SmolStr::default()))
+      .set_serial_number(Some(SmolStr::default()))
+      .set_firmware_version(Some(SmolStr::default()));
+    assert!(
+      !empty.has_camera_identity(),
+      "empty-string fdsc identity fields are not a real identity"
+    );
+    // A non-empty `OtherSerialNumber` ALONE (not a projected field) → no
+    // identity, so no make-only stamp can be justified by it.
+    let mut other_only = GoProFdscSample::new();
+    other_only.set_other_serial_number(Some("OSN123".into()));
+    assert!(
+      !other_only.has_camera_identity(),
+      "OtherSerialNumber is not a projected CameraInfo field"
+    );
+    // Each projected field non-empty individually → identity.
+    for set_one in [
+      GoProFdscSample::set_model
+        as fn(&mut GoProFdscSample, Option<SmolStr>) -> &mut GoProFdscSample,
+      GoProFdscSample::set_serial_number,
+      GoProFdscSample::set_firmware_version,
+    ] {
+      let mut s = GoProFdscSample::new();
+      set_one(&mut s, Some("X".into()));
+      assert!(s.has_camera_identity());
+    }
+  }
+
+  /// #211 R3/R4 — a GPS + `gpmd` sample whose ONLY identity field is an EMPTY
+  /// `DVNM` (`Some("")`), followed by a real-identity `fdsc`: the empty sample
+  /// must NOT stamp a make-only `CameraInfo` that blocks the `fdsc` fallback.
+  /// The projection ends with BOTH the `fdsc` identity AND the `gpmd` GPS.
+  #[test]
+  fn timed_empty_dvnm_gpmd_does_not_block_fdsc_identity() {
+    let mut timed = GoProTimedMeta::new();
+    // gpmd sample 1: a coordinate fix + an EMPTY DVNM (defined-but-empty).
+    let mut empty_id = GoProMeta::new();
+    empty_id.set_device_name(Some(SmolStr::default())); // DVNM = Some("")
+    let mut fix = GoProGpsSample::new();
+    fix
+      .set_latitude(Some(42.026625))
+      .set_longitude(Some(-129.294339))
+      .set_altitude_m(Some(9540.24));
+    empty_id.push_gps_sample(fix);
+    assert!(
+      !empty_id.is_empty(),
+      "an empty-DVNM + GPS meta is non-empty"
+    );
+    assert!(
+      !empty_id.has_camera_identity(),
+      "an empty DVNM carries no real identity"
+    );
+    timed.push_doc_sample(GoProDocSample::new(empty_id, 4, 1, Some(0.0), Some(1.0)));
+    // fdsc (GPRO) sample: the real camera identity (no GPS).
+    let mut fdsc = GoProFdscSample::new();
+    fdsc
+      .set_model(Some("HERO8 Black".into()))
+      .set_serial_number(Some("C347".into()))
+      .set_firmware_version(Some("HD8.01.01.20.00".into()));
+    assert!(fdsc.has_camera_identity());
+    timed.push_fdsc_sample(fdsc);
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    // The empty-DVNM sample no longer blocks identity: fdsc fills CameraInfo.
+    let cam = md
+      .camera()
+      .expect("fdsc identity projected past the empty-DVNM gpmd sample");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), Some("HERO8 Black"));
+    assert_eq!(cam.serial(), Some("C347"));
+    assert_eq!(cam.software(), Some("HD8.01.01.20.00"));
+    // ...and the GPS still comes from the gpmd coordinate sample.
+    let gps = md.gps().expect("gps from the empty-DVNM gpmd sample");
+    assert!((gps.latitude().unwrap() - 42.026625).abs() < 1e-9);
+    assert!((gps.longitude().unwrap() + 129.294339).abs() < 1e-9);
+    assert!((gps.altitude_m().unwrap() - 9540.24).abs() < 1e-6);
+  }
+
+  /// #211 R3/R4 — a GPS + `gpmd` sample whose ONLY identity field is an EMPTY
+  /// `MINF` (`Model` = `Some("")`), followed by a LATER real-identity `gpmd`
+  /// sample: identity is taken from the later sample (the empty-model sample
+  /// does not mask it with a make-only `CameraInfo`), while the GPS summarizes
+  /// from the FIRST coordinate-bearing sample.
+  #[test]
+  fn timed_empty_model_gpmd_does_not_block_later_gpmd_identity() {
+    let mut timed = GoProTimedMeta::new();
+    // gpmd sample 1: a coordinate fix + an EMPTY Model (defined-but-empty).
+    let mut empty_id = GoProMeta::new();
+    empty_id.set_model(Some(SmolStr::default())); // MINF = Some("")
+    let mut fix = GoProGpsSample::new();
+    fix.set_latitude(Some(1.0)).set_longitude(Some(2.0));
+    empty_id.push_gps_sample(fix);
+    assert!(
+      !empty_id.has_camera_identity(),
+      "an empty Model carries no real identity"
+    );
+    timed.push_doc_sample(GoProDocSample::new(empty_id, 4, 1, None, None));
+    // gpmd sample 2 (LATER): the real identity (and a later fix that must NOT
+    // win the GPS summary).
+    let mut identity = GoProMeta::new();
+    identity
+      .set_model(Some("HERO8 Black".into()))
+      .set_camera_serial_number(Some("C347".into()))
+      .set_firmware_version(Some("HD8.01".into()));
+    let mut later_fix = GoProGpsSample::new();
+    later_fix.set_latitude(Some(9.0)).set_longitude(Some(9.0));
+    identity.push_gps_sample(later_fix);
+    assert!(identity.has_camera_identity());
+    timed.push_doc_sample(GoProDocSample::new(identity, 4, 2, None, None));
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    // Identity comes from the LATER gpmd sample (the empty-model sample didn't
+    // mask it).
+    let cam = md
+      .camera()
+      .expect("later gpmd identity projected past the empty-model sample");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), Some("HERO8 Black"));
+    assert_eq!(cam.serial(), Some("C347"));
+    assert_eq!(cam.software(), Some("HD8.01"));
+    // GPS still summarizes from the FIRST coordinate-bearing sample.
+    let gps = md
+      .gps()
+      .expect("gps from the first coordinate-bearing sample");
+    assert_eq!(gps.latitude(), Some(1.0));
+    assert_eq!(gps.longitude(), Some(2.0));
+  }
+
+  /// #211 R3/R4 — the definitive class assertion: when EVERY timed sample's
+  /// identity is empty/absent (an empty-DVNM `gpmd` GPS sample + an all-empty
+  /// `fdsc` sample), NO `CameraInfo` is created at all, while the GPS still
+  /// projects. Proves no non-identity sample can produce a make-only stamp.
+  #[test]
+  fn timed_all_empty_identity_produces_no_camera_info() {
+    let mut timed = GoProTimedMeta::new();
+    let mut empty_id = GoProMeta::new();
+    empty_id.set_device_name(Some(SmolStr::default()));
+    let mut fix = GoProGpsSample::new();
+    fix.set_latitude(Some(3.0)).set_longitude(Some(4.0));
+    empty_id.push_gps_sample(fix);
+    timed.push_doc_sample(GoProDocSample::new(empty_id, 4, 1, None, None));
+    let mut empty_fdsc = GoProFdscSample::new();
+    empty_fdsc
+      .set_model(Some(SmolStr::default()))
+      .set_serial_number(Some(SmolStr::default()))
+      .set_firmware_version(Some(SmolStr::default()));
+    timed.push_fdsc_sample(empty_fdsc);
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    assert!(
+      md.camera().is_none(),
+      "no real identity anywhere → no make-only CameraInfo"
+    );
+    let gps = md
+      .gps()
+      .expect("gps still projects from the coordinate sample");
+    assert_eq!(gps.latitude(), Some(3.0));
+    assert_eq!(gps.longitude(), Some(4.0));
+  }
+
+  /// #211 R4-review — the PROJECTION complement of the empty-identity class: a
+  /// selected `gpmd` sample with an EMPTY `MINF` (`Model` = `Some("")`) but a
+  /// NON-EMPTY `DVNM` (`DeviceName`). `has_camera_identity` passes (DVNM is
+  /// real), so the sample is SELECTED — and the projection must fall through the
+  /// empty `Model` to the non-empty `DeviceName`, writing `DVNM` as the model
+  /// (NOT an empty-string model). The empty `Model` must never reach
+  /// `CameraInfo`, and the later real-identity sample is not needed.
+  #[test]
+  fn timed_empty_minf_nonempty_dvnm_projects_dvnm_as_model() {
+    let mut timed = GoProTimedMeta::new();
+    // gpmd sample 1: an EMPTY MINF + a NON-EMPTY DVNM (+ a coordinate fix).
+    let mut first = GoProMeta::new();
+    first
+      .set_model(Some(SmolStr::default())) // MINF = Some("") — empty
+      .set_device_name(Some("GoPro Max".into())); // DVNM = real
+    let mut fix = GoProGpsSample::new();
+    fix.set_latitude(Some(1.0)).set_longitude(Some(2.0));
+    first.push_gps_sample(fix);
+    assert!(
+      first.has_camera_identity(),
+      "a non-empty DVNM is a real identity even with an empty MINF"
+    );
+    timed.push_doc_sample(GoProDocSample::new(first, 4, 1, None, None));
+    // gpmd sample 2 (LATER): a DIFFERENT real identity that must NOT be reached
+    // (the first sample already carries real identity via DVNM).
+    let mut later = GoProMeta::new();
+    later
+      .set_model(Some("HERO8 Black".into()))
+      .set_camera_serial_number(Some("C347".into()));
+    timed.push_doc_sample(GoProDocSample::new(later, 4, 2, None, None));
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    let cam = md
+      .camera()
+      .expect("identity projected from the first sample");
+    assert_eq!(cam.make(), Some("GoPro"));
+    // The empty MINF falls through to the non-empty DVNM — NOT an empty model,
+    // and NOT the later sample's "HERO8 Black".
+    assert_eq!(
+      cam.model(),
+      Some("GoPro Max"),
+      "empty MINF must fall back to the non-empty DVNM"
+    );
+    // The first sample carried no serial/firmware → those stay absent (the
+    // later sample's serial is never reached).
+    assert_eq!(cam.serial(), None, "empty/absent serial is never written");
+    assert_eq!(
+      cam.software(),
+      None,
+      "empty/absent software is never written"
+    );
+  }
+
+  /// #211 R4-review — an EMPTY `MINF` + EMPTY `DVNM` (+ empty serial/firmware)
+  /// `gpmd` sample is NOT selected as identity (the projection complement of the
+  /// predicate): a LATER real-identity sample / `fdsc` fills `CameraInfo`. Proves
+  /// the empty-everything sample neither selects nor stamps an empty model.
+  #[test]
+  fn timed_empty_minf_empty_dvnm_not_selected_later_identity_wins() {
+    let mut timed = GoProTimedMeta::new();
+    // gpmd sample 1: EVERY identity field present-but-empty (+ a fix).
+    let mut empty = GoProMeta::new();
+    empty
+      .set_model(Some(SmolStr::default()))
+      .set_device_name(Some(SmolStr::default()))
+      .set_camera_serial_number(Some(SmolStr::default()))
+      .set_firmware_version(Some(SmolStr::default()));
+    let mut fix = GoProGpsSample::new();
+    fix.set_latitude(Some(1.0)).set_longitude(Some(2.0));
+    empty.push_gps_sample(fix);
+    assert!(
+      !empty.has_camera_identity(),
+      "all-empty identity fields → not selected"
+    );
+    timed.push_doc_sample(GoProDocSample::new(empty, 4, 1, None, None));
+    // gpmd sample 2 (LATER): the real identity.
+    let mut later = GoProMeta::new();
+    later
+      .set_device_name(Some("GoPro Max".into()))
+      .set_camera_serial_number(Some("C999".into()));
+    timed.push_doc_sample(GoProDocSample::new(later, 4, 2, None, None));
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    let cam = md.camera().expect("later real identity fills CameraInfo");
+    assert_eq!(cam.make(), Some("GoPro"));
+    // DVNM fallback for the later sample (no MINF) → model is the DVNM value.
+    assert_eq!(cam.model(), Some("GoPro Max"));
+    assert_eq!(cam.serial(), Some("C999"));
+    // GPS still summarizes from the first coordinate-bearing sample.
+    let gps = md.gps().expect("gps from the first coordinate sample");
+    assert_eq!(gps.latitude(), Some(1.0));
+    assert_eq!(gps.longitude(), Some(2.0));
+  }
+
+  /// #211 R4-review — the FLAT `udta` projection complement (shared
+  /// `project_camera_into`): a flat `GoProMeta` with an EMPTY `MINF` + a
+  /// NON-EMPTY `DVNM` projects the `DeviceName` as the model, never an empty
+  /// string, and an all-empty identity writes NO `CameraInfo` (no make-only
+  /// stamp). Guards the udta path against the same class.
+  #[test]
+  fn project_camera_into_empty_minf_falls_back_to_dvnm_no_empty_write() {
+    // Empty MINF + non-empty DVNM → model is the DVNM.
+    let mut m = GoProMeta::new();
+    m.set_model(Some(SmolStr::default())) // empty MINF
+      .set_device_name(Some("GoPro Max".into()));
+    let mut md = MediaMetadata::new();
+    m.project_into(&mut md);
+    let cam = md.camera().expect("DVNM fallback projected");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), Some("GoPro Max"));
+    assert_eq!(cam.serial(), None);
+    assert_eq!(cam.software(), None);
+
+    // Every identity field empty (but other GPMF telemetry present so `is_empty`
+    // is false) → NO CameraInfo at all (no make-only stamp).
+    let mut all_empty = GoProMeta::new();
+    all_empty
+      .set_model(Some(SmolStr::default()))
+      .set_device_name(Some(SmolStr::default()))
+      .set_camera_serial_number(Some(SmolStr::default()))
+      .set_firmware_version(Some(SmolStr::default()))
+      .set_gps_date_time(Some("2024:01:01 00:00:00".into())); // non-identity field
+    assert!(!all_empty.is_empty(), "telemetry present → non-empty meta");
+    assert!(!all_empty.has_camera_identity());
+    let mut md2 = MediaMetadata::new();
+    all_empty.project_into(&mut md2);
+    assert!(
+      md2.camera().is_none(),
+      "all-empty identity must not stamp a make-only CameraInfo"
+    );
+
+    // An empty serial/firmware sibling beside a real DVNM is never written as an
+    // empty string.
+    let mut mixed = GoProMeta::new();
+    mixed
+      .set_device_name(Some("GoPro Max".into()))
+      .set_camera_serial_number(Some(SmolStr::default())) // empty CASN
+      .set_firmware_version(Some(SmolStr::default())); // empty FMWR
+    let mut md3 = MediaMetadata::new();
+    mixed.project_into(&mut md3);
+    let cam = md3.camera().expect("DVNM identity");
+    assert_eq!(cam.model(), Some("GoPro Max"));
+    assert_eq!(cam.serial(), None, "empty CASN is not written");
+    assert_eq!(cam.software(), None, "empty FMWR is not written");
+  }
+
+  /// #211 R4-review — the `fdsc` projection complement: a selected `fdsc` sample
+  /// with a NON-EMPTY serial but an EMPTY model (`Some("")`) must write the
+  /// serial WITHOUT an empty-string model (the `fdsc` fallback also goes through
+  /// `nonempty`). `fdsc` has no `DeviceName` fallback, so an empty model simply
+  /// stays absent.
+  #[test]
+  fn timed_fdsc_empty_model_nonempty_serial_writes_no_empty_model() {
+    let mut timed = GoProTimedMeta::new();
+    let mut fdsc = GoProFdscSample::new();
+    fdsc
+      .set_model(Some(SmolStr::default())) // empty model
+      .set_serial_number(Some("C347".into())) // real serial
+      .set_firmware_version(Some(SmolStr::default())); // empty firmware
+    assert!(
+      fdsc.has_camera_identity(),
+      "a non-empty serial is a real fdsc identity"
+    );
+    timed.push_fdsc_sample(fdsc);
+
+    let mut md = MediaMetadata::new();
+    timed.project_into(&mut md);
+
+    let cam = md.camera().expect("fdsc identity projected");
+    assert_eq!(cam.make(), Some("GoPro"));
+    assert_eq!(cam.model(), None, "empty fdsc model is never written");
+    assert_eq!(cam.serial(), Some("C347"));
+    assert_eq!(cam.software(), None, "empty fdsc firmware is never written");
   }
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -62,7 +62,8 @@ pub use domain::{
   CameraInfo, CaptureSettings, GpsLocation, LensInfo, MediaInfo, MediaMetadata, TrackKind,
 };
 pub use gopro::{
-  GoProConv, GoProGlpiSample, GoProGpsSample, GoProKbat, GoProMeta, GoProTag, GoProTagValue,
+  GoProConv, GoProDocSample, GoProFdscSample, GoProGlpiSample, GoProGpsSample, GoProKbat,
+  GoProMeta, GoProTag, GoProTagValue, GoProTimedMeta,
 };
 pub(crate) use gopro::{GoProIdentity, GoProMainGroupTag, GoProScalar};
 pub use insta360::{

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1047,6 +1047,7 @@ struct DocObject<'a> {
   obj: &'a serde_json::Map<String, serde_json::Value>,
   entries: &'a [(
     u32,
+    u32,
     smol_str::SmolStr,
     smol_str::SmolStr,
     u8,
@@ -1071,8 +1072,8 @@ impl serde::Serialize for DocObject<'_> {
     // `Doc<N>:`), skip any key already emitted by `obj` (first-wins), and
     // serialize the value straight through `TagValue::Serialize`.
     let mut key = String::new();
-    for (doc, group, name, _priority, value) in self.entries {
-      crate::serialize_key::group_key_into(&mut key, *doc, group, name, self.group_mode);
+    for (doc, doc_sub, group, name, _priority, value) in self.entries {
+      crate::serialize_key::group_key_into(&mut key, *doc, *doc_sub, group, name, self.group_mode);
       if self.obj.contains_key(key.as_str()) {
         continue;
       }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -128,6 +128,7 @@ mod serde_doc {
       for t in doc.tags {
         let token = crate::serialize_key::group_key(
           t.group_ref().doc(),
+          t.group_ref().doc_sub(),
           t.group_ref().family1(),
           t.name(),
           crate::serialize_key::GroupMode::G1,

--- a/src/serialize_key.rs
+++ b/src/serialize_key.rs
@@ -26,6 +26,7 @@ pub(crate) enum GroupMode {
 pub(crate) fn group_key_into(
   buf: &mut String,
   doc: u32,
+  doc_sub: u32,
   family1: &str,
   name: &str,
   mode: GroupMode,
@@ -33,7 +34,14 @@ pub(crate) fn group_key_into(
   use core::fmt::Write;
   buf.clear();
   if matches!(mode, GroupMode::G3) && doc != 0 {
-    let _ = write!(buf, "Doc{doc}:");
+    // The GoPro GPMF `ProcessString` per-row split renders `Doc<N>-<M>`
+    // (GoPro.pm:759-774) for `doc_sub > 0`; every other source has `doc_sub ==
+    // 0` and renders the ordinary `Doc<N>`.
+    if doc_sub != 0 {
+      let _ = write!(buf, "Doc{doc}-{doc_sub}:");
+    } else {
+      let _ = write!(buf, "Doc{doc}:");
+    }
   }
   buf.reserve(family1.len() + 1 + name.len());
   buf.push_str(family1);
@@ -44,9 +52,15 @@ pub(crate) fn group_key_into(
 /// Owned-`String` convenience for callers that need to keep the token (e.g. a
 /// dedup `BTreeSet`). Allocates one `String`; prefer [`group_key_into`] in a loop.
 #[cfg(feature = "alloc")]
-pub(crate) fn group_key(doc: u32, family1: &str, name: &str, mode: GroupMode) -> String {
+pub(crate) fn group_key(
+  doc: u32,
+  doc_sub: u32,
+  family1: &str,
+  name: &str,
+  mode: GroupMode,
+) -> String {
   let mut key = String::new();
-  group_key_into(&mut key, doc, family1, name, mode);
+  group_key_into(&mut key, doc, doc_sub, family1, name, mode);
   key
 }
 
@@ -56,20 +70,41 @@ mod tests {
   #[test]
   fn g1_collapses_doc_g3_prefixes_doc() {
     assert_eq!(
-      group_key(0, "QuickTime", "GPSLatitude", GroupMode::G1),
+      group_key(0, 0, "QuickTime", "GPSLatitude", GroupMode::G1),
       "QuickTime:GPSLatitude"
     );
     assert_eq!(
-      group_key(2, "QuickTime", "GPSLatitude", GroupMode::G1),
+      group_key(2, 0, "QuickTime", "GPSLatitude", GroupMode::G1),
       "QuickTime:GPSLatitude"
     );
     assert_eq!(
-      group_key(0, "QuickTime", "TimeScale", GroupMode::G3),
+      group_key(0, 0, "QuickTime", "TimeScale", GroupMode::G3),
       "QuickTime:TimeScale"
     );
     assert_eq!(
-      group_key(1, "QuickTime", "GPSLatitude", GroupMode::G3),
+      group_key(1, 0, "QuickTime", "GPSLatitude", GroupMode::G3),
       "Doc1:QuickTime:GPSLatitude"
+    );
+  }
+
+  /// The GoPro GPMF `ProcessString` per-row split: `doc_sub > 0` renders the
+  /// two-level `Doc<N>-<M>` at `-G3`, and is collapsed away at `-G1` (the doc
+  /// axis is dropped entirely).
+  #[test]
+  fn g3_subdoc_renders_two_level() {
+    assert_eq!(
+      group_key(1, 2, "Track4", "GPSLatitude", GroupMode::G3),
+      "Doc1-2:Track4:GPSLatitude"
+    );
+    // `doc_sub == 0` is the ordinary parent `Doc<N>`.
+    assert_eq!(
+      group_key(1, 0, "Track4", "GPSLatitude", GroupMode::G3),
+      "Doc1:Track4:GPSLatitude"
+    );
+    // `-G1` collapses the whole doc axis, sub-doc included.
+    assert_eq!(
+      group_key(1, 2, "Track4", "GPSLatitude", GroupMode::G1),
+      "Track4:GPSLatitude"
     );
   }
 }

--- a/src/tagmap.rs
+++ b/src/tagmap.rs
@@ -108,12 +108,12 @@ pub(crate) struct TagMap {
   /// never collides with the same `family1:name` in another document. The
   /// stored `priority` is the SURVIVING entry's priority, so a later same-key
   /// duplicate is compared against the value that currently occupies the slot.
-  entries: Vec<(u32, SmolStr, SmolStr, u8, TagValue)>,
+  entries: Vec<(u32, u32, SmolStr, SmolStr, u8, TagValue)>,
   /// `(doc, family1, name) → index into `entries`` for O(1) dedup. The key
   /// clones the two short `SmolStr`s (inline for ≤23 bytes — no heap), so the
   /// dedup probe never builds the `"g:n"` string the old design allocated per
   /// insert. The leading `doc` keeps per-sub-document tags distinct.
-  index: HashMap<(u32, SmolStr, SmolStr), usize>,
+  index: HashMap<(u32, u32, SmolStr, SmolStr), usize>,
   warnings: Vec<String>,
   errors: Vec<String>,
 }
@@ -165,7 +165,15 @@ impl TagMap {
   /// therefore both ride the in-stream `tags()` path so their FoundTag order is
   /// faithful (the survivor is whichever the walk reached FIRST). Pinned by the
   /// `Matroska_warning_collision*.mkv` goldens.
-  fn insert(&mut self, doc: u32, group: &str, name: &str, priority: u8, value: TagValue) {
+  fn insert(
+    &mut self,
+    doc: u32,
+    doc_sub: u32,
+    group: &str,
+    name: &str,
+    priority: u8,
+    value: TagValue,
+  ) {
     // O(1) dedup on the `(doc, family1, name)` TRIPLE — no `"g:n"` string is
     // built here (it is materialized once per surviving entry at serialization).
     // The probe key clones the two `SmolStr`s; tag groups + names are short
@@ -186,23 +194,24 @@ impl TagMap {
     } else {
       priority
     };
-    let key = (doc, SmolStr::new(group), SmolStr::new(name));
+    let key = (doc, doc_sub, SmolStr::new(group), SmolStr::new(name));
     if let Some(&idx) = self.index.get(&key) {
       // ExifTool's general rule: a NEW duplicate overrides the stored entry IFF
       // its effective priority is non-zero AND `>=` the stored (`>= 1`) priority
       // (`ExifTool.pm:9544-9560`). A `Priority => 0` duplicate never overrides.
-      let stored_priority = self.entries[idx].3;
+      let stored_priority = self.entries[idx].4;
       if effective_priority != 0 && effective_priority >= stored_priority {
-        self.entries[idx].3 = effective_priority;
-        self.entries[idx].4 = value;
+        self.entries[idx].4 = effective_priority;
+        self.entries[idx].5 = value;
       }
       return;
     }
     let idx = self.entries.len();
     self.entries.push((
       key.0,
-      key.1.clone(),
+      key.1,
       key.2.clone(),
+      key.3.clone(),
       effective_priority,
       value,
     ));
@@ -235,7 +244,7 @@ impl TagMap {
     name: &str,
     value: &str,
   ) -> Result<(), Infallible> {
-    self.insert(0, group, name, 1, TagValue::Str(value.into()));
+    self.insert(0, 0, group, name, 1, TagValue::Str(value.into()));
     Ok(())
   }
 
@@ -247,7 +256,7 @@ impl TagMap {
     name: &str,
     value: u64,
   ) -> Result<(), Infallible> {
-    self.insert(0, group, name, 1, TagValue::U64(value));
+    self.insert(0, 0, group, name, 1, TagValue::U64(value));
     Ok(())
   }
 
@@ -259,7 +268,7 @@ impl TagMap {
     name: &str,
     value: i64,
   ) -> Result<(), Infallible> {
-    self.insert(0, group, name, 1, TagValue::I64(value));
+    self.insert(0, 0, group, name, 1, TagValue::I64(value));
     Ok(())
   }
 
@@ -271,7 +280,7 @@ impl TagMap {
     name: &str,
     value: f64,
   ) -> Result<(), Infallible> {
-    self.insert(0, group, name, 1, TagValue::F64(value));
+    self.insert(0, 0, group, name, 1, TagValue::F64(value));
     Ok(())
   }
 
@@ -287,7 +296,7 @@ impl TagMap {
   ) -> Result<(), Infallible> {
     let mut s = String::new();
     let _ = f(&mut s); // in-memory String write cannot fail
-    self.insert(0, group, name, 1, TagValue::Str(s.into()));
+    self.insert(0, 0, group, name, 1, TagValue::Str(s.into()));
     Ok(())
   }
 
@@ -306,7 +315,7 @@ impl TagMap {
   ) -> Result<(), Infallible> {
     // The non-`-ee` value path: Main document (`doc == 0`), ExifTool's default
     // duplicate `Priority => 1` (`ExifTool.pm:9553`).
-    self.insert(0, group, name, 1, value);
+    self.insert(0, 0, group, name, 1, value);
     Ok(())
   }
 
@@ -320,12 +329,13 @@ impl TagMap {
   pub(crate) fn write_value_doc(
     &mut self,
     doc: u32,
+    doc_sub: u32,
     group: &str,
     name: &str,
     priority: u8,
     value: TagValue,
   ) -> Result<(), Infallible> {
-    self.insert(doc, group, name, priority, value);
+    self.insert(doc, doc_sub, group, name, priority, value);
     Ok(())
   }
 
@@ -349,7 +359,7 @@ impl TagMap {
   /// is dedup bookkeeping the consumers ignore. Slice view of the backing `Vec`
   /// (§3: never expose `&Vec<T>`).
   #[inline(always)]
-  pub(crate) const fn entries(&self) -> &[(u32, SmolStr, SmolStr, u8, TagValue)] {
+  pub(crate) const fn entries(&self) -> &[(u32, u32, SmolStr, SmolStr, u8, TagValue)] {
     self.entries.as_slice()
   }
 
@@ -376,8 +386,8 @@ impl TagMap {
   /// emitted. Uses the O(1) dedup index.
   #[cfg(test)]
   pub(crate) fn get(&self, group: &str, name: &str) -> Option<&TagValue> {
-    let key = (0u32, SmolStr::new(group), SmolStr::new(name));
-    self.index.get(&key).map(|&idx| &self.entries[idx].4)
+    let key = (0u32, 0u32, SmolStr::new(group), SmolStr::new(name));
+    self.index.get(&key).map(|&idx| &self.entries[idx].5)
   }
 
   /// `true` if no tags / warnings / errors were emitted (test-only).
@@ -428,16 +438,20 @@ mod tests {
   #[test]
   fn tagmap_dedup_is_doc_aware() {
     let mut m = TagMap::new();
-    m.write_value_doc(1, "QuickTime", "GPSLatitude", 1, TagValue::F64(47.0))
+    m.write_value_doc(1, 0, "QuickTime", "GPSLatitude", 1, TagValue::F64(47.0))
       .unwrap();
-    m.write_value_doc(2, "QuickTime", "GPSLatitude", 1, TagValue::F64(-33.0))
+    m.write_value_doc(2, 0, "QuickTime", "GPSLatitude", 1, TagValue::F64(-33.0))
       .unwrap();
-    m.write_value_doc(0, "QuickTime", "TimeScale", 1, TagValue::U64(600))
+    m.write_value_doc(0, 0, "QuickTime", "TimeScale", 1, TagValue::U64(600))
       .unwrap();
-    m.write_value_doc(0, "QuickTime", "TimeScale", 1, TagValue::U64(1000))
+    m.write_value_doc(0, 0, "QuickTime", "TimeScale", 1, TagValue::U64(1000))
       .unwrap();
     assert_eq!(m.entries().len(), 3);
-    let doc2 = m.entries().iter().filter(|(d, _, _, _, _)| *d == 2).count();
+    let doc2 = m
+      .entries()
+      .iter()
+      .filter(|(d, _, _, _, _, _)| *d == 2)
+      .count();
     assert_eq!(doc2, 1);
   }
 
@@ -449,50 +463,50 @@ mod tests {
   fn tagmap_priority_dedup_general_rule() {
     // (a) Higher priority OVERRIDES the lower (2 >= 1, non-zero) ⇒ last wins.
     let mut m = TagMap::new();
-    m.insert(0, "G", "P", 1, TagValue::U64(1));
-    m.insert(0, "G", "P", 2, TagValue::U64(2));
+    m.insert(0, 0, "G", "P", 1, TagValue::U64(1));
+    m.insert(0, 0, "G", "P", 2, TagValue::U64(2));
     assert_eq!(m.get("G", "P"), Some(&TagValue::U64(2)));
 
     // (a') ...and the SURVIVING priority is the higher one, so a later
     // priority-1 duplicate can NOT override it (1 >= 2 is false).
-    m.insert(0, "G", "P", 1, TagValue::U64(3));
+    m.insert(0, 0, "G", "P", 1, TagValue::U64(3));
     assert_eq!(m.get("G", "P"), Some(&TagValue::U64(2)));
 
     // (b) A priority-0 duplicate NEVER overrides (0 != 0 is false) ⇒ first wins.
     let mut m = TagMap::new();
-    m.insert(0, "G", "Q", 1, TagValue::U64(10));
-    m.insert(0, "G", "Q", 0, TagValue::U64(99));
+    m.insert(0, 0, "G", "Q", 1, TagValue::U64(10));
+    m.insert(0, 0, "G", "Q", 0, TagValue::U64(99));
     assert_eq!(m.get("G", "Q"), Some(&TagValue::U64(10)));
 
     // (b') Two priority-0 entries: neither overrides (`0 != 0` is false), so the
     // first-extracted wins — the `Warning`/`Error` collision case.
     let mut m = TagMap::new();
-    m.insert(0, "G", "R", 0, TagValue::U64(1));
-    m.insert(0, "G", "R", 0, TagValue::U64(2));
+    m.insert(0, 0, "G", "R", 0, TagValue::U64(1));
+    m.insert(0, 0, "G", "R", 0, TagValue::U64(2));
     assert_eq!(m.get("G", "R"), Some(&TagValue::U64(1)));
 
     // (c) Two ordinary priority-1 entries ⇒ faithful last-wins (1 >= 1).
     let mut m = TagMap::new();
-    m.insert(0, "G", "S", 1, TagValue::U64(1));
-    m.insert(0, "G", "S", 1, TagValue::U64(2));
+    m.insert(0, 0, "G", "S", 1, TagValue::U64(1));
+    m.insert(0, 0, "G", "S", 1, TagValue::U64(2));
     assert_eq!(m.get("G", "S"), Some(&TagValue::U64(2)));
 
     // (d) The `Warning`/`Error` NAME fallback: a producer passing the default
     // priority `1` still gets effective-priority-0 first-wins.
     let mut m = TagMap::new();
-    m.insert(0, "G", "Warning", 1, TagValue::Str("first".into()));
-    m.insert(0, "G", "Warning", 1, TagValue::Str("second".into()));
+    m.insert(0, 0, "G", "Warning", 1, TagValue::Str("first".into()));
+    m.insert(0, 0, "G", "Warning", 1, TagValue::Str("second".into()));
     assert_eq!(m.get("G", "Warning"), Some(&TagValue::Str("first".into())));
 
     // First-occurrence POSITION is always preserved across overrides.
     let mut m = TagMap::new();
-    m.insert(0, "G", "A", 1, TagValue::U64(1));
-    m.insert(0, "G", "B", 1, TagValue::U64(1));
-    m.insert(0, "G", "A", 2, TagValue::U64(9)); // overrides A in place
+    m.insert(0, 0, "G", "A", 1, TagValue::U64(1));
+    m.insert(0, 0, "G", "B", 1, TagValue::U64(1));
+    m.insert(0, 0, "G", "A", 2, TagValue::U64(9)); // overrides A in place
     let names: std::vec::Vec<&str> = m
       .entries()
       .iter()
-      .map(|(_, _, n, _, _)| n.as_str())
+      .map(|(_, _, _, n, _, _)| n.as_str())
       .collect();
     assert_eq!(names, ["A", "B"]);
   }

--- a/src/value.rs
+++ b/src/value.rs
@@ -427,6 +427,14 @@ pub struct Group {
   /// ExifTool family-3 sub-document: `0` = Main, `N` = `Doc<N>` (the per-sample
   /// document index for `-ee` timed metadata). Almost every group is `0`.
   doc: u32,
+  /// The SECOND-level sub-document index for the GoPro GPMF `ProcessString`
+  /// shape only (`0` = none → render `Doc<N>`; `M > 0` → render `Doc<N>-<M>`,
+  /// GoPro.pm:759-774). ExifTool's `ProcessString` keeps the parent `DOC_NUM`
+  /// and splits each subsequent row of a multi-row `GPS5`/`GPS9` record into
+  /// `"$docNum-$subDoc"`; this is the only source in the port that emits the
+  /// two-level form. Every other group is `0` here (rendered as the ordinary
+  /// `Doc<N>`), so this is purely additive — no existing golden carries it.
+  doc_sub: u32,
 }
 
 impl Group {
@@ -438,6 +446,7 @@ impl Group {
       family0: family0.into(),
       family1: family1.into(),
       doc: 0,
+      doc_sub: 0,
     }
   }
 
@@ -449,6 +458,28 @@ impl Group {
       family0: family0.into(),
       family1: family1.into(),
       doc,
+      doc_sub: 0,
+    }
+  }
+
+  /// A two-level sub-document (`Doc<N>-<M>`) group — the GoPro GPMF
+  /// `ProcessString` per-row split (GoPro.pm:759-774). `sub == 0` is the parent
+  /// `Doc<N>` (identical to [`Self::with_doc`]); `sub > 0` renders `Doc<N>-<M>`.
+  /// Used ONLY by the GoPro `gpmd` timed-metadata emitter for the subsequent
+  /// rows of a multi-row `GPS5`/`GPS9` record.
+  #[must_use]
+  #[inline(always)]
+  pub fn with_subdoc(
+    family0: impl Into<SmolStr>,
+    family1: impl Into<SmolStr>,
+    doc: u32,
+    sub: u32,
+  ) -> Self {
+    Self {
+      family0: family0.into(),
+      family1: family1.into(),
+      doc,
+      doc_sub: sub,
     }
   }
 
@@ -471,6 +502,15 @@ impl Group {
   #[inline(always)]
   pub const fn doc(&self) -> u32 {
     self.doc
+  }
+
+  /// The SECOND-level sub-document index (`0` = none → `Doc<N>`; `M > 0` →
+  /// `Doc<N>-<M>`). Non-zero only for the GoPro GPMF `ProcessString` per-row
+  /// split (GoPro.pm:759-774).
+  #[must_use]
+  #[inline(always)]
+  pub const fn doc_sub(&self) -> u32 {
+    self.doc_sub
   }
 }
 

--- a/tests/quicktime_stream.rs
+++ b/tests/quicktime_stream.rs
@@ -732,6 +732,54 @@ fn quicktime_gopro_gpmf_projects_camera_and_gps_into_media_metadata() {
 }
 
 #[test]
+fn quicktime_gopro_hero8_timed_gpmd_projects_gps_into_media_metadata() {
+  // #211 finding 1 — REAL GoPro HERO8 file whose GPS lives ONLY in the timed
+  // `gpmd` track (`Track4:GPS*`, decoded into `GoProTimedMeta`); the `udta/GPMF`
+  // box carries camera identity but NO `GPS5`/`GPS9` (no `GoPro:GPSLatitude` in
+  // the default golden). The always-on `MediaMetadata` projection must still
+  // surface the timed GpsLocation — this is the product's actual output and was
+  // the regression the finding flagged. NOTE: the typed `GpsLocation` carries
+  // decimal degrees (the `GPS::ToDMS` PrintConv is deferred); the `-ee` golden's
+  // `42 deg 1' 35.85" N` / `129 deg 17' 39.62" W` / `9540.24 m` are the first fix.
+  let data = fixture("QuickTime_gopro_hero8_gpmf.mp4");
+  let meta = parse_quicktime(&data).expect("recognized");
+
+  // The flat `udta/GPMF` box surfaced camera identity but no GPS coordinates.
+  assert!(!meta.gopro().is_empty(), "udta/GPMF identity present");
+  assert!(
+    meta.gopro().first_fix().is_none(),
+    "the udta/GPMF box carries NO GPS5/GPS9 fix (GPS is only in the gpmd track)"
+  );
+  // The timed gpmd samples are accessible via the public accessor and carry GPS.
+  let timed = meta.gopro_timed();
+  assert!(!timed.is_empty(), "the gpmd timed samples decoded");
+  assert!(
+    timed.first_fix().is_some(),
+    "a timed gpmd sample carries a GPS coordinate fix"
+  );
+
+  // The always-on projection now surfaces the timed GPS (the finding-1 fix).
+  let md = meta.media_metadata();
+  let cam = md.camera().expect("GoPro CameraInfo projected");
+  assert_eq!(cam.make(), Some("GoPro"));
+  let gps = md
+    .gps()
+    .expect("GpsLocation projected from the timed gpmd track");
+  // 42 deg 1' 35.85" N = 42.026625; 129 deg 17' 39.62" W = -129.294339.
+  assert!(
+    (gps.latitude().unwrap() - 42.026_625).abs() < 1e-4,
+    "lat {:?}",
+    gps.latitude()
+  );
+  assert!(
+    (gps.longitude().unwrap() + 129.294_339).abs() < 1e-4,
+    "lon {:?}",
+    gps.longitude()
+  );
+  assert!((gps.altitude_m().unwrap() - 9540.24).abs() < 1e-1);
+}
+
+#[test]
 fn quicktime_gopro_gpmf_emits_gopro_group_tags_speed_in_kph() {
   // SP4 — the golden `Meta::tags()` path emits the GoPro GPMF tags under
   // family-0/family-1 `GoPro` (the `%GoPro::GPMF`/`GPS5` tables,

--- a/tests/timed_metadata_conformance.rs
+++ b/tests/timed_metadata_conformance.rs
@@ -209,6 +209,80 @@ fn gsen_ee_byte_exact() {
   check_ee("QuickTime_gsen.mov", "QuickTime_gsen.mov.ee.g3.json", true);
 }
 
+/// Real GoPro HERO8 Black MP4 (GoPro's official `gpmf-parser` `samples/hero8.mp4`,
+/// 4.2 MB, 12.6 s) — the `gpmd` timed-GPS `Doc<N>` port (#211 / #189). The
+/// `gpmd` `trak` (Track4) carries one GPMF `DEVC` per sample; ExifTool emits the
+/// full per-sample sensor/GPS block under `Track4:` in `-ee` mode (one `Doc<N>`
+/// per sample, the multi-row `GPS5` rows split into `Doc<N>-<M>` by
+/// `ProcessString`, GoPro.pm:759-774). The `fdsc` `trak` (Track5) is a second
+/// per-sample source (the `GoPro::fdsc` identity block). At `-ee -G1` the doc
+/// axis collapses first-wins to the first sample's block; at `-ee -G3:1` every
+/// `Doc<N>` / `Doc<N>-<M>` is its own row. Byte-exact vs bundled ExifTool 13.59.
+///
+/// NOTE: the DEFAULT (no-`ee`) `.json` is NOT byte-exact yet — its residual gap
+/// is the QuickTime *container* classes (`colr`/`tmcd`/`gmhd`/`tref`/`Gen*`/
+/// `ColorProfiles`/`VideoFrameRate`/`TimecodeTrack`), later container phases —
+/// so `quicktime_gopro_hero8_gpmf_conformance` (the no-`ee` path) stays
+/// `#[ignore]`d. This `-ee` test exercises the gpmd `Doc<N>` port that #211
+/// adds: with `-ee` the per-sample GPMF timed block is what changes, and it IS
+/// byte-exact.
+/// The QuickTime *container* tags the hero8 goldens carry that exifast does not
+/// yet emit — the SAME residual gap as the no-`ee` `.json` conformance, and
+/// ENTIRELY outside the #211 `gpmd` timed-`Doc<N>` scope: the `colr` color
+/// profile (`ColorProfiles`/`ColorPrimaries`/`TransferCharacteristics`/
+/// `MatrixCoefficients`/`VideoFullRangeFlag`), the `tref` `TimecodeTrack`, the
+/// `gmhd`/`gmin`/`text` GenMediaHeader (`Gen*`/`TextFont`/`FontName`/…), the
+/// `stts`-derived `VideoFrameRate`/`PlaybackFrameRate`, and the `vmhd`
+/// GraphicsMode/OpColor — all later QuickTime-container phases. Dropping these
+/// from BOTH sides isolates the `gpmd`/`fdsc` timed `Doc<N>` stream this test
+/// pins, which IS byte-exact. (NOT `SampleTime`/`SampleDuration` — those are
+/// emitted correctly for the gpmd/fdsc tracks here.)
+const HERO8_CONTAINER_EXCL: &[&str] = &[
+  "TimecodeTrack",
+  "GraphicsMode",
+  "OpColor",
+  "ColorProfiles",
+  "ColorPrimaries",
+  "TransferCharacteristics",
+  "MatrixCoefficients",
+  "VideoFullRangeFlag",
+  "VideoFrameRate",
+  "GenMediaVersion",
+  "GenFlags",
+  "GenGraphicsMode",
+  "GenOpColor",
+  "GenBalance",
+  "TextFont",
+  "TextFace",
+  "TextSize",
+  "TextColor",
+  "BackgroundColor",
+  "FontName",
+  "PlaybackFrameRate",
+];
+
+#[test]
+fn gopro_hero8_gpmd_ee_byte_exact() {
+  // `-ee -G1`: the doc axis collapsed first-wins — Track4's first `DEVC` block
+  // (DeviceName, the sensor streams, the GPS scalars, the first `GPS5` row's
+  // lat/lon/alt/speed) + Track5's `fdsc` identity — byte-exact once the
+  // out-of-scope QuickTime container tails are dropped from both sides.
+  check_ee_excluding(
+    "QuickTime_gopro_hero8_gpmf.mp4",
+    "QuickTime_gopro_hero8_gpmf.mp4.ee.json",
+    false,
+    HERO8_CONTAINER_EXCL,
+  );
+  // `-ee -G3:1`: every gpmd sample as its own `Doc<N>` (the `GPS5` rows split
+  // into `Doc<N>-<M>`), Track5's `fdsc` as the final `Doc<N>`, byte-exact.
+  check_ee_excluding(
+    "QuickTime_gopro_hero8_gpmf.mp4",
+    "QuickTime_gopro_hero8_gpmf.mp4.ee.g3.json",
+    true,
+    HERO8_CONTAINER_EXCL,
+  );
+}
+
 // ── Track<N>: camm (Android CAMM — per-sample Track<N>, via track_index) ─────
 // SampleTime / SampleDuration ARE emitted (one per camm SAMPLE, off the
 // sample-table timing threaded onto each sample's records) and compared; every


### PR DESCRIPTION
Ports GoPro **gpmd-track timed GPS** as a per-sample Doc<N> source (the camm/rtmd/insta360 pattern), closing #211 + #189. Each gpmd DEVC → one global Doc<N>; GPS5/GPS9 + sensor data emit per-sample at `-ee` (gated), while the always-on udta/GPMF `GoPro:` path is untouched (also fixes a pre-existing no-ee leak that clobbered `GoPro:DeviceName`). gpmd-trak tags group under `Track<N>:` (#189) via a new `doc_sub` axis for the GPS5/GPS9 per-row split.

The timed GPS + camera identity now reach the typed **`MediaMetadata`** projection (the product's normalized output) — hero8's GPS (lat 42.026625 / lon −129.294339 / alt 9540.24) surfaces via `media_metadata().gps()`, mirroring the camm/rtmd first-fix projection.

## Through 5 review rounds (each a real edge)
- R1: the Doc<N> retrofit + -ee gating + Track<N>/doc_sub + the family-3 %noDups (first-doc last-wins / subsequent first-wins).
- R2: timed GPS → MediaMetadata projection (was dropped for gpmd-only files); per-key noDups (was document-wide).
- R3–R5: the empty-identity shadowing class — domain-split projection, then a uniform non-empty rule across predicate AND projection (an empty MINF falls back to DVNM; no make-only `CameraInfo` stamp), with an exhaustive combination proof.

## Verify
`fmt=0  build(-Dwarnings)=0  conformance=426/0  timed_metadata=127/0 (hero8 .ee + .ee-g3 byte-exact)  typed_serde=531  quicktime_stream=47/0  lib=3230/0`

The 4 existing GoPro fixtures stay byte-identical. hero8 stays typed_serde NOT_ACTIVE for its no-ee QuickTime-container tags (32 keys: colr/tmcd/gmhd/tref/…, later container phases) — the timed GPS is byte-exact at `-ee`.

**Codex adversarial review: APPROVE (R5).**