### PR TITLE
feat(composite): GPS composites + prt[i] input resolution (#133)

### DIFF
--- a/src/composite/convs/datetime.rs
+++ b/src/composite/convs/datetime.rs
@@ -1,0 +1,22 @@
+//! `$self->ConvertDateTime($val)` (ExifTool.pm:6574) for the Composite
+//! `GPSDateTime` PrintConv.
+//!
+//! ExifTool's `ConvertDateTime` reformats a date/time string per the
+//! `DateFormat` option and applies the `GlobalTimeShift` option. exifast
+//! exposes NEITHER option (`$$self{OPTIONS}{DateFormat}` and
+//! `{GlobalTimeShift}` are both unset), so both the `if ($shift)` block and the
+//! `if ($fmt)` reformat block are skipped and the routine returns `$date`
+//! unchanged. So at the default `-j`, `ConvertDateTime` is the IDENTITY — the
+//! `GPSDateTime` ValueConv string (`"$datestamp $timestampZ"`) is also its
+//! PrintConv form. (This mirrors the bundled-ExifTool golden, where
+//! `Composite:GPSDateTime` is byte-identical in the `-j` and `-n` snapshots,
+//! e.g. `2021:08:14 16:45:09Z`.)
+
+/// `$self->ConvertDateTime($val)` at exifast's option set (no `DateFormat`, no
+/// `GlobalTimeShift`) — the identity. Kept as a named helper so the GPSDateTime
+/// def documents its PrintConv faithfully and a future `DateFormat` port has a
+/// single seam.
+#[must_use]
+pub(crate) fn convert_date_time(val: &str) -> &str {
+  val
+}

--- a/src/composite/convs/gps/mod.rs
+++ b/src/composite/convs/gps/mod.rs
@@ -1,0 +1,170 @@
+//! The GPS coordinate / altitude PrintConv helpers the GPS Composite defs share
+//! — a faithful transliteration of `Image::ExifTool::GPS::ToDMS` (GPS.pm:495)
+//! and the `Composite:GPSAltitude` PrintConv (GPS.pm:419-431).
+//!
+//! Only the cases the *Composite* GPS tags reach are ported: `ToDMS` is always
+//! invoked as `ToDMS($self, $val, 1, "N"|"E")` — `$doPrintConv eq '1'` with a
+//! significant hemisphere `$ref` and the DEFAULT `CoordFormat` (exifast does not
+//! expose the `-c`/`CoordFormat` option, so `$et->Options('CoordFormat')` is
+//! always unset). That collapses `ToDMS` to: format string `%d deg %d' %.2f"`
+//! plus the ` N`/` S`/` E`/` W` suffix, `$num == 3` (three captured specifiers),
+//! and the D/M/S split with the ExifTool round-off carry. The XMP (`eq '2'`),
+//! signed-unformatted (`eq '3'`), no-`$ref`, and custom-`CoordFormat` branches
+//! are unreachable here and intentionally omitted.
+
+use crate::value::format_g;
+
+/// `Image::ExifTool::GPS::ToDMS($self, $val, 1, $ref)` (GPS.pm:495) for the
+/// Composite-GPS case: `$doPrintConv eq '1'`, a significant hemisphere `ref`
+/// (`'N'` for latitude, `'E'` for longitude), and the default `CoordFormat` —
+/// i.e. `q{%d deg %d' %.2f"} . $refSuffix`, three format specifiers, the D/M/S
+/// split, and the `>= 60` minutes/seconds carry. Produces e.g.
+/// `48 deg 51' 29.34" N` (GPS.pm fmt `%d deg %d' %.2f"` then ` N`).
+///
+/// `ref_pos` is the cardinal letter for a NON-negative value; ExifTool flips it
+/// to its opposite (`N`→`S`, `E`→`W`) and takes `abs($val)` when `val < 0`.
+#[must_use]
+pub(crate) fn to_dms(val: f64, ref_pos: char) -> String {
+  // GPS.pm:505-514 `if ($ref) { if ($val < 0) { $val = -$val; $ref = {...} } ... }`.
+  // (`length $val` is always true here — the Composite RawConv only reaches
+  // PrintConv with a defined numeric `$val`; the empty-value short-circuit at
+  // GPS.pm:499-503 cannot fire.)
+  let (mag, hemi) = if val < 0.0 {
+    (-val, opposite_hemisphere(ref_pos))
+  } else {
+    (val, ref_pos)
+  };
+  // GPS.pm:515 `$ref = " $ref"` (not the `eq '2'` XMP branch) — the suffix.
+  // GPS.pm:526 default `$fmt = q{%d deg %d' %.2f"} . $ref` ⇒ three specifiers,
+  // so `$num == 3` and we always take the full D/M/S split.
+
+  // GPS.pm:548-558 the D/M/S split (`$num > 2`).
+  let mut d = mag.trunc(); // `$c[0] = int($c[0])`
+  let mut m = ((mag - d) * 60.0).trunc(); // `$c[1] = int(($val - $c[0]) * 60)`
+  let s = (mag - d - m / 60.0) * 3600.0; // `$c[2] = ($val - $c[0] - $c[1]/60) * 3600`
+
+  // GPS.pm:560-565 the round-off carry. `$c[-1]` is first FORMATTED to the
+  // seconds spec (`sprintf('%.2f', $c[-1])`), then compared `>= 60` in Perl
+  // NUMERIC context on that rounded string — so a seconds value that rounds UP
+  // to 60.00 carries into the minutes (and on into the degrees).
+  let mut s_rounded: f64 = format_seconds(s).parse().unwrap_or(s);
+  if s_rounded >= 60.0 {
+    s_rounded -= 60.0;
+    m += 1.0;
+    if m >= 60.0 {
+      m -= 60.0;
+      d += 1.0;
+    }
+  }
+
+  // GPS.pm:568 `$rtnVal = sprintf($fmt, @c)` — `%d deg %d' %.2f" $ref`. `%d`
+  // truncates toward zero (the D/M are already non-negative integers here);
+  // `%.2f` re-formats the carried seconds.
+  format!(
+    "{d} deg {m}' {s}\" {hemi}",
+    d = perl_int_d(d),
+    m = perl_int_d(m),
+    s = format_seconds(s_rounded),
+  )
+}
+
+/// One `foreach (0,2)` candidate of the `Composite:GPSAltitude` PrintConv: the
+/// altitude ingredient `$val[$_]` (as text — the single source for both the
+/// `IsFloat($val[$_])` check and the `int($val[$_]*10)/10` numeric coercion)
+/// paired with the ref-print `$prt[$_+1]`. Index 0 = the `GPS:GPSAltitude`/`Ref`
+/// pair; index 2 = the `XMP:GPSAltitude`/`Ref` pair. The number is derived from
+/// the `IsFloat`-normalized text (not carried separately) because `IsFloat`'s
+/// `tr/,/./` mutates the scalar in place, so `int($val[$_]*10)` re-coerces the
+/// translated value (`12,5` → `12.5`), exactly as a single mutated `$val[$_]`.
+#[derive(Clone, Copy)]
+pub(crate) struct AltCandidate<'a> {
+  /// `$val[$_]` in string context (for `IsFloat($val[$_])` and the coercion).
+  pub(crate) alt_text: Option<&'a str>,
+  /// `$prt[$_+1]` (the ref-print, e.g. `"Above Sea Level"`).
+  pub(crate) ref_print: Option<&'a str>,
+}
+
+/// `Composite:GPSAltitude` PrintConv (GPS.pm:419-431). `own_val` is the
+/// composite's own `$val` (the ref-signed altitude — used by the fall-through);
+/// `candidates` are the `(0,2)` ingredient pairs in order.
+///
+/// ```perl
+/// foreach (0,2) {
+///     next unless defined $val[$_] and IsFloat($val[$_]);
+///     next unless defined $prt[$_+1] and $prt[$_+1] =~ /Sea/;
+///     return((int($val[$_]*10)/10) . ' m ' . $prt[$_+1]);
+/// }
+/// $val = int($val * 10) / 10;
+/// return(($val =~ s/^-// ? "$val m Below" : "$val m Above") . " Sea Level");
+/// ```
+///
+/// The loop matches the FIRST candidate whose altitude is a float AND whose
+/// ref-print contains `/Sea/` (the EXIF `GPSAltitudeRef` PrintConv strings —
+/// `Above/Below Sea Level`, `Positive/Negative Sea Level` — and the XMP variant
+/// — all contain "Sea"), yielding `(int($val*10)/10) m $prt`. Otherwise it
+/// falls through to the unsigned form built from the composite's own `$val`
+/// (`"$mag m Below/Above Sea Level"`, the sign giving Below vs Above).
+#[must_use]
+pub(crate) fn gps_altitude_print(own_val: f64, candidates: &[AltCandidate<'_>]) -> String {
+  for cand in candidates {
+    // `next unless defined $val[$_] and IsFloat($val[$_])`. `IsFloat` both
+    // guards AND translates `,`→`.` in place; the later `int($val[$_]*10)`
+    // coerces the NORMALIZED scalar, so coerce the normalized string.
+    let Some(alt_text) = cand.alt_text else {
+      continue;
+    };
+    let Some(alt_norm) = crate::convert::is_float_norm(alt_text) else {
+      continue;
+    };
+    // `next unless defined $prt[$_+1] and $prt[$_+1] =~ /Sea/`.
+    let Some(ref_print) = cand.ref_print else {
+      continue;
+    };
+    if !ref_print.contains("Sea") {
+      continue;
+    }
+    // `(int($val[$_]*10)/10) . ' m ' . $prt[$_+1]`.
+    let alt = crate::convert::perl_str_to_f64(&alt_norm);
+    let tenths = (alt * 10.0).trunc() / 10.0;
+    return format!("{} m {ref_print}", format_g(tenths, 15));
+  }
+  // Fall-through (GPS.pm:427-430): `$val = int($val * 10) / 10; ($val =~ s/^-//
+  // ? "$val m Below" : "$val m Above") . " Sea Level"`. The composite's own
+  // `$val` is the ref-signed altitude; a leading `-` means Below.
+  let tenths = (own_val * 10.0).trunc() / 10.0;
+  let s = format_g(tenths, 15);
+  match s.strip_prefix('-') {
+    Some(mag) => format!("{mag} m Below Sea Level"),
+    None => format!("{s} m Above Sea Level"),
+  }
+}
+
+/// `{N => 'S', E => 'W'}->{$ref}` (GPS.pm:509). The Composite GPS PrintConv only
+/// ever passes `'N'` (latitude) or `'E'` (longitude); any other letter is
+/// returned unchanged (ExifTool would yield `undef`, unreachable here).
+const fn opposite_hemisphere(c: char) -> char {
+  match c {
+    'N' => 'S',
+    'E' => 'W',
+    other => other,
+  }
+}
+
+/// `sprintf('%.2f', $s)` — the seconds spec from the default `CoordFormat`.
+/// Rust's `{:.2}` matches C/Perl `%.2f` (round-half-to-even is not observable at
+/// the inputs GPS seconds reach; ExifTool uses the platform `sprintf`).
+fn format_seconds(s: f64) -> String {
+  format!("{s:.2}")
+}
+
+/// `sprintf('%d', $n)` of a non-negative integer-valued `f64` (the carried
+/// degrees / minutes are always whole and `>= 0` here). `%d` truncates toward
+/// zero; the values fit `i64`, so a direct cast is the faithful render.
+fn perl_int_d(n: f64) -> String {
+  // `%d` on a Perl NV truncates toward zero. D/M are always small non-negative
+  // integers after the carry, so an `i64` cast reproduces ExifTool's bytes.
+  (n.trunc() as i64).to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/composite/convs/gps/tests.rs
+++ b/src/composite/convs/gps/tests.rs
@@ -1,0 +1,138 @@
+//! Unit tests for the GPS Composite PrintConv helpers — `ToDMS` (the default
+//! `CoordFormat` DMS render with the hemisphere suffix, sign flip, and `>= 60`
+//! carry) and the `Composite:GPSAltitude` PrintConv. Byte-exact against the
+//! bundled-ExifTool 13.59 `Composite:*` strings.
+
+use super::*;
+
+#[test]
+fn to_dms_positive_latitude_matches_bundled() {
+  // ExifGPS.tif: GPS:GPSLatitude 48.85815, ref N ⇒ `48 deg 51' 29.34" N`.
+  assert_eq!(to_dms(48.85815, 'N'), "48 deg 51' 29.34\" N");
+}
+
+#[test]
+fn to_dms_positive_longitude_matches_bundled() {
+  // ExifGPS.tif: GPS:GPSLongitude 2.34893333333333, ref E ⇒ `2 deg 20' 56.16" E`.
+  assert_eq!(to_dms(2.34893333333333, 'E'), "2 deg 20' 56.16\" E");
+}
+
+#[test]
+fn to_dms_dji_coordinates_match_bundled() {
+  // DJIPhantom4.jpg lat 32.4785966666667 ⇒ `32 deg 28' 42.95" N`. The
+  // longitude's `Composite:GPSLongitude` ValueConv already negated the ref-W
+  // value to -90.2600013888889, so ToDMS receives the NEGATIVE coordinate and
+  // flips the positive-hemisphere `E` to `W` ⇒ `90 deg 15' 36.01" W`.
+  assert_eq!(to_dms(32.4785966666667, 'N'), "32 deg 28' 42.95\" N");
+  assert_eq!(to_dms(-90.2600013888889, 'E'), "90 deg 15' 36.01\" W");
+}
+
+#[test]
+fn to_dms_negative_flips_hemisphere_and_takes_abs() {
+  // A negative latitude (`val < 0`) ⇒ `N` flips to `S`, magnitude is `abs`.
+  assert_eq!(to_dms(-48.85815, 'N'), "48 deg 51' 29.34\" S");
+  // A negative longitude ⇒ `E` flips to `W`.
+  assert_eq!(to_dms(-2.34893333333333, 'E'), "2 deg 20' 56.16\" W");
+}
+
+#[test]
+fn to_dms_seconds_round_off_carry() {
+  // A value whose seconds round UP to 60.00 must carry into the minutes (and on
+  // into the degrees): ExifTool `convert "72 59 60.00" to "73 0 0.00"`. Pick a
+  // value where (val - d)*60 = 59 exactly and the residual seconds round to
+  // 60.00: 72 + 59/60 + 59.999/3600 ≈ 72.9999997. `%.2f` of 59.9964 → "60.00".
+  // Construct: degrees 73 minus a hair so seconds round to 60.
+  let v = 73.0 - (0.001 / 3600.0); // 72 deg 59' 59.999"
+  assert_eq!(to_dms(v, 'N'), "73 deg 0' 0.00\" N");
+}
+
+#[test]
+fn to_dms_minute_carry_only() {
+  // Seconds carry into minutes WITHOUT a degree carry: 48 deg 50' 59.999" ⇒
+  // 48 deg 51' 0.00".
+  let v = 48.0 + 50.0 / 60.0 + 59.999 / 3600.0;
+  assert_eq!(to_dms(v, 'N'), "48 deg 51' 0.00\" N");
+}
+
+/// The GPS-pair-only candidate set (index 0 = `$val[0]`/`$prt[1]`; the XMP pair
+/// absent), the common EXIF still case.
+fn gps_only(alt_text: &str, ref_print: &str) -> [AltCandidate<'static>; 2] {
+  [
+    AltCandidate {
+      alt_text: Some(Box::leak(alt_text.to_string().into_boxed_str())),
+      ref_print: Some(Box::leak(ref_print.to_string().into_boxed_str())),
+    },
+    AltCandidate {
+      alt_text: None,
+      ref_print: None,
+    },
+  ]
+}
+
+#[test]
+fn altitude_above_sea_level_matches_bundled() {
+  // ExifGPS.tif: alt 35, prt "Above Sea Level" ⇒ `35 m Above Sea Level`.
+  let c = gps_only("35", "Above Sea Level");
+  assert_eq!(gps_altitude_print(35.0, &c), "35 m Above Sea Level");
+}
+
+#[test]
+fn altitude_truncates_to_one_decimal() {
+  // DJIPhantom4.jpg: alt 109.786 ⇒ int(1097.86)/10 = 109.7.
+  let c = gps_only("109.786", "Above Sea Level");
+  assert_eq!(gps_altitude_print(109.786, &c), "109.7 m Above Sea Level");
+}
+
+#[test]
+fn altitude_below_sea_level_uses_input_ref_print() {
+  // A below-sea altitude: the ExifTool branch uses the (positive) input
+  // `$val[0]` with `$prt[1]` "Below Sea Level".
+  let c = gps_only("12.3", "Below Sea Level");
+  assert_eq!(gps_altitude_print(-12.3, &c), "12.3 m Below Sea Level");
+}
+
+#[test]
+fn altitude_comma_decimal_is_isfloat_normalized() {
+  // ExifTool `IsFloat($val[$_])` translates `,`→`.` in place (ExifTool.pm:5951),
+  // so `int($val[$_]*10)/10` coerces `12,5` AS `12.5`, NOT `12` (a raw coercion
+  // would treat the comma as a numeric-prefix terminator). Bundled-ExifTool
+  // 13.59 on a `GPSAltitude=12,5` + above-sea ref emits the `12.5 m …` PrintConv.
+  let c = gps_only("12,5", "Above Sea Level");
+  assert_eq!(gps_altitude_print(12.5, &c), "12.5 m Above Sea Level");
+}
+
+#[test]
+fn altitude_xmp_branch_uses_second_candidate() {
+  // The XMP fixtures (`XMP_gps_abovesea.xmp`): the GPS pair (index 0/1) is
+  // absent, the XMP pair (index 2/3) supplies `$val[2]`/`$prt[3]`. The loop
+  // matches the SECOND candidate.
+  let c = [
+    AltCandidate {
+      alt_text: None,
+      ref_print: None,
+    },
+    AltCandidate {
+      alt_text: Some("35"),
+      ref_print: Some("Above Sea Level"),
+    },
+  ];
+  assert_eq!(gps_altitude_print(35.0, &c), "35 m Above Sea Level");
+}
+
+#[test]
+fn altitude_falls_through_to_own_val_when_no_sea_ref() {
+  // No candidate has a `/Sea/` ref-print ⇒ fall through to the composite's own
+  // `$val`: a negative value ⇒ Below, positive ⇒ Above.
+  let c = [
+    AltCandidate {
+      alt_text: Some("35"),
+      ref_print: Some("Unknown"),
+    },
+    AltCandidate {
+      alt_text: None,
+      ref_print: None,
+    },
+  ];
+  assert_eq!(gps_altitude_print(35.0, &c), "35 m Above Sea Level");
+  assert_eq!(gps_altitude_print(-35.0, &c), "35 m Below Sea Level");
+}

--- a/src/composite/convs/mod.rs
+++ b/src/composite/convs/mod.rs
@@ -15,6 +15,9 @@
 //! `datetime::convert_duration`) so the Real / MXF / MOI / M2TS / Flash callers
 //! keep their signatures.
 
+pub(crate) mod datetime;
+pub(crate) mod gps;
+
 #[cfg(feature = "alloc")]
 use crate::value::TagValue;
 

--- a/src/composite/mod.rs
+++ b/src/composite/mod.rs
@@ -20,7 +20,9 @@
 //! pass ignoring `Inhibit`-on-Composite (the `$allBuilt` flag) and then warns
 //! `Circular dependency in Composite tags`. The defs are walked in
 //! prefixed-id sort order (`Module-Name`) so the build is deterministic
-//! regardless of registry order.
+//! regardless of registry order. `GPSPosition` (`Composite-GPSPosition`)
+//! `Require`s `Composite:GPSLatitude`/`Composite:GPSLongitude` (`GPS-…`), so it
+//! defers to a later pass — exercising the fixpoint on a real def.
 //!
 //! ## Input model — presence vs value
 //!
@@ -33,38 +35,45 @@
 //! carrying the ingredient's RAW (post-`ValueConv`) [`TagValue`], or `Missing`
 //! — and the build loop keys Inhibit/Require/Desire on `is_present()`, NOT on
 //! numeric coercibility. So a present-but-non-numeric ingredient (a STRING —
-//! GPS refs `N`/`S`/`E`/`W`, `DateStamp`, `TimeStamp`, the ingredients the GPS /
-//! EXIF / datetime defs added by later #133 PRs read) is correctly seen as
+//! GPS refs `N`/`S`/`E`/`W`, `DateStamp`, `TimeStamp`) is correctly seen as
 //! PRESENT, and a string `Inhibitor` correctly suppresses. Each
 //! [`CompositeDef::derive`](table::CompositeDef) then does its OWN coercion: the
-//! Duration defs coerce numeric and apply the Perl-truthy `&&` guard on the raw
-//! value; future string defs read the string directly. This keeps ONE input
-//! model general for PRs 2-5.
+//! Duration defs coerce numeric and apply the Perl-truthy `&&` guard; the GPS
+//! defs read the string/decimal ingredients directly.
 //!
-//! ## Inputs resolve from the RAW value, independent of `-j`/`-n`
+//! ## Two resolution views — `$val[i]` (ValueConv) and `$prt[i]` (PrintConv)
 //!
-//! ExifTool's `BuildCompositeTags` reads each input's ValueConv value for
-//! `$val[i]` (`GetValue($tag, 'ValueConv')`, ExifTool.pm:4112) REGARDLESS of the
-//! requested output conversion — the composite's own `RawConv`/`ValueConv` runs
-//! on the machine value, never the printed form. exifast mirrors this: under
-//! `-n` the emitted sink already holds the raw ValueConv values, so it is its
-//! own resolution view; under `-j` the sink holds PrintConv strings, so the
-//! caller re-emits the Meta in ValueConv mode into a separate `raw_view` and the
-//! engine resolves inputs (and Composite-dependencies) from THAT, while each
-//! composite's RENDERED (`-j`) value still lands in the output sink. (A
-//! composite's PrintConv form `$prt[i]`, needed by e.g. `GPSPosition`'s
-//! PrintConv in a later #133 PR, is not wired yet — no PR-1 composite reads it;
-//! it slots in as a parallel per-input lookup.)
+//! ExifTool's `BuildCompositeTags` builds BOTH a `@val` array (each input's
+//! ValueConv value, `GetValue($tag, 'ValueConv')`, ExifTool.pm:4112) AND a
+//! `@prt` array (each input's PrintConv value, ExifTool.pm:4116). A Composite's
+//! `RawConv`/`ValueConv` reads `$val[i]`; its `PrintConv` may read `$prt[i]`
+//! (`GPSPosition`'s PrintConv is the literal `"$prt[0], $prt[1]"`;
+//! `GPSAltitude`'s reads `$prt[1]`). exifast carries BOTH per input, in both
+//! modes, by resolving from TWO views:
+//!
+//! * the **ValueConv view** — the emitted tag set in `-n` mode (raw ValueConv
+//!   values) — supplies `$val[i]`;
+//! * the **PrintConv view** — the emitted tag set in `-j` mode (PrintConv
+//!   strings) — supplies `$prt[i]`.
+//!
+//! Under `-n` the active `out` sink already holds the ValueConv values, so it
+//! IS the ValueConv view, and the caller re-emits a throwaway PrintConv view for
+//! `$prt[i]`. Under `-j` the active `out` sink holds the PrintConv strings, so
+//! it IS the PrintConv view, and the caller re-emits a throwaway ValueConv view
+//! for `$val[i]`. Either way the engine populates BOTH views with each built
+//! composite (its ValueConv form into the ValueConv view, its PrintConv form
+//! into the PrintConv view) so a composite-on-composite (`GPSPosition`) reads a
+//! faithful `$val[i]` AND `$prt[i]` of its ingredient composites — and because
+//! `out` is one of the two views, the composite's output value for the active
+//! mode lands in `out` automatically.
 
 pub mod convs;
 mod table;
 
 #[cfg(feature = "alloc")]
-use crate::tagmap::TagMap;
-#[cfg(feature = "alloc")]
 use crate::value::TagValue;
 #[cfg(feature = "alloc")]
-use table::{CompositeDef, CompositePrintConv, CompositeValue, REGISTRY};
+use table::{CompositeDef, CompositeValue, REGISTRY};
 
 /// A dedup sink the Composite engine reads inputs from and appends results to.
 /// Implemented by [`TagMap`](crate::tagmap::TagMap) (the JSON / golden path) and
@@ -75,23 +84,21 @@ trait CompositeSink {
   /// The LAST-emitted Main-document value whose family-1 group is in `groups`
   /// (or ANY group when `groups` is empty) and whose name is `name`, as a
   /// [`CompositeValue`] carrying the RAW stored [`TagValue`]
-  /// ([`Present`](CompositeValue::Present)) — NOT pre-coerced. The engine
-  /// invokes this on the ValueConv RESOLUTION view (under `-n` the emitted sink
-  /// itself; under `-j` a separate ValueConv re-emission), so the returned value
-  /// is the faithful `$val[i]` regardless of the output mode. A `Missing` result
-  /// means no such tag was extracted (`!defined $val[i]`); a present value of
-  /// ANY shape (numeric or string) is [`Present`](CompositeValue::Present), so
-  /// `Inhibit`/`Require`/`Desire` resolve on presence and each def performs its
-  /// own coercion.
+  /// ([`Present`](CompositeValue::Present)). Invoked on whichever view supplies
+  /// the requested form (the ValueConv view for `$val[i]`, the PrintConv view
+  /// for `$prt[i]`). A `Missing` result means no such tag was extracted
+  /// (`!defined`); a present value of ANY shape is
+  /// [`Present`](CompositeValue::Present), so `Inhibit`/`Require`/`Desire`
+  /// resolve on presence and each def performs its own coercion.
   fn resolve(&self, groups: &[&str], name: &str) -> CompositeValue;
   /// Is a `Composite:<name>` already present?
   fn has_composite(&self, name: &str) -> bool;
-  /// Append a built `Composite:<name>` (at Main, ExifTool default `Priority`).
-  fn append(&mut self, name: &'static str, value: TagValue);
+  /// Append a built `Composite:<name>` (at Main, with ExifTool `Priority`).
+  fn append(&mut self, name: &'static str, priority: u8, value: TagValue);
 }
 
 #[cfg(feature = "alloc")]
-impl CompositeSink for TagMap {
+impl CompositeSink for crate::tagmap::TagMap {
   fn resolve(&self, groups: &[&str], name: &str) -> CompositeValue {
     let group_ok = |g: &str| groups.is_empty() || groups.contains(&g);
     // Reverse scan for the LAST match (entries are in first-occurrence order;
@@ -113,8 +120,8 @@ impl CompositeSink for TagMap {
       .iter()
       .any(|(_doc, _sub, fam1, n, _pri, _val)| fam1.as_str() == "Composite" && n.as_str() == name)
   }
-  fn append(&mut self, name: &'static str, value: TagValue) {
-    let _ = self.write_value_doc(0, 0, "Composite", name, 1, value);
+  fn append(&mut self, name: &'static str, priority: u8, value: TagValue) {
+    let _ = self.write_value_doc(0, 0, "Composite", name, priority, value);
   }
 }
 
@@ -139,7 +146,7 @@ impl CompositeSink for std::vec::Vec<crate::value::Tag> {
       .iter()
       .any(|t| t.group_ref().family1() == "Composite" && t.name() == name)
   }
-  fn append(&mut self, name: &'static str, value: TagValue) {
+  fn append(&mut self, name: &'static str, _priority: u8, value: TagValue) {
     self.push(crate::value::Tag::new(
       crate::value::Group::new("Composite", "Composite"),
       name,
@@ -154,107 +161,119 @@ fn t_value(t: &crate::value::Tag) -> &TagValue {
   t.value_ref()
 }
 
+/// A [`TagValue`] in Perl string context — what `$val[i]` / `$prt[i]` becomes
+/// when a Composite's ValueConv/PrintConv interpolates it. A `Str` is borrowed;
+/// the numeric scalars stringify with Perl's default NV / integer rule (so a
+/// GPS decimal `$val` interpolates as `48.85815`, matching ExifTool's
+/// `"$val[0] $val[1]"`); other shapes render via their textual form.
+#[cfg(feature = "alloc")]
+pub(crate) fn value_text(v: &TagValue) -> std::borrow::Cow<'_, str> {
+  use std::borrow::Cow;
+  match v {
+    TagValue::Str(s) => Cow::Borrowed(s.as_str()),
+    TagValue::I64(n) => Cow::Owned(n.to_string()),
+    TagValue::U64(n) => Cow::Owned(n.to_string()),
+    // Perl's default NV stringification (`%.15g`) — the form a decimal GPS
+    // coordinate interpolates as inside `"$val[0] $val[1]"`.
+    TagValue::F64(x) => Cow::Owned(crate::value::format_g(*x, 15)),
+    TagValue::Bool(b) => Cow::Borrowed(if *b { "1" } else { "" }),
+    other => Cow::Owned(std::format!("{other:?}")),
+  }
+}
+
 /// Build every registered Composite tag into `out` (the post-`run_emission`
 /// pass). `mode` is the active OUTPUT conversion mode (`-j` ⇒ PrintConv, `-n`
-/// ⇒ ValueConv); `raw` is the SAME Meta re-emitted in ValueConv mode (`-n`),
-/// supplied so the engine resolves each input from its post-ValueConv (raw)
-/// value REGARDLESS of `mode` — ExifTool's `BuildCompositeTags`/`GetValue`
-/// reads `$val[i]` as the input's ValueConv value, not the printed form
-/// (ExifTool.pm:4044-4112). `None` ⇒ resolve from `out` itself (the `-n` path,
-/// where the emitted values already ARE the raw ValueConv values, so a separate
-/// pass is redundant). `doc_count` is the highest family-3 sub-document index
-/// present (reserved for `SubDoc` composites — none of the registered Duration
-/// defs is `SubDoc`, so they build at Main only regardless, ExifTool.pm:3999).
+/// ⇒ ValueConv); `other_view` is the SAME Meta re-emitted in the OPPOSITE mode,
+/// supplied so the engine has BOTH a ValueConv view (`$val[i]`) and a PrintConv
+/// view (`$prt[i]`) regardless of `mode` — under `-n`, `out` is the ValueConv
+/// view and `other_view` is the PrintConv re-emission; under `-j`, `out` is the
+/// PrintConv view and `other_view` is the ValueConv re-emission. `None` is
+/// permitted ONLY when the defs read neither the opposite-mode view NOR a
+/// composite dependency (the legacy single-sink Duration path); the registered
+/// GPS defs always require `other_view`. `doc_count` is reserved for `SubDoc`
+/// composites (the stills GPS defs build at Main only, `doc_count == 0`).
 #[cfg(feature = "alloc")]
 pub(crate) fn build_composites(
-  out: &mut TagMap,
-  raw: Option<&mut TagMap>,
+  out: &mut crate::tagmap::TagMap,
+  other_view: Option<&mut crate::tagmap::TagMap>,
   mode: crate::emit::ConvMode,
   doc_count: u32,
 ) {
   let _ = doc_count; // reserved for SubDoc composites (later #133 PRs)
-  build_into(REGISTRY, out, raw, mode);
+  build_into(REGISTRY, out, other_view, mode);
 }
 
 /// Build every registered Composite tag into the
 /// [`iter_tags`](crate::format_parser::AnyMeta::iter_tags) `Tag` `Vec` (the
 /// public generic-extraction path), so it yields the same `Composite:*` set the
-/// JSON path does. `raw` is the SAME tag stream re-collected in ValueConv mode
-/// (the input-resolution source; see [`build_composites`]); `None` on the `-n`
-/// path where `tags` already holds the raw values.
+/// JSON path does. `other_view` is the SAME tag stream re-collected in the
+/// OPPOSITE mode (the `$prt[i]`/`$val[i]` source; see [`build_composites`]).
 #[cfg(feature = "alloc")]
 pub(crate) fn build_composites_into_tags(
   tags: &mut std::vec::Vec<crate::value::Tag>,
-  raw: Option<&mut std::vec::Vec<crate::value::Tag>>,
+  other_view: Option<&mut std::vec::Vec<crate::value::Tag>>,
   mode: crate::emit::ConvMode,
 ) {
-  build_into(REGISTRY, tags, raw, mode);
+  build_into(REGISTRY, tags, other_view, mode);
 }
 
 /// Drive the ExifTool `BuildCompositeTags` fixpoint over `defs`.
 ///
-/// Inputs are resolved from the RAW (post-ValueConv) value of each ingredient,
-/// independent of the active output `mode`: this is ExifTool's `$val[i]`
-/// (`GetValue($tag, 'ValueConv')`, ExifTool.pm:4112), so a composite's own
-/// `RawConv`/`ValueConv` always runs on the faithful machine value (a GPS ref
-/// `"N"`/`"S"`, a decimal coordinate, a `DateStamp`) — never the printed form.
-/// (A composite's PrintConv form `$prt[i]`, needed by e.g. `GPSPosition`'s
-/// PrintConv in a LATER #133 PR, is not wired yet because no PR-1 composite —
-/// `Duration` — reads it; it slots in as a second per-input lookup.)
+/// `out` is the view for the active output `mode`; `other_view` is the opposite-
+/// mode re-emission. The engine binds them to a `(val_view, prt_view)` pair (in
+/// `-n`, `out` is the ValueConv view and `other_view` the PrintConv view; in
+/// `-j`, vice versa), resolves each input's `$val[i]` from `val_view` and
+/// `$prt[i]` from `prt_view`, runs the def's derivation over `$val[]`, and
+/// appends each built composite's ValueConv form to `val_view` and PrintConv
+/// form to `prt_view` — so a composite-on-composite (`GPSPosition`) reads a
+/// faithful `$val[i]`/`$prt[i]` of its ingredients, and the composite's output
+/// for `mode` lands in `out` (which is one of the two views).
 ///
-/// `resolve_src` is the raw view to read inputs + composite-dependencies from
-/// AND to append each built composite's RAW value to (so a composite that
-/// `Require`s another `Composite:*` sees its raw value in the fixpoint). When
-/// `None`, the active `out` sink IS the raw view (the `-n` path), so the engine
-/// reads + appends there directly. The RENDERED composite (for `mode`) is
-/// always appended to `out`. Split out so the oracle tests can pass synthetic
-/// def lists, and generic over the sink so the TagMap and `Vec<Tag>` paths
-/// share ONE engine.
+/// When `other_view` is `None` (the legacy single-sink Duration path, used by
+/// the oracle tests and the `-n` build when no def reads `$prt`), `out` is BOTH
+/// views: the engine resolves and appends through it alone, rendering the
+/// composite once for `mode`. Byte-identical to the pre-`$prt` engine for any
+/// def whose PrintConv ignores `$prt`.
 #[cfg(feature = "alloc")]
 fn build_into<S: CompositeSink>(
   defs: &[CompositeDef],
   out: &mut S,
-  resolve_src: Option<&mut S>,
+  other_view: Option<&mut S>,
   mode: crate::emit::ConvMode,
 ) {
-  match resolve_src {
-    // `-j` (PrintConv): inputs + composite-dependencies resolve from the SEPARATE
-    // raw ValueConv view. Each built composite's RAW value is appended back into
-    // that view (so a Composite-requires-Composite chain reads faithful `$val[i]`
-    // in the fixpoint), while its RENDERED (`-j`) value is mirrored into `out`.
-    Some(raw_view) => run_fixpoint(defs, raw_view, |view, name, raw, pc| {
-      view.append(
-        name,
-        render_value(pc, raw, crate::emit::ConvMode::ValueConv),
-      );
-      out.append(name, render_value(pc, raw, mode));
-    }),
-    // `-n` (ValueConv) and the synthetic-map oracle/differential tests: `out` is
-    // itself the resolution view (its values are already the raw ValueConv form
-    // in `-n`; in the test maps they ARE the ingredients), so resolution reads
-    // `out` directly and the composite is appended there ONCE, rendered for the
-    // active `mode`. Under `-n` that rendered value is the raw value, so a
-    // dependent composite still resolves a faithful `$val[i]`. Byte-identical to
-    // the pre-#133-round-3 single-sink engine.
-    None => run_fixpoint(defs, out, |view, name, raw, pc| {
-      view.append(name, render_value(pc, raw, mode));
-    }),
+  use crate::emit::ConvMode;
+  match other_view {
+    Some(other) => {
+      // Bind (val_view, prt_view) by mode. `out` is whichever view holds the
+      // active mode's form; `other` is the opposite-mode re-emission.
+      let (val_view, prt_view): (&mut S, &mut S) = match mode {
+        ConvMode::ValueConv => (out, other), // out = ValueConv view
+        ConvMode::PrintConv => (other, out), // out = PrintConv view
+      };
+      run_fixpoint(defs, val_view, Some(prt_view), mode);
+    }
+    // No `$prt` source: `out` is its own sole view (the ValueConv values in `-n`,
+    // the synthetic oracle maps). A `$prt`-reading PrintConv sees `None` prt
+    // elements; the Duration defs (the only `None`-path callers) ignore `$prt`.
+    None => run_fixpoint(defs, out, None, mode),
   }
 }
 
-/// The ExifTool `BuildCompositeTags` fixpoint over `defs`, reading inputs (and
-/// Composite-dependencies) from `resolve_view`. For each built composite,
-/// `place_built(resolve_view, name, raw, print_conv)` is invoked to (1) make the
-/// composite visible in `resolve_view` for any dependent composite's `$val[i]`
-/// and (2) emit its output value — the `-j` arm appends the RAW value to the
-/// raw view AND mirrors the rendered value to the output sink; the `-n`/test arm
-/// appends the mode-rendered value once to the single sink.
+/// The ExifTool `BuildCompositeTags` fixpoint over `defs`, resolving `$val[i]`
+/// from `val_view` and `$prt[i]` from `prt_view` (the SAME sink as `val_view`
+/// when `prt_view` is `None`). The Composite-dependency deferral (`not_built` /
+/// `has_composite`) keys on `val_view` (a dependency's `$val[i]` is what gates
+/// the build). For each built composite, both forms are appended: the ValueConv
+/// form to `val_view`, the PrintConv form to `prt_view` (or, when they coincide,
+/// the active-mode form once).
 #[cfg(feature = "alloc")]
 fn run_fixpoint<S: CompositeSink>(
   defs: &[CompositeDef],
-  resolve_view: &mut S,
-  mut place_built: impl FnMut(&mut S, &'static str, f64, CompositePrintConv),
+  val_view: &mut S,
+  mut prt_view: Option<&mut S>,
+  mode: crate::emit::ConvMode,
 ) {
+  use crate::emit::ConvMode;
   // Working order: a faithful prefixed-id sort (`Module-Name`). Stable sort so
   // equal keys keep registry order (ExifTool's keys are unique, so ties don't
   // occur in practice).
@@ -275,10 +294,12 @@ fn run_fixpoint<S: CompositeSink>(
     let pending_len = pending.len();
 
     'def: for def in pending.iter().copied() {
-      // Resolve each input index to a `CompositeValue` (PRESENCE + raw value),
-      // never pre-coercing. `Require`/`Desire`/`Inhibit` key on presence; the
-      // def's `derive` does its own coercion of the `Present` raw values.
-      let mut values: std::vec::Vec<CompositeValue> =
+      // Resolve each input index to its `$val[i]` ([`CompositeValue`], presence
+      // + raw value) AND its `$prt[i]` (the PrintConv-view value, `None` for an
+      // absent/`Missing` input). `Require`/`Desire`/`Inhibit` key on `$val[i]`
+      // presence; the def's `derive` reads `$val[]`; the PrintConv reads both.
+      let mut vals: std::vec::Vec<CompositeValue> = std::vec::Vec::with_capacity(def.inputs.len());
+      let mut prts: std::vec::Vec<Option<TagValue>> =
         std::vec::Vec::with_capacity(def.inputs.len());
       let mut suppress = false; // an Inhibit input was present
       let mut require_missing = false;
@@ -287,7 +308,7 @@ fn run_fixpoint<S: CompositeSink>(
         // Composite-dependency deferral (ExifTool.pm:4044-4052): an input that
         // references a `Composite:Name` not yet built defers this def — UNLESS
         // it is an Inhibit and we are in the final `$allBuilt` pass.
-        if references_unbuilt_composite(input, &not_built, resolve_view) {
+        if references_unbuilt_composite(input, &not_built, val_view) {
           let defer = !(input.kind.is_inhibit() && all_built);
           if defer {
             deferred.push(def);
@@ -295,7 +316,7 @@ fn run_fixpoint<S: CompositeSink>(
           }
         }
 
-        let resolved = resolve_view.resolve(input.groups, input.name);
+        let resolved = val_view.resolve(input.groups, input.name);
         if resolved.is_present() {
           if input.kind.is_inhibit() {
             // ExifTool.pm:4078-4081 `$found = 0; last` — a PRESENT inhibitor of
@@ -303,7 +324,14 @@ fn run_fixpoint<S: CompositeSink>(
             suppress = true;
             break;
           }
-          values.push(resolved);
+          // The matching `$prt[i]` from the PrintConv view (the SAME sink as
+          // `val_view` when `prt_view` is `None`).
+          let prt = match prt_view.as_deref() {
+            Some(pv) => pv.resolve(input.groups, input.name),
+            None => val_view.resolve(input.groups, input.name),
+          };
+          prts.push(prt.value().cloned());
+          vals.push(resolved);
         } else {
           if input.kind.is_require() {
             // ExifTool.pm:4084-4087 `$found = 0; last` — required & missing.
@@ -311,7 +339,8 @@ fn run_fixpoint<S: CompositeSink>(
             break;
           }
           // Desire / Inhibit absent ⇒ undef element, keep going.
-          values.push(CompositeValue::Missing);
+          prts.push(None);
+          vals.push(CompositeValue::Missing);
         }
       }
 
@@ -321,12 +350,37 @@ fn run_fixpoint<S: CompositeSink>(
         continue;
       }
 
-      // All inputs resolved: run the derivation. The arm-specific `place_built`
-      // makes the composite visible in `resolve_view` (for a dependent
-      // composite's `$val[i]`) AND emits its output value (see `build_into`).
+      // All inputs resolved: run the derivation (`$val` from `$val[]`).
       not_built.remove(def.name);
-      if let Some(raw) = (def.derive)(&values) {
-        place_built(resolve_view, def.name, raw, def.print_conv);
+      if let Some(raw) = (def.derive)(&vals) {
+        // Append the ValueConv form to `val_view` and the PrintConv form to
+        // `prt_view`, so a dependent composite reads both. When the two views
+        // coincide (`None` prt_view), append the active-mode form once.
+        match prt_view.as_deref_mut() {
+          Some(prt) => {
+            val_view.append(
+              def.name,
+              def.priority,
+              def
+                .print_conv
+                .render(&raw, &vals, &prts, ConvMode::ValueConv),
+            );
+            prt.append(
+              def.name,
+              def.priority,
+              def
+                .print_conv
+                .render(&raw, &vals, &prts, ConvMode::PrintConv),
+            );
+          }
+          None => {
+            val_view.append(
+              def.name,
+              def.priority,
+              def.print_conv.render(&raw, &vals, &prts, mode),
+            );
+          }
+        }
       }
       // `None` ⇒ the `… ? … : undef` guard fired; nothing emitted, but the
       // composite is settled (already removed from `not_built`).
@@ -340,8 +394,8 @@ fn run_fixpoint<S: CompositeSink>(
       if all_built {
         // ExifTool warns `Circular dependency in Composite tags` and stops.
         // exifast has no doc-level warning channel for this synthetic case
-        // (the registered Duration defs never cycle); drop the unbuildable
-        // deferred defs and stop.
+        // (the registered defs never cycle); drop the unbuildable deferred defs
+        // and stop.
         break;
       }
       all_built = true; // one more pass, ignoring Inhibit-on-Composite
@@ -368,14 +422,6 @@ fn references_unbuilt_composite<S: CompositeSink>(
     return false;
   }
   not_built.contains(input.name)
-}
-
-/// Render the derived raw value for the def's PrintConv + the active mode.
-#[cfg(feature = "alloc")]
-fn render_value(pc: CompositePrintConv, raw: f64, mode: crate::emit::ConvMode) -> TagValue {
-  match pc {
-    CompositePrintConv::ConvertDuration => convs::duration_value(raw, mode),
-  }
 }
 
 #[cfg(test)]

--- a/src/composite/table.rs
+++ b/src/composite/table.rs
@@ -7,10 +7,33 @@
 //! `RawConv`/`ValueConv`), and how that raw value is rendered for the active
 //! conversion mode (the def's `PrintConv`).
 //!
-//! This PR registers ONLY the three `Duration` composites that the APE / FLAC /
+//! This module registers the three `Duration` composites that the APE / FLAC /
 //! AIFF formats used to emit inline (APE.pm:83-92, FLAC.pm:137-149,
-//! AIFF.pm:136-145). No new composites are introduced; the cross-format sweep
-//! (#133) adds the rest in later PRs.
+//! AIFF.pm:136-145) AND — added by #133 PR 2 — the five stills GPS composites
+//! `GPSLatitude` / `GPSLongitude` / `GPSAltitude` / `GPSDateTime` (GPS.pm:355-
+//! 432) and `GPSPosition` (Exif.pm:5271). The later #133 PRs add the rest.
+//!
+//! ## The composite value `$val` — numeric OR string
+//!
+//! A Composite's `ValueConv`/`RawConv` yields a Perl scalar that may be
+//! numeric (the Duration seconds, a GPS decimal degree) OR a string (the
+//! `GPSDateTime` `"$datestamp $timestampZ"`, the `GPSPosition` `"$val[0]
+//! $val[1]"`). [`CompositeRaw`] models that scalar: [`Num`](CompositeRaw::Num)
+//! for a numeric `$val` (rendered to its ValueConv `F64` and fed to a numeric
+//! PrintConv such as `ConvertDuration` / `ToDMS`), [`Text`](CompositeRaw::Text)
+//! for a string `$val` (rendered to its ValueConv `Str`).
+//!
+//! ## `$val[i]` (ValueConv) and `$prt[i]` (PrintConv) inputs
+//!
+//! A Composite's `RawConv`/`ValueConv` reads each input's ValueConv value
+//! `$val[i]` (`GetValue($tag, 'ValueConv')`, ExifTool.pm:4112); a Composite's
+//! `PrintConv` may ALSO read each input's PrintConv value `$prt[i]`
+//! (ExifTool.pm:4116 builds the `@prt` array). `GPSPosition`'s PrintConv is the
+//! literal `"$prt[0], $prt[1]"` — the two ingredient Composites' DMS strings —
+//! and `GPSAltitude`'s PrintConv reads `$prt[1]` (the `GPSAltitudeRef` PrintConv
+//! string). So the engine resolves BOTH a ValueConv view (`$val[i]`) and a
+//! PrintConv view (`$prt[i]`) per input and hands BOTH arrays to
+//! [`CompositePrintConv::render`].
 //!
 //! ## Input-group matching (the `APE:` ≡ `MAC:` subtlety)
 //!
@@ -28,16 +51,40 @@
 
 use crate::value::TagValue;
 
+/// A Composite tag's `ValueConv`/`RawConv` result — the Perl scalar `$val` the
+/// def derives, which may be NUMERIC (Duration seconds, a GPS decimal degree)
+/// or a STRING (`GPSDateTime`'s `"$datestamp $timestampZ"`, `GPSPosition`'s
+/// `"$val[0] $val[1]"`). The engine renders it to the sink's ValueConv form
+/// (`Num` → `F64`, `Text` → `Str`) and passes it to the def's PrintConv.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CompositeRaw {
+  /// A numeric `$val` (e.g. Duration seconds, a signed GPS decimal degree).
+  Num(f64),
+  /// A string `$val` (e.g. `"2021:08:14 16:45:09Z"`, `"48.85815 2.3489"`).
+  Text(std::string::String),
+}
+
+impl CompositeRaw {
+  /// The numeric `$val` if [`Num`](Self::Num) (for a numeric PrintConv such as
+  /// `ConvertDuration` / `ToDMS`); `None` for a [`Text`](Self::Text) raw.
+  pub(crate) fn as_num(&self) -> Option<f64> {
+    match self {
+      CompositeRaw::Num(x) => Some(*x),
+      CompositeRaw::Text(_) => None,
+    }
+  }
+}
+
 /// One resolved Composite input, as the engine hands it to a
 /// [`CompositeDef::derive`]. The model carries PRESENCE separately from any
 /// numeric coercion: ExifTool's `Require`/`Desire`/`Inhibit` resolution keys on
 /// whether the ingredient tag was extracted at all (`defined $val[i]`), while
 /// each def's RawConv then coerces the RAW value on its own terms (the Duration
-/// defs read a number; the GPS / EXIF / datetime defs added by later #133 PRs
-/// read strings — GPS refs `N`/`S`/`E`/`W`, `DateStamp`, `TimeStamp`). So the
-/// engine never pre-coerces; it delivers the actual RAW (post-`ValueConv`)
-/// [`TagValue`] — the faithful `$val[i]`, independent of the `-j`/`-n` output
-/// mode (ExifTool.pm:4112) — and lets the derivation interpret it.
+/// defs read a number; the GPS / datetime defs read strings — GPS refs
+/// `N`/`S`/`E`/`W`, `DateStamp`, `TimeStamp`). So the engine never pre-coerces;
+/// it delivers the actual RAW (post-`ValueConv`) [`TagValue`] — the faithful
+/// `$val[i]`, independent of the `-j`/`-n` output mode (ExifTool.pm:4112) — and
+/// lets the derivation interpret it.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum CompositeValue {
   /// The ingredient tag was not extracted (`!defined $val[i]`) — an absent
@@ -61,6 +108,13 @@ impl CompositeValue {
       CompositeValue::Present(v) => Some(v),
       CompositeValue::Missing => None,
     }
+  }
+  /// The present value as text (`$val[i]` in string context) — a `Str` borrowed
+  /// directly, any other present scalar via its textual rendering. `None` when
+  /// [`Missing`](Self::Missing). Used by the string-valued GPS defs
+  /// (`GPSDateTime`/`GPSPosition`) whose `ValueConv` concatenates `$val[i]`.
+  pub(crate) fn as_text(&self) -> Option<std::borrow::Cow<'_, str>> {
+    self.value().map(crate::composite::value_text)
   }
   /// Perl numeric coercion (`0 + $val`) of a PRESENT value: integers and
   /// finite/non-finite floats pass through; a numeric STRING (incl.
@@ -88,13 +142,143 @@ impl CompositeValue {
 }
 
 /// How a [`CompositeDef`] turns its resolved raw value into the stored
-/// [`TagValue`](crate::value::TagValue) for the active conversion mode.
+/// [`TagValue`](crate::value::TagValue) for the active conversion mode. Each
+/// variant is given the composite's own `$val` ([`CompositeRaw`]), the resolved
+/// input `$val[]` ([`CompositeValue`]) and the input `$prt[]`
+/// (`Option<TagValue>`, the PrintConv form, `None` for an absent/`Missing`
+/// input) so a PrintConv that reads `$val[i]`/`$prt[i]` (e.g. `GPSPosition`,
+/// `GPSAltitude`) renders faithfully.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompositePrintConv {
   /// `PrintConv => 'ConvertDuration($val)'` — the duration format under `-j`,
   /// the bare raw scalar under `-n`, the quoted Perl string for a non-finite
   /// value in both modes ([`crate::composite::convs::duration_value`]).
   ConvertDuration,
+  /// `PrintConv => 'Image::ExifTool::GPS::ToDMS($self, $val, 1, $ref)'` — the
+  /// `Composite:GPSLatitude`/`GPSLongitude` PrintConv. Under `-j` the DMS string
+  /// (`48 deg 51' 29.34" N`); under `-n` the bare signed decimal `$val`. The
+  /// `char` is the positive-hemisphere letter (`'N'` lat, `'E'` lon).
+  GpsCoordinate(char),
+  /// `Composite:GPSAltitude` PrintConv (GPS.pm:419-431) — under `-j`
+  /// `(int($val[0]*10)/10) . ' m ' . $prt[1]` (e.g. `35 m Above Sea Level`);
+  /// under `-n` the bare signed altitude `$val`.
+  GpsAltitude,
+  /// `Composite:GPSDateTime` PrintConv (`$self->ConvertDateTime($val)`,
+  /// GPS.pm:362) — the identity at exifast's option set, in BOTH modes (the
+  /// ValueConv string `"$datestamp $timestampZ"`).
+  GpsDateTime,
+  /// `Composite:GPSPosition` PrintConv (Exif.pm:5314 `"$prt[0], $prt[1]"`) —
+  /// under `-j` the two ingredient DMS strings joined by `", "`; under `-n` the
+  /// ValueConv string `$val` (`"$val[0] $val[1]"`).
+  GpsPosition,
+}
+
+impl CompositePrintConv {
+  /// Render the composite's value for the active `mode`. `raw` is the def's
+  /// `ValueConv` result (`$val`); `vals`/`prts` are the resolved input `$val[]`
+  /// / `$prt[]` arrays (for a PrintConv that reads them). The ValueConv (`-n`)
+  /// form is `raw` itself (`Num` → `F64`, `Text` → `Str`) EXCEPT where a
+  /// non-finite `Num` stringifies (Duration); the PrintConv (`-j`) form runs the
+  /// def's PrintConv expression.
+  #[cfg(feature = "alloc")]
+  pub(crate) fn render(
+    self,
+    raw: &CompositeRaw,
+    vals: &[CompositeValue],
+    prts: &[Option<TagValue>],
+    mode: crate::emit::ConvMode,
+  ) -> TagValue {
+    use crate::emit::ConvMode;
+    match self {
+      CompositePrintConv::ConvertDuration => {
+        // Duration's `$val` is always numeric; delegate to the shared
+        // finite/non-finite-aware renderer.
+        let n = raw.as_num().unwrap_or(f64::NAN);
+        crate::composite::convs::duration_value(n, mode)
+      }
+      CompositePrintConv::GpsCoordinate(ref_pos) => {
+        let n = raw.as_num().unwrap_or(f64::NAN);
+        match mode {
+          ConvMode::ValueConv => TagValue::F64(n),
+          ConvMode::PrintConv => {
+            TagValue::Str(crate::composite::convs::gps::to_dms(n, ref_pos).into())
+          }
+        }
+      }
+      CompositePrintConv::GpsAltitude => {
+        let n = raw.as_num().unwrap_or(f64::NAN);
+        match mode {
+          ConvMode::ValueConv => TagValue::F64(n),
+          ConvMode::PrintConv => {
+            // ExifTool's `foreach (0,2)` PrintConv reads the INPUT altitude
+            // `$val[$_]` + ref-print `$prt[$_+1]` (index 0 = GPS pair, 2 = XMP
+            // pair). Build both candidates; the composite's own `$val` (`n`)
+            // drives the fall-through.
+            let alt_text = |i: usize| -> Option<std::borrow::Cow<'_, str>> {
+              vals.get(i).and_then(CompositeValue::as_text)
+            };
+            let ref_text = |i: usize| -> Option<std::borrow::Cow<'_, str>> {
+              prts
+                .get(i)
+                .and_then(Option::as_ref)
+                .map(crate::composite::value_text)
+            };
+            let a0 = alt_text(0);
+            let r1 = ref_text(1);
+            let a2 = alt_text(2);
+            let r3 = ref_text(3);
+            let candidates = [
+              crate::composite::convs::gps::AltCandidate {
+                alt_text: a0.as_deref(),
+                ref_print: r1.as_deref(),
+              },
+              crate::composite::convs::gps::AltCandidate {
+                alt_text: a2.as_deref(),
+                ref_print: r3.as_deref(),
+              },
+            ];
+            TagValue::Str(crate::composite::convs::gps::gps_altitude_print(n, &candidates).into())
+          }
+        }
+      }
+      CompositePrintConv::GpsDateTime => {
+        // ValueConv == PrintConv (ConvertDateTime is the identity here).
+        let CompositeRaw::Text(s) = raw else {
+          return TagValue::Str(Default::default());
+        };
+        match mode {
+          ConvMode::ValueConv => TagValue::Str(s.as_str().into()),
+          ConvMode::PrintConv => {
+            TagValue::Str(crate::composite::convs::datetime::convert_date_time(s).into())
+          }
+        }
+      }
+      CompositePrintConv::GpsPosition => match mode {
+        ConvMode::ValueConv => {
+          // `$val` is the ValueConv string `"$val[0] $val[1]"`.
+          let CompositeRaw::Text(s) = raw else {
+            return TagValue::Str(Default::default());
+          };
+          TagValue::Str(s.as_str().into())
+        }
+        ConvMode::PrintConv => {
+          // `"$prt[0], $prt[1]"` — the two ingredient Composites' PrintConv
+          // (DMS) strings. An undefined `$prt[i]` stringifies as empty.
+          let p0 = prts
+            .first()
+            .and_then(Option::as_ref)
+            .map(crate::composite::value_text)
+            .unwrap_or(std::borrow::Cow::Borrowed(""));
+          let p1 = prts
+            .get(1)
+            .and_then(Option::as_ref)
+            .map(crate::composite::value_text)
+            .unwrap_or(std::borrow::Cow::Borrowed(""));
+          TagValue::Str(std::format!("{p0}, {p1}").into())
+        }
+      },
+    }
+  }
 }
 
 /// One `Require` / `Desire` / `Inhibit` input of a [`CompositeDef`], at a fixed
@@ -122,11 +306,11 @@ pub(crate) enum InputKind {
   Require,
   /// `Desire` — the composite may still build if this input is missing (the
   /// element is left `undef`).
-  #[allow(dead_code)] // No Desire-only Duration input yet; used by the engine + oracle tests.
   Desire,
   /// `Inhibit` — the composite is SUPPRESSED if this input is present
   /// (ExifTool.pm:4078-4081 `$found = 0; last`).
-  #[allow(dead_code)] // No Inhibit Duration input yet; used by the engine + oracle tests.
+  #[allow(dead_code)]
+  // No Inhibit input among the ported defs yet; used by the engine + oracle tests.
   Inhibit,
 }
 
@@ -148,9 +332,9 @@ impl InputKind {
 /// (`Present(value)` carrying the raw [`TagValue`] when the ingredient was
 /// extracted, `Missing` when an absent `Desire`/`Inhibit`) and performs ITS OWN
 /// Perl coercion — the Duration defs coerce numeric + apply the Perl-truthy
-/// `&&` guard; future GPS / EXIF defs read string ingredients. It returns the
-/// raw composite value, or `None` to abort the build (ExifTool's
-/// `… ? … : undef` guard, e.g. APE.pm:90 `($val[0] && $val[1]) ? … : undef`).
+/// `&&` guard; the GPS defs read string/decimal ingredients. It returns the
+/// composite's raw value [`CompositeRaw`] (`$val`), or `None` to abort the build
+/// (ExifTool's `… ? … : undef` guard, e.g. APE.pm:90, the GPSAltitude RawConv).
 #[derive(Clone, Copy)]
 pub(crate) struct CompositeDef {
   /// The composite tag name (the `-G1` key is `Composite:<name>`).
@@ -158,9 +342,13 @@ pub(crate) struct CompositeDef {
   /// The inputs in index order (ExifTool `{ 0 => …, 1 => … }`).
   pub(crate) inputs: &'static [CompositeInput],
   /// The def's `RawConv`/`ValueConv` arithmetic over the resolved inputs.
-  pub(crate) derive: fn(&[CompositeValue]) -> Option<f64>,
+  pub(crate) derive: fn(&[CompositeValue]) -> Option<CompositeRaw>,
   /// The def's `PrintConv`.
   pub(crate) print_conv: CompositePrintConv,
+  /// ExifTool `Priority => N` (default `1`). `GPSPosition` is `Priority => 0`
+  /// (never overrides a duplicate); the others use the default `1`. Threaded
+  /// into [`crate::tagmap::TagMap`]'s duplicate-override rule on append.
+  pub(crate) priority: u8,
   /// The prefixed-id sort key (ExifTool's `Module-Name`, AddCompositeTags
   /// `$prefix . $tagID`). The build order sorts by this so the registry is
   /// position-independent and the fixpoint is deterministic.
@@ -169,6 +357,7 @@ pub(crate) struct CompositeDef {
 
 /// `Require`d input on the `{APE, MAC}` family-1 group set (the APE MAC header
 /// carries family-1 `MAC` but family-0 `APE`, so it satisfies `APE:`).
+#[cfg(feature = "ape")]
 const fn ape_req(name: &'static str) -> CompositeInput {
   CompositeInput {
     kind: InputKind::Require,
@@ -187,6 +376,15 @@ const fn req(group: &'static [&'static str], name: &'static str) -> CompositeInp
   }
 }
 
+/// `Desire`d input on a single family-1 group `group`.
+const fn des(group: &'static [&'static str], name: &'static str) -> CompositeInput {
+  CompositeInput {
+    kind: InputKind::Desire,
+    groups: group,
+    name,
+  }
+}
+
 /// APE.pm:90 `($val[0] && $val[1]) ? (($val[1] - 1) * $val[2] + $val[3]) / $val[0] : undef`.
 /// `$val[0]`=SampleRate, `[1]`=TotalFrames, `[2]`=BlocksPerFrame, `[3]`=FinalFrameBlocks.
 ///
@@ -195,7 +393,8 @@ const fn req(group: &'static [&'static str], name: &'static str) -> CompositeInp
 /// Perl-TRUTHY, so it passes the guard and computes; only `""`, `"0"`, undef and
 /// a numeric/`Bytes` zero are falsy). The arithmetic itself then coerces every
 /// ingredient via Perl numeric coercion.
-fn ape_duration(v: &[CompositeValue]) -> Option<f64> {
+#[cfg(feature = "ape")]
+fn ape_duration(v: &[CompositeValue]) -> Option<CompositeRaw> {
   let sr_raw = v.first()?;
   let tf_raw = v.get(1)?;
   // `$val[0] && $val[1]` — Perl-boolean on the RAW values (string-truthy).
@@ -206,31 +405,147 @@ fn ape_duration(v: &[CompositeValue]) -> Option<f64> {
   let tf = tf_raw.coerce_numeric()?;
   let bpf = v.get(2)?.coerce_numeric()?;
   let ffb = v.get(3)?.coerce_numeric()?;
-  Some(((tf - 1.0) * bpf + ffb) / sr)
+  Some(CompositeRaw::Num(((tf - 1.0) * bpf + ffb) / sr))
 }
 
 /// FLAC.pm:147 `($val[0] and $val[1]) ? $val[1] / $val[0] : undef`.
 /// `$val[0]`=SampleRate, `[1]`=TotalSamples. The `and` guard is Perl-truthy on
 /// the RAW ingredients (string-truthy), then the arithmetic coerces numeric.
-fn flac_duration(v: &[CompositeValue]) -> Option<f64> {
+#[cfg(feature = "flac")]
+fn flac_duration(v: &[CompositeValue]) -> Option<CompositeRaw> {
   let sr_raw = v.first()?;
   let total_raw = v.get(1)?;
   if !sr_raw.is_truthy() || !total_raw.is_truthy() {
     return None;
   }
-  Some(total_raw.coerce_numeric()? / sr_raw.coerce_numeric()?)
+  Some(CompositeRaw::Num(
+    total_raw.coerce_numeric()? / sr_raw.coerce_numeric()?,
+  ))
 }
 
 /// AIFF.pm:143 `($val[0] and $val[1]) ? $val[1] / $val[0] : undef`.
 /// `$val[0]`=SampleRate, `[1]`=NumSampleFrames. The `and` guard is Perl-truthy
 /// on the RAW ingredients (string-truthy), then the arithmetic coerces numeric.
-fn aiff_duration(v: &[CompositeValue]) -> Option<f64> {
+#[cfg(feature = "aiff")]
+fn aiff_duration(v: &[CompositeValue]) -> Option<CompositeRaw> {
   let sr_raw = v.first()?;
   let frames_raw = v.get(1)?;
   if !sr_raw.is_truthy() || !frames_raw.is_truthy() {
     return None;
   }
-  Some(frames_raw.coerce_numeric()? / sr_raw.coerce_numeric()?)
+  Some(CompositeRaw::Num(
+    frames_raw.coerce_numeric()? / sr_raw.coerce_numeric()?,
+  ))
+}
+
+/// `Composite:GPSLatitude` ValueConv (GPS.pm:367) `$val[1] =~ /^S/i ? -$val[0] :
+/// $val[0]`. `$val[0]`=GPS:GPSLatitude (decimal degrees), `[1]`=GPSLatitudeRef
+/// (`"N"`/`"S"`). The ref is case-insensitively `^S` ⇒ negate.
+#[cfg(feature = "exif")]
+fn gps_latitude(v: &[CompositeValue]) -> Option<CompositeRaw> {
+  let lat = v.first()?.coerce_numeric()?;
+  let ref_s = v.get(1)?.as_text()?;
+  Some(CompositeRaw::Num(if ref_starts_with(&ref_s, b'S') {
+    -lat
+  } else {
+    lat
+  }))
+}
+
+/// `Composite:GPSLongitude` ValueConv (GPS.pm:399) `$val[1] =~ /^W/i ? -$val[0]
+/// : $val[0]`.
+#[cfg(feature = "exif")]
+fn gps_longitude(v: &[CompositeValue]) -> Option<CompositeRaw> {
+  let lon = v.first()?.coerce_numeric()?;
+  let ref_s = v.get(1)?.as_text()?;
+  Some(CompositeRaw::Num(if ref_starts_with(&ref_s, b'W') {
+    -lon
+  } else {
+    lon
+  }))
+}
+
+/// `Composite:GPSAltitude` RawConv + ValueConv (GPS.pm:412-418). The RawConv
+/// `(defined $val[1] or defined $val[3]) ? $val : undef` requires an altitude
+/// ref; the ValueConv `foreach (0,2) { next unless defined $val[$_] and
+/// IsFloat($val[$_]) and defined $val[$_+1]; return $val[$_+1] ? -abs($val[$_])
+/// : $val[$_] } return undef`. Inputs: 0=GPS:GPSAltitude, 1=GPS:GPSAltitudeRef,
+/// 2=XMP:GPSAltitude, 3=XMP:GPSAltitudeRef.
+#[cfg(feature = "exif")]
+fn gps_altitude(v: &[CompositeValue]) -> Option<CompositeRaw> {
+  // RawConv: require a ref (`$val[1]` OR `$val[3]` defined).
+  let have_ref = v.get(1).is_some_and(CompositeValue::is_present)
+    || v.get(3).is_some_and(CompositeValue::is_present);
+  if !have_ref {
+    return None;
+  }
+  // ValueConv `foreach (0, 2)`: the first index whose altitude is present + a
+  // float AND whose ref is present yields `$ref ? -abs($alt) : $alt`.
+  for base in [0usize, 2usize] {
+    let Some(alt_cv) = v.get(base) else { continue };
+    let Some(alt_text) = alt_cv.as_text() else {
+      continue;
+    };
+    // `IsFloat($val[$_])` both guards AND translates `,`→`.` in place; the
+    // subsequent `-abs($val[$_])` / `$val[$_]` coerces the NORMALIZED scalar
+    // (e.g. `12,5` → `12.5`), so coerce the normalized string, not the raw.
+    let Some(alt_norm) = crate::convert::is_float_norm(&alt_text) else {
+      continue;
+    };
+    let Some(ref_cv) = v.get(base + 1) else {
+      continue;
+    };
+    if !ref_cv.is_present() {
+      continue;
+    }
+    let alt = crate::convert::perl_str_to_f64(&alt_norm);
+    // `$val[$_+1] ? -abs(...) : ...` — Perl-boolean on the raw ref value.
+    return Some(CompositeRaw::Num(if ref_cv.is_truthy() {
+      -alt.abs()
+    } else {
+      alt
+    }));
+  }
+  None
+}
+
+/// `Composite:GPSDateTime` ValueConv (GPS.pm:361) `"$val[0] $val[1]Z"`.
+/// `$val[0]`=GPS:GPSDateStamp, `[1]`=GPS:GPSTimeStamp (both ValueConv strings).
+#[cfg(feature = "exif")]
+fn gps_datetime(v: &[CompositeValue]) -> Option<CompositeRaw> {
+  let date = v.first()?.as_text()?;
+  let time = v.get(1)?.as_text()?;
+  Some(CompositeRaw::Text(std::format!("{date} {time}Z")))
+}
+
+/// `Composite:GPSPosition` ValueConv (Exif.pm:5313) `(length($val[0]) or
+/// length($val[1])) ? "$val[0] $val[1]" : undef`. `$val[0]`=Composite:GPSLatitude
+/// (decimal), `[1]`=Composite:GPSLongitude (decimal) — both string-context.
+#[cfg(feature = "exif")]
+fn gps_position(v: &[CompositeValue]) -> Option<CompositeRaw> {
+  let lat = v
+    .first()
+    .and_then(CompositeValue::as_text)
+    .unwrap_or(std::borrow::Cow::Borrowed(""));
+  let lon = v
+    .get(1)
+    .and_then(CompositeValue::as_text)
+    .unwrap_or(std::borrow::Cow::Borrowed(""));
+  // `(length($val[0]) or length($val[1]))` — at least one non-empty.
+  if lat.is_empty() && lon.is_empty() {
+    return None;
+  }
+  Some(CompositeRaw::Text(std::format!("{lat} {lon}")))
+}
+
+/// `$ref =~ /^<C>/i` — does the ref string start (case-insensitively) with the
+/// ASCII letter `c` (`b'S'` for latitude, `b'W'` for longitude)? The GPS refs
+/// are `"N"`/`"S"`/`"E"`/`"W"` (ValueConv form), so only the first byte matters.
+#[cfg(feature = "exif")]
+fn ref_starts_with(s: &str, c: u8) -> bool {
+  s.as_bytes()
+    .first()
+    .is_some_and(|b| b.eq_ignore_ascii_case(&c))
 }
 
 /// APE `Duration` (APE.pm:83-92). Registered only when the `ape` feature is on.
@@ -245,6 +560,7 @@ const APE_DURATION: CompositeDef = CompositeDef {
   ],
   derive: ape_duration,
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "APE-Duration",
 };
 
@@ -256,6 +572,7 @@ const FLAC_DURATION: CompositeDef = CompositeDef {
   inputs: &[req(&["FLAC"], "SampleRate"), req(&["FLAC"], "TotalSamples")],
   derive: flac_duration,
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "FLAC-Duration",
 };
 
@@ -270,7 +587,85 @@ const AIFF_DURATION: CompositeDef = CompositeDef {
   ],
   derive: aiff_duration,
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "AIFF-Duration",
+};
+
+/// `Composite:GPSLatitude` (GPS.pm:368). Group2 `Location`. The composite name
+/// matches the GPS-main `GPSLatitude`, but resolves from `GPS:GPSLatitude` (the
+/// decimal-degrees ValueConv) — the family-1 `GPS` group keeps them distinct.
+#[cfg(feature = "exif")]
+const GPS_LATITUDE: CompositeDef = CompositeDef {
+  name: "GPSLatitude",
+  inputs: &[
+    req(&["GPS"], "GPSLatitude"),
+    req(&["GPS"], "GPSLatitudeRef"),
+  ],
+  derive: gps_latitude,
+  print_conv: CompositePrintConv::GpsCoordinate('N'),
+  priority: 1, // GPS.pm: Avoid sets Priority 0, then `Priority => 1` restores it.
+  sort_key: "GPS-GPSLatitude",
+};
+
+/// `Composite:GPSLongitude` (GPS.pm:385). Group2 `Location`.
+#[cfg(feature = "exif")]
+const GPS_LONGITUDE: CompositeDef = CompositeDef {
+  name: "GPSLongitude",
+  inputs: &[
+    req(&["GPS"], "GPSLongitude"),
+    req(&["GPS"], "GPSLongitudeRef"),
+  ],
+  derive: gps_longitude,
+  print_conv: CompositePrintConv::GpsCoordinate('E'),
+  priority: 1,
+  sort_key: "GPS-GPSLongitude",
+};
+
+/// `Composite:GPSAltitude` (GPS.pm:406). Group2 `Location`. `Desire`s the GPS +
+/// XMP altitude/ref pairs; the RawConv requires an altitude ref.
+#[cfg(feature = "exif")]
+const GPS_ALTITUDE: CompositeDef = CompositeDef {
+  name: "GPSAltitude",
+  inputs: &[
+    des(&["GPS"], "GPSAltitude"),
+    des(&["GPS"], "GPSAltitudeRef"),
+    des(&["XMP-exif"], "GPSAltitude"),
+    des(&["XMP-exif"], "GPSAltitudeRef"),
+  ],
+  derive: gps_altitude,
+  print_conv: CompositePrintConv::GpsAltitude,
+  priority: 1,
+  sort_key: "GPS-GPSAltitude",
+};
+
+/// `Composite:GPSDateTime` (GPS.pm:355). Group2 `Time`.
+#[cfg(feature = "exif")]
+const GPS_DATETIME: CompositeDef = CompositeDef {
+  name: "GPSDateTime",
+  inputs: &[req(&["GPS"], "GPSDateStamp"), req(&["GPS"], "GPSTimeStamp")],
+  derive: gps_datetime,
+  print_conv: CompositePrintConv::GpsDateTime,
+  priority: 1,
+  sort_key: "GPS-GPSDateTime",
+};
+
+/// `Composite:GPSPosition` (Exif.pm:5271). Group2 `Location`. Composite-on-
+/// composite: `Require`s `Composite:GPSLatitude` + `Composite:GPSLongitude`
+/// (exercises the fixpoint deferral). `Priority => 0` (never overrides).
+#[cfg(feature = "exif")]
+const GPS_POSITION: CompositeDef = CompositeDef {
+  name: "GPSPosition",
+  inputs: &[
+    req(&["Composite"], "GPSLatitude"),
+    req(&["Composite"], "GPSLongitude"),
+  ],
+  derive: gps_position,
+  print_conv: CompositePrintConv::GpsPosition,
+  priority: 0,
+  // Exif.pm's prefix is `Composite` (Exif::Composite uses the default `Image-
+  // ExifTool` prefix → `Composite-GPSPosition`). The cross-module GPS defs sort
+  // before it (`GPS-…`), so `Composite-GPSLatitude/Longitude` are built first.
+  sort_key: "Composite-GPSPosition",
 };
 
 /// The full registry of ported Composite defs, cfg-gated per input format. The
@@ -284,4 +679,14 @@ pub(crate) const REGISTRY: &[CompositeDef] = &[
   FLAC_DURATION,
   #[cfg(feature = "aiff")]
   AIFF_DURATION,
+  #[cfg(feature = "exif")]
+  GPS_LATITUDE,
+  #[cfg(feature = "exif")]
+  GPS_LONGITUDE,
+  #[cfg(feature = "exif")]
+  GPS_ALTITUDE,
+  #[cfg(feature = "exif")]
+  GPS_DATETIME,
+  #[cfg(feature = "exif")]
+  GPS_POSITION,
 ];

--- a/src/composite/tests.rs
+++ b/src/composite/tests.rs
@@ -7,7 +7,9 @@
 
 #![cfg(feature = "alloc")]
 
-use super::table::{CompositeDef, CompositeInput, CompositePrintConv, CompositeValue, InputKind};
+use super::table::{
+  CompositeDef, CompositeInput, CompositePrintConv, CompositeRaw, CompositeValue, InputKind,
+};
 use super::*;
 use crate::emit::ConvMode;
 use crate::tagmap::TagMap;
@@ -47,8 +49,10 @@ const fn inh(group: &'static [&'static str], name: &'static str) -> CompositeInp
 }
 
 /// Sum the present inputs (a stand-in derivation; `Missing`/non-numeric ⇒ 0).
-fn sum_inputs(v: &[CompositeValue]) -> Option<f64> {
-  Some(v.iter().map(|x| x.coerce_numeric().unwrap_or(0.0)).sum())
+fn sum_inputs(v: &[CompositeValue]) -> Option<CompositeRaw> {
+  Some(CompositeRaw::Num(
+    v.iter().map(|x| x.coerce_numeric().unwrap_or(0.0)).sum(),
+  ))
 }
 
 /// Build a TagMap with the given `(group, name, value)` entries in order.
@@ -70,6 +74,7 @@ const SUM_AB: CompositeDef = CompositeDef {
   inputs: &[req(GX, "A"), req(GX, "B")],
   derive: sum_inputs,
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "X-Sum",
 };
 
@@ -96,6 +101,7 @@ fn desire_absent_still_builds_with_undef_element() {
     inputs: &[req(GX, "A"), des(GX, "B")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "X-Sum",
   };
   // B (Desire) absent ⇒ element None (counted as 0) but the composite builds.
@@ -111,6 +117,7 @@ fn inhibit_present_suppresses() {
     inputs: &[req(GX, "A"), inh(GX, "Block")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "X-Sum",
   };
   // The Inhibit tag `X:Block` is present ⇒ the composite is suppressed.
@@ -138,6 +145,7 @@ fn inhibit_present_nonnumeric_string_suppresses() {
     inputs: &[req(GX, "A"), inh(GX, "Block")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "X-Sum",
   };
   // `X:Block = "present"` is a non-numeric string ⇒ still suppresses.
@@ -162,20 +170,21 @@ fn desire_present_nonnumeric_string_reaches_derive() {
   // Finding-1: a present-but-non-numeric (string) Desire reaches `derive` as a
   // `Present(Str)` element (so future GPS/EXIF/datetime defs can read strings),
   // NOT as a `Missing`. The derive here asserts the raw value it was handed.
-  fn assert_first_is_str(v: &[CompositeValue]) -> Option<f64> {
+  fn assert_first_is_str(v: &[CompositeValue]) -> Option<CompositeRaw> {
     assert_eq!(
       v.first().and_then(CompositeValue::value),
       Some(&TagValue::Str("N".into())),
       "a present string Desire must arrive as Present(Str), not Missing"
     );
     assert!(v.first().is_some_and(CompositeValue::is_present));
-    Some(1.0)
+    Some(CompositeRaw::Num(1.0))
   }
   const DEF: CompositeDef = CompositeDef {
     name: "Dur",
     inputs: &[des(GX, "Ref")],
     derive: assert_first_is_str,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "X-Dur",
   };
   let mut m = map_with(&[("X", "Ref", TagValue::Str("N".into()))]);
@@ -193,6 +202,7 @@ fn composite_requires_composite_deferred_then_built() {
     inputs: &[req(GX, "A")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "X-Inner",
   };
   const OUTER: CompositeDef = CompositeDef {
@@ -200,6 +210,7 @@ fn composite_requires_composite_deferred_then_built() {
     inputs: &[req(GCOMPOSITE, "Inner"), req(GX, "B")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "X-Outer",
   };
   let mut m = map_with(&[("X", "A", TagValue::I64(10)), ("X", "B", TagValue::I64(5))]);
@@ -218,6 +229,7 @@ fn composite_requires_composite_in_reverse_sort_order() {
     inputs: &[req(GX, "A")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "Z-Inner", // sorts AFTER Outer
   };
   const OUTER: CompositeDef = CompositeDef {
@@ -225,6 +237,7 @@ fn composite_requires_composite_in_reverse_sort_order() {
     inputs: &[req(GCOMPOSITE, "Inner")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "A-Outer", // sorts BEFORE Inner ⇒ attempted first ⇒ defers
   };
   let mut m = map_with(&[("X", "A", TagValue::I64(7))]);
@@ -243,6 +256,7 @@ fn circular_dependency_does_not_loop() {
     inputs: &[req(GCOMPOSITE, "B")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "M-A",
   };
   const B: CompositeDef = CompositeDef {
@@ -250,6 +264,7 @@ fn circular_dependency_does_not_loop() {
     inputs: &[req(GCOMPOSITE, "A")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "M-B",
   };
   let mut m = TagMap::new();
@@ -267,6 +282,7 @@ fn last_emitted_duplicate_wins_across_group_set() {
     inputs: &[req(GP_Q, "A")],
     derive: sum_inputs,
     print_conv: CompositePrintConv::ConvertDuration,
+    priority: 1,
     sort_key: "X-Sum",
   };
   let mut m = map_with(&[("P", "A", TagValue::I64(1)), ("Q", "A", TagValue::I64(99))]);
@@ -275,7 +291,7 @@ fn last_emitted_duplicate_wins_across_group_set() {
 }
 
 /// A derivation that always aborts (the `… ? … : undef` guard).
-fn always_none(_v: &[CompositeValue]) -> Option<f64> {
+fn always_none(_v: &[CompositeValue]) -> Option<CompositeRaw> {
   None
 }
 
@@ -284,6 +300,7 @@ const NONE_DEF: CompositeDef = CompositeDef {
   inputs: &[req(GX, "A")],
   derive: always_none,
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "X-Sum",
 };
 
@@ -297,8 +314,8 @@ fn derive_returning_none_emits_nothing() {
 }
 
 /// A derivation yielding input 0's numeric coercion verbatim.
-fn first_input(v: &[CompositeValue]) -> Option<f64> {
-  v.first()?.coerce_numeric()
+fn first_input(v: &[CompositeValue]) -> Option<CompositeRaw> {
+  Some(CompositeRaw::Num(v.first()?.coerce_numeric()?))
 }
 
 const DUR_DEF: CompositeDef = CompositeDef {
@@ -306,6 +323,7 @@ const DUR_DEF: CompositeDef = CompositeDef {
   inputs: &[req(GX, "A")],
   derive: first_input,
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "X-Dur",
 };
 
@@ -336,6 +354,7 @@ const PROBE_DEF: CompositeDef = CompositeDef {
   // ValueConv output ⇒ a bare f64, so the resolved-then-coerced value is read
   // back directly (no ConvertDuration formatting to decode).
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "X-Probe",
 };
 
@@ -391,6 +410,7 @@ const SIGNED_SUM: CompositeDef = CompositeDef {
   inputs: &[req(GX, "A"), req(GX, "B")],
   derive: sum_inputs,
   print_conv: CompositePrintConv::ConvertDuration,
+  priority: 1,
   sort_key: "X-Sum",
 };
 
@@ -431,4 +451,233 @@ fn signed_and_whitespace_string_ingredients_coerce_via_shared_perl_rule() {
   ]);
   build_into(&[SIGNED_SUM], &mut m3, None, ConvMode::ValueConv);
   assert_eq!(composite(&m3, "Sum"), Some(TagValue::F64(100.0)));
+}
+
+// ===========================================================================
+// The registered GPS Composites (GPS.pm / Exif.pm) — end-to-end through the
+// real `REGISTRY` over a two-view (ValueConv + PrintConv) GPS TagMap pair. These
+// mirror the bundled-ExifTool `ExifGPS.tif` truth and exercise the `$prt[i]`
+// wiring + the `GPSPosition`-requires-two-Composites fixpoint deferral.
+// ===========================================================================
+
+#[cfg(feature = "exif")]
+mod gps {
+  use super::*;
+
+  /// The ExifGPS.tif GPS inputs as the (ValueConv view, PrintConv view) pair the
+  /// engine reads `$val[i]` / `$prt[i]` from. ValueConv: decimal coords + `"N"`/
+  /// `"E"` refs + altitude `35`/ref `0` + the date/time strings. PrintConv: the
+  /// GPS-main DMS strings + `"North"`/`"East"` + `"Above Sea Level"`.
+  fn exifgps_views() -> (TagMap, TagMap) {
+    let val = map_with(&[
+      ("GPS", "GPSLatitude", TagValue::F64(48.85815)),
+      ("GPS", "GPSLatitudeRef", TagValue::Str("N".into())),
+      ("GPS", "GPSLongitude", TagValue::F64(2.34893333333333)),
+      ("GPS", "GPSLongitudeRef", TagValue::Str("E".into())),
+      ("GPS", "GPSAltitude", TagValue::F64(35.0)),
+      ("GPS", "GPSAltitudeRef", TagValue::U64(0)),
+      ("GPS", "GPSDateStamp", TagValue::Str("2021:08:14".into())),
+      ("GPS", "GPSTimeStamp", TagValue::Str("16:45:09".into())),
+    ]);
+    let prt = map_with(&[
+      (
+        "GPS",
+        "GPSLatitude",
+        TagValue::Str("48 deg 51' 29.34\"".into()),
+      ),
+      ("GPS", "GPSLatitudeRef", TagValue::Str("North".into())),
+      (
+        "GPS",
+        "GPSLongitude",
+        TagValue::Str("2 deg 20' 56.16\"".into()),
+      ),
+      ("GPS", "GPSLongitudeRef", TagValue::Str("East".into())),
+      ("GPS", "GPSAltitude", TagValue::Str("35 m".into())),
+      (
+        "GPS",
+        "GPSAltitudeRef",
+        TagValue::Str("Above Sea Level".into()),
+      ),
+      ("GPS", "GPSDateStamp", TagValue::Str("2021:08:14".into())),
+      ("GPS", "GPSTimeStamp", TagValue::Str("16:45:09".into())),
+    ]);
+    (val, prt)
+  }
+
+  #[test]
+  fn printconv_builds_all_gps_composites_byte_exact() {
+    // `-j`: `out` = the PrintConv view, `other` = the ValueConv view. Byte-exact
+    // against bundled `ExifGPS.tif` `Composite:*`.
+    let (mut val, mut prt) = exifgps_views();
+    build_into(REGISTRY, &mut prt, Some(&mut val), ConvMode::PrintConv);
+    assert_eq!(
+      composite(&prt, "GPSLatitude"),
+      Some(TagValue::Str("48 deg 51' 29.34\" N".into()))
+    );
+    assert_eq!(
+      composite(&prt, "GPSLongitude"),
+      Some(TagValue::Str("2 deg 20' 56.16\" E".into()))
+    );
+    assert_eq!(
+      composite(&prt, "GPSAltitude"),
+      Some(TagValue::Str("35 m Above Sea Level".into()))
+    );
+    assert_eq!(
+      composite(&prt, "GPSDateTime"),
+      Some(TagValue::Str("2021:08:14 16:45:09Z".into()))
+    );
+    // `GPSPosition`'s PrintConv is the literal `"$prt[0], $prt[1]"` — the two
+    // ingredient Composites' DMS strings (the `$prt[i]` wiring under test).
+    assert_eq!(
+      composite(&prt, "GPSPosition"),
+      Some(TagValue::Str(
+        "48 deg 51' 29.34\" N, 2 deg 20' 56.16\" E".into()
+      ))
+    );
+  }
+
+  #[test]
+  fn valueconv_builds_all_gps_composites_byte_exact() {
+    // `-n`: `out` = the ValueConv view, `other` = the PrintConv view. Byte-exact
+    // against bundled `ExifGPS.tif` `-n` `Composite:*`.
+    let (mut val, mut prt) = exifgps_views();
+    build_into(REGISTRY, &mut val, Some(&mut prt), ConvMode::ValueConv);
+    assert_eq!(
+      composite(&val, "GPSLatitude"),
+      Some(TagValue::F64(48.85815))
+    );
+    assert_eq!(
+      composite(&val, "GPSLongitude"),
+      Some(TagValue::F64(2.34893333333333))
+    );
+    assert_eq!(composite(&val, "GPSAltitude"), Some(TagValue::F64(35.0)));
+    assert_eq!(
+      composite(&val, "GPSDateTime"),
+      Some(TagValue::Str("2021:08:14 16:45:09Z".into()))
+    );
+    // `GPSPosition`'s ValueConv is `"$val[0] $val[1]"` — the decimal coords.
+    assert_eq!(
+      composite(&val, "GPSPosition"),
+      Some(TagValue::Str("48.85815 2.34893333333333".into()))
+    );
+  }
+
+  #[test]
+  fn ref_sign_negates_south_and_west() {
+    // ValueConv `$val[1] =~ /^S/i ? -$val[0]` (lat) / `/^W/i ? -$val[0]` (lon).
+    let entries: &[(&str, &str, TagValue)] = &[
+      ("GPS", "GPSLatitude", TagValue::F64(48.85815)),
+      ("GPS", "GPSLatitudeRef", TagValue::Str("S".into())),
+      ("GPS", "GPSLongitude", TagValue::F64(2.34893333333333)),
+      ("GPS", "GPSLongitudeRef", TagValue::Str("W".into())),
+    ];
+    let mut out = map_with(entries);
+    let mut prt = map_with(entries);
+    build_into(REGISTRY, &mut out, Some(&mut prt), ConvMode::ValueConv);
+    assert_eq!(
+      composite(&out, "GPSLatitude"),
+      Some(TagValue::F64(-48.85815)),
+      "ref S ⇒ negative latitude"
+    );
+    assert_eq!(
+      composite(&out, "GPSLongitude"),
+      Some(TagValue::F64(-2.34893333333333)),
+      "ref W ⇒ negative longitude"
+    );
+  }
+
+  #[test]
+  fn gps_position_requires_both_composites_fixpoint_defers() {
+    // `GPSPosition` `Require`s `Composite:GPSLatitude` + `Composite:GPSLongitude`
+    // (sort_key `Composite-GPSPosition`, AFTER `GPS-…`), so it is attempted, the
+    // two ingredient Composites are not yet built ⇒ it DEFERS, then builds in a
+    // later pass once they exist (the composite-on-composite fixpoint).
+    let (mut val, mut prt) = exifgps_views();
+    build_into(REGISTRY, &mut val, Some(&mut prt), ConvMode::ValueConv);
+    // Built only because the deferral resolved Composite:GPSLatitude/Longitude.
+    assert_eq!(
+      composite(&val, "GPSPosition"),
+      Some(TagValue::Str("48.85815 2.34893333333333".into()))
+    );
+  }
+
+  #[test]
+  fn gps_position_not_built_when_a_coordinate_is_missing() {
+    // No `GPSLongitude` ⇒ `Composite:GPSLongitude` never builds ⇒ `GPSPosition`'s
+    // `Require` of it fails (after the fixpoint settles), so neither builds.
+    let entries: &[(&str, &str, TagValue)] = &[
+      ("GPS", "GPSLatitude", TagValue::F64(48.85815)),
+      ("GPS", "GPSLatitudeRef", TagValue::Str("N".into())),
+    ];
+    let mut out = map_with(entries);
+    let mut prt = map_with(entries);
+    build_into(REGISTRY, &mut out, Some(&mut prt), ConvMode::ValueConv);
+    assert_eq!(
+      composite(&out, "GPSLatitude"),
+      Some(TagValue::F64(48.85815))
+    );
+    assert_eq!(composite(&out, "GPSLongitude"), None);
+    assert_eq!(composite(&out, "GPSPosition"), None);
+  }
+
+  #[test]
+  fn gps_datetime_requires_both_date_and_time() {
+    // `GPSDateTime` `Require`s GPSDateStamp + GPSTimeStamp; a TimeStamp-only
+    // input (the `ExifGPS.jpg` shape) must NOT build it.
+    let entries: &[(&str, &str, TagValue)] =
+      &[("GPS", "GPSTimeStamp", TagValue::Str("16:45:09".into()))];
+    let mut out = map_with(entries);
+    let mut prt = map_with(entries);
+    build_into(REGISTRY, &mut out, Some(&mut prt), ConvMode::ValueConv);
+    assert_eq!(composite(&out, "GPSDateTime"), None);
+  }
+
+  #[test]
+  fn gps_altitude_requires_a_ref() {
+    // The RawConv `(defined $val[1] or defined $val[3]) ? $val : undef` — an
+    // altitude with NO ref builds nothing.
+    let entries: &[(&str, &str, TagValue)] = &[("GPS", "GPSAltitude", TagValue::F64(35.0))];
+    let mut out = map_with(entries);
+    let mut prt = map_with(entries);
+    build_into(REGISTRY, &mut out, Some(&mut prt), ConvMode::ValueConv);
+    assert_eq!(composite(&out, "GPSAltitude"), None);
+  }
+
+  #[test]
+  fn gps_altitude_comma_decimal_is_isfloat_normalized_both_modes() {
+    // ExifTool `IsFloat($val[$_])` translates `,`→`.` IN PLACE (ExifTool.pm:5951),
+    // so the altitude `"12,5"` (the wire string XMP preserves) is coerced AS
+    // `12.5`, NOT `12` (a raw `$val+0` would treat the comma as a numeric-prefix
+    // terminator). Bundled-ExifTool 13.59 on an `XMP-exif:GPSAltitude=12,5` +
+    // above-sea ref emits `Composite:GPSAltitude` = `12.5` (-n) / `12.5 m Above
+    // Sea Level` (-j). The input arrives at the GPS pair (index 0/1) as a string.
+    let val_entries: &[(&str, &str, TagValue)] = &[
+      ("GPS", "GPSAltitude", TagValue::Str("12,5".into())),
+      ("GPS", "GPSAltitudeRef", TagValue::U64(0)),
+    ];
+    let prt_entries: &[(&str, &str, TagValue)] = &[
+      ("GPS", "GPSAltitude", TagValue::Str("12,5 m".into())),
+      (
+        "GPS",
+        "GPSAltitudeRef",
+        TagValue::Str("Above Sea Level".into()),
+      ),
+    ];
+
+    // `-n` (ValueConv): the normalized `12.5`, not `12`.
+    let mut val = map_with(val_entries);
+    let mut prt = map_with(prt_entries);
+    build_into(REGISTRY, &mut val, Some(&mut prt), ConvMode::ValueConv);
+    assert_eq!(composite(&val, "GPSAltitude"), Some(TagValue::F64(12.5)));
+
+    // `-j` (PrintConv): `(int($val[0]*10)/10) m $prt[1]` over the normalized
+    // value ⇒ `12.5 m Above Sea Level`, not `12 m …`.
+    let mut val = map_with(val_entries);
+    let mut prt = map_with(prt_entries);
+    build_into(REGISTRY, &mut prt, Some(&mut val), ConvMode::PrintConv);
+    assert_eq!(
+      composite(&prt, "GPSAltitude"),
+      Some(TagValue::Str("12.5 m Above Sea Level".into()))
+    );
+  }
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -315,7 +315,8 @@ fn is_int(s: &str) -> bool {
 }
 
 /// Faithful transliteration of ExifTool `sub IsFloat($)`
-/// (`ExifTool.pm:5936-5942`):
+/// (`ExifTool.pm:5947-5953`) — the float predicate AND the in-place `tr/,/./`
+/// translation, exposed as the value the caller must coerce:
 ///
 /// ```perl
 /// return 1 if $_[0] =~ /^[+-]?(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/;
@@ -328,21 +329,34 @@ fn is_int(s: &str) -> bool {
 /// Two anchored, whole-string forms (NO leading/trailing whitespace, NO hex):
 /// an optional sign, then either a dot-decimal float (`12.5`, `.5`, `3.`,
 /// `+3`, `1e3`) OR a single comma-decimal float (`12,5`, `,5` — at most one
-/// comma per the `(,\d*)?` group). On the comma branch the caller's value is
-/// rewritten `,`→`.` (the Perl `tr` mutates `$_[0]`), so we return the
-/// already-translated owned string alongside the boolean. The caller uses the
-/// returned string for the subsequent numeric coercion.
+/// comma per the `(,\d*)?` group).
 ///
-/// Returns `(matched, value_to_coerce)`:
-/// - `matched == false` ⇒ NOT a float; `value_to_coerce` is the input
-///   unchanged (the caller's `return $val unless IsFloat($val)`).
-/// - `matched == true` ⇒ a float; `value_to_coerce` is the input with a sole
-///   comma (if any) translated to a dot — a clean dot-decimal numeric string.
+/// Returns `Some(value_to_coerce)` when `s` is a float — the input with a sole
+/// comma decimal (if any) translated to a dot, a clean dot-decimal string the
+/// caller must feed into its subsequent numeric coercion (e.g.
+/// [`perl_str_to_f64`]). Returns `None` when `s` is not a float (the
+/// `... unless IsFloat ...` guard fires; the original value is untouched).
+///
+/// Returning the NORMALIZED value is load-bearing, not cosmetic: ExifTool's
+/// `tr/,/./` mutates `$_[0]` IN PLACE, so every later numeric use of the same
+/// scalar sees the translated value — `Composite:GPSAltitude` re-coerces it in
+/// both its ValueConv (`-abs($val[$_])`) and PrintConv (`int($val[$_]*10)/10`)
+/// (GPS.pm:414/421), and the `ImageSize` / `DOF` composites (PRs 3-4) likewise
+/// ingest decimal strings. A caller that discarded it would coerce `12,5` as
+/// `12` (the comma terminates the Perl numeric prefix) instead of `12.5`. This
+/// is the shared comma-normalization class; obtain the value here once and pass
+/// it on (mirroring Perl's single mutated `$val[$_]`).
 ///
 /// Bundled-Perl oracle (verified 2026-05-22 via `Image::ExifTool::IsFloat`):
 /// `"12.5"`/`".5"`/`"3."`/`"+3"`/`"1e3"`/`"-2.5"` → matched; `"12,5"`/`",5"`
 /// → matched + translated to `"12.5"`/`".5"`; `"  12.5"`/`"12.5 "`/`"0x10"`/
 /// `"12abc"`/`""`/`"1e"`/`"1,5,6"`/`"inf"`/`"nan"` → NOT matched.
+#[cfg(feature = "alloc")]
+pub(crate) fn is_float_norm(s: &str) -> Option<std::borrow::Cow<'_, str>> {
+  let (matched, value) = is_float(s);
+  matched.then_some(value)
+}
+
 fn is_float(s: &str) -> (bool, std::borrow::Cow<'_, str>) {
   use std::borrow::Cow;
   // Dot-decimal branch (ExifTool.pm:5937) — `(?=\d|\.\d)` requires the

--- a/src/emit.rs
+++ b/src/emit.rs
@@ -49,6 +49,19 @@ impl ConvMode {
       ConvMode::ValueConv
     }
   }
+
+  /// The OPPOSITE conversion mode. Used by the Composite engine, which needs
+  /// both a ValueConv view (`$val[i]`) and a PrintConv view (`$prt[i]`): the
+  /// active-output mode's view is the emitted set, and the opposite-mode
+  /// re-emission supplies the other view (see [`crate::composite`]).
+  #[must_use]
+  #[inline(always)]
+  pub const fn flipped(self) -> Self {
+    match self {
+      ConvMode::PrintConv => ConvMode::ValueConv,
+      ConvMode::ValueConv => ConvMode::PrintConv,
+    }
+  }
 }
 
 /// Options that shape a [`Taggable::tags`] emission: the conv mode (`-j`/`-n`),

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -767,20 +767,46 @@ impl AnyMeta<'_> {
     // this generic-extraction API yields the same `Composite:*` set. Appended
     // last (preserves their positional last-ness, matching the JSON path).
     //
-    // Inputs resolve from each ingredient's ValueConv (raw) value REGARDLESS of
-    // `mode` (ExifTool.pm:4112), mirroring the JSON path: under `-n`, `out`
-    // already holds raw values (its own resolution view, `None`); under `-j`, we
-    // re-collect the SAME stream in ValueConv mode into `raw_view` and resolve
-    // inputs from it while the composite's rendered value lands in `out`.
-    let mut raw_view;
-    let resolve_src = if mode == crate::emit::ConvMode::PrintConv {
-      raw_view = self.collect_deduped_tags(crate::emit::ConvMode::ValueConv);
-      Some(&mut raw_view)
-    } else {
-      None
-    };
-    crate::composite::build_composites_into_tags(&mut out, resolve_src, mode);
+    // The engine needs BOTH a ValueConv view (`$val[i]`, ExifTool.pm:4112) and
+    // a PrintConv view (`$prt[i]`, ExifTool.pm:4116) regardless of `mode`
+    // (`GPSPosition`'s PrintConv reads `$prt[i]`). `out` is the active-mode view;
+    // we re-collect the SAME stream in the OPPOSITE mode for the other view.
+    let mut other_view = self.collect_deduped_tags(mode.flipped());
+    if !self.defers_composites() {
+      crate::composite::build_composites_into_tags(&mut out, Some(&mut other_view), mode);
+    }
     out.into_iter()
+  }
+
+  /// Does this `AnyMeta` DEFER the Composite post-pass to a later #133 PR?
+  ///
+  /// The GPS Composites are `SubDoc => 1` (GPS.pm/Exif.pm — generate for every
+  /// sub-document). For a STILL (a single Main document) they build at Main, and
+  /// #133 PR 2 ports them there. For the TIMED / video formats the GPS lives in
+  /// per-sample sub-documents (`Doc<N>`), so the faithful build requires the
+  /// SubDoc / `Doc<N>` Composite axis that #133 PR 5 adds — and bundled's
+  /// per-frame `Doc<N>:GPSLatitude`/`…Position` are exactly that axis. Until
+  /// then these formats keep their Composites EXCLUDED (the M2TS/QuickTime
+  /// golden precedent), so the post-pass is skipped:
+  ///
+  /// * `M2ts` — the AVCHD H.264 PES GPS is timed; bundled builds `Doc<N>` GPS
+  ///   Composites under `-ee` (and a Main set from the first frame), the PR-5
+  ///   SubDoc shape. (Its non-GPS goldens stay byte-identical.)
+  /// * `H264` — engine-only: a raw `.h264` is `Unknown file type`, so bundled
+  ///   NEVER reaches `BuildCompositeTags` for it (its GPS only becomes a
+  ///   Composite through the M2TS file pipeline, as a timed `Doc<N>` sample).
+  ///
+  /// Every still / single-document format (TIFF/JPEG EXIF, XMP, the audio
+  /// Durations) returns `false` and builds its Composites in this PR.
+  #[cfg(feature = "alloc")]
+  const fn defers_composites(&self) -> bool {
+    match self {
+      #[cfg(feature = "m2ts")]
+      AnyMeta::M2ts(_) => true,
+      #[cfg(feature = "h264")]
+      AnyMeta::H264(_) => true,
+      _ => false,
+    }
   }
 
   /// Serialize this typed Meta's FORMAT tags into the inline tag-collection
@@ -826,32 +852,26 @@ impl AnyMeta<'_> {
     // ExifTool.pm:1125). `doc_count` is the highest family-3 sub-document index
     // present (reserved for `SubDoc` composites; the Duration defs build at Main
     // only).
-    let doc_count = out.entries().iter().map(|e| e.0).max().unwrap_or(0);
-    // ExifTool resolves a composite's inputs from each ingredient's ValueConv
-    // (raw) value — `GetValue($tag, 'ValueConv')`, ExifTool.pm:4112 — REGARDLESS
-    // of the `-j`/`-n` output mode. Under `-n` the emitted `out` already holds
-    // those raw values, so it is its own resolution view. Under `-j` the emitted
-    // values are PrintConv strings, so we re-emit the SAME Meta in ValueConv mode
-    // into a throwaway `raw_view` (identical tag set + dedup; only the rendered
-    // values differ) and resolve inputs from it, while the composite's RENDERED
-    // (`-j`) value still lands in `out`. (Duration's ingredients have no
-    // PrintConv, so raw == rendered and the goldens are unchanged; the GPS /
-    // datetime composites of later #133 PRs are the ones that genuinely need the
-    // raw `"N"`/`"S"` / decimal-coordinate inputs.)
-    let mut raw_view;
-    let resolve_src = if print_conv {
-      raw_view = crate::tagmap::TagMap::new();
-      let raw_opts = crate::emit::EmitOptions::with_group_mode(
-        crate::emit::ConvMode::ValueConv,
-        extract_embedded,
-        group_mode,
-      );
-      crate::emit::run_emission(self, raw_opts, &mut raw_view);
-      Some(&mut raw_view)
-    } else {
-      None
-    };
-    crate::composite::build_composites(out, resolve_src, mode, doc_count);
+    // ExifTool's `BuildCompositeTags` builds BOTH a `@val` array (each input's
+    // ValueConv value, `GetValue($tag, 'ValueConv')`, ExifTool.pm:4112) and a
+    // `@prt` array (each input's PrintConv value, ExifTool.pm:4116). A
+    // composite's `RawConv`/`ValueConv` reads `$val[i]`; its `PrintConv` may read
+    // `$prt[i]` (`Composite:GPSPosition`'s PrintConv is the literal `"$prt[0],
+    // $prt[1]"`). So the engine needs BOTH views REGARDLESS of `-j`/`-n`: `out`
+    // is the active-mode view, and we re-emit the SAME Meta in the OPPOSITE mode
+    // (identical tag set + dedup; only the rendered values differ) for the other
+    // view. (Duration's ingredients have no PrintConv difference, so its goldens
+    // are unchanged; the GPS composites genuinely need the raw `"N"`/`"S"` /
+    // decimal `$val[i]` AND the DMS `$prt[i]`.) Skipped for the timed/video
+    // formats whose GPS Composites defer to #133 PR 5 (`defers_composites`).
+    if !self.defers_composites() {
+      let doc_count = out.entries().iter().map(|e| e.0).max().unwrap_or(0);
+      let mut other_view = crate::tagmap::TagMap::new();
+      let other_opts =
+        crate::emit::EmitOptions::with_group_mode(mode.flipped(), extract_embedded, group_mode);
+      crate::emit::run_emission(self, other_opts, &mut other_view);
+      crate::composite::build_composites(out, Some(&mut other_view), mode, doc_count);
+    }
     crate::diagnostics::run_diagnostics(self, out);
     Ok(())
   }

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1057,9 +1057,11 @@ fn m2ts_h264_mdpm_multiframe_noee_conformance() {
   // `tests/timed_metadata_conformance.rs::m2ts_h264_mdpm_ee_byte_exact`.
   //
   // Goldens are bundled `perl exiftool -j -G1 -struct` with `System:*` +
-  // `Composite:*` stripped (the M2TS precedent — the Composite engine is a
-  // deferred Phase-2 forward item; the bundled output synthesizes
-  // `Composite:GPSLatitude`/`Longitude`/`Position` from the H.264/GPS values).
+  // `Composite:*` stripped. Bundled synthesizes `Composite:GPSLatitude`/
+  // `Longitude`/`Position` from the H.264/GPS values, but the M2TS GPS is TIMED
+  // (per-PES sub-document) — its faithful Composites are the SubDoc / `Doc<N>`
+  // axis #133 PR 5 adds, so exifast DEFERS them here (`AnyMeta::M2ts` ⇒
+  // `defers_composites`); the GPS stills got their Composites in #133 PR 2.
   check("M2TS_h264_mdpm.mts", "M2TS_h264_mdpm.mts.json", true);
   check("M2TS_h264_mdpm.mts", "M2TS_h264_mdpm.mts.n.json", false);
 }
@@ -9094,16 +9096,19 @@ fn makernotes_dji_phantom4_conformance() {
   // `CameraRoll` (-29.80 / -7.80 / +0.00) gimbal angles. The standard EXIF GPS
   // IFD is ALSO byte-exact (exifast emits the GPS IFD directly): `GPSLatitude`
   // = 32 deg 28' 42.95" N, `GPSLongitude` = 90 deg 15' 36.01" W, `GPSAltitude`
-  // = 109.786 m — these are the raw GPS IFD tags, NOT the `Composite:GPS*`
-  // synthesis (which exifast cannot emit). All 83 shared tags match for BOTH
-  // the `-j` PrintConv and `-n` numeric snapshots.
+  // = 109.786 m — the raw GPS IFD tags. The ported GPS `Composite:*`
+  // (`GPSLatitude`/`Longitude`/`Altitude`/`Position`, #133 PR 2) are ALSO
+  // retained and byte-exact. All shared tags match for BOTH the `-j` PrintConv
+  // and `-n` numeric snapshots.
   //
   // The goldens are generated with `gen_golden.sh EXCLUDE="…"` dropping the
   // tags exifast does NOT emit — every exclusion is a documented, NON-DJI-
   // MakerNote-path deferral (none masks a DJI faithfulness gap):
-  //   -x Composite:all   — exifast has no EXIF Composite subsystem (this drops
-  //                        the `Composite:GPS{Latitude,Longitude,Altitude,
-  //                        Position}` synthesis; the RAW GPS IFD above is kept).
+  //   -x Composite:{Aperture,CircleOfConfusion,FOV,FocalLength35efl,
+  //                 HyperfocalDistance,ImageSize,LightValue,Megapixels,
+  //                 ScaleFactor35efl,ShutterSpeed}
+  //                      — the still-deferred EXIF/lens Composite subsystem (a
+  //                        later #133 PR); the GPS Composites above ARE kept.
   //   -x XMP:all         — the XMP-drone-dji / XMP-crs / XMP-tiff / … packet is
   //                        not ported (no XMP subsystem).
   //   -x IFD1:ThumbnailImage — the embedded-thumbnail binary placeholder is a
@@ -9588,7 +9593,10 @@ fn gps_conformance() {
   //   - GPSDateStamp ExifDate (Exif.pm:6068-6076)
   //   - GPSAltitude `"$val m"` + GPSAltitudeRef hash
   // Goldens: bundled `perl exiftool -j -G1 -struct` (`-n` too), `System:*`
-  // + `Composite:*` stripped uniformly.
+  // stripped. The five ported GPS `Composite:*` (`GPSLatitude`/`Longitude`/
+  // `Altitude`/`DateTime`/`Position`, #133 PR 2) ARE retained — this fixture
+  // carries ONLY GPS Composites, so no `Composite:*` exclusion is needed
+  // (`tools/gen_golden.sh` default path).
   check("ExifGPS.tif", "ExifGPS.tif.json", true);
   check("ExifGPS.tif", "ExifGPS.tif.n.json", false);
 }
@@ -9616,8 +9624,13 @@ fn jpeg_exif_gps_conformance() {
   // timestamp/mapdatum/versionid), plus IFD0/ExifIFD/IFD1 + File:ExifByteOrder
   // and the File:* JPEG triplet.
   //
-  // Goldens are bundled `tools/gen_golden.sh` output with `System:*` +
-  // `Composite:*` stripped uniformly (every format conformance does this).
+  // Goldens are bundled `tools/gen_golden.sh` output with `System:*` stripped.
+  // The ported GPS `Composite:*` (`GPSLatitude`/`Longitude`/`Position`, #133 PR
+  // 2) ARE retained (this file has GPS lat/lon but no altitude/datestamp, so
+  // those two GPS Composites do not build); the still-deferred camera
+  // Composites (`Aperture`/`ImageSize`/`Megapixels`/`ShutterSpeed`/
+  // `FocalLength35efl`, a later #133 PR) are excluded by name in
+  // `tools/gen_golden.sh`, alongside the JPEG-port-deferred IPTC/thumbnail.
   // The `SOF` size tags (`File:ImageWidth`/`ImageHeight`/`BitsPerSample`/
   // `ColorComponents`/`EncodingProcess`/`YCbCrSubSampling`,
   // ExifTool.pm:7419-7462) are NOW EMITTED (#261) — this file's
@@ -10594,6 +10607,12 @@ fn xmp_projects_gps_altitude_signed_by_ref() {
   assert_eq!(agps.altitude_m(), Some(35.0));
 }
 
+// The `Composite:GPSAltitude` def `Desire`s the XMP altitude/ref pair
+// (GPS.pm:406), so exifast emits `Composite:GPSAltitude` from the embedded
+// `XMP-exif:GPSAltitude`/`…Ref` here — byte-matching bundled (`-j` `35 m Below/
+// Above Sea Level`, `-n` `-35`/`35`). The XMP-only ref Composites bundled ALSO
+// synthesizes (`GPSLatitudeRef`/`GPSLongitudeRef`/`GPSPosition`) are NOT ported,
+// so they stay excluded (`tools/gen_golden.sh` drops just those three).
 #[test]
 fn xmp_gps_belowsea_conformance() {
   check("XMP_gps_belowsea.xmp", "XMP_gps_belowsea.xmp.json", true);

--- a/tests/golden/DJIPhantom4.jpg.json
+++ b/tests/golden/DJIPhantom4.jpg.json
@@ -104,5 +104,9 @@
   "MPImage2:MPImageStart": 4768674,
   "MPImage2:DependentImage1EntryNumber": 0,
   "MPImage2:DependentImage2EntryNumber": 0,
-  "MPImage2:PreviewImage": "(Binary data 301118 bytes, use -b option to extract)"
+  "MPImage2:PreviewImage": "(Binary data 301118 bytes, use -b option to extract)",
+  "Composite:GPSAltitude": "109.7 m Above Sea Level",
+  "Composite:GPSLatitude": "32 deg 28' 42.95\" N",
+  "Composite:GPSLongitude": "90 deg 15' 36.01\" W",
+  "Composite:GPSPosition": "32 deg 28' 42.95\" N, 90 deg 15' 36.01\" W"
 }]

--- a/tests/golden/DJIPhantom4.jpg.n.json
+++ b/tests/golden/DJIPhantom4.jpg.n.json
@@ -104,5 +104,9 @@
   "MPImage2:MPImageStart": 4768674,
   "MPImage2:DependentImage1EntryNumber": 0,
   "MPImage2:DependentImage2EntryNumber": 0,
-  "MPImage2:PreviewImage": "(Binary data 301118 bytes, use -b option to extract)"
+  "MPImage2:PreviewImage": "(Binary data 301118 bytes, use -b option to extract)",
+  "Composite:GPSAltitude": 109.786,
+  "Composite:GPSLatitude": 32.4785966666667,
+  "Composite:GPSLongitude": -90.2600013888889,
+  "Composite:GPSPosition": "32.4785966666667 -90.2600013888889"
 }]

--- a/tests/golden/ExifGPS.jpg.json
+++ b/tests/golden/ExifGPS.jpg.json
@@ -60,5 +60,8 @@
   "IFD1:YResolution": 72,
   "IFD1:ResolutionUnit": "inches",
   "IFD1:ThumbnailOffset": 1050,
-  "IFD1:ThumbnailLength": 28
+  "IFD1:ThumbnailLength": 28,
+  "Composite:GPSLatitude": "54 deg 59' 22.80\" N",
+  "Composite:GPSLongitude": "1 deg 54' 51.00\" W",
+  "Composite:GPSPosition": "54 deg 59' 22.80\" N, 1 deg 54' 51.00\" W"
 }]

--- a/tests/golden/ExifGPS.jpg.n.json
+++ b/tests/golden/ExifGPS.jpg.n.json
@@ -60,5 +60,8 @@
   "IFD1:YResolution": 72,
   "IFD1:ResolutionUnit": 2,
   "IFD1:ThumbnailOffset": 1050,
-  "IFD1:ThumbnailLength": 28
+  "IFD1:ThumbnailLength": 28,
+  "Composite:GPSLatitude": 54.9896666666667,
+  "Composite:GPSLongitude": -1.91416666666667,
+  "Composite:GPSPosition": "54.9896666666667 -1.91416666666667"
 }]

--- a/tests/golden/ExifGPS.tif.json
+++ b/tests/golden/ExifGPS.tif.json
@@ -16,5 +16,10 @@
   "GPS:GPSAltitude": "35 m",
   "GPS:GPSTimeStamp": "16:45:09",
   "GPS:GPSMapDatum": "WGS84",
-  "GPS:GPSDateStamp": "2021:08:14"
+  "GPS:GPSDateStamp": "2021:08:14",
+  "Composite:GPSAltitude": "35 m Above Sea Level",
+  "Composite:GPSDateTime": "2021:08:14 16:45:09Z",
+  "Composite:GPSLatitude": "48 deg 51' 29.34\" N",
+  "Composite:GPSLongitude": "2 deg 20' 56.16\" E",
+  "Composite:GPSPosition": "48 deg 51' 29.34\" N, 2 deg 20' 56.16\" E"
 }]

--- a/tests/golden/ExifGPS.tif.n.json
+++ b/tests/golden/ExifGPS.tif.n.json
@@ -16,5 +16,10 @@
   "GPS:GPSAltitude": 35,
   "GPS:GPSTimeStamp": "16:45:09",
   "GPS:GPSMapDatum": "WGS84",
-  "GPS:GPSDateStamp": "2021:08:14"
+  "GPS:GPSDateStamp": "2021:08:14",
+  "Composite:GPSAltitude": 35,
+  "Composite:GPSDateTime": "2021:08:14 16:45:09Z",
+  "Composite:GPSLatitude": 48.85815,
+  "Composite:GPSLongitude": 2.34893333333333,
+  "Composite:GPSPosition": "48.85815 2.34893333333333"
 }]

--- a/tests/golden/XMP_gps_abovesea.xmp.json
+++ b/tests/golden/XMP_gps_abovesea.xmp.json
@@ -7,5 +7,6 @@
   "XMP-exif:GPSLatitude": "45 deg 30' 0.00\" N",
   "XMP-exif:GPSLongitude": "122 deg 30' 30.00\" W",
   "XMP-exif:GPSAltitude": "35 m",
-  "XMP-exif:GPSAltitudeRef": "Above Sea Level"
+  "XMP-exif:GPSAltitudeRef": "Above Sea Level",
+  "Composite:GPSAltitude": "35 m Above Sea Level"
 }]

--- a/tests/golden/XMP_gps_abovesea.xmp.n.json
+++ b/tests/golden/XMP_gps_abovesea.xmp.n.json
@@ -7,5 +7,6 @@
   "XMP-exif:GPSLatitude": 45.5,
   "XMP-exif:GPSLongitude": -122.508333333333,
   "XMP-exif:GPSAltitude": 35,
-  "XMP-exif:GPSAltitudeRef": 0
+  "XMP-exif:GPSAltitudeRef": 0,
+  "Composite:GPSAltitude": 35
 }]

--- a/tests/golden/XMP_gps_belowsea.xmp.json
+++ b/tests/golden/XMP_gps_belowsea.xmp.json
@@ -7,5 +7,6 @@
   "XMP-exif:GPSLatitude": "45 deg 30' 0.00\" N",
   "XMP-exif:GPSLongitude": "122 deg 30' 30.00\" W",
   "XMP-exif:GPSAltitude": "35 m",
-  "XMP-exif:GPSAltitudeRef": "Below Sea Level"
+  "XMP-exif:GPSAltitudeRef": "Below Sea Level",
+  "Composite:GPSAltitude": "35 m Below Sea Level"
 }]

--- a/tests/golden/XMP_gps_belowsea.xmp.n.json
+++ b/tests/golden/XMP_gps_belowsea.xmp.n.json
@@ -7,5 +7,6 @@
   "XMP-exif:GPSLatitude": 45.5,
   "XMP-exif:GPSLongitude": -122.508333333333,
   "XMP-exif:GPSAltitude": 35,
-  "XMP-exif:GPSAltitudeRef": 1
+  "XMP-exif:GPSAltitudeRef": 1,
+  "Composite:GPSAltitude": -35
 }]

--- a/tools/gen_golden.sh
+++ b/tools/gen_golden.sh
@@ -72,12 +72,48 @@ EXCLUDE_ARR=(${EXCLUDE:-})
 # be forgotten on regen; non-XMP fixtures are unaffected and keep their ported
 # Composite tags. (Idempotent if the caller already passed it via EXCLUDE.)
 case "$FIX" in
+  # The XMP-GPS-altitude fixtures (#133 PR 2): the `Composite:GPSAltitude` def
+  # `Desire`s the XMP altitude/ref pair (GPS.pm:406), so exifast emits
+  # `Composite:GPSAltitude` from the embedded `XMP-exif:GPSAltitude`/`…Ref`
+  # (byte-matching bundled). The XMP-only ref composites bundled ALSO synthesizes
+  # (`Composite:GPSLatitudeRef`/`GPSLongitudeRef`/`GPSPosition`) are NOT ported,
+  # so drop ONLY those three (NOT `Composite:all` — that would also drop the
+  # ported `GPSAltitude`). Must precede the generic `XMP*` arm (first match wins).
+  XMP_gps_abovesea.xmp | XMP_gps_belowsea.xmp)
+    EXCLUDE_ARR+=(-x Composite:GPSLatitudeRef -x Composite:GPSLongitudeRef \
+                  -x Composite:GPSPosition) ;;
   XMP*) EXCLUDE_ARR+=(-x Composite:all) ;;
   # The PNG raw-profile fixtures (#179) carry the engine-synthesized
   # `Composite:ImageSize`/`Megapixels` (from the IHDR dimensions) that the PNG
   # port does not emit (it has no Composite subsystem). Drop Composite so the
   # decoded profile content (`XMP-*`) is what the golden compares.
   PNG_rawprofile_*) EXCLUDE_ARR+=(-x Composite:all) ;;
+  # The GPS-bearing stills (#133 PR 2): exifast emits the ported GPS Composites
+  # (`Composite:GPSLatitude`/`GPSLongitude`/`GPSAltitude`/`GPSDateTime`/
+  # `GPSPosition`, GPS.pm/Exif.pm) but NOT the still-deferred camera composites
+  # (`Aperture`/`ImageSize`/`Megapixels`/`ShutterSpeed`/`FocalLength35efl`/
+  # `CircleOfConfusion`/`FOV`/`HyperfocalDistance`/`LightValue`/
+  # `ScaleFactor35efl` — the EXIF/lens Composite subsystem, a later #133 PR). So
+  # these goldens KEEP the GPS Composites and drop ONLY the unported ones by
+  # name (NOT `Composite:all`), byte-matching exifast — PLUS the same non-GPS
+  # JPEG-port deferrals these goldens already excluded (the APP13 Photoshop/IPTC
+  # segment + `IFD1:ThumbnailImage` binary body for `ExifGPS.jpg`; the embedded
+  # `XMP:*` + `IFD1:ThumbnailImage` for `DJIPhantom4.jpg`), so the GPS
+  # Composites are the ONLY net change vs the pre-#133 goldens. `ExifGPS.tif`
+  # carries ONLY GPS Composites and no deferred segments, so it needs no
+  # exclusion at all (default path).
+  ExifGPS.jpg)
+    EXCLUDE_ARR+=(-x IPTC:all -x File:CurrentIPTCDigest -x IFD1:ThumbnailImage \
+                  -x Composite:Aperture -x Composite:ImageSize \
+                  -x Composite:Megapixels -x Composite:ShutterSpeed \
+                  -x Composite:FocalLength35efl) ;;
+  DJIPhantom4.jpg)
+    EXCLUDE_ARR+=(-x XMP:all -x IFD1:ThumbnailImage \
+                  -x Composite:Aperture -x Composite:CircleOfConfusion \
+                  -x Composite:FOV -x Composite:FocalLength35efl \
+                  -x Composite:HyperfocalDistance -x Composite:ImageSize \
+                  -x Composite:LightValue -x Composite:Megapixels \
+                  -x Composite:ScaleFactor35efl -x Composite:ShutterSpeed) ;;
 esac
 
 # Run from the fixtures dir and pass only the basename so the embedded


### PR DESCRIPTION
**Composite engine PR 2 of 5** (#133). The GPS composites + wiring the inputs' PrintConv form (`prt[i]`) into the engine.

## prt[i] wiring
The engine now carries both `val[i]` (ValueConv) and `prt[i]` (PrintConv) per input via two views (`val_view`/`prt_view`); `format_parser` re-emits the Meta in `mode.flipped()` for the opposite-mode view. (GPSPosition's PrintConv `$prt[0], $prt[1]` is the first consumer.)

## GPS composites (faithful to GPS.pm / Exif.pm)
GPSLatitude/GPSLongitude (ref-sign `/^S/i`,`/^W/i` + ToDMS), GPSAltitude (ref-required + below-sea + the `IsFloat` comma-decimal normalization), GPSDateTime (`…Z` + ConvertDateTime), GPSPosition (Priority-0, requires the two GPS composites — exercises the fixpoint deferral end-to-end). ToDMS ported byte-exact (`%d deg %d' %.2f"` + hemisphere + the ≥60 carry). `is_float_str`→`is_float_norm` exposes the comma→dot value (shared with ImageSize/DOF in PRs 3–4).

## Goldens
**5 stills regenerated** (ExifGPS.tif/.jpg, DJIPhantom4.jpg, XMP_gps_abovesea/belowsea) — GPS-composite-only diffs, byte-exact vs bundled. The 70 video GPS goldens + M2TS/H264 are deferred to PR 5 (SubDoc/Doc<N>) via a new `defers_composites()` gate; their goldens stay byte-identical.

## Verify
`fmt=0  build(-Dwarnings)=0  conformance=432/0  timed=130/0  typed_serde=539  lib=3392/0`

**Codex adversarial review: APPROVE (R2).** Second of the #133 Composite series.