### PR TITLE
feat(composite): generic Composite-tag engine core + migrate Composite:Duration (#133)

### DIFF
--- a/src/composite/convs/mod.rs
+++ b/src/composite/convs/mod.rs
@@ -1,0 +1,179 @@
+//! The canonical ExifTool `ConvertDuration` (ExifTool.pm:6877-6895) and the
+//! Perl number-stringification primitives the Composite engine and the
+//! cross-format duration callers share.
+//!
+//! Before the Composite engine existed, three independent transliterations of
+//! `ConvertDuration` lived in the tree (`datetime::convert_duration`,
+//! `convert::write_convert_duration`, and an APE-local copy). The APE copy was
+//! the most faithful — it keeps the `$h`/`$m`/`$s` and the days carve-out as
+//! Perl NV (f64) scalars throughout and stringifies them with Perl's default
+//! number-to-string rule (`perl_nv_str`), so it reproduces the extreme-input
+//! goldens (`APE_u64_days`, `AIFF_huge_duration`, `APE_two63_boundary`) that an
+//! `as i64` cast corrupts by saturating at `i64::MAX`. This module promotes
+//! that faithful impl to the one canonical [`convert_duration`]; the former
+//! entry points are now thin aliases over it (`convert::write_convert_duration`,
+//! `datetime::convert_duration`) so the Real / MXF / MOI / M2TS / Flash callers
+//! keep their signatures.
+
+#[cfg(feature = "alloc")]
+use crate::value::TagValue;
+
+/// `ConvertDuration($time)` (ExifTool.pm:6877-6895) — the canonical
+/// transliteration.
+///
+/// ```text
+/// return $time unless IsFloat($time);          # non-finite: stringify Inf/-Inf/NaN
+/// return '0 s' if $time == 0;
+/// my $sign = ($time > 0 ? '' : (($time = -$time), '-'));
+/// return sprintf("$sign%.2f s", $time) if $time < 30;
+/// $time += 0.5;                                 # round to nearest second
+/// my $h = int($time / 3600); $time -= $h * 3600;
+/// my $m = int($time / 60);   $time -= $m * 60;
+/// if ($h > 24) { my $d = int($h / 24); $h -= $d * 24; $sign = "$sign$d days "; }
+/// return sprintf("$sign%d:%.2d:%.2d", $h, $m, int($time));
+/// ```
+///
+/// A NON-FINITE input fails Perl's `IsFloat` regex (its stringified form
+/// `Inf`/`-Inf`/`NaN` is not a float literal), so `ConvertDuration` returns the
+/// scalar unchanged and it stringifies to Perl's titlecase casing via
+/// [`crate::value::perl_nonfinite_str`] — NOT Rust's lowercase `inf`.
+///
+/// `int()` is truncate-toward-zero on a Perl NV (f64): the magnitude is kept as
+/// f64 through the modulo arithmetic and the days carve-out, and only the
+/// already-reduced small remainders are formatted. The days count `$d` and the
+/// post-carve hours `$h` are stringified with Perl's default NV rule
+/// ([`perl_nv_str`]) — exact decimal up to `u64::MAX`, then `%.15g` — so a huge
+/// finite duration prints the same bytes ExifTool does (`"…e+20 days 0:00:00"`,
+/// `"10000000000000002048 days -32768:00:00"`).
+#[must_use]
+pub fn convert_duration(time: f64) -> String {
+  // ExifTool.pm:6879 `return $time unless IsFloat($time)`. A non-finite f64 is
+  // not IsFloat; Perl returns it unchanged and it stringifies with titlecase
+  // `Inf`/`-Inf`/`NaN`.
+  if !time.is_finite() {
+    return crate::value::perl_nonfinite_str(time)
+      .unwrap_or("NaN")
+      .to_string();
+  }
+  // ExifTool.pm:6880 `return '0 s' if $time == 0`.
+  if time == 0.0 {
+    return "0 s".to_string();
+  }
+  // ExifTool.pm:6881 `$sign = ($time > 0 ? '' : (($time = -$time), '-'))`.
+  let (sign, t) = if time > 0.0 { ("", time) } else { ("-", -time) };
+  // ExifTool.pm:6882 `return sprintf("$sign%.2f s", $time) if $time < 30`.
+  if t < 30.0 {
+    return format!("{sign}{t:.2} s");
+  }
+  // ExifTool.pm:6883 `$time += 0.5` — round to nearest second.
+  let mut rounded = t + 0.5;
+  // ExifTool.pm:6884-6887 `$h = int($time/3600); $time -= $h*3600; ...`. Keep
+  // h/m/s as f64 (Perl NV); `int()` ⇒ `f64::trunc` (truncate toward zero).
+  let h_f = (rounded / 3600.0).trunc();
+  rounded -= h_f * 3600.0;
+  let m_f = (rounded / 60.0).trunc();
+  rounded -= m_f * 60.0;
+  let s_f = rounded.trunc(); // `int($time)` of the remaining seconds
+  // ExifTool.pm:6888-6892 days carve-out (`$h > 24`).
+  if h_f > 24.0 {
+    let d_f = (h_f / 24.0).trunc();
+    let h_remainder = h_f - d_f * 24.0;
+    // `"$sign$d days "` then `sprintf("%d:%.2d:%.2d", $h, $m, int($time))`.
+    // `$d` and the post-carve `$h` are Perl NV ⇒ `perl_nv_str`; `$m`/`$s` are
+    // small (always in `0..60`) ⇒ zero-padded.
+    return format!(
+      "{sign}{d} days {h}:{m}:{s}",
+      d = perl_nv_str(d_f),
+      h = perl_nv_str(h_remainder),
+      m = perl_int_str_padded(m_f, 2),
+      s = perl_int_str_padded(s_f, 2),
+    );
+  }
+  // ExifTool.pm:6893 final `sprintf("$sign%d:%.2d:%.2d", $h, $m, int($time))`.
+  format!(
+    "{sign}{h}:{m}:{s}",
+    h = perl_nv_str(h_f),
+    m = perl_int_str_padded(m_f, 2),
+    s = perl_int_str_padded(s_f, 2),
+  )
+}
+
+/// Perl default NV (number-in-string-context) stringification:
+/// `sprintf("%.15g", $nv)` for finite values, with an exact-decimal carve-out
+/// for any integer-valued f64 that fits Perl's signed (`i64`) or unsigned
+/// (`u64`) integer range. Special values spell `Inf` / `-Inf` / `NaN`.
+///
+/// Empirically against Perl 5: `int(1e19) ⇒ "10000000000000000000"` (decimal,
+/// above `i64::MAX`), `int(u64::MAX as f64) ⇒ "18446744073709551615"`, and
+/// `int(1.84467440737096e19) ⇒ "1.84467440737096e+19"` (above `u64` ⇒
+/// scientific). The signed/unsigned split is taken at the exact f64
+/// power-of-two boundary `2^63`, because `i64::MAX as f64` rounds UP to `2^63`
+/// (so `n as i64` would saturate to `2^63 - 1`, losing one).
+#[must_use]
+pub fn perl_nv_str(n: f64) -> String {
+  if n.is_nan() {
+    return "NaN".to_string();
+  }
+  if n.is_infinite() {
+    return if n.is_sign_negative() { "-Inf" } else { "Inf" }.to_string();
+  }
+  let two63 = (1u128 << 63) as f64; // exactly 9223372036854775808.0
+  let two64 = (1u128 << 64) as f64; // exactly 18446744073709551616.0
+  // Signed-integer carve-out: integer-valued f64 in [i64::MIN, 2^63),
+  // EXCLUDING 2^63 (`n as i64` would saturate to i64::MAX = 2^63 - 1).
+  if n == n.trunc() && n >= i64::MIN as f64 && n < two63 {
+    return (n as i64).to_string();
+  }
+  // Unsigned-integer carve-out: positive integer-valued f64 in [2^63, 2^64).
+  if n == n.trunc() && n >= two63 && n < two64 {
+    return (n as u64).to_string();
+  }
+  crate::value::format_g(n, 15)
+}
+
+/// Left-pad an integer-valued, in-`i64`-range, non-negative `n` to `width`
+/// with leading zeros (`5` → `"05"` at width 2). Out-of-range / non-integer
+/// values fall back to [`perl_nv_str`] (impossible for `ConvertDuration`'s
+/// minutes/seconds, which are always in `0..60`, but kept faithful).
+#[must_use]
+pub fn perl_int_str_padded(n: f64, width: usize) -> String {
+  if n.is_finite() && (0.0..i64::MAX as f64).contains(&n) && n == n.trunc() {
+    let iv = n as i64;
+    format!("{iv:0width$}")
+  } else {
+    perl_nv_str(n)
+  }
+}
+
+/// The post-arithmetic `Composite:Duration` value as the sink should store it,
+/// for the active conversion mode.
+///
+/// `raw` is the result of the def's RawConv/ValueConv arithmetic (the APE
+/// `((tf-1)*bpf+ffb)/sr`, the FLAC/AIFF `frames/sr`). Under `-n`
+/// ([`ConvMode::ValueConv`](crate::emit::ConvMode::ValueConv)) the sink stores
+/// the raw scalar (a finite f64 as a bare number, a non-finite f64 as the
+/// quoted Perl string). Under `-j`
+/// ([`ConvMode::PrintConv`](crate::emit::ConvMode::PrintConv)) the PrintConv
+/// `ConvertDuration($val)` runs — a finite value formats, a non-finite value
+/// passes through `IsFloat`-unchanged to the same quoted Perl string. This is
+/// the single place the three migrated formats agreed on (APE stored a
+/// `Str("Inf")` for non-finite, FLAC/AIFF a bare f64 for finite).
+#[cfg(feature = "alloc")]
+#[must_use]
+pub(crate) fn duration_value(raw: f64, mode: crate::emit::ConvMode) -> TagValue {
+  if !raw.is_finite() {
+    // Both modes emit the titlecase Perl string (quoted by EscapeJSON).
+    return TagValue::Str(
+      crate::value::perl_nonfinite_str(raw)
+        .unwrap_or("NaN")
+        .into(),
+    );
+  }
+  match mode {
+    crate::emit::ConvMode::PrintConv => TagValue::Str(convert_duration(raw).into()),
+    crate::emit::ConvMode::ValueConv => TagValue::F64(raw),
+  }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/composite/convs/tests.rs
+++ b/src/composite/convs/tests.rs
@@ -1,0 +1,124 @@
+//! Unit tests for the canonical [`convert_duration`] and its Perl
+//! number-stringification primitives — including the extreme-input cases the
+//! migrated APE/AIFF goldens pin (huge-days carve-out, `2^63` boundary,
+//! non-finite passthrough).
+
+use super::*;
+
+#[test]
+fn convert_duration_zero_and_sub_30() {
+  assert_eq!(convert_duration(0.0), "0 s");
+  assert_eq!(convert_duration(2.63922902494331), "2.64 s");
+  assert_eq!(convert_duration(14.7127916666667), "14.71 s");
+  assert_eq!(convert_duration(-2.5), "-2.50 s");
+}
+
+#[test]
+fn convert_duration_hms_and_rounding() {
+  // FLAC_duration: 240000/8000 = 30 → "0:00:30".
+  assert_eq!(convert_duration(30.0), "0:00:30");
+  // AIFF_duration: 44100/22050 = 2 → "2.00 s" (< 30, the `%.2f s` path).
+  assert_eq!(convert_duration(2.0), "2.00 s");
+  assert_eq!(convert_duration(5400.0), "1:30:00");
+  // +0.5 rounding to the nearest second.
+  assert_eq!(convert_duration(59.6), "0:01:00");
+}
+
+#[test]
+fn convert_duration_days_carve_out_faithful() {
+  // AIFF_huge_duration golden: a huge finite duration prints `$d` via `%.15g`.
+  assert_eq!(
+    convert_duration(1.93428131138341e25),
+    "2.23875151780487e+20 days 0:00:00"
+  );
+  // APE_huge_composite golden.
+  assert_eq!(
+    convert_duration(9.99999999999999e29),
+    "1.15740740740741e+25 days 0:00:00"
+  );
+}
+
+#[test]
+fn convert_duration_non_finite_titlecase() {
+  assert_eq!(convert_duration(f64::INFINITY), "Inf");
+  assert_eq!(convert_duration(f64::NEG_INFINITY), "-Inf");
+  assert_eq!(convert_duration(f64::NAN), "NaN");
+}
+
+#[test]
+fn perl_nv_str_matches_perl_default_stringify() {
+  // Finite integers in safe IV range ⇒ exact decimal (matches Perl
+  // `print 1e10 . "\n"` ⇒ `10000000000`).
+  assert_eq!(perl_nv_str(0.0), "0");
+  assert_eq!(perl_nv_str(42.0), "42");
+  assert_eq!(perl_nv_str(1.0e10), "10000000000");
+  assert_eq!(perl_nv_str(1.0e15), "1000000000000000");
+  // Negative integer in safe IV range.
+  assert_eq!(perl_nv_str(-42.0), "-42");
+  assert_eq!(perl_nv_str(-32768.0), "-32768");
+  // Outside IV range ⇒ Perl `%.15g` (e.g. `1e25/24/3600` ≈ 1.157e+20).
+  assert_eq!(perl_nv_str(1.0e25 / 24.0 / 3600.0), "1.15740740740741e+20");
+  assert_eq!(perl_nv_str(1.0e25), "1e+25");
+  // Fractional values use `%.15g`.
+  assert_eq!(perl_nv_str(2.5), "2.5");
+  // Special values.
+  assert_eq!(perl_nv_str(f64::INFINITY), "Inf");
+  assert_eq!(perl_nv_str(f64::NEG_INFINITY), "-Inf");
+  assert_eq!(perl_nv_str(f64::NAN), "NaN");
+  // Positive integer-valued f64 in (i64::MAX, u64::MAX] ⇒ DECIMAL (Perl's UV
+  // path), NOT scientific. Boundaries empirically verified against Perl 5:
+  //   int(1e19) ⇒ "10000000000000000000"
+  //   int(1.5e19) ⇒ "15000000000000000000"
+  //   int(2^64-2048) ⇒ "18446744073709549568" (largest f64 below 2^64)
+  //   int(2^64) ⇒ "1.84467440737096e+19" (scientific, > u64::MAX)
+  assert_eq!(perl_nv_str(1.0e19), "10000000000000000000");
+  assert_eq!(perl_nv_str(1.5e19), "15000000000000000000");
+  assert_eq!(perl_nv_str(18446744073709549568.0), "18446744073709549568");
+  let two64 = (1u128 << 64) as f64;
+  assert_eq!(perl_nv_str(two64), "1.84467440737096e+19");
+  // The duration helper's worst-case path: 8.64e23 → days = 1e19.
+  let days_at_864e23 = (8.64e23_f64 / 3600.0 / 24.0).trunc();
+  assert_eq!(perl_nv_str(days_at_864e23), "10000000000000002048");
+  // `i64::MAX as f64` rounds UP to 2^63; exactly-2^63 must go via the UV path
+  // (`"9223372036854775808"`), NOT the saturating signed `"…807"`.
+  let two63 = (1u128 << 63) as f64;
+  assert_eq!(perl_nv_str(two63), "9223372036854775808");
+  // 2^63 - 1024 (representable as f64) goes via the signed path.
+  assert_eq!(perl_nv_str(9223372036854774784.0), "9223372036854774784");
+}
+
+#[test]
+fn perl_int_str_padded_in_range_pads_with_zeros() {
+  // ConvertDuration's m/s values are always in [0, 60) ⇒ `%02d` zero-pads.
+  assert_eq!(perl_int_str_padded(0.0, 2), "00");
+  assert_eq!(perl_int_str_padded(5.0, 2), "05");
+  assert_eq!(perl_int_str_padded(59.0, 2), "59");
+  // In-range but wider than `width` ⇒ the full number.
+  assert_eq!(perl_int_str_padded(100.0, 2), "100");
+  // Out-of-range or fractional ⇒ fall through to perl_nv_str.
+  assert_eq!(perl_int_str_padded(f64::INFINITY, 2), "Inf");
+  assert_eq!(perl_int_str_padded(1.5, 2), "1.5");
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn duration_value_modes() {
+  use crate::emit::ConvMode;
+  use crate::value::TagValue;
+  assert_eq!(
+    duration_value(30.0, ConvMode::PrintConv),
+    TagValue::Str("0:00:30".into())
+  );
+  assert_eq!(
+    duration_value(30.0, ConvMode::ValueConv),
+    TagValue::F64(30.0)
+  );
+  assert_eq!(
+    duration_value(f64::INFINITY, ConvMode::PrintConv),
+    TagValue::Str("Inf".into())
+  );
+  assert_eq!(
+    duration_value(f64::INFINITY, ConvMode::ValueConv),
+    TagValue::Str("Inf".into())
+  );
+}

--- a/src/composite/mod.rs
+++ b/src/composite/mod.rs
@@ -1,0 +1,382 @@
+//! The generic ExifTool Composite-tag engine (a faithful transliteration of
+//! `Image::ExifTool::BuildCompositeTags`, ExifTool.pm:3976-4162).
+//!
+//! ExifTool builds Composite tags AFTER all format extraction completes
+//! (`ExifTool.pm:4577`, inside `ExtractInfo` once `$$opts{Composite}` is on —
+//! default ON, `ExifTool.pm:1125`). exifast mirrors that ordering: the format
+//! tag stream is driven into the [`TagMap`](crate::tagmap::TagMap) by
+//! [`run_emission`](crate::emit::run_emission), and then — as a STANDALONE
+//! post-pass — [`build_composites`] reads the FINAL emitted tag set, resolves
+//! each registered [`CompositeDef`]'s `Require`/`Desire`/`Inhibit` inputs
+//! against it, runs the derivation, and APPENDS the surviving composites. Being
+//! appended after every format tag preserves their positional last-ness (the
+//! `Composite:Duration` goldens have it as the final key).
+//!
+//! ## The fixpoint
+//!
+//! ExifTool loops until no def is deferred. A def that references another
+//! `Composite:Name` not yet built is pushed onto `@deferredTags` and retried in
+//! the next pass; if a whole pass defers everything, ExifTool tries ONE more
+//! pass ignoring `Inhibit`-on-Composite (the `$allBuilt` flag) and then warns
+//! `Circular dependency in Composite tags`. The defs are walked in
+//! prefixed-id sort order (`Module-Name`) so the build is deterministic
+//! regardless of registry order.
+//!
+//! ## Input model — presence vs value
+//!
+//! ExifTool resolves each `Require`/`Desire`/`Inhibit` input by PRESENCE
+//! (`defined $val[i]`, ExifTool.pm:4044-4087): a present `Inhibit` of ANY value
+//! suppresses; a missing `Require` aborts; a missing `Desire` is an `undef`
+//! element. Only AFTER an input survives does the def's `RawConv`/`ValueConv`
+//! coerce the actual value. exifast mirrors that split: [`CompositeSink::
+//! resolve`] returns a [`CompositeValue`](table::CompositeValue) — `Present`
+//! carrying the ingredient's RAW (post-`ValueConv`) [`TagValue`], or `Missing`
+//! — and the build loop keys Inhibit/Require/Desire on `is_present()`, NOT on
+//! numeric coercibility. So a present-but-non-numeric ingredient (a STRING —
+//! GPS refs `N`/`S`/`E`/`W`, `DateStamp`, `TimeStamp`, the ingredients the GPS /
+//! EXIF / datetime defs added by later #133 PRs read) is correctly seen as
+//! PRESENT, and a string `Inhibitor` correctly suppresses. Each
+//! [`CompositeDef::derive`](table::CompositeDef) then does its OWN coercion: the
+//! Duration defs coerce numeric and apply the Perl-truthy `&&` guard on the raw
+//! value; future string defs read the string directly. This keeps ONE input
+//! model general for PRs 2-5.
+//!
+//! ## Inputs resolve from the RAW value, independent of `-j`/`-n`
+//!
+//! ExifTool's `BuildCompositeTags` reads each input's ValueConv value for
+//! `$val[i]` (`GetValue($tag, 'ValueConv')`, ExifTool.pm:4112) REGARDLESS of the
+//! requested output conversion — the composite's own `RawConv`/`ValueConv` runs
+//! on the machine value, never the printed form. exifast mirrors this: under
+//! `-n` the emitted sink already holds the raw ValueConv values, so it is its
+//! own resolution view; under `-j` the sink holds PrintConv strings, so the
+//! caller re-emits the Meta in ValueConv mode into a separate `raw_view` and the
+//! engine resolves inputs (and Composite-dependencies) from THAT, while each
+//! composite's RENDERED (`-j`) value still lands in the output sink. (A
+//! composite's PrintConv form `$prt[i]`, needed by e.g. `GPSPosition`'s
+//! PrintConv in a later #133 PR, is not wired yet — no PR-1 composite reads it;
+//! it slots in as a parallel per-input lookup.)
+
+pub mod convs;
+mod table;
+
+#[cfg(feature = "alloc")]
+use crate::tagmap::TagMap;
+#[cfg(feature = "alloc")]
+use crate::value::TagValue;
+#[cfg(feature = "alloc")]
+use table::{CompositeDef, CompositePrintConv, CompositeValue, REGISTRY};
+
+/// A dedup sink the Composite engine reads inputs from and appends results to.
+/// Implemented by [`TagMap`](crate::tagmap::TagMap) (the JSON / golden path) and
+/// by the [`Tag`](crate::value::Tag) `Vec` ([`iter_tags`](crate::format_parser
+/// ::AnyMeta::iter_tags) path) so ONE fixpoint engine serves both.
+#[cfg(feature = "alloc")]
+trait CompositeSink {
+  /// The LAST-emitted Main-document value whose family-1 group is in `groups`
+  /// (or ANY group when `groups` is empty) and whose name is `name`, as a
+  /// [`CompositeValue`] carrying the RAW stored [`TagValue`]
+  /// ([`Present`](CompositeValue::Present)) — NOT pre-coerced. The engine
+  /// invokes this on the ValueConv RESOLUTION view (under `-n` the emitted sink
+  /// itself; under `-j` a separate ValueConv re-emission), so the returned value
+  /// is the faithful `$val[i]` regardless of the output mode. A `Missing` result
+  /// means no such tag was extracted (`!defined $val[i]`); a present value of
+  /// ANY shape (numeric or string) is [`Present`](CompositeValue::Present), so
+  /// `Inhibit`/`Require`/`Desire` resolve on presence and each def performs its
+  /// own coercion.
+  fn resolve(&self, groups: &[&str], name: &str) -> CompositeValue;
+  /// Is a `Composite:<name>` already present?
+  fn has_composite(&self, name: &str) -> bool;
+  /// Append a built `Composite:<name>` (at Main, ExifTool default `Priority`).
+  fn append(&mut self, name: &'static str, value: TagValue);
+}
+
+#[cfg(feature = "alloc")]
+impl CompositeSink for TagMap {
+  fn resolve(&self, groups: &[&str], name: &str) -> CompositeValue {
+    let group_ok = |g: &str| groups.is_empty() || groups.contains(&g);
+    // Reverse scan for the LAST match (entries are in first-occurrence order;
+    // the last duplicate is the highest-precedence — `APE_dup_override`).
+    match self
+      .entries()
+      .iter()
+      .rev()
+      .find(|(doc, _sub, fam1, n, _pri, _val)| {
+        *doc == 0 && n.as_str() == name && group_ok(fam1.as_str())
+      }) {
+      Some(entry) => CompositeValue::Present(entry.5.clone()),
+      None => CompositeValue::Missing,
+    }
+  }
+  fn has_composite(&self, name: &str) -> bool {
+    self
+      .entries()
+      .iter()
+      .any(|(_doc, _sub, fam1, n, _pri, _val)| fam1.as_str() == "Composite" && n.as_str() == name)
+  }
+  fn append(&mut self, name: &'static str, value: TagValue) {
+    let _ = self.write_value_doc(0, 0, "Composite", name, 1, value);
+  }
+}
+
+/// The [`iter_tags`](crate::format_parser::AnyMeta::iter_tags) sink — the
+/// deduped [`Tag`](crate::value::Tag) `Vec`. Appended composites carry the full
+/// `Composite`/`Composite` group (family-0 = family-1), matching the JSON path.
+#[cfg(feature = "alloc")]
+impl CompositeSink for std::vec::Vec<crate::value::Tag> {
+  fn resolve(&self, groups: &[&str], name: &str) -> CompositeValue {
+    let group_ok = |g: &str| groups.is_empty() || groups.contains(&g);
+    match self
+      .iter()
+      .rev()
+      .find(|t| t.group_ref().doc() == 0 && t.name() == name && group_ok(t.group_ref().family1()))
+    {
+      Some(tag) => CompositeValue::Present(t_value(tag).clone()),
+      None => CompositeValue::Missing,
+    }
+  }
+  fn has_composite(&self, name: &str) -> bool {
+    self
+      .iter()
+      .any(|t| t.group_ref().family1() == "Composite" && t.name() == name)
+  }
+  fn append(&mut self, name: &'static str, value: TagValue) {
+    self.push(crate::value::Tag::new(
+      crate::value::Group::new("Composite", "Composite"),
+      name,
+      value,
+    ));
+  }
+}
+
+/// Borrow a [`Tag`](crate::value::Tag)'s value (the `Vec` sink's accessor).
+#[cfg(feature = "alloc")]
+fn t_value(t: &crate::value::Tag) -> &TagValue {
+  t.value_ref()
+}
+
+/// Build every registered Composite tag into `out` (the post-`run_emission`
+/// pass). `mode` is the active OUTPUT conversion mode (`-j` ⇒ PrintConv, `-n`
+/// ⇒ ValueConv); `raw` is the SAME Meta re-emitted in ValueConv mode (`-n`),
+/// supplied so the engine resolves each input from its post-ValueConv (raw)
+/// value REGARDLESS of `mode` — ExifTool's `BuildCompositeTags`/`GetValue`
+/// reads `$val[i]` as the input's ValueConv value, not the printed form
+/// (ExifTool.pm:4044-4112). `None` ⇒ resolve from `out` itself (the `-n` path,
+/// where the emitted values already ARE the raw ValueConv values, so a separate
+/// pass is redundant). `doc_count` is the highest family-3 sub-document index
+/// present (reserved for `SubDoc` composites — none of the registered Duration
+/// defs is `SubDoc`, so they build at Main only regardless, ExifTool.pm:3999).
+#[cfg(feature = "alloc")]
+pub(crate) fn build_composites(
+  out: &mut TagMap,
+  raw: Option<&mut TagMap>,
+  mode: crate::emit::ConvMode,
+  doc_count: u32,
+) {
+  let _ = doc_count; // reserved for SubDoc composites (later #133 PRs)
+  build_into(REGISTRY, out, raw, mode);
+}
+
+/// Build every registered Composite tag into the
+/// [`iter_tags`](crate::format_parser::AnyMeta::iter_tags) `Tag` `Vec` (the
+/// public generic-extraction path), so it yields the same `Composite:*` set the
+/// JSON path does. `raw` is the SAME tag stream re-collected in ValueConv mode
+/// (the input-resolution source; see [`build_composites`]); `None` on the `-n`
+/// path where `tags` already holds the raw values.
+#[cfg(feature = "alloc")]
+pub(crate) fn build_composites_into_tags(
+  tags: &mut std::vec::Vec<crate::value::Tag>,
+  raw: Option<&mut std::vec::Vec<crate::value::Tag>>,
+  mode: crate::emit::ConvMode,
+) {
+  build_into(REGISTRY, tags, raw, mode);
+}
+
+/// Drive the ExifTool `BuildCompositeTags` fixpoint over `defs`.
+///
+/// Inputs are resolved from the RAW (post-ValueConv) value of each ingredient,
+/// independent of the active output `mode`: this is ExifTool's `$val[i]`
+/// (`GetValue($tag, 'ValueConv')`, ExifTool.pm:4112), so a composite's own
+/// `RawConv`/`ValueConv` always runs on the faithful machine value (a GPS ref
+/// `"N"`/`"S"`, a decimal coordinate, a `DateStamp`) — never the printed form.
+/// (A composite's PrintConv form `$prt[i]`, needed by e.g. `GPSPosition`'s
+/// PrintConv in a LATER #133 PR, is not wired yet because no PR-1 composite —
+/// `Duration` — reads it; it slots in as a second per-input lookup.)
+///
+/// `resolve_src` is the raw view to read inputs + composite-dependencies from
+/// AND to append each built composite's RAW value to (so a composite that
+/// `Require`s another `Composite:*` sees its raw value in the fixpoint). When
+/// `None`, the active `out` sink IS the raw view (the `-n` path), so the engine
+/// reads + appends there directly. The RENDERED composite (for `mode`) is
+/// always appended to `out`. Split out so the oracle tests can pass synthetic
+/// def lists, and generic over the sink so the TagMap and `Vec<Tag>` paths
+/// share ONE engine.
+#[cfg(feature = "alloc")]
+fn build_into<S: CompositeSink>(
+  defs: &[CompositeDef],
+  out: &mut S,
+  resolve_src: Option<&mut S>,
+  mode: crate::emit::ConvMode,
+) {
+  match resolve_src {
+    // `-j` (PrintConv): inputs + composite-dependencies resolve from the SEPARATE
+    // raw ValueConv view. Each built composite's RAW value is appended back into
+    // that view (so a Composite-requires-Composite chain reads faithful `$val[i]`
+    // in the fixpoint), while its RENDERED (`-j`) value is mirrored into `out`.
+    Some(raw_view) => run_fixpoint(defs, raw_view, |view, name, raw, pc| {
+      view.append(
+        name,
+        render_value(pc, raw, crate::emit::ConvMode::ValueConv),
+      );
+      out.append(name, render_value(pc, raw, mode));
+    }),
+    // `-n` (ValueConv) and the synthetic-map oracle/differential tests: `out` is
+    // itself the resolution view (its values are already the raw ValueConv form
+    // in `-n`; in the test maps they ARE the ingredients), so resolution reads
+    // `out` directly and the composite is appended there ONCE, rendered for the
+    // active `mode`. Under `-n` that rendered value is the raw value, so a
+    // dependent composite still resolves a faithful `$val[i]`. Byte-identical to
+    // the pre-#133-round-3 single-sink engine.
+    None => run_fixpoint(defs, out, |view, name, raw, pc| {
+      view.append(name, render_value(pc, raw, mode));
+    }),
+  }
+}
+
+/// The ExifTool `BuildCompositeTags` fixpoint over `defs`, reading inputs (and
+/// Composite-dependencies) from `resolve_view`. For each built composite,
+/// `place_built(resolve_view, name, raw, print_conv)` is invoked to (1) make the
+/// composite visible in `resolve_view` for any dependent composite's `$val[i]`
+/// and (2) emit its output value — the `-j` arm appends the RAW value to the
+/// raw view AND mirrors the rendered value to the output sink; the `-n`/test arm
+/// appends the mode-rendered value once to the single sink.
+#[cfg(feature = "alloc")]
+fn run_fixpoint<S: CompositeSink>(
+  defs: &[CompositeDef],
+  resolve_view: &mut S,
+  mut place_built: impl FnMut(&mut S, &'static str, f64, CompositePrintConv),
+) {
+  // Working order: a faithful prefixed-id sort (`Module-Name`). Stable sort so
+  // equal keys keep registry order (ExifTool's keys are unique, so ties don't
+  // occur in practice).
+  let mut order: std::vec::Vec<&CompositeDef> = defs.iter().collect();
+  order.sort_by(|a, b| a.sort_key.cmp(b.sort_key));
+
+  // `not_built`: composite NAMES not yet built (drives the Composite-dependency
+  // deferral). A name leaves the set when it is built OR proven unbuildable.
+  let mut not_built: std::collections::HashSet<&'static str> =
+    order.iter().map(|d| d.name).collect();
+
+  // The defs still to attempt this pass (starts as the whole sorted list).
+  let mut pending: std::vec::Vec<&CompositeDef> = order;
+  let mut all_built = false; // ExifTool's `$allBuilt` (the last-ditch Inhibit-ignore pass)
+
+  loop {
+    let mut deferred: std::vec::Vec<&CompositeDef> = std::vec::Vec::new();
+    let pending_len = pending.len();
+
+    'def: for def in pending.iter().copied() {
+      // Resolve each input index to a `CompositeValue` (PRESENCE + raw value),
+      // never pre-coercing. `Require`/`Desire`/`Inhibit` key on presence; the
+      // def's `derive` does its own coercion of the `Present` raw values.
+      let mut values: std::vec::Vec<CompositeValue> =
+        std::vec::Vec::with_capacity(def.inputs.len());
+      let mut suppress = false; // an Inhibit input was present
+      let mut require_missing = false;
+
+      for input in def.inputs {
+        // Composite-dependency deferral (ExifTool.pm:4044-4052): an input that
+        // references a `Composite:Name` not yet built defers this def — UNLESS
+        // it is an Inhibit and we are in the final `$allBuilt` pass.
+        if references_unbuilt_composite(input, &not_built, resolve_view) {
+          let defer = !(input.kind.is_inhibit() && all_built);
+          if defer {
+            deferred.push(def);
+            continue 'def;
+          }
+        }
+
+        let resolved = resolve_view.resolve(input.groups, input.name);
+        if resolved.is_present() {
+          if input.kind.is_inhibit() {
+            // ExifTool.pm:4078-4081 `$found = 0; last` — a PRESENT inhibitor of
+            // ANY value (numeric or string) suppresses the composite.
+            suppress = true;
+            break;
+          }
+          values.push(resolved);
+        } else {
+          if input.kind.is_require() {
+            // ExifTool.pm:4084-4087 `$found = 0; last` — required & missing.
+            require_missing = true;
+            break;
+          }
+          // Desire / Inhibit absent ⇒ undef element, keep going.
+          values.push(CompositeValue::Missing);
+        }
+      }
+
+      if suppress || require_missing {
+        // Can't / shouldn't build — proven settled this pass.
+        not_built.remove(def.name);
+        continue;
+      }
+
+      // All inputs resolved: run the derivation. The arm-specific `place_built`
+      // makes the composite visible in `resolve_view` (for a dependent
+      // composite's `$val[i]`) AND emits its output value (see `build_into`).
+      not_built.remove(def.name);
+      if let Some(raw) = (def.derive)(&values) {
+        place_built(resolve_view, def.name, raw, def.print_conv);
+      }
+      // `None` ⇒ the `… ? … : undef` guard fired; nothing emitted, but the
+      // composite is settled (already removed from `not_built`).
+    }
+
+    if deferred.is_empty() {
+      break; // fixpoint reached
+    }
+    if deferred.len() == pending_len {
+      // Nothing built this pass.
+      if all_built {
+        // ExifTool warns `Circular dependency in Composite tags` and stops.
+        // exifast has no doc-level warning channel for this synthetic case
+        // (the registered Duration defs never cycle); drop the unbuildable
+        // deferred defs and stop.
+        break;
+      }
+      all_built = true; // one more pass, ignoring Inhibit-on-Composite
+    }
+    pending = deferred;
+  }
+}
+
+/// Does `input` reference a `Composite:Name` that is neither already built (in
+/// `not_built`) nor present in `sink`? Such an input must defer (ExifTool.pm:
+/// 4044-4052). An input targets the Composite group when its group set contains
+/// `"Composite"`.
+#[cfg(feature = "alloc")]
+fn references_unbuilt_composite<S: CompositeSink>(
+  input: &table::CompositeInput,
+  not_built: &std::collections::HashSet<&'static str>,
+  sink: &S,
+) -> bool {
+  if !input.groups.contains(&"Composite") {
+    return false;
+  }
+  // Already produced into the sink ⇒ not pending.
+  if sink.has_composite(input.name) {
+    return false;
+  }
+  not_built.contains(input.name)
+}
+
+/// Render the derived raw value for the def's PrintConv + the active mode.
+#[cfg(feature = "alloc")]
+fn render_value(pc: CompositePrintConv, raw: f64, mode: crate::emit::ConvMode) -> TagValue {
+  match pc {
+    CompositePrintConv::ConvertDuration => convs::duration_value(raw, mode),
+  }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/composite/table.rs
+++ b/src/composite/table.rs
@@ -1,0 +1,287 @@
+//! The [`CompositeDef`] model and the registry of ported Composite tags.
+//!
+//! A [`CompositeDef`] is exifast's transliteration of one `%…::Composite`
+//! entry: the `Require` / `Desire` / `Inhibit` index→input map (ExifTool's
+//! `AddCompositeTags` form, ExifTool.pm:5763-5840), the derivation that
+//! computes the raw value from the resolved inputs (the def's
+//! `RawConv`/`ValueConv`), and how that raw value is rendered for the active
+//! conversion mode (the def's `PrintConv`).
+//!
+//! This PR registers ONLY the three `Duration` composites that the APE / FLAC /
+//! AIFF formats used to emit inline (APE.pm:83-92, FLAC.pm:137-149,
+//! AIFF.pm:136-145). No new composites are introduced; the cross-format sweep
+//! (#133) adds the rest in later PRs.
+//!
+//! ## Input-group matching (the `APE:` ≡ `MAC:` subtlety)
+//!
+//! ExifTool's `Require => 'APE:SampleRate'` resolves via `GroupMatches('APE',
+//! …)`, which matches a stored tag whose group in ANY family equals `APE`. The
+//! APE MAC header table is `GROUPS => { 0 => 'APE', 1 => 'MAC' }`, so its
+//! `MAC:SampleRate` (family-1 `MAC`) still satisfies `APE:SampleRate` through
+//! its family-0 `APE`. exifast's [`TagMap`](crate::tagmap::TagMap) keys only on
+//! family-1, so a [`CompositeInput`] carries the SET of family-1 groups that
+//! map to the requested ExifTool group — `{APE, MAC}` for the APE inputs — and
+//! the resolver takes the LAST-emitted match across that set (faithful to
+//! ExifTool walking the duplicate keys in reverse precedence; the
+//! `APE_dup_override` golden has `MAC:SampleRate=44100` then `APE:SampleRate=
+//! 48000` and `Duration` must use `48000`).
+
+use crate::value::TagValue;
+
+/// One resolved Composite input, as the engine hands it to a
+/// [`CompositeDef::derive`]. The model carries PRESENCE separately from any
+/// numeric coercion: ExifTool's `Require`/`Desire`/`Inhibit` resolution keys on
+/// whether the ingredient tag was extracted at all (`defined $val[i]`), while
+/// each def's RawConv then coerces the RAW value on its own terms (the Duration
+/// defs read a number; the GPS / EXIF / datetime defs added by later #133 PRs
+/// read strings — GPS refs `N`/`S`/`E`/`W`, `DateStamp`, `TimeStamp`). So the
+/// engine never pre-coerces; it delivers the actual RAW (post-`ValueConv`)
+/// [`TagValue`] — the faithful `$val[i]`, independent of the `-j`/`-n` output
+/// mode (ExifTool.pm:4112) — and lets the derivation interpret it.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CompositeValue {
+  /// The ingredient tag was not extracted (`!defined $val[i]`) — an absent
+  /// `Desire`/`Inhibit` leaves this `undef` element; an absent `Require` aborts.
+  Missing,
+  /// The ingredient tag IS present, carrying its RAW (post-`ValueConv`) value
+  /// (numeric OR string) — the same `$val[i]` ExifTool reads regardless of the
+  /// output mode. A present `Inhibit` of ANY value suppresses the composite.
+  Present(TagValue),
+}
+
+impl CompositeValue {
+  /// `defined $val[i]` — the ingredient was extracted (ExifTool keys
+  /// `Require`/`Desire`/`Inhibit` resolution on this, NOT on coercibility).
+  pub(crate) const fn is_present(&self) -> bool {
+    matches!(self, CompositeValue::Present(_))
+  }
+  /// The raw [`TagValue`] when present (for the def's own RawConv coercion).
+  pub(crate) const fn value(&self) -> Option<&TagValue> {
+    match self {
+      CompositeValue::Present(v) => Some(v),
+      CompositeValue::Missing => None,
+    }
+  }
+  /// Perl numeric coercion (`0 + $val`) of a PRESENT value: integers and
+  /// finite/non-finite floats pass through; a numeric STRING (incl.
+  /// `"Inf"`/`"NaN"`) is parsed with the faithful leading-prefix scan; a
+  /// present-but-otherwise-nonnumeric value or [`Missing`](Self::Missing) ⇒
+  /// `None` (the def's `... ? ... : undef` guard then fires).
+  pub(crate) fn coerce_numeric(&self) -> Option<f64> {
+    match self.value()? {
+      TagValue::I64(n) => Some(*n as f64),
+      TagValue::U64(n) => Some(*n as f64),
+      TagValue::F64(x) => Some(*x),
+      TagValue::Str(s) => Some(crate::convert::perl_str_to_f64(s)),
+      _ => None,
+    }
+  }
+  /// Perl boolean context (`if ($val[i]`) on the RAW present value — the
+  /// `($val[0] && $val[1])`-style RawConv guard. A wire-format string `"0.0"`
+  /// is TRUTHY here (unlike its numeric coercion `0.0`); a [`Missing`](Self::
+  /// Missing) element is falsy (`!defined` ⇒ false).
+  pub(crate) fn is_truthy(&self) -> bool {
+    self
+      .value()
+      .is_some_and(crate::convert::perl_boolean_truthy)
+  }
+}
+
+/// How a [`CompositeDef`] turns its resolved raw value into the stored
+/// [`TagValue`](crate::value::TagValue) for the active conversion mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompositePrintConv {
+  /// `PrintConv => 'ConvertDuration($val)'` — the duration format under `-j`,
+  /// the bare raw scalar under `-n`, the quoted Perl string for a non-finite
+  /// value in both modes ([`crate::composite::convs::duration_value`]).
+  ConvertDuration,
+}
+
+/// One `Require` / `Desire` / `Inhibit` input of a [`CompositeDef`], at a fixed
+/// index (ExifTool's `{ 0 => …, 1 => … }` hash position).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CompositeInput {
+  /// Whether this input is required (missing ⇒ the whole composite is skipped),
+  /// desired (missing ⇒ an `undef` element, the composite may still build), or
+  /// an inhibitor (present ⇒ the composite is suppressed).
+  pub(crate) kind: InputKind,
+  /// The family-1 group(s) a stored tag may carry to satisfy this input. A
+  /// single ExifTool `Group:Name` requirement expands to every exifast family-1
+  /// group that shares the ExifTool family-0 group (see the module note); a
+  /// bare-name requirement uses an empty slice (matches any group).
+  pub(crate) groups: &'static [&'static str],
+  /// The tag name to resolve (e.g. `"SampleRate"`).
+  pub(crate) name: &'static str,
+}
+
+/// The role of a [`CompositeInput`] (ExifTool `Require` / `Desire` / `Inhibit`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputKind {
+  /// `Require` — the composite is NOT built if this input is missing
+  /// (ExifTool.pm:4084-4087 `$found = 0; last`).
+  Require,
+  /// `Desire` — the composite may still build if this input is missing (the
+  /// element is left `undef`).
+  #[allow(dead_code)] // No Desire-only Duration input yet; used by the engine + oracle tests.
+  Desire,
+  /// `Inhibit` — the composite is SUPPRESSED if this input is present
+  /// (ExifTool.pm:4078-4081 `$found = 0; last`).
+  #[allow(dead_code)] // No Inhibit Duration input yet; used by the engine + oracle tests.
+  Inhibit,
+}
+
+impl InputKind {
+  /// `true` for [`Require`](Self::Require).
+  pub(crate) const fn is_require(self) -> bool {
+    matches!(self, InputKind::Require)
+  }
+  /// `true` for [`Inhibit`](Self::Inhibit).
+  pub(crate) const fn is_inhibit(self) -> bool {
+    matches!(self, InputKind::Inhibit)
+  }
+}
+
+/// A ported Composite tag: the inputs (index = slice position), the derivation
+/// that computes the raw value, and the print-conversion.
+///
+/// `derive` receives the resolved inputs by index as [`CompositeValue`]s
+/// (`Present(value)` carrying the raw [`TagValue`] when the ingredient was
+/// extracted, `Missing` when an absent `Desire`/`Inhibit`) and performs ITS OWN
+/// Perl coercion — the Duration defs coerce numeric + apply the Perl-truthy
+/// `&&` guard; future GPS / EXIF defs read string ingredients. It returns the
+/// raw composite value, or `None` to abort the build (ExifTool's
+/// `… ? … : undef` guard, e.g. APE.pm:90 `($val[0] && $val[1]) ? … : undef`).
+#[derive(Clone, Copy)]
+pub(crate) struct CompositeDef {
+  /// The composite tag name (the `-G1` key is `Composite:<name>`).
+  pub(crate) name: &'static str,
+  /// The inputs in index order (ExifTool `{ 0 => …, 1 => … }`).
+  pub(crate) inputs: &'static [CompositeInput],
+  /// The def's `RawConv`/`ValueConv` arithmetic over the resolved inputs.
+  pub(crate) derive: fn(&[CompositeValue]) -> Option<f64>,
+  /// The def's `PrintConv`.
+  pub(crate) print_conv: CompositePrintConv,
+  /// The prefixed-id sort key (ExifTool's `Module-Name`, AddCompositeTags
+  /// `$prefix . $tagID`). The build order sorts by this so the registry is
+  /// position-independent and the fixpoint is deterministic.
+  pub(crate) sort_key: &'static str,
+}
+
+/// `Require`d input on the `{APE, MAC}` family-1 group set (the APE MAC header
+/// carries family-1 `MAC` but family-0 `APE`, so it satisfies `APE:`).
+const fn ape_req(name: &'static str) -> CompositeInput {
+  CompositeInput {
+    kind: InputKind::Require,
+    groups: &["APE", "MAC"],
+    name,
+  }
+}
+
+/// `Require`d input on a single family-1 group `group` (a `&'static` one-element
+/// slice supplied by the caller, e.g. `&["FLAC"]`).
+const fn req(group: &'static [&'static str], name: &'static str) -> CompositeInput {
+  CompositeInput {
+    kind: InputKind::Require,
+    groups: group,
+    name,
+  }
+}
+
+/// APE.pm:90 `($val[0] && $val[1]) ? (($val[1] - 1) * $val[2] + $val[3]) / $val[0] : undef`.
+/// `$val[0]`=SampleRate, `[1]`=TotalFrames, `[2]`=BlocksPerFrame, `[3]`=FinalFrameBlocks.
+///
+/// The `&&` guard is Perl-truthy on the RAW ingredient (APE main tags can supply
+/// `SampleRate`/`TotalFrames` as MakeTag STRINGS — a string `"0.0"`/`"0E0"` is
+/// Perl-TRUTHY, so it passes the guard and computes; only `""`, `"0"`, undef and
+/// a numeric/`Bytes` zero are falsy). The arithmetic itself then coerces every
+/// ingredient via Perl numeric coercion.
+fn ape_duration(v: &[CompositeValue]) -> Option<f64> {
+  let sr_raw = v.first()?;
+  let tf_raw = v.get(1)?;
+  // `$val[0] && $val[1]` — Perl-boolean on the RAW values (string-truthy).
+  if !sr_raw.is_truthy() || !tf_raw.is_truthy() {
+    return None;
+  }
+  let sr = sr_raw.coerce_numeric()?;
+  let tf = tf_raw.coerce_numeric()?;
+  let bpf = v.get(2)?.coerce_numeric()?;
+  let ffb = v.get(3)?.coerce_numeric()?;
+  Some(((tf - 1.0) * bpf + ffb) / sr)
+}
+
+/// FLAC.pm:147 `($val[0] and $val[1]) ? $val[1] / $val[0] : undef`.
+/// `$val[0]`=SampleRate, `[1]`=TotalSamples. The `and` guard is Perl-truthy on
+/// the RAW ingredients (string-truthy), then the arithmetic coerces numeric.
+fn flac_duration(v: &[CompositeValue]) -> Option<f64> {
+  let sr_raw = v.first()?;
+  let total_raw = v.get(1)?;
+  if !sr_raw.is_truthy() || !total_raw.is_truthy() {
+    return None;
+  }
+  Some(total_raw.coerce_numeric()? / sr_raw.coerce_numeric()?)
+}
+
+/// AIFF.pm:143 `($val[0] and $val[1]) ? $val[1] / $val[0] : undef`.
+/// `$val[0]`=SampleRate, `[1]`=NumSampleFrames. The `and` guard is Perl-truthy
+/// on the RAW ingredients (string-truthy), then the arithmetic coerces numeric.
+fn aiff_duration(v: &[CompositeValue]) -> Option<f64> {
+  let sr_raw = v.first()?;
+  let frames_raw = v.get(1)?;
+  if !sr_raw.is_truthy() || !frames_raw.is_truthy() {
+    return None;
+  }
+  Some(frames_raw.coerce_numeric()? / sr_raw.coerce_numeric()?)
+}
+
+/// APE `Duration` (APE.pm:83-92). Registered only when the `ape` feature is on.
+#[cfg(feature = "ape")]
+const APE_DURATION: CompositeDef = CompositeDef {
+  name: "Duration",
+  inputs: &[
+    ape_req("SampleRate"),
+    ape_req("TotalFrames"),
+    ape_req("BlocksPerFrame"),
+    ape_req("FinalFrameBlocks"),
+  ],
+  derive: ape_duration,
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "APE-Duration",
+};
+
+/// FLAC `Duration` (FLAC.pm:137-149). Registered only when the `flac` feature
+/// is on.
+#[cfg(feature = "flac")]
+const FLAC_DURATION: CompositeDef = CompositeDef {
+  name: "Duration",
+  inputs: &[req(&["FLAC"], "SampleRate"), req(&["FLAC"], "TotalSamples")],
+  derive: flac_duration,
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "FLAC-Duration",
+};
+
+/// AIFF `Duration` (AIFF.pm:136-145). Registered only when the `aiff` feature
+/// is on.
+#[cfg(feature = "aiff")]
+const AIFF_DURATION: CompositeDef = CompositeDef {
+  name: "Duration",
+  inputs: &[
+    req(&["AIFF"], "SampleRate"),
+    req(&["AIFF"], "NumSampleFrames"),
+  ],
+  derive: aiff_duration,
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "AIFF-Duration",
+};
+
+/// The full registry of ported Composite defs, cfg-gated per input format. The
+/// engine sorts a working copy by [`CompositeDef::sort_key`] (ExifTool's
+/// prefixed-id order) before the fixpoint, so this declaration order is
+/// irrelevant.
+pub(crate) const REGISTRY: &[CompositeDef] = &[
+  #[cfg(feature = "ape")]
+  APE_DURATION,
+  #[cfg(feature = "flac")]
+  FLAC_DURATION,
+  #[cfg(feature = "aiff")]
+  AIFF_DURATION,
+];

