### PR TITLE
fix(m2ts/tests): activate MPEG2_TS_misb_klv — no MISB KLV present (#130)

### DIFF
--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -11211,12 +11211,14 @@ fn mp4_viofo_a119_gps_conformance() {
   );
 }
 
-// #130 — MPEG-TS with MISB KLV metadata stream
+// #130 — MPEG-TS with MISB KLV metadata stream. This fixture's PMT declares
+// only a type-0x1b H.264 video stream (no type-0x15 packetized-metadata PID),
+// and the file carries no SMPTE/MISB universal label (06 0e 2b 34), so bundled
+// ExifTool 13.59 decodes no MISB KLV tags — even under `-ee`. The byte-exact
+// tag set is the standard M2TS/H264/Composite one exifast already emits (plus
+// the `ExtractEmbedded` Warning); there is nothing to MISB-decode here.
 #[test]
-#[ignore]
 fn mpeg2_ts_misb_klv_conformance() {
   check("MPEG2_TS_misb_klv.ts", "MPEG2_TS_misb_klv.ts.json", true);
   check("MPEG2_TS_misb_klv.ts", "MPEG2_TS_misb_klv.ts.n.json", false);
-  check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.json", true);
-  check("JPEG_pentax_ks2.jpg", "JPEG_pentax_ks2.jpg.n.json", false);
 }

--- a/tests/golden/MPEG2_TS_misb_klv.ts.json
+++ b/tests/golden/MPEG2_TS_misb_klv.ts.json
@@ -1,21 +1,13 @@
-[
-  {
-    "ExifTool:ExifToolVersion": 13.55,
-    "ExifTool:Warning": "[minor] The ExtractEmbedded option may find more tags in the video data",
-    "File:FileName": "MPEG2_TS_misb_klv.ts",
-    "File:Directory": "tests/fixtures",
-    "File:FileSize": 5224708,
-    "File:FileModifyDate": "2026:06:21 14:18:30+09:00",
-    "File:FileAccessDate": "2026:06:21 14:18:31+09:00",
-    "File:FileInodeChangeDate": "2026:06:21 14:18:30+09:00",
-    "File:FilePermissions": 100644,
-    "File:FileType": "M2T",
-    "File:FileTypeExtension": "M2T",
-    "File:MIMEType": "video/mpeg",
-    "H264:ImageWidth": 1280,
-    "H264:ImageHeight": 720,
-    "M2TS:Duration": 9.9,
-    "Composite:ImageSize": "1280 720",
-    "Composite:Megapixels": 0.9216
-  }
-]
+[{
+  "SourceFile": "MPEG2_TS_misb_klv.ts",
+  "ExifTool:ExifToolVersion": 13.59,
+  "ExifTool:Warning": "[minor] The ExtractEmbedded option may find more tags in the video data",
+  "File:FileType": "M2T",
+  "File:FileTypeExtension": "m2t",
+  "File:MIMEType": "video/mpeg",
+  "H264:ImageWidth": 1280,
+  "H264:ImageHeight": 720,
+  "M2TS:Duration": "9.90 s",
+  "Composite:ImageSize": "1280x720",
+  "Composite:Megapixels": 0.922
+}]

