### PR TITLE
fix(tests): EXPECTED_ACTIVE_FIXTURES 549→555 (#318 left main red)

### DIFF
--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -756,7 +756,7 @@ const NOT_ACTIVE: &[&str] = &[
 /// `OtherFormat` + the `[minor]` `Track1:Warning`; the `Doc<N>` timing is `-ee`-only,
 /// pinned in `timed_metadata_conformance.rs`). `Composite:GPSPosition` is the
 /// unported timed-GPS deferral, excluded at regen.
-const EXPECTED_ACTIVE_FIXTURES: usize = 549;
+const EXPECTED_ACTIVE_FIXTURES: usize = 555;
 
 /// Every `tests/fixtures/<f>` that has both `tests/golden/<f>.json` and
 /// `tests/golden/<f>.n.json`, MINUS the [`NOT_ACTIVE`] formally-accept-


### PR DESCRIPTION
#318 added 6 active Pentax body fixtures (k1/k3/k5_ii/k70/kp/ks2, paired goldens, not in NOT_ACTIVE) but did not bump EXPECTED_ACTIVE_FIXTURES — so typed_serde_parity panics on main (active=555, expected=549). One-line: bump to 555 (the fixtures are legitimately active). conformance + typed_serde green.