### PR TITLE
fix(tests): conformance.rs stable-fmt (#318 left CI fmt red)

### DIFF
--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -11033,46 +11033,50 @@ fn mpeg2_ts_pruveeo_d90_conformance() {
 #[test]
 #[ignore]
 fn jpeg_pentax_k1_conformance() {
-    check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.json", true);
-    check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.n.json", false);
+  check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.json", true);
+  check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.n.json", false);
 }
 
 // #311 — Pentax K-3 MakerNote (FlashExposureComp count-2, AFPointsInFocus)
 #[test]
 #[ignore]
 fn jpeg_pentax_k3_conformance() {
-    check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.json", true);
-    check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.n.json", false);
+  check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.json", true);
+  check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.n.json", false);
 }
 
 // #311 — Pentax K-5 II MakerNote (AFPointSelected count-2, AFPointSelected 2)
 #[test]
 #[ignore]
 fn jpeg_pentax_k5_ii_conformance() {
-    check("JPEG_pentax_k5_ii.jpg", "JPEG_pentax_k5_ii.jpg.json", true);
-    check("JPEG_pentax_k5_ii.jpg", "JPEG_pentax_k5_ii.jpg.n.json", false);
+  check("JPEG_pentax_k5_ii.jpg", "JPEG_pentax_k5_ii.jpg.json", true);
+  check(
+    "JPEG_pentax_k5_ii.jpg",
+    "JPEG_pentax_k5_ii.jpg.n.json",
+    false,
+  );
 }
 
 // #311 — Pentax KP MakerNote (AFPointSelected, BatteryVoltage)
 #[test]
 #[ignore]
 fn jpeg_pentax_kp_conformance() {
-    check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.json", true);
-    check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.n.json", false);
+  check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.json", true);
+  check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.n.json", false);
 }
 
 // #311 — Pentax K-70 MakerNote (AFPointSelected, BatteryVoltage)
 #[test]
 #[ignore]
 fn jpeg_pentax_k70_conformance() {
-    check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.json", true);
-    check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.n.json", false);
+  check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.json", true);
+  check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.n.json", false);
 }
 
 // #311 — Pentax K-S2 MakerNote (AFPointSelected, AFPointsInFocus)
 #[test]
 #[ignore]
 fn jpeg_pentax_ks2_conformance() {
-    check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.json", true);
-    check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.n.json", false);
+  check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.json", true);
+  check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.n.json", false);
 }


### PR DESCRIPTION
#318's 6 #[ignore]d Pentax conformance test blocks were committed with non-stable-fmt formatting → cargo fmt --all -- --check (CI rustfmt job) red on conformance.rs:11033-11073. Pure whitespace: 1 file, the 6 blocks. fmt --check clean. (Second half of restoring main green after #318; #333 fixed the typed_serde active-count.)