### PR TITLE
fix(tests): restore main green after #342 (NOT_ACTIVE the 3 new fixtures + fmt)

### DIFF
--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -11125,8 +11125,8 @@ fn mpeg2_ts_pruveeo_d90_conformance() {
 #[test]
 #[ignore]
 fn jpeg_pentax_k1_conformance() {
-    check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.json", true);
-    check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.n.json", false);
+  check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.json", true);
+  check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.n.json", false);
   check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.json", true);
   check("JPEG_pentax_k1.jpg", "JPEG_pentax_k1.jpg.n.json", false);
 }
@@ -11135,8 +11135,8 @@ fn jpeg_pentax_k1_conformance() {
 #[test]
 #[ignore]
 fn jpeg_pentax_k3_conformance() {
-    check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.json", true);
-    check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.n.json", false);
+  check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.json", true);
+  check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.n.json", false);
   check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.json", true);
   check("JPEG_pentax_k3.jpg", "JPEG_pentax_k3.jpg.n.json", false);
 }
@@ -11145,8 +11145,12 @@ fn jpeg_pentax_k3_conformance() {
 #[test]
 #[ignore]
 fn jpeg_pentax_k5_ii_conformance() {
-    check("JPEG_pentax_k5_ii.jpg", "JPEG_pentax_k5_ii.jpg.json", true);
-    check("JPEG_pentax_k5_ii.jpg", "JPEG_pentax_k5_ii.jpg.n.json", false);
+  check("JPEG_pentax_k5_ii.jpg", "JPEG_pentax_k5_ii.jpg.json", true);
+  check(
+    "JPEG_pentax_k5_ii.jpg",
+    "JPEG_pentax_k5_ii.jpg.n.json",
+    false,
+  );
   check("JPEG_pentax_k5_ii.jpg", "JPEG_pentax_k5_ii.jpg.json", true);
   check(
     "JPEG_pentax_k5_ii.jpg",
@@ -11159,8 +11163,8 @@ fn jpeg_pentax_k5_ii_conformance() {
 #[test]
 #[ignore]
 fn jpeg_pentax_kp_conformance() {
-    check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.json", true);
-    check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.n.json", false);
+  check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.json", true);
+  check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.n.json", false);
   check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.json", true);
   check("JPEG_pentax_kp.jpg", "JPEG_pentax_kp.jpg.n.json", false);
 }
@@ -11169,8 +11173,8 @@ fn jpeg_pentax_kp_conformance() {
 #[test]
 #[ignore]
 fn jpeg_pentax_k70_conformance() {
-    check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.json", true);
-    check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.n.json", false);
+  check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.json", true);
+  check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.n.json", false);
   check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.json", true);
   check("JPEG_pentax_k70.jpg", "JPEG_pentax_k70.jpg.n.json", false);
 }
@@ -11179,32 +11183,40 @@ fn jpeg_pentax_k70_conformance() {
 #[test]
 #[ignore]
 fn jpeg_pentax_ks2_conformance() {
-    check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.json", true);
-    check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.n.json", false);
+  check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.json", true);
+  check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.n.json", false);
 }
 
 // #122 — Parrot Anafi drone MP4 with mett metadata track (GPS + flight telemetry)
 #[test]
 #[ignore]
 fn mp4_parrot_anafi_conformance() {
-    check("MP4_parrot_anafi.mp4", "MP4_parrot_anafi.mp4.json", true);
-    check("MP4_parrot_anafi.mp4", "MP4_parrot_anafi.mp4.n.json", false);
+  check("MP4_parrot_anafi.mp4", "MP4_parrot_anafi.mp4.json", true);
+  check("MP4_parrot_anafi.mp4", "MP4_parrot_anafi.mp4.n.json", false);
 }
 
 // #138 — Viofo A119 dashcam with LigoGPS freeGPS atom in MP4
 #[test]
 #[ignore]
 fn mp4_viofo_a119_gps_conformance() {
-    check("MP4_viofo_a119_gps.mp4", "MP4_viofo_a119_gps.mp4.json", true);
-    check("MP4_viofo_a119_gps.mp4", "MP4_viofo_a119_gps.mp4.n.json", false);
+  check(
+    "MP4_viofo_a119_gps.mp4",
+    "MP4_viofo_a119_gps.mp4.json",
+    true,
+  );
+  check(
+    "MP4_viofo_a119_gps.mp4",
+    "MP4_viofo_a119_gps.mp4.n.json",
+    false,
+  );
 }
 
 // #130 — MPEG-TS with MISB KLV metadata stream
 #[test]
 #[ignore]
 fn mpeg2_ts_misb_klv_conformance() {
-    check("MPEG2_TS_misb_klv.ts", "MPEG2_TS_misb_klv.ts.json", true);
-    check("MPEG2_TS_misb_klv.ts", "MPEG2_TS_misb_klv.ts.n.json", false);
+  check("MPEG2_TS_misb_klv.ts", "MPEG2_TS_misb_klv.ts.json", true);
+  check("MPEG2_TS_misb_klv.ts", "MPEG2_TS_misb_klv.ts.n.json", false);
   check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.json", true);
   check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.n.json", false);
 }

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -112,6 +112,15 @@ use exifast::{
 /// typed-serde path — and is exercised both here and, byte-exact incl.
 /// `MetaFormat`, by `tests/timed_metadata_conformance.rs`.)
 const NOT_ACTIVE: &[&str] = &[
+  // #342/#336: the 3 real-device fixtures (Parrot Anafi mett, Viofo A119 LigoGPS,
+  // MISB KLV M2TS) ship full bundled goldens + #[ignore]'d conformance tests, but
+  // exifast does not yet emit the full tag set (the parsers need completion — #122
+  // Parrot, #138 LigoGPS, #130 MISB). Accept-deferred here until activated; #342
+  // added them but missed this NOT_ACTIVE entry, leaving main red on the
+  // auto-discovered active-fixture parity check.
+  "MP4_parrot_anafi.mp4",
+  "MP4_viofo_a119_gps.mp4",
+  "MPEG2_TS_misb_klv.ts",
   // #318/#311: the 6 Pentax body fixtures (k1/k3/k5_ii/k70/kp/ks2) carry full
   // bundled goldens for the #173 MakerNote conditional branches, but their
   // conformance tests are #[ignore]d (aspirational) — exifast's Pentax port does


### PR DESCRIPTION
#342 (#336 fixture acquisition) left main RED: the 3 real-device fixtures (Parrot Anafi, Viofo A119 LigoGPS, MISB KLV) ship full bundled goldens + #[ignore]'d conformance, but typed_serde_parity auto-discovered them as active (559 vs 556) and the new conformance test blocks weren't stable-fmt'd. Fix: add them to NOT_ACTIVE (the parsers need completion — #122/#138/#130) + stable-fmt. typed_serde + conformance + fmt green. The fixtures are now ready to drive to activation.