### PR TITLE
fix(tests): restore main green after #345 (NOT_ACTIVE GoPro HERO6 + NX1)

### DIFF
--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -11227,14 +11227,22 @@ fn mpeg2_ts_misb_klv_conformance() {
 #[test]
 #[ignore]
 fn quicktime_gopro_hero6_gpmf_conformance() {
-    check("QuickTime_gopro_hero6_gpmf.mp4", "QuickTime_gopro_hero6_gpmf.mp4.json", true);
-    check("QuickTime_gopro_hero6_gpmf.mp4", "QuickTime_gopro_hero6_gpmf.mp4.n.json", false);
+  check(
+    "QuickTime_gopro_hero6_gpmf.mp4",
+    "QuickTime_gopro_hero6_gpmf.mp4.json",
+    true,
+  );
+  check(
+    "QuickTime_gopro_hero6_gpmf.mp4",
+    "QuickTime_gopro_hero6_gpmf.mp4.n.json",
+    false,
+  );
 }
 
 // #210 — Real Samsung NX1 SRW with populated Type2 MakerNote (DeviceType/SamsungModelID/LensType)
 #[test]
 #[ignore]
 fn makernotes_samsung_nx1_conformance() {
-    check("SamsungNX1.srw", "SamsungNX1.srw.json", true);
-    check("SamsungNX1.srw", "SamsungNX1.srw.n.json", false);
+  check("SamsungNX1.srw", "SamsungNX1.srw.json", true);
+  check("SamsungNX1.srw", "SamsungNX1.srw.n.json", false);
 }

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -112,6 +112,11 @@ use exifast::{
 /// typed-serde path — and is exercised both here and, byte-exact incl.
 /// `MetaFormat`, by `tests/timed_metadata_conformance.rs`.)
 const NOT_ACTIVE: &[&str] = &[
+  // #345/#211/#210: GoPro HERO6 gpmd + Samsung NX1 fixtures ship raw bundled
+  // goldens (System tags) + #[ignore]'d conformance; exifast does not yet match
+  // (GoPro real gpmd GPS = #211; NX1 Type2 = #210). Accept-deferred until driven.
+  "QuickTime_gopro_hero6_gpmf.mp4",
+  "SamsungNX1.srw",
   // #342/#336: two real-device fixtures (Parrot Anafi mett, Viofo A119 LigoGPS)
   // ship full bundled goldens + #[ignore]'d conformance tests, but exifast does
   // not yet emit the full tag set (the parsers need completion — #122 Parrot,


### PR DESCRIPTION
#345 (#211/#210 fixtures) left main RED (same as #342): the 2 new real-device fixtures (QuickTime_gopro_hero6_gpmf.mp4, SamsungNX1.srw) ship raw bundled goldens (System tags) + #[ignore]'d conformance, but typed_serde_parity auto-discovered them active (559 vs 557) + the new conformance blocks weren't stable-fmt'd. Fix: NOT_ACTIVE both + fmt. They're ready to drive (#211 GoPro gpmd GPS, #210 Samsung NX1 Type2).