### PR TITLE
chore(composite): fix stable-rustfmt drift in composite/tests.rs (CI fmt gate)

### DIFF
--- a/src/composite/tests.rs
+++ b/src/composite/tests.rs
@@ -2536,14 +2536,7 @@ mod subdoc {
         1,
         TagValue::Str("South".into()),
       ),
-      (
-        1,
-        "GoPro",
-        "Track1",
-        "GPSLongitude",
-        0,
-        TagValue::F64(22.0),
-      ),
+      (1, "GoPro", "Track1", "GPSLongitude", 0, TagValue::F64(22.0)),
       (
         1,
         "GoPro",


### PR DESCRIPTION
#325 left a 6-element tuple multi-line that stable `cargo fmt --all -- --check` (the CI rustfmt job, ci.yml:38) collapses to one line — main's fmt gate was red. Pure whitespace: 1 file, the tuple collapse, fmt --check clean. No code/behavior change.