### PR TITLE
feat(dji): emit the protobuf FrameNumber tag (path 3-1-1) for all 16 protocols (#359)

### DIFF
--- a/src/formats/dji_protobuf.rs
+++ b/src/formats/dji_protobuf.rs
@@ -659,6 +659,12 @@ enum FieldKind {
   SerialNumber2,
   /// `1-1-10` Model — LEN ASCII string (DJI.pm:273 etc.).
   Model,
+  /// `FrameNumber` (`3-1-1`), `Format => 'unsigned'` (a VARINT) — a per-frame
+  /// counter declared on all 16 protocol arms (DJI.pm:279/:320/:361/:404 etc.,
+  /// `#forum17996`). No ValueConv/PrintConv ⇒ emitted as the raw integer. Lives
+  /// in the per-frame `3-1` message alongside [`Self::TimeStamp`] (`3-1-2`), so
+  /// it lands PER `djmd` sample (one `Doc<N>` each), not clip-level.
+  FrameNumber,
   /// `ISO`, `Format => 'float'` (an I32 float wire value).
   Iso,
   /// `ShutterSpeed`, `Format => 'rational'` (a LEN packed rational, seconds).
@@ -1356,6 +1362,13 @@ fn apply_leaf(
       {
         let converted: String = v.chars().map(|c| if c == '-' { ':' } else { c }).collect();
         s.set_gps_date_time(Some(SmolStr::new(converted)));
+      }
+    }
+    FieldKind::FrameNumber => {
+      // `3-1-1` FrameNumber, Format => 'unsigned' (VARINT), no conversions
+      // (DJI.pm:279 etc.). Per-frame counter — kept as the raw `u64`.
+      if let Some(v) = varint_value(rec) {
+        s.set_frame_number(Some(v));
       }
     }
     FieldKind::TimeStamp => {
@@ -2380,6 +2393,56 @@ mod tests {
     let mut dji_st = DjiTrackState::new();
     process_djmd(&buf, &mut dji_st, &mut out);
     assert_eq!(out.samples()[0].time_stamp_us(), Some(1_234_567_890));
+  }
+
+  #[test]
+  fn field_lookup_frame_number_all_protocols() {
+    // `3-1-1` FrameNumber (Format => 'unsigned') is a NAMED, default-extracted
+    // leaf on EVERY protocol arm (DJI.pm:279/:320/:361/:404/:446/:479/:515/:558/
+    // :598/:639/:677/:721/:744/:782/:833/:868, `#forum17996`).
+    for kp in [
+      "dvtm_ac203",
+      "dvtm_ac204",
+      "dvtm_ac206",
+      "dvtm_AVATA2",
+      "dvtm_wm265e",
+      "dvtm_pm320",
+      "dvtm_Mini4_Pro",
+      "dvtm_dji_neo",
+      "dvtm_Air3",
+      "dvtm_Air3s",
+      "dvtm_oq101",
+      "dvtm_PP-101",
+      "dvtm_wa345e",
+      "dvtm_wm261",
+      "dvtm_Mavic4",
+      "dvtm_Mini5Pro",
+    ] {
+      let p = protocol_for(kp).unwrap();
+      assert_eq!(
+        field_for(p, &[3, 1, 1]),
+        Some(FieldKind::FrameNumber),
+        "{kp} 3-1-1 must map to FrameNumber"
+      );
+    }
+  }
+
+  #[test]
+  fn djmd_frame_number_decodes_per_sample() {
+    // FrameNumber `3-1-1` (unsigned VARINT) lands on the per-sample row (one
+    // `Doc<N>` each), like TimeStamp `3-1-2`. Decode an ac203 sample carrying a
+    // `3-1-1` varint and assert the raw counter on the sample.
+    let lvl31 = nest(1, &[rec_varint(1, 1701)]); // 3-1-1 FrameNumber
+    let lvl3 = nest(3, &[lvl31]);
+    let proto = proto_block("dvtm_ac203.proto");
+    let mut buf = Vec::new();
+    buf.extend(proto);
+    buf.extend(lvl3);
+
+    let mut out = DjiProtobufMeta::new();
+    let mut dji_st = DjiTrackState::new();
+    process_djmd(&buf, &mut dji_st, &mut out);
+    assert_eq!(out.samples()[0].frame_number(), Some(1701));
   }
 
   #[test]

--- a/src/formats/dji_protobuf_tables.rs
+++ b/src/formats/dji_protobuf_tables.rs
@@ -18,11 +18,16 @@
 // `# (NC)` "Not Confirmed" markers in DJI.pm are preserved as-is — they are
 // included exactly when the bundled default table extracts them.
 //
-// Walked-but-discarded fields (FrameNumber `3-1-1`, AccelerometerX/Y/Z,
-// "model code", version numbers) are NOT rows here: the camera-indexing typed
-// surface drops them (FrameNumber is a per-frame video index, not camera/GPS
-// metadata; the accelerometer/model-code/version fields are `Unknown => 1`
-// non-default extractions). See the module docs.
+// FrameNumber (`3-1-1`) IS a row on EVERY protocol arm (DJI.pm:279/:320/:361/
+// :404/:446/:479/:515/:558/:598/:639/:677/:721/:744/:782/:833/:868,
+// `#forum17996`): a NAMED tag (`Name => 'FrameNumber', Format => 'unsigned'`)
+// with no `Unknown` flag ⇒ ExifTool extracts it by default at `-ee`. It lives
+// in the per-frame `3-1` message next to TimeStamp (`3-1-2`), so it is emitted
+// PER `djmd` sample (one `Doc<N>` each), not clip-level.
+//
+// Walked-but-discarded fields (AccelerometerX/Y/Z, "model code", version
+// numbers) are NOT rows here: they are `Unknown => 1` non-default extractions.
+// See the module docs.
 //
 // SerialNumber2 (`2-2-3-1`) IS a row on the AVATA2 + DJI Neo arms only
 // (DJI.pm:399/:553): a NAMED tag with no `Unknown` flag ⇒ ExifTool extracts it
@@ -49,6 +54,7 @@ static AC203: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:274-277 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },      //   "
   Row { path: &[2, 3, 3], kind: K::FrameRate },        //   "
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:279 (forum17996)
   Row { path: &[3, 2, 3, 1], kind: K::Iso },           // DJI.pm:280 (forum17996)
   Row { path: &[3, 2, 4, 1], kind: K::ShutterSpeed },  // DJI.pm:281-285
   Row { path: &[3, 2, 6, 1], kind: K::ColorTemperature }, // DJI.pm:284
@@ -68,6 +74,7 @@ static AC204: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:314-317 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:320 (forum17996)
   Row { path: &[3, 2, 3, 1], kind: K::Iso },           // DJI.pm:321 (forum17996)
   Row { path: &[3, 2, 4, 1], kind: K::ShutterSpeed },  // DJI.pm:322-326
   Row { path: &[3, 2, 6, 1], kind: K::ColorTemperature }, // DJI.pm:327
@@ -87,6 +94,7 @@ static AC206: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:353-356 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:361 (forum17996)
   Row { path: &[3, 2, 3, 1], kind: K::Iso },           // DJI.pm:362 (forum17996)
   Row { path: &[3, 2, 4, 1], kind: K::ShutterSpeed },  // DJI.pm:363-367
   Row { path: &[3, 2, 6, 1], kind: K::ColorTemperature }, // DJI.pm:368
@@ -107,6 +115,7 @@ static AVATA2: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:394-397 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:404
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:399-405
   Row { path: &[3, 2, 2, 1], kind: K::Iso },           // DJI.pm:408
   Row { path: &[3, 2, 4, 1], kind: K::ShutterSpeed },  // DJI.pm:409-413
@@ -131,6 +140,7 @@ static WM265E: &[Row] = &[
   Row { path: &[2, 2, 1], kind: K::FrameWidth },       // DJI.pm:436-439 FrameInfo
   Row { path: &[2, 2, 2], kind: K::FrameHeight },
   Row { path: &[2, 2, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:446
   Row { path: &[3, 2, 2, 1], kind: K::Iso },           // DJI.pm:441
   Row { path: &[3, 2, 3, 1], kind: K::ShutterSpeed },  // DJI.pm:442-446
   Row { path: &[3, 2, 6, 1], kind: K::DigitalZoom },   // DJI.pm:448
@@ -156,6 +166,7 @@ static PM320: &[Row] = &[
   Row { path: &[2, 2, 1], kind: K::FrameWidth },       // DJI.pm:468-471 FrameInfo
   Row { path: &[2, 2, 2], kind: K::FrameHeight },
   Row { path: &[2, 2, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:479
   Row { path: &[3, 2, 2, 1], kind: K::Iso },           // DJI.pm:472
   Row { path: &[3, 2, 3, 1], kind: K::ShutterSpeed },  // DJI.pm:473-477
   Row { path: &[3, 2, 4, 1], kind: K::FNumber },       // DJI.pm:478-482
@@ -182,6 +193,7 @@ static MINI4PRO: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:503-506 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:515
   Row { path: &[3, 2, 7, 1], kind: K::Iso },           // DJI.pm:507
   Row { path: &[3, 2, 10, 1], kind: K::ShutterSpeed }, // DJI.pm:508-512
   Row { path: &[3, 2, 11, 1], kind: K::FNumber },      // DJI.pm:513-517
@@ -210,6 +222,7 @@ static DJI_NEO: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:545-548 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:558
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:550-556
   Row { path: &[3, 2, 2, 1], kind: K::Iso },           // DJI.pm:559
   Row { path: &[3, 2, 4, 1], kind: K::ShutterSpeed },  // DJI.pm:560-564
@@ -232,6 +245,7 @@ static AIR3: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:585-588 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:598 (NC)
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:589-594
   Row { path: &[3, 2, 7, 1], kind: K::Iso },           // DJI.pm:595
   Row { path: &[3, 2, 10, 1], kind: K::ShutterSpeed }, // DJI.pm:596-600
@@ -258,6 +272,7 @@ static AIR3S: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:625-628 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:639 (NC)
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:629-634
   Row { path: &[3, 2, 7, 1], kind: K::Iso },           // DJI.pm:635
   Row { path: &[3, 2, 10, 1], kind: K::ShutterSpeed }, // DJI.pm:636-640
@@ -283,6 +298,7 @@ static OQ101: &[Row] = &[
   Row { path: &[1, 1, 5], kind: K::SerialNumber },     // DJI.pm:664
   Row { path: &[1, 1, 10], kind: K::Model },           // DJI.pm:665
   Row { path: &[1, 14, 1], kind: K::FNumber },         // DJI.pm:679-683
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:677
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:666-671
   Row { path: &[3, 2, 3, 1], kind: K::Iso },           // DJI.pm:672
   Row { path: &[3, 2, 4, 1], kind: K::ShutterSpeed },  // DJI.pm:673-677
@@ -303,6 +319,7 @@ static PP101: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:705-708 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:721
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:709-714
   Row { path: &[3, 2, 9, 1], kind: K::Iso },           // DJI.pm:715
   Row { path: &[3, 2, 10, 1], kind: K::ShutterSpeed }, // DJI.pm:716-720
@@ -318,6 +335,7 @@ static WA345E: &[Row] = &[
   Row { path: &[2, 2, 1], kind: K::FrameWidth },       // DJI.pm:727-730 FrameInfo
   Row { path: &[2, 2, 2], kind: K::FrameHeight },
   Row { path: &[2, 2, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:744
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:731-736
   Row { path: &[3, 3, 3, 1], kind: K::DroneRoll },     // DJI.pm:737-740 DroneInfo
   Row { path: &[3, 3, 3, 2], kind: K::DronePitch },
@@ -342,6 +360,7 @@ static WM261: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:764-767 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:782
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:768-773
   Row { path: &[3, 2, 9, 1], kind: K::Iso },           // DJI.pm:774
   Row { path: &[3, 2, 10, 1], kind: K::ShutterSpeed }, // DJI.pm:775-779
@@ -371,6 +390,7 @@ static MAVIC4: &[Row] = &[
   Row { path: &[2, 3, 1], kind: K::FrameWidth },       // DJI.pm:814-817 FrameInfo
   Row { path: &[2, 3, 2], kind: K::FrameHeight },
   Row { path: &[2, 3, 3], kind: K::FrameRate },
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:833
   Row { path: &[3, 1, 2], kind: K::TimeStamp },        // DJI.pm:818-823
   Row { path: &[3, 2, 9, 1], kind: K::Iso },           // DJI.pm:826
   Row { path: &[3, 2, 10, 1], kind: K::ShutterSpeed }, // DJI.pm:827-831
@@ -393,6 +413,7 @@ static MAVIC4: &[Row] = &[
 static MINI5PRO: &[Row] = &[
   Row { path: &[1, 1, 5], kind: K::SerialNumber },     // DJI.pm:850
   Row { path: &[1, 1, 10], kind: K::Model },           // DJI.pm:851
+  Row { path: &[3, 1, 1], kind: K::FrameNumber },      // DJI.pm:868 (NC)
   Row { path: &[3, 2, 37, 1], kind: K::Temperature },  // DJI.pm:852
   Row { path: &[3, 3, 4, 1, 1], kind: K::CoordinateUnits }, // DJI.pm:853-857 GPSInfo
   Row { path: &[3, 3, 4, 1, 2], kind: K::GpsLatitude },

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -13373,6 +13373,10 @@ fn dji_push_sample_tags(
   if let Some(r) = s.frame_rate() {
     push(scratch, "FrameRate", TagValue::F64(r));
   }
+  // ── FrameNumber (3-1-1) — Format => 'unsigned', no conv ⇒ raw integer ────
+  if let Some(fno) = s.frame_number() {
+    push(scratch, "FrameNumber", TagValue::U64(fno));
+  }
   // ── TimeStamp (3-1-2) — ValueConv `$val / 1e6` seconds, raw number ───────
   if let Some(us) = s.time_stamp_us() {
     #[allow(clippy::cast_precision_loss)]

--- a/src/metadata/dji_protobuf.rs
+++ b/src/metadata/dji_protobuf.rs
@@ -350,6 +350,10 @@ pub struct DjiTelemetrySample {
   /// `TimeStamp` microsecond counter (Avata 2 / Mavic 3 Pro / 4 Pro
   /// etc.; DJI.pm:430-432).
   time_stamp_us: Option<u64>,
+  /// `FrameNumber` (`3-1-1`) — a `Format => 'unsigned'` per-frame counter
+  /// declared on all 16 protocol arms (DJI.pm:279 etc., `#forum17996`). No
+  /// ValueConv/PrintConv ⇒ the raw varint, emitted as `Protobuf:DJI:FrameNumber`.
+  frame_number: Option<u64>,
   /// `ISO` (float in the wire).
   iso: Option<f64>,
   /// `ShutterSpeed` seconds — a `Format => 'rational'` reading (the num/den
@@ -432,6 +436,7 @@ impl DjiTelemetrySample {
       gps_date_time: None,
       synth_gps_date_time: None,
       time_stamp_us: None,
+      frame_number: None,
       iso: None,
       shutter_speed_s: None,
       f_number: None,
@@ -539,6 +544,13 @@ impl DjiTelemetrySample {
   #[must_use]
   pub const fn time_stamp_us(&self) -> Option<u64> {
     self.time_stamp_us
+  }
+
+  /// `FrameNumber` (`3-1-1`) — the raw `Format => 'unsigned'` per-frame counter.
+  #[inline(always)]
+  #[must_use]
+  pub const fn frame_number(&self) -> Option<u64> {
+    self.frame_number
   }
 
   /// `ISO`.
@@ -746,6 +758,7 @@ impl DjiTelemetrySample {
       && self.relative_altitude_m.is_none()
       && self.gps_date_time.is_none()
       && self.time_stamp_us.is_none()
+      && self.frame_number.is_none()
       && self.iso.is_none()
       && self.shutter_speed_s.is_none()
       && self.f_number.is_none()
@@ -811,6 +824,11 @@ impl DjiTelemetrySample {
   #[inline(always)]
   pub(crate) const fn set_time_stamp_us(&mut self, v: Option<u64>) -> &mut Self {
     self.time_stamp_us = v;
+    self
+  }
+  #[inline(always)]
+  pub(crate) const fn set_frame_number(&mut self, v: Option<u64>) -> &mut Self {
+    self.frame_number = v;
     self
   }
   #[inline(always)]
@@ -1355,6 +1373,7 @@ mod tests {
     s.set_relative_altitude_m(Some(50.2));
     s.set_gps_date_time(Some(SmolStr::from("2025:01:15 12:34:56")));
     s.set_time_stamp_us(Some(1_234_567_890));
+    s.set_frame_number(Some(4242));
     s.set_iso(Some(100.0));
     s.set_shutter_speed_s(Some(RationalValue::Num(1.0 / 60.0)));
     s.set_f_number(Some(RationalValue::Num(2.8)));
@@ -1377,6 +1396,7 @@ mod tests {
     assert_eq!(s.relative_altitude_m(), Some(50.2));
     assert_eq!(s.gps_date_time(), Some("2025:01:15 12:34:56"));
     assert_eq!(s.time_stamp_us(), Some(1_234_567_890));
+    assert_eq!(s.frame_number(), Some(4242));
     assert_eq!(s.iso(), Some(100.0));
     assert_eq!(s.shutter_speed_s(), Some(1.0 / 60.0));
     assert_eq!(s.f_number(), Some(2.8));


### PR DESCRIPTION
ExifTool 13.59 (DJI.pm v1.19, forum17996) added `FrameNumber` (Format=>'unsigned', no conversion) at protobuf path `3-1-1` to 16 DJI protocols (ac203/204/206, AVATA2, wm265e, pm320, Mini4_Pro, dji_neo, Air3/3s, oq101, PP-101, wa345e, wm261, Mavic4, Mini5Pro). It's a **per-frame/timed** value (in the per-frame `3-1` message next to TimeStamp `3-1-2`).

Added `Row{path:[3,1,1], kind:FrameNumber}` to all 16 protocol tables (the path-sort invariant holds), `FieldKind::FrameNumber` + the `varint→set_frame_number` decode (mirrors TimeStamp), `DjiTelemetrySample::frame_number`, and the per-sample Doc<N> emit (raw integer, no conv). Table + unit-test only — the only DJI telemetry fixture is text-format (no protobuf), so no golden gains it and all goldens are byte-identical. 2 unit tests (the 3-1-1→FrameNumber mapping on all 16 + per-sample decode).

`build(-Dwarnings)=0 conformance=447/0 typed_serde=567 lib(189 DJI)+3`. **Codex review: APPROVE.** Closes #359.