--- a/tests/golden/MPEG2_TS_misb_klv.ts.n.json
+++ b/tests/golden/MPEG2_TS_misb_klv.ts.n.json
@@ -1,21 +1,13 @@
-[
-  {
-    "ExifTool:ExifToolVersion": 13.55,
-    "ExifTool:Warning": "[minor] The ExtractEmbedded option may find more tags in the video data",
-    "File:FileName": "MPEG2_TS_misb_klv.ts",
-    "File:Directory": "tests/fixtures",
-    "File:FileSize": 5224708,
-    "File:FileModifyDate": "2026:06:21 14:18:30+09:00",
-    "File:FileAccessDate": "2026:06:21 14:18:31+09:00",
-    "File:FileInodeChangeDate": "2026:06:21 14:18:30+09:00",
-    "File:FilePermissions": 100644,
-    "File:FileType": "M2T",
-    "File:FileTypeExtension": "M2T",
-    "File:MIMEType": "video/mpeg",
-    "H264:ImageWidth": 1280,
-    "H264:ImageHeight": 720,
-    "M2TS:Duration": 9.9,
-    "Composite:ImageSize": "1280 720",
-    "Composite:Megapixels": 0.9216
-  }
-]
+[{
+  "SourceFile": "MPEG2_TS_misb_klv.ts",
+  "ExifTool:ExifToolVersion": 13.59,
+  "ExifTool:Warning": "[minor] The ExtractEmbedded option may find more tags in the video data",
+  "File:FileType": "M2T",
+  "File:FileTypeExtension": "M2T",
+  "File:MIMEType": "video/mpeg",
+  "H264:ImageWidth": 1280,
+  "H264:ImageHeight": 720,
+  "M2TS:Duration": 9.9,
+  "Composite:ImageSize": "1280 720",
+  "Composite:Megapixels": 0.9216
+}]

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -112,15 +112,18 @@ use exifast::{
 /// typed-serde path — and is exercised both here and, byte-exact incl.
 /// `MetaFormat`, by `tests/timed_metadata_conformance.rs`.)
 const NOT_ACTIVE: &[&str] = &[
-  // #342/#336: the 3 real-device fixtures (Parrot Anafi mett, Viofo A119 LigoGPS,
-  // MISB KLV M2TS) ship full bundled goldens + #[ignore]'d conformance tests, but
-  // exifast does not yet emit the full tag set (the parsers need completion — #122
-  // Parrot, #138 LigoGPS, #130 MISB). Accept-deferred here until activated; #342
-  // added them but missed this NOT_ACTIVE entry, leaving main red on the
-  // auto-discovered active-fixture parity check.
+  // #342/#336: two real-device fixtures (Parrot Anafi mett, Viofo A119 LigoGPS)
+  // ship full bundled goldens + #[ignore]'d conformance tests, but exifast does
+  // not yet emit the full tag set (the parsers need completion — #122 Parrot,
+  // #138 LigoGPS). Accept-deferred here until activated; #342 added them but
+  // missed this NOT_ACTIVE entry, leaving main red on the auto-discovered
+  // active-fixture parity check.
+  // (#130 MISB KLV M2TS was here too but is now ACTIVE: this fixture's PMT
+  // declares only a type-0x1b H.264 stream — no type-0x15 packetized-metadata
+  // PID — and the file carries no SMPTE/MISB universal label, so bundled
+  // ExifTool 13.59 decodes no MISB tags and exifast already matches it byte-exact.)
   "MP4_parrot_anafi.mp4",
   "MP4_viofo_a119_gps.mp4",
-  "MPEG2_TS_misb_klv.ts",
   // #318/#311: the 6 Pentax body fixtures (k1/k3/k5_ii/k70/kp/ks2) carry full
   // bundled goldens for the #173 MakerNote conditional branches, but their
   // conformance tests are #[ignore]d (aspirational) — exifast's Pentax port does
@@ -823,7 +826,7 @@ const NOT_ACTIVE: &[&str] = &[
 /// `gpmd`-handler `.mov`s (no-`ee` `.json`/`.n.json` = structural scalars + the
 /// `[minor]` EEWarn, byte-exact); the `-ee` group behavior is pinned in
 /// `tests/timed_metadata_conformance.rs`.
-const EXPECTED_ACTIVE_FIXTURES: usize = 556;
+const EXPECTED_ACTIVE_FIXTURES: usize = 557;
 
 /// Every `tests/fixtures/<f>` that has both `tests/golden/<f>.json` and
 /// `tests/golden/<f>.n.json`, MINUS the [`NOT_ACTIVE`] formally-accept-


### PR DESCRIPTION
The acquired `MPEG2_TS_misb_klv.ts` fixture (#342/#336) is **misnamed — it contains no MISB KLV**: ground-truthed that bundled ExifTool 13.59 emits zero MISB tags (no type-0x15 metadata PID — the PMT declares only PID 0x0100 H.264 stream-type 0x1b; the SMPTE universal label `06 0e 2b 34` appears nowhere in the 5.2 MB file). So exifast's existing M2TS type-dispatch already produces the byte-exact (MISB-less) output — no parser change (inventing an unexercised MISB decoder would be unfaithful).

Test-only: (1) regenerated the goldens via gen_golden.sh conventioned (13.59-stamped, machine-dependent System tags removed — the teammate goldens were raw 13.55 output); (2) removed `#[ignore]` from `mpeg2_ts_misb_klv_conformance` + a stray duplicate `JPEG_pentax_ks2` check a teammate had bundled into it (pentax_ks2 isn't byte-exact yet; its coverage is preserved by its own ignored test); (3) un-NOT_ACTIVE'd + bumped EXPECTED_ACTIVE 556→557.

The actual **MISB KLV decoder (stream type 0x15) remains unimplemented** — #130 stays open for a genuine MISB-carrying `.ts`.

`fmt=0 build(-Dwarnings)=0 conformance=437/0 typed_serde=557 lib=3515/0` — only the 2 misb goldens + 2 test files changed. **Codex: APPROVE.**