--- a/src/composite/tests.rs
+++ b/src/composite/tests.rs
@@ -1,0 +1,434 @@
+//! Oracle tests for the Composite fixpoint engine ([`build_into`]) — hand-built
+//! input maps proving the `Require`/`Desire`/`Inhibit` resolution, the
+//! Composite-requires-Composite multi-pass deferral, the circular-dependency
+//! guard, and the prefixed-id sort tiebreak. These exercise the GENERIC engine
+//! with synthetic defs (the real Duration migration is pinned by the
+//! conformance goldens + the differential tests in the format modules).
+
+#![cfg(feature = "alloc")]
+
+use super::table::{CompositeDef, CompositeInput, CompositePrintConv, CompositeValue, InputKind};
+use super::*;
+use crate::emit::ConvMode;
+use crate::tagmap::TagMap;
+use crate::value::TagValue;
+
+// `&'static` group slices the synthetic inputs reference (a runtime `&["X"]`
+// would be a dropped temporary; these `const` items give the slices `'static`).
+const GX: &[&str] = &["X"];
+const GP_Q: &[&str] = &["P", "Q"];
+const GCOMPOSITE: &[&str] = &["Composite"];
+
+/// A synthetic `Require`d input on `group`.
+const fn req(group: &'static [&'static str], name: &'static str) -> CompositeInput {
+  CompositeInput {
+    kind: InputKind::Require,
+    groups: group,
+    name,
+  }
+}
+
+/// A synthetic `Desire`d input.
+const fn des(group: &'static [&'static str], name: &'static str) -> CompositeInput {
+  CompositeInput {
+    kind: InputKind::Desire,
+    groups: group,
+    name,
+  }
+}
+
+/// A synthetic `Inhibit` input.
+const fn inh(group: &'static [&'static str], name: &'static str) -> CompositeInput {
+  CompositeInput {
+    kind: InputKind::Inhibit,
+    groups: group,
+    name,
+  }
+}
+
+/// Sum the present inputs (a stand-in derivation; `Missing`/non-numeric ⇒ 0).
+fn sum_inputs(v: &[CompositeValue]) -> Option<f64> {
+  Some(v.iter().map(|x| x.coerce_numeric().unwrap_or(0.0)).sum())
+}
+
+/// Build a TagMap with the given `(group, name, value)` entries in order.
+fn map_with(entries: &[(&str, &str, TagValue)]) -> TagMap {
+  let mut m = TagMap::new();
+  for (g, n, v) in entries {
+    let _ = m.write_value_doc(0, 0, g, n, 1, v.clone());
+  }
+  m
+}
+
+/// The stored `Composite:<name>` value, if present.
+fn composite(m: &TagMap, name: &str) -> Option<TagValue> {
+  m.get("Composite", name).cloned()
+}
+
+const SUM_AB: CompositeDef = CompositeDef {
+  name: "Sum",
+  inputs: &[req(GX, "A"), req(GX, "B")],
+  derive: sum_inputs,
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "X-Sum",
+};
+
+#[test]
+fn require_present_builds() {
+  let mut m = map_with(&[("X", "A", TagValue::I64(40)), ("X", "B", TagValue::I64(20))]);
+  build_into(&[SUM_AB], &mut m, None, ConvMode::ValueConv);
+  // 40 + 20 = 60 seconds, ValueConv ⇒ bare f64.
+  assert_eq!(composite(&m, "Sum"), Some(TagValue::F64(60.0)));
+}
+
+#[test]
+fn require_missing_aborts() {
+  // B is absent ⇒ Require miss ⇒ no composite.
+  let mut m = map_with(&[("X", "A", TagValue::I64(40))]);
+  build_into(&[SUM_AB], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Sum"), None);
+}
+
+#[test]
+fn desire_absent_still_builds_with_undef_element() {
+  const DEF: CompositeDef = CompositeDef {
+    name: "Sum",
+    inputs: &[req(GX, "A"), des(GX, "B")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "X-Sum",
+  };
+  // B (Desire) absent ⇒ element None (counted as 0) but the composite builds.
+  let mut m = map_with(&[("X", "A", TagValue::I64(40))]);
+  build_into(&[DEF], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Sum"), Some(TagValue::F64(40.0)));
+}
+
+#[test]
+fn inhibit_present_suppresses() {
+  const DEF: CompositeDef = CompositeDef {
+    name: "Sum",
+    inputs: &[req(GX, "A"), inh(GX, "Block")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "X-Sum",
+  };
+  // The Inhibit tag `X:Block` is present ⇒ the composite is suppressed.
+  let mut m = map_with(&[
+    ("X", "A", TagValue::I64(40)),
+    ("X", "Block", TagValue::I64(1)),
+  ]);
+  build_into(&[DEF], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Sum"), None);
+
+  // Without the Inhibit tag, it builds.
+  let mut m2 = map_with(&[("X", "A", TagValue::I64(40))]);
+  build_into(&[DEF], &mut m2, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m2, "Sum"), Some(TagValue::F64(40.0)));
+}
+
+#[test]
+fn inhibit_present_nonnumeric_string_suppresses() {
+  // Finding-1 regression: a PRESENT inhibitor of a NON-NUMERIC value (a string)
+  // must suppress. ExifTool keys `Inhibit` on `defined $val[i]`, not on numeric
+  // coercibility — the pre-coerced-`Option<f64>` model wrongly saw a string as
+  // absent and let the composite build. The presence model fixes it.
+  const DEF: CompositeDef = CompositeDef {
+    name: "Sum",
+    inputs: &[req(GX, "A"), inh(GX, "Block")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "X-Sum",
+  };
+  // `X:Block = "present"` is a non-numeric string ⇒ still suppresses.
+  let mut m = map_with(&[
+    ("X", "A", TagValue::I64(40)),
+    ("X", "Block", TagValue::Str("present".into())),
+  ]);
+  build_into(&[DEF], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Sum"), None);
+
+  // Even an empty string is PRESENT (ExifTool: `defined ""` is true) ⇒ suppresses.
+  let mut m2 = map_with(&[
+    ("X", "A", TagValue::I64(40)),
+    ("X", "Block", TagValue::Str("".into())),
+  ]);
+  build_into(&[DEF], &mut m2, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m2, "Sum"), None);
+}
+
+#[test]
+fn desire_present_nonnumeric_string_reaches_derive() {
+  // Finding-1: a present-but-non-numeric (string) Desire reaches `derive` as a
+  // `Present(Str)` element (so future GPS/EXIF/datetime defs can read strings),
+  // NOT as a `Missing`. The derive here asserts the raw value it was handed.
+  fn assert_first_is_str(v: &[CompositeValue]) -> Option<f64> {
+    assert_eq!(
+      v.first().and_then(CompositeValue::value),
+      Some(&TagValue::Str("N".into())),
+      "a present string Desire must arrive as Present(Str), not Missing"
+    );
+    assert!(v.first().is_some_and(CompositeValue::is_present));
+    Some(1.0)
+  }
+  const DEF: CompositeDef = CompositeDef {
+    name: "Dur",
+    inputs: &[des(GX, "Ref")],
+    derive: assert_first_is_str,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "X-Dur",
+  };
+  let mut m = map_with(&[("X", "Ref", TagValue::Str("N".into()))]);
+  build_into(&[DEF], &mut m, None, ConvMode::ValueConv);
+  // 1.0 s ⇒ ValueConv bare f64; proves the derive ran (the asserts inside fired).
+  assert_eq!(composite(&m, "Dur"), Some(TagValue::F64(1.0)));
+}
+
+#[test]
+fn composite_requires_composite_deferred_then_built() {
+  // `Outer` requires `Composite:Inner`; `Inner` requires `X:A`. The engine must
+  // build `Inner` first (pass 1) then `Outer` (sees the just-built Inner).
+  const INNER: CompositeDef = CompositeDef {
+    name: "Inner",
+    inputs: &[req(GX, "A")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "X-Inner",
+  };
+  const OUTER: CompositeDef = CompositeDef {
+    name: "Outer",
+    inputs: &[req(GCOMPOSITE, "Inner"), req(GX, "B")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "X-Outer",
+  };
+  let mut m = map_with(&[("X", "A", TagValue::I64(10)), ("X", "B", TagValue::I64(5))]);
+  build_into(&[OUTER, INNER], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Inner"), Some(TagValue::F64(10.0)));
+  // Outer = Composite:Inner (10) + X:B (5) = 15.
+  assert_eq!(composite(&m, "Outer"), Some(TagValue::F64(15.0)));
+}
+
+#[test]
+fn composite_requires_composite_in_reverse_sort_order() {
+  // Same as above but Outer sorts BEFORE Inner — Outer is attempted first,
+  // must defer (Inner not built), then built in the second pass.
+  const INNER: CompositeDef = CompositeDef {
+    name: "Inner",
+    inputs: &[req(GX, "A")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "Z-Inner", // sorts AFTER Outer
+  };
+  const OUTER: CompositeDef = CompositeDef {
+    name: "Outer",
+    inputs: &[req(GCOMPOSITE, "Inner")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "A-Outer", // sorts BEFORE Inner ⇒ attempted first ⇒ defers
+  };
+  let mut m = map_with(&[("X", "A", TagValue::I64(7))]);
+  build_into(&[INNER, OUTER], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Inner"), Some(TagValue::F64(7.0)));
+  assert_eq!(composite(&m, "Outer"), Some(TagValue::F64(7.0)));
+}
+
+#[test]
+fn circular_dependency_does_not_loop() {
+  // A requires Composite:B, B requires Composite:A — neither can build. The
+  // fixpoint must terminate (the `$allBuilt` last-ditch pass then stop) and
+  // emit neither.
+  const A: CompositeDef = CompositeDef {
+    name: "A",
+    inputs: &[req(GCOMPOSITE, "B")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "M-A",
+  };
+  const B: CompositeDef = CompositeDef {
+    name: "B",
+    inputs: &[req(GCOMPOSITE, "A")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "M-B",
+  };
+  let mut m = TagMap::new();
+  build_into(&[A, B], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "A"), None);
+  assert_eq!(composite(&m, "B"), None);
+}
+
+#[test]
+fn last_emitted_duplicate_wins_across_group_set() {
+  // The APE_dup_override shape: a multi-group input set `{P, Q}`; the LAST
+  // emitted match wins. `Q:A` is emitted after `P:A`, so 99 wins over 1.
+  const DEF: CompositeDef = CompositeDef {
+    name: "Sum",
+    inputs: &[req(GP_Q, "A")],
+    derive: sum_inputs,
+    print_conv: CompositePrintConv::ConvertDuration,
+    sort_key: "X-Sum",
+  };
+  let mut m = map_with(&[("P", "A", TagValue::I64(1)), ("Q", "A", TagValue::I64(99))]);
+  build_into(&[DEF], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Sum"), Some(TagValue::F64(99.0)));
+}
+
+/// A derivation that always aborts (the `… ? … : undef` guard).
+fn always_none(_v: &[CompositeValue]) -> Option<f64> {
+  None
+}
+
+const NONE_DEF: CompositeDef = CompositeDef {
+  name: "Sum",
+  inputs: &[req(GX, "A")],
+  derive: always_none,
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "X-Sum",
+};
+
+#[test]
+fn derive_returning_none_emits_nothing() {
+  // The `… ? … : undef` guard: a derivation returning None settles the def
+  // without emitting (no panic, no spurious tag).
+  let mut m = map_with(&[("X", "A", TagValue::I64(5))]);
+  build_into(&[NONE_DEF], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m, "Sum"), None);
+}
+
+/// A derivation yielding input 0's numeric coercion verbatim.
+fn first_input(v: &[CompositeValue]) -> Option<f64> {
+  v.first()?.coerce_numeric()
+}
+
+const DUR_DEF: CompositeDef = CompositeDef {
+  name: "Dur",
+  inputs: &[req(GX, "A")],
+  derive: first_input,
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "X-Dur",
+};
+
+#[test]
+fn composite_appended_after_format_tags_keeps_last_position() {
+  // The positional last-ness the Duration goldens require: the composite is the
+  // LAST entry in the map after the build pass.
+  let mut m = map_with(&[
+    ("X", "A", TagValue::I64(30)),
+    ("X", "Z", TagValue::Str("tail".into())),
+  ]);
+  build_into(&[DUR_DEF], &mut m, None, ConvMode::PrintConv);
+  let last = m.entries().last().expect("non-empty");
+  assert_eq!(last.2.as_str(), "Composite");
+  assert_eq!(last.3.as_str(), "Dur");
+  // 30 s ⇒ ConvertDuration "0:00:30" under PrintConv.
+  assert_eq!(last.5, TagValue::Str("0:00:30".into()));
+}
+
+// A def over one `Require`d input `X:A` whose derivation simply Perl-coerces
+// that input numerically (`coerce_numeric` ⇒ `convert::perl_str_to_f64`). The
+// appended `Composite:Probe` value is the f64 the engine resolved + coerced —
+// so the stored value reveals WHICH form (raw vs printed) the input resolved to.
+const PROBE_DEF: CompositeDef = CompositeDef {
+  name: "Probe",
+  inputs: &[req(GX, "A")],
+  derive: first_input,
+  // ValueConv output ⇒ a bare f64, so the resolved-then-coerced value is read
+  // back directly (no ConvertDuration formatting to decode).
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "X-Probe",
+};
+
+#[test]
+fn input_resolves_from_raw_value_not_printconv_in_both_modes() {
+  // Finding 2 (input model): a composite's inputs must resolve from each
+  // ingredient's RAW / post-ValueConv value REGARDLESS of the `-j`/`-n` output
+  // mode (ExifTool `GetValue($tag, 'ValueConv')` for `$val[i]`, ExifTool.pm:
+  // 4112) — NOT the printed (PrintConv) form. Here `X:A`'s RAW value is
+  // `I64(42)` (coerces to 42.0) while its hypothetical PRINTED form is
+  // `Str("North")` (coerces to 0.0), so the resolved-and-coerced composite
+  // value distinguishes the two: 42.0 ⇒ raw was read, 0.0 ⇒ the printed sink
+  // leaked in.
+
+  // `-n` (ValueConv): the single `out` sink holds the raw value (its own
+  // resolution view). The composite must read 42.0.
+  let mut out_n = map_with(&[("X", "A", TagValue::I64(42))]);
+  build_into(&[PROBE_DEF], &mut out_n, None, ConvMode::ValueConv);
+  assert_eq!(
+    composite(&out_n, "Probe"),
+    Some(TagValue::F64(42.0)),
+    "-n: composite must resolve its input from the raw ValueConv value (42), not 0"
+  );
+
+  // `-j` (PrintConv): the OUTPUT sink holds the PRINTED form `Str("North")`
+  // (which would coerce to 0.0), while a SEPARATE raw view holds the raw
+  // `I64(42)`. The engine must resolve the input from the raw view ⇒ 42.0, even
+  // though the output is rendered in `-j`. This is the case Duration could not
+  // exercise (its ingredients have no PrintConv, so raw == printed).
+  let mut out_j = map_with(&[("X", "A", TagValue::Str("North".into()))]);
+  let mut raw_view = map_with(&[("X", "A", TagValue::I64(42))]);
+  build_into(
+    &[PROBE_DEF],
+    &mut out_j,
+    Some(&mut raw_view),
+    ConvMode::PrintConv,
+  );
+  // 42 s ⇒ ConvertDuration "0:00:42" under `-j` — proving the input was the raw
+  // 42 (a leaked `Str("North")` ⇒ 0.0 ⇒ ConvertDuration "0 s").
+  assert_eq!(
+    composite(&out_j, "Probe"),
+    Some(TagValue::Str("0:00:42".into())),
+    "-j: composite must resolve its input from the raw ValueConv value (42 ⇒ \"0:00:42\"), not the printed \"North\" (⇒ 0 ⇒ \"0 s\")"
+  );
+  // And the composite's RENDERED value lands in `out`, NOT in the raw view's
+  // rendered slot — the raw view carries the composite's RAW form (F64) for any
+  // dependent composite's `$val[i]`.
+  assert_eq!(composite(&raw_view, "Probe"), Some(TagValue::F64(42.0)));
+}
+
+const SIGNED_SUM: CompositeDef = CompositeDef {
+  name: "Sum",
+  inputs: &[req(GX, "A"), req(GX, "B")],
+  derive: sum_inputs,
+  print_conv: CompositePrintConv::ConvertDuration,
+  sort_key: "X-Sum",
+};
+
+#[test]
+fn signed_and_whitespace_string_ingredients_coerce_via_shared_perl_rule() {
+  // Finding 1: a Composite ingredient supplied as a Perl-numeric STRING with a
+  // leading sign / whitespace / dual sign must coerce through the SHARED
+  // `convert::perl_str_to_f64` (now carrying APE's dual-sign + inter-sign
+  // whitespace rule). APE main tags hand `SampleRate`/`TotalFrames` as MakeTag
+  // strings, so the engine's `coerce_numeric` is the path under test.
+
+  // `" +44100"` (leading ws + sign) → 44100; `"++1000"` (dual `+`) → 1000.
+  let mut m = map_with(&[
+    ("X", "A", TagValue::Str(" +44100".into())),
+    ("X", "B", TagValue::Str("++1000".into())),
+  ]);
+  build_into(&[SIGNED_SUM], &mut m, None, ConvMode::ValueConv);
+  assert_eq!(
+    composite(&m, "Sum"),
+    Some(TagValue::F64(45100.0)),
+    "signed/dual-sign/whitespace string ingredients must Perl-coerce (44100 + 1000)"
+  );
+
+  // Dual-sign that resolves NEGATIVE (`"+-20"` → -20) and the inter-sign
+  // whitespace form (`"- +5"` → -5): sum = -25.
+  let mut m2 = map_with(&[
+    ("X", "A", TagValue::Str("+-20".into())),
+    ("X", "B", TagValue::Str("- +5".into())),
+  ]);
+  build_into(&[SIGNED_SUM], &mut m2, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m2, "Sum"), Some(TagValue::F64(-25.0)));
+
+  // A REJECTED dual-sign form (ws after sign 2: `"+- 20"` → 0) coerces to 0,
+  // matching Perl — so the shared reject rule is live in the engine path too.
+  let mut m3 = map_with(&[
+    ("X", "A", TagValue::Str("+- 20".into())),
+    ("X", "B", TagValue::Str("100".into())),
+  ]);
+  build_into(&[SIGNED_SUM], &mut m3, None, ConvMode::ValueConv);
+  assert_eq!(composite(&m3, "Sum"), Some(TagValue::F64(100.0)));
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -433,7 +433,13 @@ fn matches_float_shape(s: &str, sep: u8) -> bool {
 ///     (`1` or `1.`, not `1.0` / `01.`) followed by `#` then a case-insensitive
 ///     `INF` / `IND` / `NAN` / `QNAN` / `SNAN` prefix → `Inf` / `NaN`
 ///     (sign carries for `INF`: `-1.#INF` → `-Inf`). `1.#IN` / `1.#I` (no full
-///     keyword) fall back to the finite mantissa `1`.
+///     keyword) fall back to the finite mantissa `1`. Recognition of this
+///     spelling is GATED on a tight sign-form (`Perl_grok_infnan`): a single
+///     directly-adjacent sign or a `+`-led adjacent dual sign fires
+///     (`++1.#INF` → `Inf`, `+-1.#INF` → `-Inf`), but inter-sign / post-sign
+///     whitespace or a `-`-led dual sign breaks it and the value falls through
+///     to the finite scan `1.` → `1` with the product sign (`+ 1.#INF` → `1`,
+///     `-+1.#INF` → `-1`, `--1.#IND` → `1`).
 ///
 /// Leading junk before `inf`/`nan` is NOT a numeric prefix (`xinf`/`12inf` →
 /// `0` / `12`, matching the finite rule), and a partial keyword (`in`, `na`,
@@ -455,7 +461,8 @@ fn matches_float_shape(s: &str, sep: u8) -> bool {
 /// `".5"` → `0.5`; `"3."` → `3.0`; `"+3.5"` → `3.5`; `"-2"` → `-2.0`;
 /// `"abc"`/`""`/`"  "`/`"0x10"` → `0.0`; `"inf"`/`"Infinity"`/`"+inf"` → `Inf`;
 /// `"-inf"`/`"-1.#INF"` → `-Inf`; `"nan"`/`"NaN"`/`"1.#IND"`/`"-nan"` → `NaN`.
-#[allow(dead_code)] // Used by `feature = "flash"`; unused under feature-pruned builds without it.
+
+#[allow(dead_code)] // Used by `feature = "flash"` + `feature = "ape"` + the Composite engine; pruned otherwise.
 pub fn perl_str_to_f64(s: &str) -> f64 {
   let bytes = s.as_bytes();
   let mut i = 0;
@@ -464,12 +471,48 @@ pub fn perl_str_to_f64(s: &str) -> f64 {
   while matches!(bytes.get(i), Some(b) if b.is_ascii_whitespace()) {
     i += 1;
   }
-  let prefix_start = i;
-  // Optional sign (captured for the non-finite spellings — `-inf` carries the
-  // sign onto `Inf`; `nan`/`-nan` are unsigned `NaN`).
-  let negative = bytes.get(i) == Some(&b'-');
+  // Optional dual-sign parsing. Perl's numeric context accepts up to TWO sign
+  // characters with one whitespace block permitted between them (NOT after the
+  // second sign), the effective sign being the PRODUCT of the signs seen
+  // (oracle, verified against Perl 5 — APE Composite `Duration` ingredients
+  // arrive as MakeTag strings that hit exactly this path):
+  //   "+ 20000000" → 20000000   "++20000000" → 20000000   "+-20" → -20
+  //   "--20"       → 20          "-+Inf"      → -Inf        "++Inf" → Inf
+  //   "+ +20"      → 20          "+- 20"      → 0 (ws after sign2 ⇒ reject)
+  //   "+--20"      → 0 (three signs)          "-  -  20"   → 0 (ws after sign2)
+  // A bare lone sign is settled below by the `i == mantissa_start` no-magnitude
+  // guard (`mantissa_start` is the post-sign position).
+  let mut negative = false;
+  let mut sign_count = 0u8;
+  // Track two sign-form facts that gate the MSVCRT `1.#…` branch below: whether
+  // sign 1 is `-`, and whether any whitespace was skipped between sign 1 and the
+  // magnitude. The MSVCRT non-finite spelling is recognised by Perl only for a
+  // tight sign-form (oracle below); these record the two breaking conditions.
+  let mut sign1_minus = false;
+  let mut inter_sign_ws = false;
   if matches!(bytes.get(i), Some(b'+' | b'-')) {
+    sign1_minus = bytes.get(i) == Some(&b'-');
+    negative ^= sign1_minus;
     i += 1;
+    sign_count = 1;
+    // Optional whitespace between sign 1 and sign 2 / the magnitude.
+    while matches!(bytes.get(i), Some(b) if b.is_ascii_whitespace()) {
+      i += 1;
+      inter_sign_ws = true;
+    }
+    // Sign 2 (no whitespace permitted after it).
+    if matches!(bytes.get(i), Some(b'+' | b'-')) {
+      negative ^= bytes.get(i) == Some(&b'-');
+      i += 1;
+      sign_count = 2;
+    }
+  }
+  // After a second sign, a further sign OR whitespace rejects the whole prefix
+  // (Perl: "+--20" / "-+ 20" / "+- 20" → 0).
+  if sign_count == 2
+    && matches!(bytes.get(i), Some(b) if *b == b'+' || *b == b'-' || b.is_ascii_whitespace())
+  {
+    return 0.0;
   }
   // IEEE non-finite spellings — checked AFTER the sign, BEFORE the digit grammar
   // (a leading digit means a finite mantissa, so `inf`/`nan` can only begin the
@@ -509,7 +552,18 @@ pub fn perl_str_to_f64(s: &str) -> f64 {
   // `[mantissa_start..i]` are `"1"` or `"1."` (so `1.0` / `01.` / `2.` do NOT
   // qualify; oracle: `1.0#INF` → 1, `2.#INF` → 2). The `#` then a keyword
   // prefix selects Inf/NaN; `INF` honours the sign, the NaN keywords drop it.
-  if bytes.get(i) == Some(&b'#') {
+  //
+  // The MSVCRT spelling is recognised by Perl only under a TIGHT sign-form
+  // (`Perl_grok_infnan` runs on the post-`my_atof`-sign run with no whitespace).
+  // Oracle 2026-06-19 (`$s + 0`): a single sign directly adjacent fires
+  // (`-1.#INF` → -Inf), and a `+`-led dual sign fires (`++1.#INF` → Inf,
+  // `+-1.#INF` → -Inf). It does NOT fire when whitespace separates the sign(s)
+  // from the magnitude (`+ 1.#INF` → 1, `+ -1.#INF` → -1), nor for a `-`-led
+  // dual sign (`-+1.#INF` → -1, `--1.#IND` → 1); those fall through to the
+  // finite mantissa scan (`1.` → 1) and carry the product sign. Encode the two
+  // breaking conditions directly.
+  let msvcrt_allowed = !(inter_sign_ws || (sign1_minus && sign_count == 2));
+  if msvcrt_allowed && bytes.get(i) == Some(&b'#') {
     let mantissa = &bytes[mantissa_start..i];
     if mantissa == b"1" || mantissa == b"1." {
       let kw = &bytes[i + 1..];
@@ -546,15 +600,60 @@ pub fn perl_str_to_f64(s: &str) -> f64 {
       i = j;
     }
   }
-  // No numeric prefix (only whitespace, a lone sign, or junk) ⇒ Perl yields 0.
-  if i == prefix_start || i == mantissa_start {
+  // No magnitude consumed (only whitespace, a lone/dual sign, or junk) ⇒ Perl
+  // yields 0. `mantissa_start` is positioned AFTER any sign(s), so this guard
+  // also covers the bare-sign case (`"+"`, `"--"` → 0).
+  if i == mantissa_start {
     return 0.0;
   }
-  // The prefix is a clean numeric form Rust's `f64` parser accepts (it handles
-  // `"3."`, `".5"`, `"+3"`, `"1e3"`). On the rare overflow-to-inf parse, Perl
-  // would likewise carry ±Inf, so the parsed value is faithful; the unreachable
-  // `Err` arm (the prefix is always well-formed) falls back to 0.
-  s[prefix_start..i].parse::<f64>().unwrap_or(0.0)
+  // Parse the MAGNITUDE prefix `[mantissa_start..i]` (signs already consumed
+  // above), then apply the product sign. The slice is a clean unsigned numeric
+  // form Rust's `f64` parser accepts (`"3."`, `".5"`, `"1e3"`); parsing the
+  // magnitude (not the signed slice) is what lets the dual-sign forms
+  // (`"--20"`, `"+-20"`) carry their effective sign. On the rare
+  // overflow-to-inf parse Perl likewise carries ±Inf; the unreachable `Err`
+  // arm (the magnitude is always well-formed) falls back to 0.
+  let mag = s
+    .get(mantissa_start..i)
+    .and_then(|t| t.parse::<f64>().ok())
+    .unwrap_or(0.0);
+  if negative { -mag } else { mag }
+}
+
+/// Perl boolean context (`if ($val)`) for a [`TagValue`]. Faithful semantics
+/// (verified empirically against Perl 5):
+///   - `Str(s)`: TRUE iff `s` is non-empty AND not the exact literal `"0"`.
+///     So `"0E0"`, `"0.0"`, `"00"`, `"+0"`, `" 0"`, `"0abc"` are all TRUE.
+///   - `I64(n)` / `U64(n)`: TRUE iff `n != 0`.
+///   - `F64(x)`: TRUE iff `x != 0.0` (NaN compares unequal to 0.0 in IEEE, so
+///     NaN is reported as TRUE — faithful: Perl NaN is truthy).
+///   - `Bool(b)`: direct Perl-bool mapping.
+///   - `Bytes(b)`: TRUE iff `!b.is_empty()` AND `b != [b'0']` (byte-faithful to
+///     the string rule).
+///   - `Rational(n,d)`: TRUE iff `n != 0` (Perl scalar stringifies; `0/X`
+///     evaluates to `"0"`, which is falsey).
+///   - `List(_)` / `Map(_)`: list/hash-context truthiness in Perl is the count;
+///     conservative: TRUE iff non-empty (a `$val[N]` deref'd from `@val` is a
+///     scalar in practice, so this case does not arise for a Composite input).
+///
+/// This is the predicate ExifTool's `($val[0] && $val[1])`-style RawConv guards
+/// evaluate (the APE / FLAC / AIFF Composite Duration guards): it runs on the
+/// RAW ingredient value — a wire-format string `"0.0"` is TRUTHY, unlike a
+/// numeric-coerced `0.0`.
+#[allow(dead_code)] // Used by `feature = "ape"` + the Composite engine; pruned otherwise.
+pub(crate) fn perl_boolean_truthy(v: &TagValue) -> bool {
+  match v {
+    TagValue::Str(s) => !s.is_empty() && s.as_str() != "0",
+    TagValue::I64(n) => *n != 0,
+    TagValue::U64(n) => *n != 0,
+    #[allow(clippy::float_cmp)]
+    TagValue::F64(x) => *x != 0.0,
+    TagValue::Bool(b) => *b,
+    TagValue::Bytes(b) => !b.is_empty() && b.as_slice() != b"0",
+    TagValue::Rational(r) => r.numerator() != 0,
+    TagValue::List(l) => !l.is_empty(),
+    TagValue::Map(m) => !m.is_empty(),
+  }
 }
 
 /// Case-insensitive ASCII prefix test: does `hay` begin with `needle` (which
@@ -880,32 +979,12 @@ pub fn write_convert_duration<W: core::fmt::Write + ?Sized>(
   w: &mut W,
   time: f64,
 ) -> core::fmt::Result {
-  // ExifTool.pm:6869 `return $time unless IsFloat($time)`. As in
-  // `write_convert_bitrate`, `IsFloat` rejects a stringified non-finite, so the
-  // value passes through verbatim and stringifies to Perl's titlecase
-  // `Inf`/`-Inf`/`NaN` (via `perl_nonfinite_str`), not Rust's lowercase `{}`.
-  if !time.is_finite() {
-    return w.write_str(crate::value::perl_nonfinite_str(time).unwrap_or("NaN"));
-  }
-  if time == 0.0 {
-    return w.write_str("0 s"); // ExifTool.pm:6870
-  }
-  let (sign, mut t) = if time > 0.0 { ("", time) } else { ("-", -time) }; // ExifTool.pm:6871
-  if t < 30.0 {
-    return write!(w, "{sign}{t:.2} s"); // ExifTool.pm:6872
-  }
-  t += 0.5; // ExifTool.pm:6873 round to nearest second
-  let mut h: i64 = (t / 3600.0) as i64;
-  t -= (h as f64) * 3600.0;
-  let m: i64 = (t / 60.0) as i64;
-  t -= (m as f64) * 60.0;
-  let s_int: i64 = t as i64;
-  if h > 24 {
-    let d = h / 24;
-    h -= d * 24;
-    return write!(w, "{sign}{d} days {h}:{m:02}:{s_int:02}");
-  }
-  write!(w, "{sign}{h}:{m:02}:{s_int:02}")
+  // Thin alias over the single canonical `ConvertDuration` (`composite::convs`).
+  // The streaming `Write` shape is kept for the Real/MXF/MOI/M2TS/Flash/FLAC
+  // callers; the canonical is byte-identical to the former inline impl for all
+  // finite/normal durations and strictly more faithful at extreme magnitudes
+  // (Perl-NV days/hours stringification instead of a saturating `as i64`).
+  w.write_str(&crate::composite::convs::convert_duration(time))
 }
 
 /// `ConvertDuration($val)` applied to a STRING-typed value, honouring the
@@ -2570,6 +2649,123 @@ mod tests {
       ("1.#IN", Finite(1.0)),
       ("1.#I", Finite(1.0)),
       ("#INF", Finite(0.0)),
+    ];
+    for &(s, want) in cases {
+      let got = perl_str_to_f64(s);
+      match want {
+        PosInf => assert!(
+          got.is_infinite() && got.is_sign_positive(),
+          "perl_str_to_f64({s:?}) = {got}, want +Inf"
+        ),
+        NegInf => assert!(
+          got.is_infinite() && got.is_sign_negative(),
+          "perl_str_to_f64({s:?}) = {got}, want -Inf"
+        ),
+        Nan => assert!(got.is_nan(), "perl_str_to_f64({s:?}) = {got}, want NaN"),
+        Finite(w) => assert!(
+          (got - w).abs() < 1e-12 || (got == 0.0 && w == 0.0),
+          "perl_str_to_f64({s:?}) = {got}, want {w}"
+        ),
+      }
+    }
+  }
+
+  // Perl numeric context accepts up to TWO sign characters (with one whitespace
+  // block permitted between sign 1 and sign 2, but NONE after sign 2), the
+  // effective sign being the product. Promoted INTO this shared helper from the
+  // former APE-local `perl_numeric_coerce_f64` so the Composite engine + APE
+  // share ONE coercion (oracle verified vs Perl 5). The non-finite + MSVCRT
+  // forms above still hold under dual signs (`++Inf`/`-+Inf`/`+ Inf`).
+  #[test]
+  fn perl_str_to_f64_dual_sign_and_inter_sign_whitespace() {
+    use NonFinite::{Finite, NegInf, PosInf};
+    let cases: &[(&str, NonFinite)] = &[
+      // Single sign with leading / inter-sign whitespace.
+      (" +44100", Finite(44100.0)),
+      ("+ 20000000", Finite(20_000_000.0)),
+      ("-  20", Finite(-20.0)),
+      ("   20", Finite(20.0)),
+      // Dual sign — product rule.
+      ("++1000", Finite(1000.0)),
+      ("+-20000000", Finite(-20_000_000.0)),
+      ("--20000000", Finite(20_000_000.0)),
+      ("-+20", Finite(-20.0)),
+      ("+ +20", Finite(20.0)),
+      ("- +5", Finite(-5.0)),
+      ("-  +20", Finite(-20.0)),
+      ("+ -20", Finite(-20.0)),
+      // Dual sign onto non-finite spellings.
+      ("++Inf", PosInf),
+      ("-+Inf", NegInf),
+      ("+ Inf", PosInf),
+      // Rejected: whitespace after sign 2, or a third sign ⇒ 0.
+      ("+- 20", Finite(0.0)),
+      ("-- 20", Finite(0.0)),
+      ("-+ 20", Finite(0.0)),
+      ("-  -  20", Finite(0.0)),
+      ("+--20000000", Finite(0.0)),
+      ("+ - 20", Finite(0.0)),
+      // Bare / dangling signs ⇒ 0.
+      ("+", Finite(0.0)),
+      ("-", Finite(0.0)),
+      ("--", Finite(0.0)),
+    ];
+    for &(s, want) in cases {
+      let got = perl_str_to_f64(s);
+      match want {
+        PosInf => assert!(
+          got.is_infinite() && got.is_sign_positive(),
+          "perl_str_to_f64({s:?}) = {got}, want +Inf"
+        ),
+        NegInf => assert!(
+          got.is_infinite() && got.is_sign_negative(),
+          "perl_str_to_f64({s:?}) = {got}, want -Inf"
+        ),
+        NonFinite::Nan => unreachable!(),
+        Finite(w) => assert!(
+          (got - w).abs() < 1e-12 || (got == 0.0 && w == 0.0),
+          "perl_str_to_f64({s:?}) = {got}, want {w}"
+        ),
+      }
+    }
+  }
+
+  // The MSVCRT `1.#…` spelling crossed with sign-whitespace and dual signs.
+  // Perl's `Perl_grok_infnan` recognises the spelling only for a single
+  // directly-adjacent sign or a `+`-led adjacent dual sign; inter-sign / post-
+  // sign whitespace and a `-`-led dual sign break recognition, so the value
+  // falls through to the finite mantissa scan (`1.` → 1) and carries the
+  // product sign — turning what looked non-finite into a finite ±1. Oracle
+  // 2026-06-19 (`no warnings "numeric"; $s + 0`).
+  #[test]
+  fn perl_str_to_f64_msvcrt_spelling_sign_forms() {
+    use NonFinite::{Finite, Nan, NegInf, PosInf};
+    let cases: &[(&str, NonFinite)] = &[
+      // Still recognised: bare / single adjacent sign / `+`-led adjacent dual.
+      ("1.#INF", PosInf),
+      ("-1.#INF", NegInf),
+      ("+1.#INF", PosInf),
+      ("1.#IND", Nan),
+      ("-1.#IND", Nan),
+      ("++1.#INF", PosInf),
+      ("+-1.#INF", NegInf),
+      ("++1.#IND", Nan),
+      ("+-1.#IND", Nan),
+      // Inter-sign / post-sign whitespace ⇒ NOT recognised ⇒ finite ±1.
+      ("+ 1.#INF", Finite(1.0)),
+      ("- 1.#INF", Finite(-1.0)),
+      ("+ 1.#IND", Finite(1.0)),
+      ("- 1.#IND", Finite(-1.0)),
+      ("+ -1.#INF", Finite(-1.0)),
+      ("- +1.#INF", Finite(-1.0)),
+      ("+ +1.#INF", Finite(1.0)),
+      ("- -1.#INF", Finite(1.0)),
+      ("+ -1.#IND", Finite(-1.0)),
+      // `-`-led adjacent dual sign ⇒ NOT recognised ⇒ finite ±1 (product sign).
+      ("-+1.#INF", Finite(-1.0)),
+      ("--1.#INF", Finite(1.0)),
+      ("-+1.#IND", Finite(-1.0)),
+      ("--1.#IND", Finite(1.0)),
     ];
     for &(s, want) in cases {
       let got = perl_str_to_f64(s);

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -386,71 +386,11 @@ pub fn convert_datetime(val: &str) -> String {
 /// other branches for future composite-tag consumers.
 #[must_use]
 pub fn convert_duration(time: f64) -> String {
-  // ExifTool.pm:6869 `return $time unless IsFloat($time)`. A non-finite
-  // f64 is NOT IsFloat (IsFloat checks for a numeric scalar that parses
-  // as a float); Perl returns the input scalar unchanged, and the scalar
-  // stringifies via Perl's default NV-to-string with titlecase `Inf`/
-  // `-Inf`/`NaN` casing (verified 2026-05-20). Codex R8 fix: use
-  // `perl_nonfinite_str` for byte-exact casing (the prior `format!
-  // ("{time}")` emitted Rust's lowercase `inf`/`-inf`).
-  if !time.is_finite() {
-    return crate::value::perl_nonfinite_str(time)
-      .unwrap_or("")
-      .to_string();
-  }
-  // ExifTool.pm:6870 `return '0 s' if $time == 0`.
-  if time == 0.0 {
-    return "0 s".to_string();
-  }
-  // ExifTool.pm:6871 `$sign = ($time > 0 ? '' : (($time = -$time), '-'))`.
-  let (sign, t) = if time > 0.0 { ("", time) } else { ("-", -time) };
-  // ExifTool.pm:6872 `return sprintf("$sign%.2f s", $time) if $time < 30`.
-  if t < 30.0 {
-    return format!("{sign}{t:.2} s");
-  }
-  // ExifTool.pm:6873 `$time += 0.5` — round to nearest second.
-  let mut rounded = t + 0.5;
-  // ExifTool.pm:6874-6877 `$h = int($time/3600); $time -= $h*3600;
-  // $m = int($time/60); $time -= $m*60;`. `int()` in Perl is truncate-
-  // toward-zero ON A FLOAT (NV); the FLOAT magnitude is preserved through
-  // the modulo arithmetic (Codex R7 fix: prior `as i64` cast saturated for
-  // huge finite durations, e.g. a SampleRate of 2^-84 / NumSampleFrames=1
-  // yields ~1.93e+25 seconds and the i64 cast saturated to i64::MAX,
-  // producing wrong sub-day values. Perl keeps `$h`, `$m`, `$d` as NV-
-  // typed scalars whose magnitudes can exceed i64; we faithfully use f64
-  // throughout and only cast the SMALL REMAINDERS to i64 for the final
-  // `%d:%.2d:%.2d` printf).
-  let h_f = (rounded / 3600.0).trunc();
-  rounded -= h_f * 3600.0;
-  let m_f = (rounded / 60.0).trunc();
-  rounded -= m_f * 60.0;
-  let s_f = rounded.trunc(); // `int($time)` of remaining
-  // ExifTool.pm:6878-6882 `if ($h > 24) { my $d = int($h/24); $h -= $d*24;
-  // $sign = "$sign$d days "; }`.
-  let mut prefix = sign.to_string();
-  let h_after_days = if h_f > 24.0 {
-    let d_f = (h_f / 24.0).trunc();
-    let h_left = h_f - d_f * 24.0;
-    // Perl `"$sign$d days "` interpolates `$d` as Perl's default NV
-    // stringification. Small integer d ⇒ no decimal (e.g. "12 days ");
-    // very large d ⇒ scientific notation via `format_g(_, 15)` (Perl's
-    // default NV → string precision). Oracle (2026-05-20) on SampleRate=
-    // 2^-84 / NumSampleFrames=1 (`/tmp/test_ext_tiny.aif`) emits
-    // `"2.23875151780487e+20 days 0:00:00"` — byte-exact via format_g(d, 15).
-    prefix.push_str(&crate::value::format_g(d_f, 15));
-    prefix.push_str(" days ");
-    h_left
-  } else {
-    h_f
-  };
-  // ExifTool.pm:6883 `return sprintf("$sign%d:%.2d:%.2d", $h, $m, int($time))`.
-  // After the `days` reduction `h_after_days` is in `0.0..=24.0` (always
-  // a small float); m_f is in `0.0..=60.0`; s_f is in `0.0..=60.0`. All
-  // safely fit i64 for `%d`/`%.2d` printf semantics.
-  let h_i = h_after_days as i64;
-  let m_i = m_f as i64;
-  let s_i = s_f as i64;
-  format!("{prefix}{h_i}:{m_i:02}:{s_i:02}")
+  // The single canonical `ConvertDuration` lives in `composite::convs` (the
+  // Composite engine + every duration caller share it). This is now a thin
+  // alias; the AIFF Composite Duration that used to call this is built by the
+  // engine, but the cross-format callers (e.g. Matroska/MXF) still route here.
+  crate::composite::convs::convert_duration(time)
 }
 
 /// Convert a Unix timestamp (seconds since 1970-01-01T00:00:00Z) to its

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -700,27 +700,17 @@ impl AnyMeta<'_> {
     }
   }
 
-  /// The format tag stream as [`value::Tag`](crate::value::Tag)s
-  /// (golden-pattern **L4**) — the public, no-JSON generic-extraction API.
-  /// Yields the Unknown-gated, de-duplicated tag set carrying the full
-  /// [`Group`](crate::value::Group) (family-0 + family-1). Diagnostics
-  /// (`ExifTool:Warning` / `ExifTool:Error`) are NOT included — they are a
-  /// separate channel surfaced by the JSON path (and the engine-orchestration
-  /// tags `SourceFile` / `File:FileType` / version are added by
-  /// [`crate::parser::extract_info`], not here).
-  ///
-  /// This yields the same tag set the JSON path produces (same keys, same
-  /// values, same dedup) MINUS those diagnostics + orchestration tags, but it
-  /// carries family-0 too (which the `-G1` JSON key drops). `mode` selects
-  /// PrintConv (`-j`) vs ValueConv (`-n`) values.
-  #[must_use = "iter_tags yields the tag stream lazily; consume the iterator"]
-  pub fn iter_tags(
-    &self,
-    mode: crate::emit::ConvMode,
-  ) -> impl Iterator<Item = crate::value::Tag> + '_ {
-    // The generic-extraction path is the `-G1` default with `-ee` off — this
-    // option-free tag iterator is the faithful baseline; the `-ee`/`-G3`-aware
-    // render path is [`Rendered::new_with_options`] (driven by `ParseOptions`).
+  /// Collect this Meta's `-G1`/`-ee`-off [`Taggable`](crate::emit::Taggable)
+  /// stream into a deduped [`Tag`](crate::value::Tag) `Vec` for the given
+  /// `mode`, applying the SAME cross-cutting rules
+  /// [`run_emission`](crate::emit::run_emission) does — Unknown-suppression
+  /// (`ExifTool.pm:9179`) then the faithful `(family1, name)` last-wins-in-place
+  /// dedup (with the priority-0 `Warning`/`Error` first-wins exception,
+  /// `ExifTool.pm:9544-9560`). Shared by [`iter_tags`](Self::iter_tags) (the
+  /// public output) and the Composite engine's ValueConv resolution view, so
+  /// both observe an identical pre-composite tag set.
+  #[cfg(feature = "alloc")]
+  fn collect_deduped_tags(&self, mode: crate::emit::ConvMode) -> std::vec::Vec<crate::value::Tag> {
     let opts = crate::emit::EmitOptions::g1(mode, false);
     let mut out: std::vec::Vec<crate::value::Tag> = std::vec::Vec::new();
     for e in self.collect_emitted(opts) {
@@ -747,6 +737,49 @@ impl AnyMeta<'_> {
         out.push(tag);
       }
     }
+    out
+  }
+
+  /// The format tag stream as [`value::Tag`](crate::value::Tag)s
+  /// (golden-pattern **L4**) — the public, no-JSON generic-extraction API.
+  /// Yields the Unknown-gated, de-duplicated tag set carrying the full
+  /// [`Group`](crate::value::Group) (family-0 + family-1). Diagnostics
+  /// (`ExifTool:Warning` / `ExifTool:Error`) are NOT included — they are a
+  /// separate channel surfaced by the JSON path (and the engine-orchestration
+  /// tags `SourceFile` / `File:FileType` / version are added by
+  /// [`crate::parser::extract_info`], not here).
+  ///
+  /// This yields the same tag set the JSON path produces (same keys, same
+  /// values, same dedup) MINUS those diagnostics + orchestration tags, but it
+  /// carries family-0 too (which the `-G1` JSON key drops). `mode` selects
+  /// PrintConv (`-j`) vs ValueConv (`-n`) values.
+  #[must_use = "iter_tags yields the tag stream lazily; consume the iterator"]
+  pub fn iter_tags(
+    &self,
+    mode: crate::emit::ConvMode,
+  ) -> impl Iterator<Item = crate::value::Tag> + '_ {
+    // The generic-extraction path is the `-G1` default with `-ee` off — this
+    // option-free tag iterator is the faithful baseline; the `-ee`/`-G3`-aware
+    // render path is [`Rendered::new_with_options`] (driven by `ParseOptions`).
+    let mut out = self.collect_deduped_tags(mode);
+    // Composite tags (ExifTool.pm:4577 — built after extraction). The same
+    // standalone post-pass the JSON path runs, over the deduped `Tag` Vec, so
+    // this generic-extraction API yields the same `Composite:*` set. Appended
+    // last (preserves their positional last-ness, matching the JSON path).
+    //
+    // Inputs resolve from each ingredient's ValueConv (raw) value REGARDLESS of
+    // `mode` (ExifTool.pm:4112), mirroring the JSON path: under `-n`, `out`
+    // already holds raw values (its own resolution view, `None`); under `-j`, we
+    // re-collect the SAME stream in ValueConv mode into `raw_view` and resolve
+    // inputs from it while the composite's rendered value lands in `out`.
+    let mut raw_view;
+    let resolve_src = if mode == crate::emit::ConvMode::PrintConv {
+      raw_view = self.collect_deduped_tags(crate::emit::ConvMode::ValueConv);
+      Some(&mut raw_view)
+    } else {
+      None
+    };
+    crate::composite::build_composites_into_tags(&mut out, resolve_src, mode);
     out.into_iter()
   }
 
@@ -783,12 +816,42 @@ impl AnyMeta<'_> {
     group_mode: crate::serialize_key::GroupMode,
     out: &mut crate::tagmap::TagMap,
   ) -> Result<(), core::convert::Infallible> {
-    let opts = crate::emit::EmitOptions::with_group_mode(
-      crate::emit::ConvMode::from_print_conv(print_conv),
-      extract_embedded,
-      group_mode,
-    );
+    let mode = crate::emit::ConvMode::from_print_conv(print_conv);
+    let opts = crate::emit::EmitOptions::with_group_mode(mode, extract_embedded, group_mode);
     crate::emit::run_emission(self, opts, out);
+    // ExifTool builds Composite tags AFTER all format extraction completes
+    // (ExifTool.pm:4577, inside ExtractInfo). The standalone post-pass reads the
+    // FINAL emitted tag set and APPENDS each surviving `Composite:*` (so its
+    // positional last-ness is preserved). Always-on (Composite default ON,
+    // ExifTool.pm:1125). `doc_count` is the highest family-3 sub-document index
+    // present (reserved for `SubDoc` composites; the Duration defs build at Main
+    // only).
+    let doc_count = out.entries().iter().map(|e| e.0).max().unwrap_or(0);
+    // ExifTool resolves a composite's inputs from each ingredient's ValueConv
+    // (raw) value — `GetValue($tag, 'ValueConv')`, ExifTool.pm:4112 — REGARDLESS
+    // of the `-j`/`-n` output mode. Under `-n` the emitted `out` already holds
+    // those raw values, so it is its own resolution view. Under `-j` the emitted
+    // values are PrintConv strings, so we re-emit the SAME Meta in ValueConv mode
+    // into a throwaway `raw_view` (identical tag set + dedup; only the rendered
+    // values differ) and resolve inputs from it, while the composite's RENDERED
+    // (`-j`) value still lands in `out`. (Duration's ingredients have no
+    // PrintConv, so raw == rendered and the goldens are unchanged; the GPS /
+    // datetime composites of later #133 PRs are the ones that genuinely need the
+    // raw `"N"`/`"S"` / decimal-coordinate inputs.)
+    let mut raw_view;
+    let resolve_src = if print_conv {
+      raw_view = crate::tagmap::TagMap::new();
+      let raw_opts = crate::emit::EmitOptions::with_group_mode(
+        crate::emit::ConvMode::ValueConv,
+        extract_embedded,
+        group_mode,
+      );
+      crate::emit::run_emission(self, raw_opts, &mut raw_view);
+      Some(&mut raw_view)
+    } else {
+      None
+    };
+    crate::composite::build_composites(out, resolve_src, mode, doc_count);
     crate::diagnostics::run_diagnostics(self, out);
     Ok(())
   }

--- a/src/formats/aiff.rs
+++ b/src/formats/aiff.rs
@@ -64,7 +64,7 @@
 
 use crate::{
   charset::decode_macroman,
-  datetime::{AIFF_EPOCH_OFFSET, convert_datetime, convert_duration, convert_unix_time},
+  datetime::{AIFF_EPOCH_OFFSET, convert_datetime, convert_unix_time},
   format_parser::{FormatParser, parser_sealed},
   processbinarydata::process_binary_data,
   tagtable::{PrintConv, PrintConvHash, PrintValue, TagDef, TagId, TagTable, ValueConv},
@@ -1574,34 +1574,11 @@ impl crate::emit::Taggable for Meta<'_> {
       }
     }
 
-    // Composite Duration (AIFF.pm:136-145). Emitted POST-chunk-loop in the
-    // bundled-Perl AddCompositeTags pass. Group is ExifTool's own `Composite`
-    // table (family-0/1 = "Composite").
-    if let Some(secs) = self.composite_duration {
-      let value = if print_conv {
-        // PrintConv = ConvertDuration. ConvertDuration's `unless
-        // IsFloat($time)` early-return is wired through
-        // `perl_nonfinite_str` for byte-exact casing of Inf/NaN — but
-        // `convert_duration` already routes non-finite values through it, so
-        // the formatted string is byte-exact either way.
-        TagValue::Str(convert_duration(secs).into())
-      } else if let Some(non_finite) = perl_nonfinite_str(secs) {
-        // `-n` mode, non-finite. Perl still emits the titlecase text (the
-        // serializer's `EscapeJSON` quotes non-numeric scalars); a
-        // `TagValue::Str` reproduces that quoted string.
-        TagValue::Str(non_finite.into())
-      } else {
-        // `-n` mode, finite. `TagValue::F64` routes through the serializer's
-        // bare-number gate (byte-identical to the retired `write_f64`).
-        TagValue::F64(secs)
-      };
-      tags.push(EmittedTag::new(
-        Group::new("Composite", "Composite"),
-        "Duration".into(),
-        value,
-        false,
-      ));
-    }
+    // Composite:Duration (AIFF.pm:136-145) is no longer emitted inline: the
+    // generic Composite engine (`crate::composite`) derives it from the emitted
+    // `AIFF:SampleRate` + `AIFF:NumSampleFrames` as a post-`run_emission` pass.
+    // The typed `composite_duration` field is retained — it backs the
+    // cross-format `duration()` MediaInfo accessor.
 
     tags.into_iter()
   }
@@ -2206,10 +2183,11 @@ mod tests {
     assert_eq!(w.get("AIFF", "SampleRate"), Some(&TagValue::I64(0)));
   }
 
-  /// AIFF_duration.aif: the post-loop Composite `Duration` lands under the
-  /// `Composite` family-1 group as the ConvertDuration string `"2.00 s"`
-  /// (`-j`) / the bare number `2` from `F64(2.0)` (`-n`) — byte-identical to
-  /// the `AIFF_duration.aif` golden.
+  /// AIFF_duration.aif: the generic Composite engine derives `Composite:
+  /// Duration` from the emitted `AIFF:SampleRate` + `AIFF:NumSampleFrames` as
+  /// the post-`run_emission` pass — the ConvertDuration string `"2.00 s"`
+  /// (`-j`) / the bare number `2` from `F64(2.0)` (`-n`), byte-identical to the
+  /// `AIFF_duration.aif` golden.
   #[test]
   fn taggable_emits_composite_duration() {
     use crate::emit::ConvMode;
@@ -2220,8 +2198,10 @@ mod tests {
     .expect("read AIFF_duration.aif fixture");
     let meta = parse_borrowed(&data).expect("AIFF parsed");
 
-    // -j: ConvertDuration string, under the Composite (-G1) group.
-    let w = emit_into_tagmap(&meta, ConvMode::PrintConv);
+    // -j: run_emission emits the AIFF inputs, then build_composites derives the
+    // ConvertDuration string under the Composite (-G1) group.
+    let mut w = emit_into_tagmap(&meta, ConvMode::PrintConv);
+    crate::composite::build_composites(&mut w, None, ConvMode::PrintConv, 0);
     assert_eq!(
       w.get_str("Composite", "Duration"),
       Some("2.00 s".to_string())
@@ -2230,12 +2210,43 @@ mod tests {
 
     // -n: finite f64 ⇒ bare number (serializer renders 2.0 as `2`); assert
     // the variant carried is F64 so the bare-number gate applies.
-    let w = emit_into_tagmap(&meta, ConvMode::ValueConv);
+    let mut w = emit_into_tagmap(&meta, ConvMode::ValueConv);
+    crate::composite::build_composites(&mut w, None, ConvMode::ValueConv, 0);
     assert_eq!(w.get("Composite", "Duration"), Some(&TagValue::F64(2.0)));
   }
 
-  /// `tags()` yields AIFF tags under family-0/1 `"AIFF"` and the Composite
-  /// `Duration` under family-0/1 `"Composite"`; no tag is `Unknown=>1`.
+  /// Migration safety net (old ≡ new): the engine-derived `Composite:Duration`
+  /// equals the value the retained typed compute (`composite_duration_secs` —
+  /// the former inline path) would have emitted, for both modes.
+  #[test]
+  fn composite_duration_engine_matches_typed_compute() {
+    use crate::emit::ConvMode;
+    let data = std::fs::read(format!(
+      "{}/tests/fixtures/AIFF_duration.aif",
+      env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read AIFF_duration.aif fixture");
+    let meta = parse_borrowed(&data).expect("AIFF parsed");
+    let secs = meta.composite_duration_secs().expect("typed duration");
+
+    // -j: engine string == canonical ConvertDuration of the typed value.
+    let mut w = emit_into_tagmap(&meta, ConvMode::PrintConv);
+    crate::composite::build_composites(&mut w, None, ConvMode::PrintConv, 0);
+    assert_eq!(
+      w.get_str("Composite", "Duration"),
+      Some(crate::composite::convs::convert_duration(secs))
+    );
+    // -n: engine bare f64 == the typed value.
+    let mut wn = emit_into_tagmap(&meta, ConvMode::ValueConv);
+    crate::composite::build_composites(&mut wn, None, ConvMode::ValueConv, 0);
+    assert_eq!(wn.get("Composite", "Duration"), Some(&TagValue::F64(secs)));
+  }
+
+  /// The format's `tags()` stream now yields ONLY AIFF tags under family-0/1
+  /// `"AIFF"` (no tag is `Unknown=>1`); `Composite:Duration` is no longer part
+  /// of this stream — the generic Composite engine appends it as a separate
+  /// post-`run_emission` pass (asserted by `taggable_emits_composite_duration`
+  /// and the `AIFF_duration.aif` golden).
   #[test]
   fn taggable_group_family0_family1_and_unknown() {
     use crate::emit::{ConvMode, Taggable};
@@ -2250,27 +2261,18 @@ mod tests {
       .collect();
 
     let mut saw_aiff = false;
-    let mut saw_composite = false;
     for t in &tags {
       assert!(!t.unknown(), "no AIFF table carries Unknown=>1");
-      match t.tag().name() {
-        "Duration" => {
-          // Composite table is its own group0/1.
-          assert_eq!(t.tag().group_ref().family0(), "Composite");
-          assert_eq!(t.tag().group_ref().family1(), "Composite");
-          saw_composite = true;
-        }
-        _ => {
-          assert_eq!(t.tag().group_ref().family0(), "AIFF");
-          assert_eq!(t.tag().group_ref().family1(), "AIFF");
-          saw_aiff = true;
-        }
-      }
+      assert_ne!(
+        t.tag().name(),
+        "Duration",
+        "Composite:Duration must come from the engine, not the AIFF tag stream"
+      );
+      assert_eq!(t.tag().group_ref().family0(), "AIFF");
+      assert_eq!(t.tag().group_ref().family1(), "AIFF");
+      saw_aiff = true;
     }
     assert!(saw_aiff, "expected at least one AIFF-group tag");
-    assert!(saw_composite, "expected the Composite Duration tag");
-    // Emission order: the COMM sub-fields precede the post-loop Duration.
-    assert_eq!(tags.last().unwrap().tag().name(), "Duration");
   }
 
   /// The DjVu branch (`AT&TFORM` + `DJVU`) emits NO body tags through the

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -83,143 +83,23 @@ const APE_GROUP0: &str = "APE";
 // ConvertDuration — PrintConv (ExifTool.pm:6866-6884)
 // =============================================================================
 
-/// Faithful port of `sub ConvertDuration` (ExifTool.pm:6866-6884). Used by
-/// both APE Main `DURATION` (PrintConv) and the local Composite `Duration`
-/// (PrintConv). Operates on the post-ValueConv numeric value.
+/// `sub ConvertDuration` (ExifTool.pm:6877-6895) applied to a [`TagValue`],
+/// used by APE Main `DURATION` (PrintConv) on the post-ValueConv value.
 ///
-/// IsFloat gate (ExifTool.pm `sub IsFloat`) rejects non-numeric values ⇒ they
-/// pass through unchanged. Integer-valued strings/numbers DO satisfy IsFloat
-/// (its regex accepts bare `\d+` with no fraction).
+/// The numeric formatting is the single canonical
+/// [`crate::composite::convs::convert_duration`] (the APE Composite Duration
+/// that used to share this is now built by the generic engine). This wrapper
+/// keeps the ExifTool `IsFloat` gate (ExifTool.pm:6879 `return $time unless
+/// IsFloat($time)`): a non-numeric value (e.g. `"abc"`, or a non-finite f64
+/// that stringifies to `Inf`/`NaN` and fails the IsFloat regex) passes through
+/// UNCHANGED; an integer-valued string/number satisfies IsFloat and is
+/// formatted.
 fn convert_duration(v: &TagValue) -> TagValue {
-  // ExifTool.pm:6869 `return $time unless IsFloat($time);`
+  // ExifTool.pm:6879 `return $time unless IsFloat($time);`
   let Some(time) = as_perl_float(v) else {
     return v.clone();
   };
-  // ExifTool.pm:6870 `return '0 s' if $time == 0;`
-  if time == 0.0 {
-    return TagValue::Str("0 s".into());
-  }
-  // ExifTool.pm:6871 `my $sign = ($time > 0 ? '' : (($time = -$time), '-'));`
-  let (sign, mut time) = if time > 0.0 { ("", time) } else { ("-", -time) };
-  // ExifTool.pm:6872 `return sprintf("$sign%.2f s", $time) if $time < 30;`
-  if time < 30.0 {
-    return TagValue::Str(format!("{sign}{time:.2} s").into());
-  }
-  // ExifTool.pm:6873 `$time += 0.5;` (round to nearest second).
-  time += 0.5;
-  // ExifTool.pm:6874-6877:
-  //   my $h = int($time / 3600);  $time -= $h * 3600;
-  //   my $m = int($time / 60);    $time -= $m * 60;
-  //
-  // Codex r10 finding: Perl `int(f64)` truncates the FLOAT toward zero
-  // but keeps the result as Perl NV (f64) when the value exceeds the IV
-  // range. `$h -= $d*24` runs on the NV; `"$d days "` interpolation
-  // stringifies the NV (`%.15g` for very large values, exact decimal for
-  // those within IV range). Naively casting `time/3600.0 as i64`
-  // saturates at i64::MAX (≈ 9.2e18) and produces a garbage h:m:s for
-  // `time > i64::MAX * 3600` (≈ 3.3e22). Match Perl faithfully:
-  //   - Keep h/m/s as f64 for the arithmetic.
-  //   - Use `f64::trunc` for Perl's `int()` (truncate toward zero).
-  //   - Format the days carve-out's `$d` via `perl_nv_str` (Perl NV
-  //     stringify — exact decimal up to i64::MAX, else `%.15g`).
-  let h_f = (time / 3600.0).trunc();
-  time -= h_f * 3600.0;
-  let m_f = (time / 60.0).trunc();
-  time -= m_f * 60.0;
-  let s_f = time.trunc();
-  // ExifTool.pm:6878-6882 days carve-out (`$h > 24`).
-  if h_f > 24.0 {
-    let d_f = (h_f / 24.0).trunc();
-    let h_remainder = h_f - d_f * 24.0;
-    return TagValue::Str(
-      format!(
-        "{sign}{d} days {h}:{m}:{s}",
-        d = perl_nv_str(d_f),
-        h = perl_nv_str(h_remainder),
-        m = perl_int_str_padded(m_f, 2),
-        s = perl_int_str_padded(s_f, 2),
-      )
-      .into(),
-    );
-  }
-  // ExifTool.pm:6883 final sprintf.
-  TagValue::Str(
-    format!(
-      "{sign}{h}:{m}:{s}",
-      h = perl_nv_str(h_f),
-      m = perl_int_str_padded(m_f, 2),
-      s = perl_int_str_padded(s_f, 2),
-    )
-    .into(),
-  )
-}
-
-/// Left-pad `n` with leading zeros to `width` when the number is a
-/// non-negative integer that fits in i64 (e.g. `5` → `"05"` at width 2).
-/// For ConvertDuration's minutes/seconds (always in [0, 60)) this is the
-/// in-range path; out-of-range values (impossible for m/s after
-/// `time -= h*3600` etc., but defensive against synthetic input) fall
-/// back to plain [`perl_nv_str`].
-fn perl_int_str_padded(n: f64, width: usize) -> String {
-  if n.is_finite() && (0.0..i64::MAX as f64).contains(&n) && n == n.trunc() {
-    let iv = n as i64;
-    format!("{iv:0width$}")
-  } else {
-    perl_nv_str(n)
-  }
-}
-
-/// Perl default NV (number-value-in-string-context) stringification.
-/// Equivalent to `sprintf("%.15g", $nv)` for finite values (Perl uses 15
-/// significant figures by default). Special values are spelled `Inf` /
-/// `-Inf` / `NaN`.
-///
-/// **Integer carve-out (Codex r11 finding).** Perl's `int()` returns
-/// IV/UV-aware integers; stringification preserves the exact decimal as
-/// long as the value fits Perl's UV (u64). Empirically against Perl 5:
-///   - `int(1e19) ⇒ "10000000000000000000"` (decimal, > i64::MAX)
-///   - `int(1.5e19) ⇒ "15000000000000000000"` (decimal)
-///   - `int(u64::MAX as f64) ⇒ "18446744073709551615"` (decimal)
-///   - `int(1.84467440737096e19) ⇒ "1.84467440737096e+19"` (above u64,
-///     scientific)
-///
-/// We therefore preserve decimal for ANY integer-valued f64 that fits
-/// either `i64` (signed range, negatives covered) OR `u64` (positive
-/// range up to u64::MAX). Above that ⇒ `%.15g`.
-fn perl_nv_str(n: f64) -> String {
-  if n.is_nan() {
-    return "NaN".to_string();
-  }
-  if n.is_infinite() {
-    return if n.is_sign_negative() { "-Inf" } else { "Inf" }.to_string();
-  }
-  // Signed-integer carve-out: any integer-valued f64 in [i64::MIN, i64::MAX].
-  // Codex r12 finding: `i64::MAX as f64` actually equals 2^63 (not 2^63-1)
-  // because i64::MAX is not exactly representable in f64; the cast rounds
-  // UP to the next representable f64 value. So `n = 9223372036854775808.0`
-  // (exactly 2^63) passes the inclusive `(i64::MIN as f64..=i64::MAX as
-  // f64).contains` check, but `n as i64` then saturates to i64::MAX
-  // (9223372036854775807), losing exactly one. Perl uses the UV path here
-  // and emits the full `9223372036854775808` decimal. Faithful fix: split
-  // the signed/unsigned carve-outs at the exact f64 power-of-two boundary
-  // 2^63 (signed: n < 2^63; unsigned: 2^63 <= n < 2^64).
-  let two63 = (1u128 << 63) as f64; // exactly 9223372036854775808.0
-  let two64 = (1u128 << 64) as f64; // exactly 18446744073709551616.0
-  // Signed-integer carve-out: integer-valued f64 in [i64::MIN, 2^63),
-  // EXCLUDING 2^63 because `n as i64` would saturate to i64::MAX = 2^63-1.
-  if n == n.trunc() && n >= i64::MIN as f64 && n < two63 {
-    let iv = n as i64;
-    return iv.to_string();
-  }
-  // Unsigned-integer carve-out (Codex r11 + r12): positive integer-valued
-  // f64 in [2^63, 2^64). `n as u64` saturates to u64::MAX for `n >= 2^64`,
-  // so the strict upper bound is exactly `2^64`. The f64 values exactly
-  // at 2^63 and just below 2^64 are both correctly representable as u64.
-  if n == n.trunc() && n >= two63 && n < two64 {
-    let uv = n as u64;
-    return uv.to_string();
-  }
-  crate::value::format_g(n, 15)
+  TagValue::Str(crate::composite::convs::convert_duration(time).into())
 }
 
 /// Perl `IsFloat`-gated coercion (ExifTool.pm `sub IsFloat`):
@@ -728,40 +608,13 @@ fn process_ape_binary_data(
 }
 
 // =============================================================================
-// Perl boolean truthiness (Codex r10 finding for Composite RawConv guard)
+// Perl boolean truthiness (the `if ($val)` RawConv guard)
 // =============================================================================
 
-/// Perl boolean context (`if ($val)`) for a `TagValue`. Faithful semantics
-/// (verified empirically against Perl 5):
-///   - `Str(s)`: TRUE iff `s` is non-empty AND not the exact literal `"0"`.
-///     So `"0E0"`, `"0.0"`, `"00"`, `"+0"`, `" 0"`, `"0abc"` are all TRUE.
-///   - `I64(n)`: TRUE iff `n != 0`.
-///   - `F64(x)`: TRUE iff `x != 0.0` (NaN compares unequal to 0.0 in
-///     IEEE, so NaN is reported as TRUE — faithful: Perl NaN is truthy).
-///   - `Bool(b)`: TRUE iff `b` (direct Perl-bool mapping).
-///   - `Bytes(b)`: TRUE iff `!b.is_empty()` AND `b != [b'0']`
-///     (byte-faithful to the string rule).
-///   - `Rational(n,d)`: TRUE iff `n != 0` (Perl scalar stringifies; 0/X
-///     evaluates to "0" which is falsey).
-///   - `List(_)`: list-context truthiness in Perl is the count, but here
-///     `$val[N]` deref'd from `@val` returns a scalar; this can't be a
-///     `List` realistically. Conservative: TRUE iff non-empty.
-fn perl_boolean_truthy(v: &TagValue) -> bool {
-  match v {
-    TagValue::Str(s) => !s.is_empty() && s.as_str() != "0",
-    TagValue::I64(n) => *n != 0,
-    TagValue::U64(n) => *n != 0,
-    #[allow(clippy::float_cmp)]
-    TagValue::F64(x) => *x != 0.0,
-    TagValue::Bool(b) => *b,
-    TagValue::Bytes(b) => !b.is_empty() && b.as_slice() != b"0",
-    TagValue::Rational(r) => r.numerator() != 0,
-    TagValue::List(l) => !l.is_empty(),
-    // `Map` (XMP structured value) never reaches an APE boolean conv;
-    // a non-empty struct is truthy by the same count semantics as List.
-    TagValue::Map(m) => !m.is_empty(),
-  }
-}
+// The faithful Perl-boolean predicate now lives in `crate::convert` (the
+// Composite engine's per-def guards share it). Re-exported here so the APE
+// Composite arithmetic + its unit test keep referring to it unqualified.
+pub(crate) use crate::convert::perl_boolean_truthy;
 
 // =============================================================================
 // %APE::Main tag dictionary (APE.pm:21-42)
@@ -829,165 +682,23 @@ fn ape_duration_value_conv(v: &TagValue) -> TagValue {
   TagValue::F64(scaled)
 }
 
-/// Perl numeric coercion (leading-prefix scan) returning `f64`. Faithful
-/// to Perl's `0 + $str` rule for any APE tag value passed through a
-/// numeric ValueConv:
+/// Perl numeric coercion (leading-prefix scan) returning `f64`, faithful to
+/// Perl's `0 + $str` rule for any APE tag value passed through a numeric
+/// ValueConv (the `DURATION` field arrives as a MakeTag string).
 ///
-/// Step 1 — skip optional ASCII whitespace.
-/// Step 2a — match the special tokens `[+-]?(Inf(inity)?|NaN)`
-/// case-insensitively FIRST (Perl numeric context accepts these; Codex r6
-/// finding 2). A successful match returns `f64::INFINITY`,
-/// `f64::NEG_INFINITY`, or `f64::NAN`.
-/// Step 2b — otherwise match `[+-]?(\d+(\.\d*)?|\.\d+)([Ee][+-]?\d+)?`
-/// greedily from the start.
-/// Step 3 — if neither matches, return `0.0` (Perl `"abc" + 0 == 0`).
-/// Step 4 — else parse the captured prefix as `f64`; overflow (e.g.
-/// `1e309`) naturally yields `f64::INFINITY`, matching Perl.
-///
-/// This is local to APE because the engine's `convert::perl_numeric_coerce`
-/// returns `u64` (BITMASK semantics); DURATION needs signed/float coercion.
-/// (Engine-tier promotion is the right move once a second format consumer
-/// arrives.)
+/// Now a thin alias over the shared engine helper
+/// [`crate::convert::perl_str_to_f64`]: the dual-sign + inter-sign-whitespace
+/// coercion this function pioneered (`"+ 20000000"`, `"++20000000"`, `"+-20"`,
+/// `"--20"`, the `"+- 20"` reject) was promoted INTO that shared helper so the
+/// Composite engine and APE share ONE implementation (the Composite GPS / EXIF
+/// defs added by later #133 PRs feed it string ingredients too). The APE oracle
+/// tests below now exercise the shared impl as a regression guard. The shared
+/// helper additionally recognises the legacy MSVCRT `1.#INF` / `1.#IND`
+/// spellings (a strict superset never reached by an APE DURATION wire value, so
+/// the four APE composite goldens stay byte-identical).
+#[inline]
 fn perl_numeric_coerce_f64(s: &str) -> f64 {
-  // Checked-indexing (Phase C S2): every `bytes[i]` had a preceding
-  // `i < bytes.len()` guard and `&bytes[i..]` always has `i <= len` (i only
-  // advances past a `.get`-checked byte), so the `.get()` forms below read the
-  // same bytes and take the same branches ⇒ byte-identical.
-  let bytes = s.as_bytes();
-  let is_ws = |b: u8| matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b'\x0b' | b'\x0c');
-  let mut i = 0;
-  // 1. Leading ASCII whitespace.
-  while bytes.get(i).copied().is_some_and(is_ws) {
-    i += 1;
-  }
-  // 2. Optional dual-sign parsing (Codex r7 finding). Perl's numeric
-  // context accepts up to TWO sign characters with one whitespace block
-  // between them, with NO whitespace permitted after the second sign.
-  // Empirically verified against Perl 5:
-  //   "+ 20000000"   → 20000000 (sign1, ws, no sign2, digits)
-  //   "+-20000000"   → -20000000 (sign1, sign2 adjacent, digits)
-  //   "--20000000"   → 20000000  (multiplicative: -×- = +)
-  //   "-+Inf"        → -Inf
-  //   "++Inf"        → Inf
-  //   "+ +20"        → 20 (sign1 + ws + sign2 + digits)
-  //   "+ +Inf"       → not tested but presumed Inf by same rule
-  //   "+-20"         → -20 (sign1, sign2 adjacent)
-  //   "+- 20"        → 0  (sign1 + sign2 + ws + digits — REJECTED:
-  //                       ws not allowed after sign2)
-  //   "-  -  20"     → 0  (same: sign2 followed by ws → reject)
-  //   "+--20000000"  → 0  (three signs)
-  //   "+- +20"       → not parseable per pattern
-  //   "   20"        → 20 (no sign at all)
-  // Algorithm: track effective sign = product of any signs seen.
-  let mut neg = false;
-  let mut sign_count = 0u8;
-  // Sign 1.
-  if let Some(&sign1) = bytes.get(i)
-    && (sign1 == b'+' || sign1 == b'-')
-  {
-    if sign1 == b'-' {
-      neg = !neg;
-    }
-    i += 1;
-    sign_count = 1;
-    // Optional whitespace between sign 1 and sign 2 / digits.
-    while bytes.get(i).copied().is_some_and(is_ws) {
-      i += 1;
-    }
-    // Sign 2 (no whitespace after this sign).
-    if let Some(&sign2) = bytes.get(i)
-      && (sign2 == b'+' || sign2 == b'-')
-    {
-      if sign2 == b'-' {
-        neg = !neg;
-      }
-      i += 1;
-      sign_count = 2;
-    }
-  }
-  // After sign 2, if there's another sign character OR whitespace, Perl
-  // rejects the whole prefix. (Empirically: "+--20" / "-+ 20" / "+- 20"
-  // all return 0.)
-  if sign_count == 2
-    && bytes
-      .get(i)
-      .is_some_and(|&b| b == b'+' || b == b'-' || is_ws(b))
-  {
-    return 0.0;
-  }
-  // 3. Special tokens Inf/Infinity/NaN (Codex r6 + r7). Case-insensitive
-  // ASCII; PREFIX scan — `"InfX" + 0` is still Inf.
-  let starts_with_ci = |rest: &[u8], lit: &[u8]| -> bool {
-    rest.get(..lit.len()).is_some_and(|head| {
-      head
-        .iter()
-        .zip(lit.iter())
-        .all(|(a, b)| a.eq_ignore_ascii_case(b))
-    })
-  };
-  let tail = bytes.get(i..).unwrap_or(&[]);
-  // Match "Infinity" first (longest), then "Inf", then "NaN".
-  if starts_with_ci(tail, b"Infinity") || starts_with_ci(tail, b"Inf") {
-    return if neg {
-      f64::NEG_INFINITY
-    } else {
-      f64::INFINITY
-    };
-  }
-  if starts_with_ci(tail, b"NaN") {
-    // Perl NaN has no sign distinction in stringification ("NaN" not
-    // "-NaN"), so we ignore `neg` here.
-    return f64::NAN;
-  }
-  // 4. Finite numeric prefix: `\d+(\.\d*)?` or `\.\d+`, optional exponent.
-  // The sign characters were already consumed above; we now parse digits
-  // only, manually wrapping the sign into the parsed value.
-  let num_start = i;
-  let digits_before_dot_start = i;
-  while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-    i += 1;
-  }
-  let had_int_digits = i > digits_before_dot_start;
-  if bytes.get(i) == Some(&b'.') {
-    i += 1;
-    let frac_start = i;
-    while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-      i += 1;
-    }
-    let had_frac_digits = i > frac_start;
-    if !had_int_digits && !had_frac_digits {
-      // Just a lone `.` with no digits ⇒ no numeric prefix.
-      return 0.0;
-    }
-  } else if !had_int_digits {
-    // No leading digits and no `.\d+` form ⇒ no numeric prefix.
-    return 0.0;
-  }
-  // Optional exponent.
-  let pre_exp = i;
-  if matches!(bytes.get(i), Some(b'E' | b'e')) {
-    i += 1;
-    if matches!(bytes.get(i), Some(b'+' | b'-')) {
-      i += 1;
-    }
-    let exp_digits_start = i;
-    while bytes.get(i).is_some_and(u8::is_ascii_digit) {
-      i += 1;
-    }
-    if i == exp_digits_start {
-      // `E` with no following digits ⇒ Perl's prefix scan rejects the `E`
-      // (the regex requires `\d+` after `[Ee][+-]?`), so the prefix
-      // terminates BEFORE the `E`. Faithful: drop back to `pre_exp`.
-      i = pre_exp;
-    }
-  }
-  // Parse the matched numeric prefix as positive, then apply the sign.
-  // `s.get(num_start..i)` is `Some` (num_start <= i <= len) ⇒ byte-identical.
-  let mag = s
-    .get(num_start..i)
-    .and_then(|t| t.parse::<f64>().ok())
-    .unwrap_or(0.0);
-  if neg { -mag } else { mag }
+  crate::convert::perl_str_to_f64(s)
 }
 
 // APE.pm:29
@@ -2278,30 +1989,11 @@ impl crate::emit::Taggable for Meta<'_> {
       tags.push(EmittedTag::new(ape(), t.name().into(), value, false));
     }
 
-    // (3) Intra-APE Composite:Duration (APE.pm:83-92). Family-1 group
-    // `"Composite"`. Mirrors `sink_composite_duration`: a finite f64 gets
-    // `ConvertDuration` under `-j` (a `TagValue::Str`) and the raw f64 under
-    // `-n`; a non-finite value is stored as `Str` ("Inf"/"-Inf"/"NaN") and
-    // emitted verbatim in both modes via `emitted_tag_value`.
-    if let Some(comp) = &self.composite_duration {
-      let composite = || Group::new("Composite", "Composite");
-      let value = match comp {
-        TagValue::F64(dur) => {
-          if print_conv {
-            emitted_tag_value(&convert_duration(&TagValue::F64(*dur)))
-          } else {
-            TagValue::F64(*dur)
-          }
-        }
-        other => emitted_tag_value(other),
-      };
-      tags.push(EmittedTag::new(
-        composite(),
-        "Duration".into(),
-        value,
-        false,
-      ));
-    }
+    // Composite:Duration (APE.pm:83-92) is no longer emitted inline: the
+    // generic Composite engine (`crate::composite`) derives it from the emitted
+    // `APE:`/`MAC:` SampleRate/TotalFrames/BlocksPerFrame/FinalFrameBlocks tags
+    // as a post-`run_emission` pass. The typed `composite_duration` field is
+    // retained — it backs the cross-format `duration()` MediaInfo projection.
 
     tags.into_iter()
   }
@@ -3804,12 +3496,162 @@ mod tests {
       crate::emit::EmitOptions::g1(ConvMode::PrintConv, false),
       &mut tm,
     );
+    // The generic Composite engine (post-`run_emission` pass) derives Duration
+    // from the emitted ingredients.
+    crate::composite::build_composites(&mut tm, None, ConvMode::PrintConv, 0);
     // Composite:Duration MUST be present (14.71 s — same arithmetic + PrintConv
     // as the standalone APE_spaced_composite fixture).
     assert_eq!(
       tm.get("Composite", "Duration"),
       Some(&TagValue::Str("14.71 s".into()))
     );
+  }
+
+  /// Migration safety net (old ≡ new): the engine-derived `Composite:Duration`
+  /// equals the value the retained typed compute (`composite_duration_ref` —
+  /// the former inline path) would have emitted. The typed value is the RAW
+  /// f64 (`-n`); `-j` is its canonical ConvertDuration.
+  #[test]
+  fn composite_duration_engine_matches_typed_compute() {
+    let data = std::fs::read(format!(
+      "{}/tests/fixtures/APE.ape",
+      env!("CARGO_MANIFEST_DIR")
+    ))
+    .expect("read APE.ape fixture");
+    let mut shared = SharedFlags::new();
+    let meta = parse_full_chained(&data, &mut shared).expect("APE parsed");
+    let Some(TagValue::F64(secs)) = meta.composite_duration_ref() else {
+      panic!("APE.ape has a finite typed composite duration");
+    };
+    let secs = *secs;
+
+    let mut w = TagMap::new();
+    crate::emit::run_emission(
+      &meta,
+      crate::emit::EmitOptions::g1(ConvMode::PrintConv, false),
+      &mut w,
+    );
+    crate::composite::build_composites(&mut w, None, ConvMode::PrintConv, 0);
+    assert_eq!(
+      w.get("Composite", "Duration"),
+      Some(&TagValue::Str(
+        crate::composite::convs::convert_duration(secs).into()
+      ))
+    );
+    let mut wn = TagMap::new();
+    crate::emit::run_emission(
+      &meta,
+      crate::emit::EmitOptions::g1(ConvMode::ValueConv, false),
+      &mut wn,
+    );
+    crate::composite::build_composites(&mut wn, None, ConvMode::ValueConv, 0);
+    assert!(matches!(wn.get("Composite", "Duration"), Some(TagValue::F64(x)) if *x == secs));
+  }
+
+  /// Finding-2 regression (Perl-truthiness on the RAW value, extending the
+  /// old ≡ new differential to the STRING-ZERO edge). APE main tags can supply
+  /// `TotalFrames`/`SampleRate` as MakeTag strings; a zero-SHAPED string like
+  /// `"0.0"` / `"0E0"` is Perl-TRUTHY (non-empty AND not the literal `"0"`), so
+  /// APE.pm:90's `($val[0] && $val[1])` guard PASSES and the duration IS
+  /// computed — even though the string coerces to numeric `0.0`. The retained
+  /// typed compute (`composite_duration_from_header_and_main`) and the generic
+  /// engine must agree, and both must produce a value (not `undef`).
+  #[test]
+  fn composite_duration_string_zero_total_frames_is_perl_truthy() {
+    fn mt(name: &str, value: TagValue) -> MainTag {
+      MainTag {
+        name: name.into(),
+        value,
+      }
+    }
+    // SampleRate numeric, TotalFrames a zero-shaped STRING (Perl-truthy), the
+    // other two numeric. Both coerce TotalFrames → 0.0, so the arithmetic is
+    // ((0-1)*73728 + 42662)/48000 = -0.647… s (finite, negative).
+    for tf_str in ["0.0", "0E0", "00"] {
+      let main_tags = vec![
+        mt("SampleRate", TagValue::I64(48000)),
+        mt("TotalFrames", TagValue::Str(tf_str.into())),
+        mt("BlocksPerFrame", TagValue::I64(73728)),
+        mt("FinalFrameBlocks", TagValue::I64(42662)),
+      ];
+      // OLD path (retained typed compute) — the RAW f64 (the sink applies
+      // PrintConv later). Perl-truthy ⇒ it COMPUTES (not undef).
+      let Some(TagValue::F64(old_raw)) = composite_duration_from_header_and_main(&None, &main_tags)
+      else {
+        panic!("string-truthy TotalFrames {tf_str:?} must COMPUTE (Perl-truthy), not undef");
+      };
+      // The string `"0.0"`/`"0E0"`/`"00"` coerces numeric to 0.0, so the
+      // arithmetic is ((0-1)*73728 + 42662)/48000 = -0.647… (finite, negative).
+      let expected = ((0.0_f64 - 1.0) * 73728.0 + 42662.0) / 48000.0;
+      assert!(
+        (old_raw - expected).abs() < 1e-9,
+        "old raw {old_raw} != {expected}"
+      );
+
+      // NEW engine fed the SAME ingredients via a TagMap (family-1 `APE`,
+      // satisfying the `{APE, MAC}` Require set). PrintConv ⇒ ConvertDuration of
+      // the old raw; ValueConv ⇒ the old raw verbatim. old ≡ new on BOTH axes.
+      let mut w = TagMap::new();
+      for t in &main_tags {
+        let _ = w.write_value_doc(0, 0, "APE", t.name(), 1, t.value_ref().clone());
+      }
+      crate::composite::build_composites(&mut w, None, ConvMode::PrintConv, 0);
+      assert_eq!(
+        w.get("Composite", "Duration"),
+        Some(&TagValue::Str(
+          crate::composite::convs::convert_duration(old_raw).into()
+        )),
+        "engine PrintConv ≢ old typed compute for TotalFrames {tf_str:?}"
+      );
+
+      let mut wn = TagMap::new();
+      for t in &main_tags {
+        let _ = wn.write_value_doc(0, 0, "APE", t.name(), 1, t.value_ref().clone());
+      }
+      crate::composite::build_composites(&mut wn, None, ConvMode::ValueConv, 0);
+      assert!(
+        matches!(wn.get("Composite", "Duration"), Some(TagValue::F64(x)) if (*x - old_raw).abs() < 1e-12),
+        "engine ValueConv ≢ old raw for TotalFrames {tf_str:?}"
+      );
+    }
+  }
+
+  /// Finding-2 (the falsy side): a TRUE zero — the literal string `"0"`, or a
+  /// numeric `0` — is Perl-FALSY, so the `&&` guard fires and NO composite is
+  /// built. Pins the boundary the truthiness fix must NOT cross.
+  #[test]
+  fn composite_duration_literal_zero_total_frames_is_falsy() {
+    fn mt(name: &str, value: TagValue) -> MainTag {
+      MainTag {
+        name: name.into(),
+        value,
+      }
+    }
+    for tf in [
+      TagValue::Str("0".into()),
+      TagValue::I64(0),
+      TagValue::F64(0.0),
+    ] {
+      let main_tags = vec![
+        mt("SampleRate", TagValue::I64(48000)),
+        mt("TotalFrames", tf.clone()),
+        mt("BlocksPerFrame", TagValue::I64(73728)),
+        mt("FinalFrameBlocks", TagValue::I64(42662)),
+      ];
+      let old = composite_duration_from_header_and_main(&None, &main_tags);
+      assert!(old.is_none(), "falsy TotalFrames {tf:?} must NOT compute");
+
+      let mut w = TagMap::new();
+      for t in &main_tags {
+        let _ = w.write_value_doc(0, 0, "APE", t.name(), 1, t.value_ref().clone());
+      }
+      crate::composite::build_composites(&mut w, None, ConvMode::PrintConv, 0);
+      assert_eq!(
+        w.get("Composite", "Duration"),
+        None,
+        "engine: falsy TotalFrames {tf:?} must NOT compute"
+      );
+    }
   }
 
   // APE.pm:172: `$buff =~ /^APETAGEX/ or return 1` — no trailer at EOF ⇒
@@ -3842,83 +3684,6 @@ mod tests {
   // and_main`), covered by `APE_dup_override`/`APE_spaced_composite`
   // conformance + `process_trailer_only_emits_composite_when_ingredients_in_
   // trailer` above. Cross-format ingredient injection is a deferred item.
-
-  // Codex r10 finding: ConvertDuration must handle huge finite values
-  // by keeping the arithmetic in f64 (NV-style) and stringifying the
-  // out-of-IV components via Perl's default NV stringify (`%.15g`).
-  // perl_nv_str / perl_int_str_padded are the helpers; tests below pin
-  // the empirically-verified Perl behaviour.
-  #[test]
-  fn perl_nv_str_matches_perl_default_stringify() {
-    // Finite integers in safe IV range ⇒ exact decimal (matches Perl
-    // `print 1e10 . "\n"` ⇒ `10000000000`).
-    assert_eq!(perl_nv_str(0.0), "0");
-    assert_eq!(perl_nv_str(42.0), "42");
-    assert_eq!(perl_nv_str(1.0e10), "10000000000");
-    assert_eq!(perl_nv_str(1.0e15), "1000000000000000");
-    // Negative integer in safe IV range.
-    assert_eq!(perl_nv_str(-42.0), "-42");
-    // Outside IV range ⇒ Perl `%.15g` (e.g. `1e25/24/3600` ≈ 1.157e+20).
-    assert_eq!(perl_nv_str(1.0e25 / 24.0 / 3600.0), "1.15740740740741e+20");
-    assert_eq!(perl_nv_str(1.0e25), "1e+25");
-    // Fractional values use `%.15g`.
-    assert_eq!(perl_nv_str(2.5), "2.5");
-    // Special values.
-    assert_eq!(perl_nv_str(f64::INFINITY), "Inf");
-    assert_eq!(perl_nv_str(f64::NEG_INFINITY), "-Inf");
-    assert_eq!(perl_nv_str(f64::NAN), "NaN");
-    // Codex r11 finding: positive integer-valued f64 in
-    // (i64::MAX, u64::MAX] must stringify as DECIMAL (Perl's UV path),
-    // NOT scientific. Boundary cases empirically verified against
-    // Perl 5:
-    //   int(1e19) ⇒ "10000000000000000000"
-    //   int(1.5e19) ⇒ "15000000000000000000"
-    //   int(2^64-2048) ⇒ "18446744073709549568" (largest representable
-    //     f64 below 2^64)
-    //   int(2^64) ⇒ "1.84467440737096e+19" (next representable f64,
-    //     scientific because > u64::MAX)
-    assert_eq!(perl_nv_str(1.0e19), "10000000000000000000");
-    assert_eq!(perl_nv_str(1.5e19), "15000000000000000000");
-    // 2^64 - 2048 = 18446744073709549568 (representable in f64).
-    assert_eq!(perl_nv_str(18446744073709549568.0), "18446744073709549568");
-    // 2^64 (the f64 representation of u64::MAX+1) ⇒ scientific.
-    // Note: `18446744073709551616.0_f64 == u64::MAX as f64` in Rust.
-    let two64 = (1u128 << 64) as f64;
-    assert_eq!(perl_nv_str(two64), "1.84467440737096e+19");
-    // The duration helper's worst-case path: 8.64e23 → days = 1e19.
-    // perl_nv_str(1e19) → "10000000000000000000" (decimal).
-    let days_at_864e23 = (8.64e23_f64 / 3600.0 / 24.0).trunc();
-    // Expected exact value (matches Perl `int(8.64e23/86400)`):
-    assert_eq!(perl_nv_str(days_at_864e23), "10000000000000002048");
-    // Codex r12 finding: `i64::MAX as f64` actually equals 2^63 because
-    // i64::MAX (2^63 - 1) is not exactly representable in f64; the cast
-    // rounds UP. So `n = 9223372036854775808.0` (exactly 2^63) must
-    // stringify via the UV path as `"9223372036854775808"`, NOT via the
-    // signed path's saturating `"9223372036854775807"`. Boundary
-    // verified against Perl 5: `int(9223372036854775808.0) ⇒
-    // "9223372036854775808"`. Largest representable f64 strictly below
-    // 2^63 is `2^63 - 1024 = 9223372036854774784.0`.
-    let two63 = (1u128 << 63) as f64;
-    assert_eq!(perl_nv_str(two63), "9223372036854775808");
-    // 2^63 - 1024 (representable as f64) goes via signed path.
-    assert_eq!(perl_nv_str(9223372036854774784.0), "9223372036854774784");
-  }
-
-  #[test]
-  fn perl_int_str_padded_in_range_pads_with_zeros() {
-    // ConvertDuration's m/s values are always in [0, 60) when reached
-    // via the normal path, so `%02d` zero-pads exactly.
-    assert_eq!(perl_int_str_padded(0.0, 2), "00");
-    assert_eq!(perl_int_str_padded(5.0, 2), "05");
-    assert_eq!(perl_int_str_padded(59.0, 2), "59");
-    // Boundary: i64::MAX as f64 is in-range — emits exact decimal padded
-    // (though the value vastly exceeds width=2, format! just emits the
-    // full number).
-    assert_eq!(perl_int_str_padded(100.0, 2), "100");
-    // Out-of-range or fractional ⇒ fall through to perl_nv_str.
-    assert_eq!(perl_int_str_padded(f64::INFINITY, 2), "Inf");
-    assert_eq!(perl_int_str_padded(1.5, 2), "1.5");
-  }
 
   // Codex r11 finding: Perl boolean truthiness for `if ($val[0] &&
   // $val[1])` in the Composite Duration RawConv must use STRING-truthy

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -1615,7 +1615,6 @@ impl crate::emit::Taggable for Meta<'_> {
     // Picture → "FLAC"; Vorbis.pm comments → "Vorbis"; Composite → "Composite".
     let flac_group = || Group::new("FLAC", "FLAC");
     let vorbis_group = || Group::new("Vorbis", "Vorbis");
-    let composite_group = || Group::new("Composite", "Composite");
     let print_conv = matches!(mode, crate::emit::ConvMode::PrintConv);
 
     let mut tags: Vec<EmittedTag> = Vec::new();
@@ -1794,24 +1793,9 @@ impl crate::emit::Taggable for Meta<'_> {
       push_picture_tags(&mut tags, p, print_conv);
     }
 
-    // -- Composite:Duration (FLAC.pm:137-149) -----------------------------
-    if let Some(d) = self.duration() {
-      let secs = d.as_secs_f64();
-      let value = if print_conv {
-        // ConvertDuration (the retired `write_fmt` → `TagValue::Str`).
-        let mut s = String::new();
-        let _ = write_convert_duration(&mut s, secs);
-        TagValue::Str(s.into())
-      } else {
-        TagValue::F64(secs)
-      };
-      tags.push(EmittedTag::new(
-        composite_group(),
-        "Duration".into(),
-        value,
-        false,
-      ));
-    }
+    // Composite:Duration (FLAC.pm:137-149) is no longer emitted inline: the
+    // generic Composite engine (`crate::composite`) derives it from the emitted
+    // `FLAC:SampleRate` + `FLAC:TotalSamples` as a post-`run_emission` pass.
 
     tags.into_iter()
   }
@@ -1927,37 +1911,6 @@ impl crate::metadata::Project for Meta<'_> {
     media.media_mut().update_duration(self.duration());
     media
   }
-}
-
-/// Format-into-writer port of `Image::ExifTool::ConvertDuration`
-/// (ExifTool.pm:6866-6884). Writes directly into a [`core::fmt::Write`]
-/// sink — no intermediate `String` allocation.
-pub fn write_convert_duration<W: core::fmt::Write + ?Sized>(
-  w: &mut W,
-  time: f64,
-) -> core::fmt::Result {
-  if !time.is_finite() {
-    return write!(w, "{time}");
-  }
-  if time == 0.0 {
-    return w.write_str("0 s");
-  }
-  let (sign, mut t) = if time > 0.0 { ("", time) } else { ("-", -time) };
-  if t < 30.0 {
-    return write!(w, "{sign}{t:.2} s");
-  }
-  t += 0.5;
-  let mut h: i64 = (t / 3600.0) as i64;
-  t -= (h as f64) * 3600.0;
-  let m: i64 = (t / 60.0) as i64;
-  t -= (m as f64) * 60.0;
-  let s_int: i64 = t as i64;
-  if h > 24 {
-    let d = h / 24;
-    h -= d * 24;
-    return write!(w, "{sign}{d} days {h}:{m:02}:{s_int:02}");
-  }
-  write!(w, "{sign}{h}:{m:02}:{s_int:02}")
 }
 
 // ===========================================================================
@@ -2537,9 +2490,8 @@ mod tests {
   // ---------- ConvertDuration oracle table -------------------------------
 
   fn fmt_duration(t: f64) -> String {
-    let mut s = String::new();
-    write_convert_duration(&mut s, t).unwrap();
-    s
+    // The canonical `ConvertDuration` (the FLAC-local copy was folded into it).
+    crate::composite::convs::convert_duration(t)
   }
 
   #[test]
@@ -2730,9 +2682,11 @@ mod tests {
     assert_eq!(wn.get_str("FLAC", "PictureType"), Some("3".to_string()));
   }
 
-  /// Group identity: StreamInfo + Picture tags carry family-0/1 `"FLAC"`,
-  /// Vorbis comments `"Vorbis"`, and `Composite:Duration` `"Composite"`
-  /// (each sub-table group0 == group1). Every tag is known ⇒ `!unknown`.
+  /// Group identity: StreamInfo + Picture tags carry family-0/1 `"FLAC"` and
+  /// Vorbis comments `"Vorbis"` (each sub-table group0 == group1); every tag is
+  /// known ⇒ `!unknown`. `Composite:Duration` is NOT part of this stream — the
+  /// generic Composite engine appends it as a separate post-`run_emission` pass
+  /// (asserted by `taggable_emits_composite_duration` + the golden).
   #[test]
   fn taggable_group_family0_and_family1_per_subtable() {
     let data = fixture("FLAC_duration.flac");
@@ -2744,22 +2698,24 @@ mod tests {
     assert!(!tags.is_empty());
     let mut saw_flac = false;
     let mut saw_vorbis = false;
-    let mut saw_composite = false;
     for t in &tags {
       let g = t.tag().group_ref();
       // family-0 always equals family-1 across FLAC's sub-tables.
       assert_eq!(g.family0(), g.family1(), "tag {}", t.tag().name());
       assert!(!t.unknown());
+      assert_ne!(
+        t.tag().name(),
+        "Duration",
+        "Composite:Duration must come from the engine, not the FLAC tag stream"
+      );
       match g.family1() {
         "FLAC" => saw_flac = true,
         "Vorbis" => saw_vorbis = true,
-        "Composite" => saw_composite = true,
         other => panic!("unexpected FLAC group {other:?} for {}", t.tag().name()),
       }
     }
     assert!(saw_flac, "StreamInfo FLAC:* tags present");
     assert!(saw_vorbis, "Vorbis:* tags present");
-    assert!(saw_composite, "Composite:Duration present");
   }
 
   /// `Composite:Duration` (FLAC.pm:137-149): `-j` is `ConvertDuration`
@@ -2775,6 +2731,9 @@ mod tests {
       crate::emit::EmitOptions::g1(ConvMode::PrintConv, false),
       &mut w,
     );
+    // The generic Composite engine (post-`run_emission` pass) derives Duration
+    // from the emitted FLAC:SampleRate + FLAC:TotalSamples.
+    crate::composite::build_composites(&mut w, None, ConvMode::PrintConv, 0);
     assert_eq!(
       w.get_str("Composite", "Duration"),
       Some("0:00:30".to_string())
@@ -2785,7 +2744,39 @@ mod tests {
       crate::emit::EmitOptions::g1(ConvMode::ValueConv, false),
       &mut wn,
     );
+    crate::composite::build_composites(&mut wn, None, ConvMode::ValueConv, 0);
     assert!(matches!(wn.get("Composite", "Duration"), Some(TagValue::F64(x)) if *x == 30.0));
+  }
+
+  /// Migration safety net (old ≡ new): the engine-derived `Composite:Duration`
+  /// equals the value the retained typed compute (`duration()` — the former
+  /// inline path) would have emitted, for both modes.
+  #[test]
+  fn composite_duration_engine_matches_typed_compute() {
+    let data = fixture("FLAC_duration.flac");
+    let mut shared = crate::format_parser::SharedFlags::new();
+    let meta = parse_borrowed(&data, &mut shared).unwrap();
+    let secs = meta.duration().expect("typed duration").as_secs_f64();
+
+    let mut w = TagMap::new();
+    crate::emit::run_emission(
+      &meta,
+      crate::emit::EmitOptions::g1(ConvMode::PrintConv, false),
+      &mut w,
+    );
+    crate::composite::build_composites(&mut w, None, ConvMode::PrintConv, 0);
+    assert_eq!(
+      w.get_str("Composite", "Duration"),
+      Some(crate::composite::convs::convert_duration(secs))
+    );
+    let mut wn = TagMap::new();
+    crate::emit::run_emission(
+      &meta,
+      crate::emit::EmitOptions::g1(ConvMode::ValueConv, false),
+      &mut wn,
+    );
+    crate::composite::build_composites(&mut wn, None, ConvMode::ValueConv, 0);
+    assert!(matches!(wn.get("Composite", "Duration"), Some(TagValue::F64(x)) if *x == secs));
   }
 
   /// An ID3-prefixed FLAC (the `FLAC_id3_prefix.flac` fixture) splices the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,12 @@ extern crate std;
 pub mod bitstream;
 pub mod charset;
 pub mod convert;
+// The generic ExifTool Composite-tag engine (`BuildCompositeTags`): a
+// standalone post-`run_emission` pass that derives `Composite:*` tags from the
+// final emitted tag set. `alloc`-gated to match `tagmap` (the engine's sink);
+// the canonical `ConvertDuration` (`composite::convs`) is the single source the
+// cross-format duration callers alias.
+pub mod composite;
 pub mod datetime;
 // The format-agnostic emission framework (`Taggable` + the `run_emission`
 // engine + `ConvMode`/`EmittedTag`): the single place the cross-cutting

--- a/tests/iter_tags.rs
+++ b/tests/iter_tags.rs
@@ -226,3 +226,46 @@ fn chained_id3v1_iter_tags_family0_is_id3() {
     );
   }
 }
+
+/// `iter_tags` (the public generic-extraction L4 API) yields the engine-built
+/// `Composite:Duration` too — the same `Composite:*` set the JSON path produces.
+/// FLAC_duration.flac: family-0/1 `Composite`, value `"0:00:30"` under `-j`, and
+/// (as the post-pass append) the LAST tag in the stream.
+#[cfg(feature = "flac")]
+#[test]
+fn flac_iter_tags_carries_engine_composite_duration() {
+  let data = std::fs::read(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/FLAC_duration.flac"
+  ))
+  .unwrap();
+  let meta = exifast::parse_bytes(&data).expect("FLAC recognized");
+
+  let tags: Vec<exifast::Tag> = meta.iter_tags(ConvMode::PrintConv).collect();
+  let dur = tags
+    .iter()
+    .find(|t| t.group_ref().family1() == "Composite" && t.name() == "Duration")
+    .expect("iter_tags must yield the engine-built Composite:Duration");
+  assert_eq!(dur.group_ref().family0(), "Composite");
+  assert!(
+    matches!(dur.value_ref(), exifast::TagValue::Str(s) if s == "0:00:30"),
+    "got {:?}",
+    dur.value_ref()
+  );
+  // The composite is appended last (positional last-ness).
+  let last = tags.last().expect("non-empty");
+  assert_eq!(last.name(), "Duration");
+  assert_eq!(last.group_ref().family1(), "Composite");
+
+  // -n: the raw f64 (30.0).
+  let raw: Vec<exifast::Tag> = meta.iter_tags(ConvMode::ValueConv).collect();
+  let dur_n = raw
+    .iter()
+    .find(|t| t.group_ref().family1() == "Composite" && t.name() == "Duration")
+    .expect("Composite:Duration under -n");
+  assert!(
+    matches!(dur_n.value_ref(), exifast::TagValue::F64(x) if (*x - 30.0).abs() < 1e-9),
+    "got {:?}",
+    dur_n.value_ref()
+  );
+}


### PR DESCRIPTION
**Composite engine PR 1 of 5** (#133, full cross-format sweep). The foundation: a generic, faithful port of ExifTool's `BuildCompositeTags` + migrating the existing per-format `Composite:Duration` onto it, byte-identically. **No new composite tags this PR** (GPS/EXIF/ScaleFactor/QuickTime follow in PRs 2–5).

## Engine (`src/composite/`)
The `BuildCompositeTags` fixpoint: registry sorted by prefixed-id; per def resolves inputs by index (Require/Desire/Inhibit), multi-pass deferral for Composite-requires-Composite with the circular-dependency guard. Generic over a `CompositeSink` trait so the golden/JSON path and the public `iter_tags` API share one engine; hooked as a standalone post-pass after `run_emission` (no emission refactor).

## Input model (faithful, hardened across review)
`CompositeValue { Missing | Present(TagValue) }` — Require/Desire/Inhibit resolve on **presence**; each derive coerces its own raw value. Inputs resolve from **raw/ValueConv values** regardless of `-j`/`-n` mode (in `-j`, a throwaway ValueConv re-emission feeds the engine). String coercion is exact Perl `0+` — dual-sign/whitespace (`+ 20000000`, `++20`) and the MSVCRT `1.#INF` sign-form rule all ground-truthed against Perl. (`prt[i]`, inputs' PrintConv form, lands in PR 2 with GPSPosition.)

## Duration migration
3 defs (APE/FLAC/AIFF) replace the inline pushes; **4** duplicated `ConvertDuration` impls consolidated to one + thin aliases (−192 lines net). **45 Duration goldens byte-identical** (incl Inf/NaN + extreme-days), guarded by a differential old≡new oracle.

## Verify
`fmt=0  build(-Dwarnings)=0  conformance=432/0 (45 Duration + all byte-identical)  timed=130/0  typed_serde=539 (unchanged)  lib=3372/0 (engine oracle + differential + presence/coercion tests)`

**Codex adversarial review: APPROVE (R4).** First of the #133 Composite series.