### PR TITLE
feat(exif): Composite Flash/LensID/DateTimeCreated + PrintIM parser — un-exclude from the Pentax fixtures (#381)

### DIFF
--- a/src/composite/convs/exif/mod.rs
+++ b/src/composite/convs/exif/mod.rs
@@ -255,5 +255,59 @@ pub(crate) fn print_megapixels(val: f64) -> String {
   format!("{val:.prec$}")
 }
 
+/// The complete `%Image::ExifTool::Exif::flash` enumerated hash (Exif.pm:175-
+/// 209), ported key-for-key — the table `Composite:Flash`'s PrintConv references
+/// (`PrintConv => \%Image::ExifTool::Exif::flash`, XMP.pm:2834). A faithful copy
+/// is kept here (the same value the EXIF `Flash` leaf and `h264::flash_print_conv`
+/// render) to avoid cross-feature table plumbing — `crate::exif::tables::FLASH`
+/// is `exif`-private and the `xmp`/`exif` features are independent.
+#[cfg(feature = "alloc")]
+const FLASH: &[(i64, &str)] = &[
+  (0x00, "No Flash"),
+  (0x01, "Fired"),
+  (0x05, "Fired, Return not detected"),
+  (0x07, "Fired, Return detected"),
+  (0x08, "On, Did not fire"),
+  (0x09, "On, Fired"),
+  (0x0d, "On, Return not detected"),
+  (0x0f, "On, Return detected"),
+  (0x10, "Off, Did not fire"),
+  (0x14, "Off, Did not fire, Return not detected"),
+  (0x18, "Auto, Did not fire"),
+  (0x19, "Auto, Fired"),
+  (0x1d, "Auto, Fired, Return not detected"),
+  (0x1f, "Auto, Fired, Return detected"),
+  (0x20, "No flash function"),
+  (0x30, "Off, No flash function"),
+  (0x41, "Fired, Red-eye reduction"),
+  (0x45, "Fired, Red-eye reduction, Return not detected"),
+  (0x47, "Fired, Red-eye reduction, Return detected"),
+  (0x49, "On, Red-eye reduction"),
+  (0x4d, "On, Red-eye reduction, Return not detected"),
+  (0x4f, "On, Red-eye reduction, Return detected"),
+  (0x50, "Off, Red-eye reduction"),
+  (0x58, "Auto, Did not fire, Red-eye reduction"),
+  (0x59, "Auto, Fired, Red-eye reduction"),
+  (0x5d, "Auto, Fired, Red-eye reduction, Return not detected"),
+  (0x5f, "Auto, Fired, Red-eye reduction, Return detected"),
+];
+
+/// `Composite:Flash`'s PrintConv (`PrintConv => \%Image::ExifTool::Exif::flash`,
+/// XMP.pm:2834) on the composite's numeric `$val` (the assembled bitmask).
+///
+/// The XMP Flash composite carries `PrintHex => 1` (XMP.pm:2820), so a value
+/// absent from `%flash` renders `sprintf('Unknown (0x%x)', $val)` (ExifTool.pm:
+/// 3623-3627) — the same `Conv::IntLabelHex` fallback the EXIF `Flash` leaf uses.
+/// `$val` is the non-negative bitmask the ValueConv built (`0..=0x7f`), so the
+/// lowercase-hex `{:x}` matches Perl's unsigned `%x`.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub(crate) fn flash_print_conv(code: i64) -> std::string::String {
+  match FLASH.iter().find(|(k, _)| *k == code) {
+    Some((_, label)) => (*label).to_string(),
+    None => std::format!("Unknown (0x{code:x})"),
+  }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/composite/table.rs
+++ b/src/composite/table.rs
@@ -367,6 +367,23 @@ pub(crate) enum CompositePrintConv {
   /// degrees, identity PrintConv (no PrintConv on the def), so BOTH modes emit
   /// the bare numeric angle (`0`/`90`/`180`/`270`).
   Rotation,
+  /// `Composite:Flash` PrintConv (`PrintConv => \%Image::ExifTool::Exif::flash`,
+  /// XMP.pm:2834) — the `%flash` enumerated label under `-j` (`Off, Did not
+  /// fire`); the bare numeric `$val` (the assembled bitmask, e.g. `16`) under
+  /// `-n`. A value absent from `%flash` renders `Unknown (0x%x)` (`PrintHex`).
+  Flash,
+  /// `Composite:LensID` PrintConv (Exif.pm:5341 `PrintLensID(...)`) for the
+  /// UNAMBIGUOUS-LensType case (the Pentax bodies): the resolved lens name IS the
+  /// LensType's own PrintConv value `$prt[0]` (a single `%pentaxLensTypes` hit,
+  /// no `.1` collision / converter), so PrintConv renders `$prt[0]` under `-j`;
+  /// the ValueConv `$val` (`= $val[0]`, the raw LensType value e.g. `"8 61"`)
+  /// under `-n`. See [`lens_id`] for the build guard that restricts the def to
+  /// this case (the ambiguous / non-HASH / cross-vendor-DB paths stay deferred).
+  LensId,
+  /// `Composite:DateTimeCreated` PrintConv (`$self->ConvertDateTime($val)`,
+  /// IPTC.pm:953) — the identity at exifast's option set, in BOTH modes (the
+  /// RawConv-assembled `Text` `"$DateCreated $TimeCreated"`).
+  DateTimeCreated,
 }
 
 impl CompositePrintConv {
@@ -644,6 +661,48 @@ impl CompositePrintConv {
         let n = raw.as_num().unwrap_or(f64::NAN);
         TagValue::F64(n)
       }
+      CompositePrintConv::Flash => {
+        // `$val` is the assembled bitmask (`Num`). `-n` the bare f64; `-j` the
+        // `%flash` enumerated label (`PrintHex` `Unknown (0x%x)` on a miss).
+        let n = raw.as_num().unwrap_or(f64::NAN);
+        match mode {
+          ConvMode::ValueConv => TagValue::F64(n),
+          ConvMode::PrintConv => {
+            TagValue::Str(crate::composite::convs::exif::flash_print_conv(n as i64).into())
+          }
+        }
+      }
+      CompositePrintConv::LensId => {
+        // The UNAMBIGUOUS Pentax-LensType case: `Composite:LensID`'s ValueConv is
+        // `$val` (`= $val[0]`, the raw LensType, carried as `Scalar`), and the
+        // resolved lens name IS the LensType's own PrintConv value `$prt[0]`
+        // (`PrintLensID` returns `$$printConv{$lensType}` for a single hit). So
+        // `-n` emits the raw LensType scalar verbatim; `-j` emits `$prt[0]`.
+        let CompositeRaw::Scalar(v) = raw else {
+          return TagValue::Str(Default::default());
+        };
+        match mode {
+          ConvMode::ValueConv => v.clone(),
+          ConvMode::PrintConv => prts
+            .first()
+            .and_then(Option::as_ref)
+            .cloned()
+            .unwrap_or_else(|| v.clone()),
+        }
+      }
+      CompositePrintConv::DateTimeCreated => {
+        // ValueConv == PrintConv (ConvertDateTime is the identity here) — the
+        // RawConv `"$DateCreated $TimeCreated"` `Text` in both modes.
+        let CompositeRaw::Text(s) = raw else {
+          return TagValue::Str(Default::default());
+        };
+        match mode {
+          ConvMode::ValueConv => TagValue::Str(s.as_str().into()),
+          ConvMode::PrintConv => {
+            TagValue::Str(crate::composite::convs::datetime::convert_date_time(s).into())
+          }
+        }
+      }
     }
   }
 }
@@ -807,6 +866,22 @@ const fn qt_req(name: &'static str) -> CompositeInput {
     kind: InputKind::Require,
     groups: &[],
     group0: Some("QuickTime"),
+    name,
+  }
+}
+
+/// `Desire`d input qualified by family-0 `"XMP"` (ExifTool's `Desire =>
+/// 'XMP:FlashFired'` / `'XMP:Flash'`, XMP.pm:2812-2817) — matches an XMP tag in
+/// ANY `XMP-*` family-1 group (every XMP namespace carries family-0 `XMP`,
+/// family-1 the namespace group `XMP-exif`/`XMP-aux`/…). The family-1 set is
+/// empty (any), the family-0 qualifier restricts to XMP so a same-named EXIF /
+/// MakerNote leaf does not satisfy it.
+#[cfg(feature = "exif")]
+const fn xmp_des(name: &'static str) -> CompositeInput {
+  CompositeInput {
+    kind: InputKind::Desire,
+    groups: &[],
+    group0: Some("XMP"),
     name,
   }
 }
@@ -1183,6 +1258,294 @@ fn aperture(
   }
   // `($val[0] || $val[1]) ? $val : undef` — neither truthy ⇒ undef.
   None
+}
+
+/// One Flash ingredient `$val[i]` as the XMP-Flash ValueConv reads it — either a
+/// directly-resolved flat `XMP:FlashFired`/… (the `$val[0..4]` Desires) or a
+/// field copied OUT of the structured `XMP:Flash` HASH (`$val[5]{Fired}`/…). The
+/// bit math interprets BOOLEAN fields as `lc($val) eq 'true'` and the NUMERIC
+/// fields (`Return`/`Mode`) via Perl `($val || 0) << n` — so each ingredient is
+/// the RAW (ValueConv) text it carries (`"True"`/`"False"`, `"0"`/`"2"`).
+///
+/// `$val[5]{$_}` copies the struct field's RAW (post-ValueConv) value; the
+/// XMP-exif Flash struct's `Fired`/`Function`/`RedEyeMode` are `Writable =>
+/// 'boolean'` with a PrintConv-only `%boolConv` (so their ValueConv value is the
+/// literal `"True"`/`"False"`), and `Return`/`Mode` are `Writable => 'integer'`
+/// (ValueConv `"0"`/`"2"`). exifast stores every XMP scalar as a `Str`, so a
+/// resolved ingredient is read as its `value_text`.
+#[cfg(feature = "exif")]
+fn flash_field_truthy_true(text: Option<&str>) -> bool {
+  // `$val[i] and lc($val[i]) eq 'true'` (XMP.pm:2828-2832) — a present field
+  // equal (case-insensitively) to "true". A `Missing`/`undef` field is false.
+  text.is_some_and(|s| s.eq_ignore_ascii_case("true"))
+}
+
+/// Perl `($val[i] || 0) << shift` (XMP.pm:2829-2830) on a Flash NUMERIC field
+/// (`Return`/`Mode`). The Perl `||` yields the FIRST truthy operand: a present
+/// Perl-truthy field is numified (its leading numeric prefix), otherwise `0`. A
+/// string `"0"` is Perl-FALSY, so it contributes `0`; `"2"` numifies to `2`.
+#[cfg(feature = "exif")]
+fn flash_field_shifted(text: Option<&str>, shift: u32) -> i64 {
+  let n = match text {
+    // `$val[i] || 0` — a Perl-FALSY field (`""`, `"0"`, `"0.0"` numeric-zero,
+    // undef) takes the `0`; a truthy field numifies to its leading float.
+    Some(s) if crate::convert::perl_boolean_truthy(&TagValue::Str(s.into())) => {
+      crate::convert::perl_str_to_f64(s) as i64
+    }
+    _ => 0,
+  };
+  n << shift
+}
+
+/// `Composite:Flash` ValueConv (XMP.pm:2823-2833) — assemble the EXIF Flash
+/// bitmask from the XMP flash fields. `$val[0..4]` are the flat
+/// `XMP:FlashFired`/`FlashReturn`/`FlashMode`/`FlashFunction`/`FlashRedEyeMode`
+/// Desires; `$val[5]` is the structured `XMP:Flash` HASH. When `$val[5]` is a
+/// HASH its `Fired`/`Return`/`Mode`/`Function`/`RedEyeMode` fields OVERRIDE
+/// `$val[0..4]` (XMP.pm:2824-2827):
+///
+/// ```perl
+/// if (ref $val[5] eq 'HASH') {
+///     my $i = 0;
+///     $val[$i++] = $val[5]{$_} foreach qw(Fired Return Mode Function RedEyeMode);
+/// }
+/// return((($val[0] and lc($val[0]) eq 'true') ? 0x01 : 0) |
+///        (($val[1] || 0) << 1) |
+///        (($val[2] || 0) << 3) |
+///        (($val[3] and lc($val[3]) eq 'true') ? 0x20 : 0) |
+///        (($val[4] and lc($val[4]) eq 'true') ? 0x40 : 0));
+/// ```
+///
+/// The result is the EXIF Flash bitmask (`Num`), rendered via the `%flash`
+/// PrintConv. The composite has NO `RawConv` guard, so it ALWAYS builds when the
+/// engine attempts it — but the Desires are ALL `Desire`, so with no XMP flash
+/// field present every operand is `0` and `$val == 0` (`"No Flash"`).
+#[cfg(feature = "exif")]
+fn composite_flash(
+  v: &[CompositeValue],
+  _prts: &[Option<TagValue>],
+  _ctx: &CompositeContext,
+) -> Option<CompositeRaw> {
+  // `$val[5]` — the structured `XMP:Flash`. When it is a HASH (a `Map`), its
+  // fields OVERRIDE the flat `$val[0..4]`; otherwise (a scalar `XMP:Flash` like
+  // the `exif:Flash=5` integer, or absent) the flat fields stand.
+  let flash_struct = v.get(5).and_then(CompositeValue::value).and_then(|val| {
+    if let TagValue::Map(fields) = val {
+      Some(fields)
+    } else {
+      None
+    }
+  });
+  // Resolve each of the five fields: the struct field (if `$val[5]` is a HASH),
+  // else the flat `$val[i]` ingredient. Returns the field's RAW text.
+  let field = |i: usize, key: &str| -> Option<std::string::String> {
+    if let Some(fields) = flash_struct {
+      fields
+        .iter()
+        .find(|(k, _)| k.as_str() == key)
+        .map(|(_, fv)| crate::composite::value_text(fv).into_owned())
+    } else {
+      v.get(i)
+        .and_then(CompositeValue::as_text)
+        .map(|c| c.into_owned())
+    }
+  };
+  // ExifTool's `BuildCompositeTags` `$found` gate (ExifTool.pm:4082-4095): an
+  // all-`Desire` composite is built ONLY when AT LEAST ONE input is present
+  // (`defined $$rawValue{$reqTag}` for some index sets `$found = 1`). The
+  // XMP-Flash ValueConv has no `? : undef` guard (it always returns a bitmask),
+  // so WITHOUT this gate it would synthesize `Composite:Flash = 0` ("No Flash")
+  // for EVERY file with no XMP flash data (every AIFF/APE/…). Mirror the gate
+  // here: no present input ⇒ `None` ⇒ not built. (For `XMP_exif_printconv.xmp`
+  // a SCALAR `XMP:Flash=5` IS present — `$val[5]` resolves — so it builds and
+  // yields `0`/"No Flash", matching bundled, since the scalar is not a HASH and
+  // the flat `$val[0..4]` are absent.)
+  if v.iter().all(|input| !input.is_present()) {
+    return None;
+  }
+  let fired = field(0, "Fired");
+  let ret = field(1, "Return");
+  let mode = field(2, "Mode");
+  let function = field(3, "Function");
+  let red_eye = field(4, "RedEyeMode");
+
+  let bits = (if flash_field_truthy_true(fired.as_deref()) {
+    0x01
+  } else {
+    0
+  }) | flash_field_shifted(ret.as_deref(), 1)
+    | flash_field_shifted(mode.as_deref(), 3)
+    | (if flash_field_truthy_true(function.as_deref()) {
+      0x20
+    } else {
+      0
+    })
+    | (if flash_field_truthy_true(red_eye.as_deref()) {
+      0x40
+    } else {
+      0
+    });
+  Some(CompositeRaw::Num(bits as f64))
+}
+
+/// `Composite:LensID` ValueConv (Exif.pm:5337 `$val`) + RawConv guard
+/// (Exif.pm:5325-5332), the UNAMBIGUOUS-LensType subset.
+///
+/// ExifTool's `Composite:LensID` `Require`s `LensType` and renders
+/// `PrintLensID($self, $prt[0], $pcv, $prt[8], @val)` (Exif.pm:5353). For a
+/// LensType whose `PrintConv` is a `HASH` and resolves to a SINGLE unambiguous
+/// lens (no `"$lensType.1"` collision, no Sony LensType2 / Canon RFLensType
+/// branch, no teleconverter), `PrintLensID` returns `$$printConv{$lensType}` —
+/// which IS the LensType's own PrintConv value `$prt[0]`. The ValueConv is the
+/// bare `$val` (`= $val[0]`, the raw LensType, e.g. Pentax `"8 61"`).
+///
+/// exifast's post-pass cannot inspect the LensType `PrintConv` ref or run the
+/// full `PrintLensID` lens-DB / focal-length disambiguation, so this derive
+/// ports ONLY the case the resolved data already settles: BUILD iff the
+/// PrintConv-view `$prt[0]` is a CONFIRMED resolved lens NAME — it contains a
+/// focal-length / aperture token (`mm` or `\d/F`, mirroring the RawConv's
+/// `$val[0] =~ /(mm|\d\/F)/`) AND is NOT an AMBIGUOUS placeholder (`" or "`, the
+/// `%pentaxLensTypes` "Sigma or Tamron Lens (…)" form) NOR a raw `(N N)`
+/// fallback. In that case the composite's `-j` output == `$prt[0]` and its `-n`
+/// output == `$val[0]` (carried as `Scalar`). Every other LensType (the Nikon
+/// bitfield `"D"`, the ambiguous Pentax `"Sigma or Tamron Lens (3 44)"`, a
+/// vendor LensID needing its own `Canon::PrintLensID` / focal-range DB) stays
+/// DEFERRED — the derive returns `None`, so no wrong `Composite:LensID` is
+/// emitted (those fixtures' goldens keep `Composite:LensID` excluded).
+///
+/// A VENDOR DISAMBIGUATOR also forces deferral: ExifTool's PrintConv
+/// (Exif.pm:5335-5366) does NOT simply key off `$val[0]`/`$prt[0]` when a
+/// Sony LensType2 (`$val[9]`), Canon RFLensType (`$val[12]`), or Pentax
+/// converter (`$val[11]`+`$val[1]`) ingredient is present and active — it
+/// SUBSTITUTES the LensType2/LensType3/RFLensType base (a different lens-DB
+/// lookup) or APPENDS a `+ Nx converter` suffix. exifast can't reproduce those
+/// vendor-DB / suffix branches, so when any of them FIRES (see
+/// [`lens_id_disambiguator_active`]) the derive returns `None` rather than
+/// emit the stale plain-LensType name. The branch GUARDS are mirrored exactly,
+/// so a present-but-inactive disambiguator (Canon RFLensType `0` = "n/a", a
+/// Sony LensType2 that fails the `0x8000`/`0` mask) does NOT defer — the
+/// unambiguous Pentax/Samsung path (those ingredients absent/inactive) still
+/// emits byte-identically.
+#[cfg(feature = "exif")]
+fn lens_id(
+  v: &[CompositeValue],
+  prts: &[Option<TagValue>],
+  _ctx: &CompositeContext,
+) -> Option<CompositeRaw> {
+  // `$val[0]` — the raw LensType (the `Require`d input). Absent ⇒ no build.
+  let raw_lens_type = v.first()?.value()?.clone();
+  // A vendor disambiguator (Sony LensType2 / Canon RFLensType / Pentax
+  // converter) that ExifTool's PrintConv would act on ⇒ the LensID is NOT the
+  // plain LensType name; defer rather than mis-emit a stale value.
+  if lens_id_disambiguator_active(v) {
+    return None;
+  }
+  // `$prt[0]` — the LensType PrintConv value (the resolved lens name candidate).
+  let name = prts.first().and_then(Option::as_ref)?;
+  let name_text = crate::composite::value_text(name);
+  // Confirmed resolved lens name: carries a focal-length / aperture token
+  // (`PrintLensID`'s lens-name shape) AND is not an ambiguity placeholder.
+  if !lens_name_is_resolved(&name_text) {
+    return None;
+  }
+  // ValueConv `$val` = `$val[0]` (raw LensType) carried verbatim; the PrintConv
+  // renders `$prt[0]` (= `name`).
+  Some(CompositeRaw::Scalar(raw_lens_type))
+}
+
+/// Does a vendor disambiguator ingredient FIRE one of ExifTool's
+/// `Composite:LensID` PrintConv branches (Exif.pm:5335-5366), making the LensID
+/// something other than the plain LensType name?
+///
+/// The compact input layout (see [`LENS_ID`]) is `[0]`=LensType,
+/// `[1]`=FocalLength, `[2]`=LensType2, `[3]`=LensType3, `[4]`=LensFocalLength,
+/// `[5]`=RFLensType — each carrying the RAW (ValueConv) `$val[i]`, exactly what
+/// the Perl branches test. The three branches, mirrored:
+///
+/// * Sony LensType2 (`if (defined $val[9] and ($val[9] & 0x8000 or $val[9] ==
+///   0))`, :5338): substitutes the LensType2/LensType3 base + PrintConv ⇒
+///   different lens DB. Fires when LensType2 is present and its integer value
+///   has bit `0x8000` set OR is `0`.
+/// * Canon RFLensType (`if ($val[12])`, :5350): substitutes the RFLensType
+///   base ⇒ Canon RF DB. Fires when RFLensType is present and TRUTHY (a `0` /
+///   "n/a" RFLensType is falsy ⇒ does NOT fire — the `CanonRaw_ctmd.cr3`
+///   fixture's `RFLensType=0` keeps its plain-LensType LensID).
+/// * Pentax converter (Exif.pm:5357-5361): the `+ Nx converter` suffix is
+///   appended by `$lens .= sprintf(' + %.1fx converter', $conv) if $conv > 1.1`
+///   where `$conv = $val[1] / $val[11]` (FocalLength / LensFocalLength), guarded
+///   by `if ($val[11] and $val[1] and $lens)`. So a real teleconverter is
+///   detected ONLY when both are truthy AND that ratio exceeds 1.1; this defers
+///   exactly then. A bare lens with `LensFocalLength` ≈ `FocalLength` (ratio
+///   ≤ 1.1, e.g. the `JPEG_pentax_k70` 28/27.5 = 1.018) appends NOTHING and
+///   stays the plain byte-exact name.
+#[cfg(feature = "exif")]
+fn lens_id_disambiguator_active(v: &[CompositeValue]) -> bool {
+  // Sony LensType2 (`$val[9]`): present AND (bit 0x8000 set OR == 0).
+  let lens_type2_fires = v.get(2).is_some_and(|lt2| {
+    lt2
+      .coerce_numeric()
+      .is_some_and(|n| (n as i64) & 0x8000 != 0 || (n as i64) == 0)
+  });
+  // Canon RFLensType (`$val[12]`): present AND truthy (Perl `if ($val[12])`).
+  let rf_lens_type_fires = v.get(5).is_some_and(CompositeValue::is_truthy);
+  // Pentax converter: BOTH LensFocalLength (`$val[11]`) and FocalLength
+  // (`$val[1]`) truthy AND `$val[1] / $val[11] > 1.1` (an actual teleconverter).
+  // `coerce_numeric` is the faithful `0 + $val` the Perl division uses.
+  let converter_fires = match (
+    v.get(1).and_then(CompositeValue::coerce_numeric),
+    v.get(4).and_then(CompositeValue::coerce_numeric),
+  ) {
+    (Some(focal), Some(lens_focal))
+      if v.get(1).is_some_and(CompositeValue::is_truthy)
+        && v.get(4).is_some_and(CompositeValue::is_truthy)
+        && lens_focal != 0.0 =>
+    {
+      focal / lens_focal > 1.1
+    }
+    _ => false,
+  };
+  lens_type2_fires || rf_lens_type_fires || converter_fires
+}
+
+/// Is `prt0` (the LensType `$prt[0]`) a CONFIRMED single-lens name — the only
+/// `Composite:LensID` case exifast's resolved-data passthrough handles?
+///
+/// Mirrors the RawConv lens-name shape (`/(mm|\d\/F)/`, Exif.pm:5331) plus the
+/// "unambiguous" requirement `PrintLensID` enforces (it returns the LensType
+/// PrintConv only when there is no `.1` collision): the name must carry a
+/// focal-length / aperture token and must NOT be an AMBIGUOUS placeholder
+/// (`%pentaxLensTypes`'s "X or Y Lens (N N)" form, marked by `" or "`) or a raw
+/// `(N N)`-style unresolved fallback.
+#[cfg(feature = "exif")]
+fn lens_name_is_resolved(prt0: &str) -> bool {
+  // `$val[0] =~ /(mm|\d\/F)/` — a focal-length (`18-55mm`) or `\d/F` aperture
+  // token marks a real lens name (vs the Nikon bitfield `"D"`, `"n/a"`, a bare
+  // numeric raw value).
+  let has_lens_token = prt0.contains("mm")
+    || prt0
+      .as_bytes()
+      .windows(2)
+      .any(|w| w[0].is_ascii_digit() && w[1] == b'/');
+  // An ambiguous `%pentaxLensTypes` value (`"Sigma or Tamron Lens (3 44)"`)
+  // needs `PrintLensID`'s focal-length disambiguation that exifast lacks — defer.
+  let is_ambiguous = prt0.contains(" or ");
+  has_lens_token && !is_ambiguous
+}
+
+/// `Composite:DateTimeCreated` ValueConv (IPTC.pm:952 `"$val[0] $val[1]"`).
+/// `$val[0]`=`IPTC:DateCreated` (Require), `$val[1]`=`IPTC:TimeCreated` (Require)
+/// — concatenated with a single space into the `Text` `$val` (the PrintConv is
+/// `ConvertDateTime`, the identity at exifast's option set). Both inputs are
+/// `Require`d, so the engine only attempts the build when both are present.
+#[cfg(feature = "exif")]
+fn datetime_created(
+  v: &[CompositeValue],
+  _prts: &[Option<TagValue>],
+  _ctx: &CompositeContext,
+) -> Option<CompositeRaw> {
+  let date = v.first()?.as_text()?;
+  let time = v.get(1)?.as_text()?;
+  Some(CompositeRaw::Text(std::format!("{date} {time}")))
 }
 
 /// The shared `%subSecConv` derivation (Exif.pm:4726) for the three SubSec
@@ -1904,6 +2267,82 @@ const APERTURE: CompositeDef = CompositeDef {
   sort_key: "Composite-Aperture",
 };
 
+/// `Composite:Flash` (XMP.pm:2808, the `Image::ExifTool::XMP` Composite table).
+/// `Desire`s the flat `XMP:FlashFired`/`FlashReturn`/`FlashMode`/`FlashFunction`/
+/// `FlashRedEyeMode` (indices 0-4) + the structured `XMP:Flash` (index 5); the
+/// ValueConv [`composite_flash`] assembles the EXIF Flash bitmask, rendered via
+/// the `%flash` PrintConv. All `Desire`, so it builds whenever the engine
+/// attempts it (a file with no XMP flash data yields `0` ⇒ `"No Flash"` — but
+/// such a file has no flash ingredient to trigger the attempt, so none is built).
+#[cfg(feature = "exif")]
+const FLASH: CompositeDef = CompositeDef {
+  name: "Flash",
+  inputs: &[
+    xmp_des("FlashFired"),
+    xmp_des("FlashReturn"),
+    xmp_des("FlashMode"),
+    xmp_des("FlashFunction"),
+    xmp_des("FlashRedEyeMode"),
+    xmp_des("Flash"),
+  ],
+  derive: composite_flash,
+  print_conv: CompositePrintConv::Flash,
+  sub_doc: SubDoc::No,
+  priority: 1,
+  sort_key: "XMP-Flash",
+};
+
+/// `Composite:LensID` (Exif.pm:5303, the `Image::ExifTool::Exif` Composite table).
+/// `Require`s `LensType`; the UNAMBIGUOUS-LensType subset (see [`lens_id`]) builds
+/// the resolved lens name from the LensType PrintConv `$prt[0]` (ValueConv `$val`
+/// = the raw LensType `$val[0]`).
+///
+/// The ExifTool `Desire`s 1-12 (FocalLength/MaxAperture/LensType2/RFLensType/…)
+/// drive `PrintLensID`'s disambiguation / vendor-DB branches. exifast ports only
+/// the plain-LensType case, but it MUST KNOW when a vendor disambiguator is
+/// present so it can DEFER (return `None`) instead of mis-emitting a stale
+/// LensType name (a Canon RFLensType / Sony LensType2 file would otherwise emit
+/// the wrong lens). So the inputs carry the disambiguators the PrintConv
+/// branches on, in a COMPACT internal layout (`lens_id` reads them by THESE
+/// indices, not ExifTool's numbered slots): `[0]`=LensType (Require),
+/// `[1]`=FocalLength, `[2]`=LensType2, `[3]`=LensType3, `[4]`=LensFocalLength,
+/// `[5]`=RFLensType (all Desire). The remaining ExifTool Desires
+/// (MaxAperture/MaxApertureValue/MinFocalLength/MaxFocalLength/LensModel/
+/// LensFocalRange/LensSpec) only feed `PrintLensID`'s lens-DB lookup that this
+/// subset defers wholesale, so they are still omitted.
+#[cfg(feature = "exif")]
+const LENS_ID: CompositeDef = CompositeDef {
+  name: "LensID",
+  inputs: &[
+    bare_req("LensType"),
+    bare_des("FocalLength"),
+    bare_des("LensType2"),
+    bare_des("LensType3"),
+    bare_des("LensFocalLength"),
+    bare_des("RFLensType"),
+  ],
+  derive: lens_id,
+  print_conv: CompositePrintConv::LensId,
+  sub_doc: SubDoc::No,
+  priority: 1,
+  sort_key: "Exif-LensID",
+};
+
+/// `Composite:DateTimeCreated` (IPTC.pm:943, the `Image::ExifTool::IPTC`
+/// Composite table). `Require`s `IPTC:DateCreated` + `IPTC:TimeCreated`;
+/// [`datetime_created`] concatenates them with a space, rendered through
+/// `ConvertDateTime` (the identity at exifast's option set).
+#[cfg(feature = "exif")]
+const DATETIME_CREATED: CompositeDef = CompositeDef {
+  name: "DateTimeCreated",
+  inputs: &[req(&["IPTC"], "DateCreated"), req(&["IPTC"], "TimeCreated")],
+  derive: datetime_created,
+  print_conv: CompositePrintConv::DateTimeCreated,
+  sub_doc: SubDoc::No,
+  priority: 1,
+  sort_key: "IPTC-DateTimeCreated",
+};
+
 /// `Composite:SubSecDateTimeOriginal` (Exif.pm:5164). `Require`s
 /// `EXIF:DateTimeOriginal`, `Desire`s `EXIF:SubSecTimeOriginal` +
 /// `EXIF:OffsetTimeOriginal`; the shared `%subSecConv` assembles the result.
@@ -2241,6 +2680,12 @@ pub(crate) const REGISTRY: &[CompositeDef] = &[
   SHUTTER_SPEED,
   #[cfg(feature = "exif")]
   APERTURE,
+  #[cfg(feature = "exif")]
+  FLASH,
+  #[cfg(feature = "exif")]
+  LENS_ID,
+  #[cfg(feature = "exif")]
+  DATETIME_CREATED,
   #[cfg(feature = "exif")]
   SUBSEC_DATETIME_ORIGINAL,
   #[cfg(feature = "exif")]

--- a/src/composite/tests.rs
+++ b/src/composite/tests.rs
@@ -1667,6 +1667,154 @@ mod exif {
     );
   }
 
+  /// Drive `Composite:LensID` through the registry fixpoint from a `(val, prt)`
+  /// pair of input triples — `val` carries the raw `$val[i]` (LensType + the
+  /// disambiguator ingredients), `prt` the PrintConv `$prt[i]` (the resolved
+  /// lens name). Returns the `-j` (PrintConv) LensID, or `None` when deferred.
+  fn lens_id_pj(
+    val_entries: &[(&str, &str, TagValue)],
+    prt_entries: &[(&str, &str, TagValue)],
+  ) -> Option<String> {
+    let mut prt = map_with(prt_entries);
+    let mut val = map_with(val_entries);
+    build_into(
+      REGISTRY,
+      &mut prt,
+      Some(&mut val),
+      ConvMode::PrintConv,
+      0,
+      &ctx0(),
+    );
+    composite(&prt, "LensID").map(|v| emit(&v))
+  }
+
+  #[test]
+  fn lens_id_unambiguous_lenstype_emits() {
+    // The Samsung NX1 case (`SamsungNX1.srw`): LensType raw 13, PrintConv the
+    // resolved name; NO LensType2 / RFLensType / converter ingredient ⇒ the
+    // plain-LensType path emits the name (ValueConv `$val` = 13, PrintConv the
+    // name). The byte-exact in-tree fixture goldens depend on this still firing.
+    let name = "Samsung NX 16-50mm F2-2.8 S ED OIS";
+    let got = lens_id_pj(
+      &[("Samsung", "LensType", TagValue::U64(13))],
+      &[("Samsung", "LensType", TagValue::Str(name.into()))],
+    );
+    assert_eq!(got.as_deref(), Some(&*std::format!("\"{name}\"")));
+  }
+
+  #[test]
+  fn lens_id_inactive_rf_lens_type_still_emits() {
+    // The `CanonRaw_ctmd.cr3` case: a Canon RFLensType IS present but its RAW
+    // `$val[12]` is `0` (PrintConv "n/a"). ExifTool's `if ($val[12])` is FALSE
+    // (0 is falsy) ⇒ the Canon RF branch does NOT fire ⇒ the plain-LensType
+    // LensID emits (byte-exact with the fixture's "Canon EF-M …" golden).
+    let name = "Canon EF-M 15-45mm f/3.5-6.3 IS STM";
+    let got = lens_id_pj(
+      &[
+        ("Track1", "LensType", TagValue::U64(4153)),
+        ("Track1", "RFLensType", TagValue::U64(0)),
+      ],
+      &[
+        ("Track1", "LensType", TagValue::Str(name.into())),
+        ("Track1", "RFLensType", TagValue::Str("n/a".into())),
+      ],
+    );
+    assert_eq!(got.as_deref(), Some(&*std::format!("\"{name}\"")));
+  }
+
+  #[test]
+  fn lens_id_active_rf_lens_type_defers() {
+    // A Canon RFLensType with a TRUTHY raw `$val[12]` (e.g. 61182) makes
+    // ExifTool substitute the RFLensType base + Canon RF PrintConv — a different
+    // lens DB exifast can't reproduce. The plain LensType name would be STALE,
+    // so the derive defers (returns `None`), emitting no Composite:LensID.
+    let got = lens_id_pj(
+      &[
+        ("Exif", "LensType", TagValue::U64(4153)),
+        ("Exif", "RFLensType", TagValue::U64(61182)),
+      ],
+      &[
+        (
+          "Exif",
+          "LensType",
+          TagValue::Str("Canon EF-M 15-45mm f/3.5-6.3 IS STM".into()),
+        ),
+        (
+          "Exif",
+          "RFLensType",
+          TagValue::Str("Canon RF 24-105mm F4 L IS USM".into()),
+        ),
+      ],
+    );
+    assert_eq!(got, None, "an active RFLensType defers LensID");
+  }
+
+  #[test]
+  fn lens_id_active_lens_type2_defers() {
+    // A Sony LensType2 whose raw `$val[9]` has bit 0x8000 set (an E-mount lens
+    // ID) fires `if (defined $val[9] and ($val[9] & 0x8000 or $val[9] == 0))`:
+    // ExifTool swaps in the LensType2 base + Sony PrintConv. exifast can't, so
+    // it defers. (`$val[9] == 0` — a 3rd-party E-mount — fires the same branch.)
+    let got = lens_id_pj(
+      &[
+        ("Exif", "LensType", TagValue::U64(0)),
+        ("Exif", "LensType2", TagValue::U64(32790)), // 0x8016 — 0x8000 set
+      ],
+      &[
+        (
+          "Exif",
+          "LensType",
+          TagValue::Str("Sony E 18-55mm F3.5-5.6 OSS".into()),
+        ),
+        (
+          "Exif",
+          "LensType2",
+          TagValue::Str("Sony FE 24-70mm F2.8 GM".into()),
+        ),
+      ],
+    );
+    assert_eq!(got, None, "an active LensType2 (0x8000 set) defers LensID");
+  }
+
+  #[test]
+  fn lens_id_pentax_converter_defers() {
+    // The Pentax converter branch appends a `+ Nx converter` suffix only when
+    // `$conv = $val[1] / $val[11] > 1.1` (FocalLength / LensFocalLength). Here
+    // 300 / 200 = 1.5 > 1.1 ⇒ a real teleconverter; ExifTool appends the suffix
+    // exifast can't compute, so the derive defers (no bare name emitted).
+    let got = lens_id_pj(
+      &[
+        ("Exif", "LensType", TagValue::Str("8 61".into())),
+        ("Exif", "FocalLength", TagValue::F64(300.0)),
+        ("Exif", "LensFocalLength", TagValue::F64(200.0)),
+      ],
+      &[(
+        "Exif",
+        "LensType",
+        TagValue::Str("smc PENTAX-DA* 200mm F2.8 ED [IF] SDM".into()),
+      )],
+    );
+    assert_eq!(got, None, "a >1.1 converter ratio defers LensID");
+  }
+
+  #[test]
+  fn lens_id_pentax_no_converter_ratio_still_emits() {
+    // The `JPEG_pentax_k70` case: BOTH LensFocalLength and FocalLength present
+    // but their ratio is ≈ 1 (28 / 27.5 = 1.018, NOT > 1.1) ⇒ ExifTool appends
+    // NOTHING ⇒ the plain LensType name emits, byte-exact with the fixture's
+    // golden. A present-but-inactive converter must NOT defer.
+    let name = "smc PENTAX-DA 18-135mm F3.5-5.6 ED AL [IF] DC WR";
+    let got = lens_id_pj(
+      &[
+        ("Pentax", "LensType", TagValue::Str("8 215".into())),
+        ("Pentax", "FocalLength", TagValue::F64(28.0)),
+        ("Pentax", "LensFocalLength", TagValue::F64(27.5)),
+      ],
+      &[("Pentax", "LensType", TagValue::Str(name.into()))],
+    );
+    assert_eq!(got.as_deref(), Some(&*std::format!("\"{name}\"")));
+  }
+
   #[test]
   fn focal_length_35efl_falls_back_to_focal_only_without_scale_factor() {
     // ExifGPS.jpg: FocalLength=0, no FocalLengthIn35mmFormat ⇒ ScaleFactor NOT

--- a/src/exif/jpeg.rs
+++ b/src/exif/jpeg.rs
@@ -226,6 +226,10 @@ pub fn parse_jpeg_exif_with_base(data: &[u8], base_offset: usize) -> Option<Exif
   // the MakerNote for JPEGs exactly as for a standalone TIFF (the seam #75+
   // consume). First-wins matches bundled keeping the PRIMARY MakerNote.
   let mut maker_note: Option<MakerNote<'_>> = None;
+  // The PrintIM versions (IFD0 `0xc4a5`) accumulated across the merged `APP1`
+  // Exif blocks — a JPEG carries its PrintIM in the `APP1` Exif block's IFD0, so
+  // the merge must preserve it (the engine emits `PrintIM:PrintIMVersion`).
+  let mut printim_versions: Vec<smol_str::SmolStr> = Vec::new();
   // The embedded XMP packet decoded from a JPEG `APP1` "XMP" segment
   // (`ExifTool.pm:7794`, the `$$valPt =~ /^$xmpAPP1hdr/` → `ProcessXMP` arm). A
   // JPEG normally carries exactly one; a file with more than one is handled by
@@ -497,6 +501,7 @@ pub fn parse_jpeg_exif_with_base(data: &[u8], base_offset: usize) -> Option<Exif
             &mut warnings_ignorable,
             &mut byte_order,
             &mut maker_note,
+            &mut printim_versions,
             exif,
           );
         }
@@ -543,6 +548,7 @@ pub fn parse_jpeg_exif_with_base(data: &[u8], base_offset: usize) -> Option<Exif
     warnings_ignorable,
     byte_order,
     maker_note,
+    printim_versions,
   );
   // The JPEG auxiliary `APP`-segment tags: JFIF (`APP0`), MPF (`APP2`) and the
   // DJI thermal arms (`APP3`/`APP4`/`APP5`/`APP7`). Decoded for BOTH print-conv
@@ -1167,10 +1173,17 @@ fn merge_exif_block<'a>(
   warnings_ignorable: &mut Vec<u8>,
   byte_order: &mut Option<ByteOrder>,
   maker_note: &mut Option<MakerNote<'a>>,
+  printim_versions: &mut Vec<smol_str::SmolStr>,
   block: ExifMeta<'a>,
 ) {
-  let (block_entries, block_warnings, block_warnings_ignorable, block_order, block_maker_note) =
-    block.into_jpeg_parts();
+  let (
+    block_entries,
+    block_warnings,
+    block_warnings_ignorable,
+    block_order,
+    block_maker_note,
+    block_printim_versions,
+  ) = block.into_jpeg_parts();
   if byte_order.is_none() {
     *byte_order = block_order;
   }
@@ -1183,6 +1196,9 @@ fn merge_exif_block<'a>(
   warnings.extend(block_warnings);
   // Keep the parallel ignorable levels index-aligned with `warnings`.
   warnings_ignorable.extend(block_warnings_ignorable);
+  // The PrintIM versions accumulate across blocks (in block order), faithful to
+  // ExifTool emitting each PrintIM's `PrintIMVersion` as the IFD walk reaches it.
+  printim_versions.extend(block_printim_versions);
 }
 
 /// `true` when `block` begins with a BigTIFF header — a valid TIFF byte-order

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -98,6 +98,9 @@ mod jpeg_app;
 // JPEG IPTC (APP13 8BIM IIM) + the `COM` `File:Comment` — the Photoshop / IPTC
 // arm of `ProcessJPEG` and the IPTC IIM walker (`IPTC.pm`/`Photoshop.pm`).
 mod iptc;
+// PrintIM (Print Image Matching) — the EXIF IFD0 `0xc4a5` SubDirectory reader
+// (`PrintIM.pm`'s `ProcessPrintIM`), emitting `PrintIM:PrintIMVersion`.
+mod printim;
 
 use std::{string::String, vec::Vec};
 
@@ -1706,6 +1709,12 @@ pub struct ExifMeta<'a> {
   /// parsing is deferred to the MakerNotes wave. Borrows from the input
   /// TIFF block — the sole reason `ExifMeta` carries a lifetime.
   maker_note: Option<MakerNote<'a>>,
+  /// The `PrintIMVersion` strings parsed from each PrintIM (`0xc4a5`)
+  /// SubDirectory the IFD walk reached (`PrintIM.pm`'s `ProcessPrintIM`), in walk
+  /// order. [`Taggable::tags`](crate::emit::Taggable::tags) emits each as a
+  /// `PrintIM:PrintIMVersion` tag ([`push_printim_tags`](Self::push_printim_tags)).
+  /// EMPTY for the common no-PrintIM case.
+  printim_versions: Vec<smol_str::SmolStr>,
   /// The synthesized `File:PageCount` value when this `ExifMeta` is the
   /// outer result of a standalone-TIFF walk that triggered the multi-page
   /// gate (`ExifTool.pm:8756-8757`). `Some(n)` ⇒ `serialize_tags` emits
@@ -2083,6 +2092,7 @@ impl<'a> ExifMeta<'a> {
     warnings_ignorable: Vec<u8>,
     byte_order: Option<ByteOrder>,
     maker_note: Option<MakerNote<'a>>,
+    printim_versions: Vec<smol_str::SmolStr>,
   ) -> Self {
     // JPEG `APP1` Exif blocks come through `ProcessTIFF` with
     // `Parent='APP1'` (`ExifTool.pm:7779-7783`), so `TIFF_TYPE='APP1'` and
@@ -2094,6 +2104,7 @@ impl<'a> ExifMeta<'a> {
       warnings,
       warnings_ignorable,
       byte_order,
+      printim_versions,
       maker_note,
       multi_page_count: None,
       // The SOF dimension tags are attached AFTER construction by the JPEG
@@ -2310,12 +2321,13 @@ impl<'a> ExifMeta<'a> {
       })
   }
 
-  /// Decompose this `ExifMeta` into `(entries, warnings, byte_order,
-  /// maker_note)` — the inverse of [`from_jpeg_parts`](Self::from_jpeg_parts),
-  /// used by the JPEG front-end to merge one decoded `APP1` Exif block into
-  /// the accumulating JPEG-level parts. The `MakerNote` borrows from the input
-  /// TIFF block (the `'a` lifetime), so it threads through the merge unchanged.
-  /// (`pub(crate)`: a merge-time internal, not API surface.)
+  /// Decompose this `ExifMeta` into `(entries, warnings, warnings_ignorable,
+  /// byte_order, maker_note, printim_versions)` — the inverse of
+  /// [`from_jpeg_parts`](Self::from_jpeg_parts), used by the JPEG front-end to
+  /// merge one decoded `APP1` Exif block into the accumulating JPEG-level parts.
+  /// The `MakerNote` borrows from the input TIFF block (the `'a` lifetime), so
+  /// it threads through the merge unchanged. (`pub(crate)`: a merge-time
+  /// internal, not API surface.)
   #[must_use]
   pub(crate) fn into_jpeg_parts(
     self,
@@ -2325,17 +2337,21 @@ impl<'a> ExifMeta<'a> {
     Vec<u8>,
     Option<ByteOrder>,
     Option<MakerNote<'a>>,
+    Vec<smol_str::SmolStr>,
   ) {
     // `multi_page_count` is dropped — the JPEG-merge path constructs the
     // merged `ExifMeta` via `from_jpeg_parts`, which always sets
     // `multi_page_count = None` (`Parent='APP1'`, not 'TIFF', so bundled
-    // suppresses the emit). Restoring it on merge would be incorrect.
+    // suppresses the emit). Restoring it on merge would be incorrect. The
+    // PrintIM versions (IFD0 `0xc4a5`) DO thread through — a JPEG carries its
+    // PrintIM in the `APP1` Exif block, so it must survive the merge.
     (
       self.entries,
       self.warnings,
       self.warnings_ignorable,
       self.byte_order,
       self.maker_note,
+      self.printim_versions,
     )
   }
 }
@@ -2769,6 +2785,7 @@ fn parse_tiff_with_base_no_raf<'a>(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     captured_make: None,
     captured_model: None,
     // COMMON path: a fresh per-block set ⇒ silent trailing-chain revisit
@@ -2842,6 +2859,7 @@ fn parse_tiff_with_base_no_raf<'a>(
     warnings_ignorable: w.warnings_ignorable,
     byte_order: Some(order),
     maker_note: w.maker_note,
+    printim_versions: w.printim_versions,
     multi_page_count,
     // The SOF dimension tags are a JPEG-container concern; a standalone TIFF
     // has no JPEG SOF segment.
@@ -2936,6 +2954,7 @@ fn parse_bigtiff<'a>(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     captured_make: None,
     captured_model: None,
     chain_guard: ChainGuard::Owned(std::collections::HashSet::new()),
@@ -2982,6 +3001,7 @@ fn parse_bigtiff<'a>(
     // local `order`.
     byte_order: None,
     maker_note: w.maker_note,
+    printim_versions: w.printim_versions,
     // `File:PageCount` IS emitted for a BigTIFF whose IFD chain tripped `MultiPage`
     // (a `SubfileType == 2` / `OldSubfileType == 3` `RawConv` tap in `Walker::emit`,
     // `Exif.pm:456`/`:473`) — the `:8667` `FoundTag` gates on `$$self{MultiPage}`
@@ -3132,6 +3152,7 @@ fn parse_tiff_with_base_shared<'a>(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     captured_make: None,
     captured_model: None,
     // SHARED path: the external `$$et{PROCESSED}` map. A chain-IFD revisit —
@@ -3182,6 +3203,7 @@ fn parse_tiff_with_base_shared<'a>(
     warnings_ignorable: w.warnings_ignorable,
     byte_order: Some(order),
     maker_note: w.maker_note,
+    printim_versions: w.printim_versions,
     // Embedded block (PNG `eXIf`): never the standalone-TIFF dispatch, so no
     // synthesized `File:PageCount`.
     multi_page_count: None,
@@ -3380,6 +3402,13 @@ struct Walker<'a, 'g> {
   warnings_ignorable: Vec<u8>,
   /// The captured MakerNote (0x927c) blob, if seen.
   maker_note: Option<MakerNote<'a>>,
+  /// The `PrintIMVersion` strings parsed from each PrintIM SubDirectory
+  /// (`0xc4a5` in a core IFD, `PrintIM.pm`'s `ProcessPrintIM`) reached during the
+  /// walk, in walk order. ExifTool's `%PrintIM::Main` emits `PrintIMVersion`
+  /// under `GROUPS => { 0 => 'PrintIM', 1 => 'PrintIM' }`; the engine surfaces
+  /// each as a `PrintIM:PrintIMVersion` tag ([`ExifMeta::push_printim_tags`]).
+  /// Almost always EMPTY (no PrintIM) or a single `"0300"`/`"0250"`.
+  printim_versions: Vec<smol_str::SmolStr>,
   /// IFD0's `Make` tag value (`Exif.pm:585`) — captured at emit time so
   /// the MakerNotes dispatcher (`MakerNotes.pm`'s `$$self{Make}`
   /// conditions) sees it when the ExifIFD's 0x927c is reached. For a
@@ -3614,6 +3643,16 @@ impl Walker<'_, '_> {
   fn warn(&mut self, message: String) {
     self.warnings.push(message);
     self.warnings_ignorable.push(0);
+  }
+
+  /// Record a MINOR `$et->Warn(msg, 1)` (ignorable `1` ⇒ `[minor]`, applied by
+  /// `run_diagnostics`), keeping [`warnings`](Self::warnings) and
+  /// [`warnings_ignorable`](Self::warnings_ignorable) index-aligned. Used for
+  /// the `ProcessPrintIM` empty-block warning (`PrintIM.pm:52`,
+  /// `$et->Warn('Empty PrintIM data', 1)`).
+  fn warn_minor(&mut self, message: String) {
+    self.warnings.push(message);
+    self.warnings_ignorable.push(1);
   }
 
   /// Record a MINOR-WITH-BEHAVIOURAL-CHANGE `$et->Warn(msg, 2)` (ignorable
@@ -4970,6 +5009,66 @@ impl Walker<'_, '_> {
       self.dispatch_subdir(sub, value_offset, read_len, format, count);
       // The SubDirectory was dispatched (recursed/captured) — a normal entry:
       // [`Step::Keep`].
+      return Step::Keep;
+    }
+
+    // ---- PrintIM (`0xc4a5`) SubDirectory -------------------------------------
+    // `%Exif::Main` `0xc4a5` is a `SubDirectory => { TagTable => PrintIM::Main }`
+    // (Exif.pm:3280) carried in a CORE IFD (IFD0 in practice). It is NOT an
+    // IFD-chain pointer (so `sub_dir_for` returns `None` and it falls through
+    // here), but a self-contained binary block. Parse it via `ProcessPrintIM`
+    // (`printim::parse_version`) and record the `PrintIMVersion`; the engine
+    // emits it as `PrintIM:PrintIMVersion` (`ExifMeta::push_printim_tags`). Read
+    // the value SPAN exactly as the MakerNote / Canon-special paths do —
+    // `value_offset .. value_offset + read_len` (the out-of-line / inline value
+    // pointer + on-disk byte size, already bounds-resolved above). The vendor
+    // MakerNote `0x0e00` PrintIM is handled inside each vendor body, not here.
+    //
+    // The gate is the `%Exif::Main` table SCOPE, NOT [`is_core_ifd`] — the
+    // `0xc4a5` PrintIM SubDirectory lives ONLY in `%Exif::Main` (Exif.pm:3280),
+    // never in `%GPS::Main` (`is_core_ifd` would also fire for [`TableRef::Gps`],
+    // where a crafted `0xc4a5` entry is just an unknown GPS tag — parsing it as
+    // PrintIM would emit a spurious `[minor] Empty PrintIM data`). `%Exif::Main`
+    // is the table for IFD0/IFD1/ExifIFD/SubIFDs ([`TableRef::Exif`]) AND the
+    // Interop IFD, which reuses `%Exif::Main` ([`TableRef::Interop`],
+    // Exif.pm:6939) — so ExifTool would parse a `0xc4a5` there too. GPS is
+    // excluded.
+    if matches!(self.active_table, TableRef::Exif | TableRef::Interop) && tag_id == 0xc4a5 {
+      let end = value_offset.saturating_add(read_len).min(self.data.len());
+      // Resolve the `ProcessPrintIM` outcome BEFORE touching `&mut self`: the
+      // window borrow of `self.data` must end before `self.warn`/the version
+      // push (which need `&mut self`). The `Err` is a `&'static str`, the `Ok` an
+      // owned `SmolStr`, so the resolved `Result` carries no borrow.
+      let outcome = self
+        .data
+        .get(value_offset..end)
+        .map(|bytes| printim::parse_version(bytes, self.order));
+      match outcome {
+        // A structurally-valid block: record the `PrintIMVersion`; the engine
+        // emits it as `PrintIM:PrintIMVersion`.
+        Some(Ok(version)) => self.printim_versions.push(version),
+        // A malformed block: surface ExifTool's faithful file-level Warning on
+        // the shared warning channel at its EXACT `sub Warn` level, emitting NO
+        // version (`ProcessPrintIM` returns 0 without `HandleTag`). The empty
+        // case is `$et->Warn('Empty PrintIM data', 1)` (PrintIM.pm:52) — a MINOR
+        // warning (`[minor] ` prefix) routed to `warn_minor`; the other three
+        // ('Bad PrintIM data' / 'Invalid PrintIM header' / 'Bad PrintIM size')
+        // are plain `$et->Warn(msg)` (level 0) → `warn`.
+        Some(Err(warning)) => {
+          let message = String::from(warning.message());
+          if warning.is_minor() {
+            self.warn_minor(message);
+          } else {
+            self.warn(message);
+          }
+        }
+        // An out-of-bounds value window (the pointer/size did not resolve to a
+        // readable span) — nothing to parse or warn, matching the prior gate.
+        None => {}
+      }
+      // The PrintIM SubDirectory was processed (or rejected) — a normal entry,
+      // its pointer leaf is not separately emitted (ExifTool drops the
+      // SubDirectory tag itself): [`Step::Keep`].
       return Step::Keep;
     }
 
@@ -7406,6 +7505,29 @@ impl ExifMeta<'_> {
     }
   }
 
+  /// Append the captured PrintIM versions as `PrintIM:PrintIMVersion`
+  /// [`EmittedTag`](crate::emit::EmittedTag)s — the `%PrintIM::Main`
+  /// `PrintIMVersion` tag (PrintIM.pm:24-27, `GROUPS => { 0 => 'PrintIM',
+  /// 1 => 'PrintIM' }`, `PrintConv => undef` so identical in `-j`/`-n`).
+  ///
+  /// Family-0 AND family-1 are both `"PrintIM"`; the value is the raw 4-char
+  /// version string (`"0300"`/`"0250"`). `unknown:false` (a real extracted tag).
+  /// Emitted right after the EXIF/MakerNote block — ExifTool reaches the IFD0
+  /// `0xc4a5` SubDirectory mid-IFD-walk, but the `-G1 -j` conformance compares
+  /// the key MULTISET (`src/jsondiff.rs`), so the exact position is insensitive.
+  /// Almost always EMPTY (no PrintIM) or a single version.
+  fn push_printim_tags(&self, out: &mut std::vec::Vec<crate::emit::EmittedTag>) {
+    out.reserve(self.printim_versions.len());
+    for version in &self.printim_versions {
+      out.push(crate::emit::EmittedTag::new(
+        crate::value::Group::new("PrintIM", "PrintIM"),
+        smol_str::SmolStr::new_static("PrintIMVersion"),
+        crate::value::TagValue::Str(version.clone()),
+        false,
+      ));
+    }
+  }
+
   /// Append the captured MakerNote's cached vendor emissions to `out` as
   /// [`EmittedTag`](crate::emit::EmittedTag)s — the golden-pattern parallel to
   /// the MakerNote branch of [`serialize_tags`](Self::serialize_tags). Emitted
@@ -7705,6 +7827,10 @@ impl crate::emit::Taggable for ExifMeta<'_> {
       self.push_exif_tags(print_conv, &mut tags);
       self.push_maker_note_tags(print_conv, &mut tags);
     }
+    // The PrintIM `PrintIM:PrintIMVersion` (IFD0 `0xc4a5`) — emitted after the
+    // EXIF/MakerNote block (the key MULTISET is position-insensitive). EMPTY for
+    // the common no-PrintIM case.
+    self.push_printim_tags(&mut tags);
     // The JPEG auxiliary `APP`-segment tags (JFIF / MPF / DJI thermal) decoded
     // by [`jpeg_app::process_app_markers`] — appended after the EXIF block. The
     // `-G1 -j` conformance compares the key MULTISET (`src/jsondiff.rs`), so
@@ -9573,6 +9699,7 @@ pub(in crate::exif) fn apple_makernote_isolated(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     // The parent IFD0 `Make`, threaded from the dispatch — the format-16
     // (`int64u`) Apple carve-out in the per-entry gate requires
     // `captured_make == Some("Apple")` (`Exif.pm:6464` `$$et{Make} eq 'Apple'`),
@@ -9774,6 +9901,7 @@ pub(in crate::exif) fn sony_makernote_isolated(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     captured_make: None,
     // `$$self{Model}` gates the four conditional-ARRAY AF tags + the single-HASH
     // `Condition` rows; the Sony walk itself reads no model-conditional structure,
@@ -10063,6 +10191,7 @@ pub(in crate::exif) fn panasonic_makernote_isolated_with_offset(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     captured_make: None,
     // `$$self{Model}` selects the 0x0f AFAreaMode / 0x2c ContrastMode branches; the
     // Panasonic walk itself reads no model-conditional structure, but the captured
@@ -10332,6 +10461,7 @@ pub(in crate::exif) fn nikon_makernote_isolated(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     captured_make: None,
     // `$$self{Model}` gates the AFInfo BigEndian read + the LensData Z telemetry;
     // it is threaded into the capture-loop emitters (NOT the walk), so leave it
@@ -10665,6 +10795,7 @@ pub(in crate::exif) fn pentax_makernote_isolated(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     // `$$self{Make}`/`$$self{Model}` feed the FixBase heuristic
     // (`GetMakerNoteOffset`'s `make.starts_with("PENTAX")` absolute-addressing
     // arm, `MakerNotes.pm:1215-1220`) the AOC/Asahi primaries run via
@@ -11120,6 +11251,7 @@ pub(in crate::exif) fn samsung_makernote_isolated(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     // `$$self{Make}`/`$$self{Model}` feed the generic FixBase heuristic; the
     // Samsung walk reads no model-conditional structure (no PENTAX-style make
     // arm), but thread them for parity with the other vendors.
@@ -11416,6 +11548,7 @@ pub(in crate::exif) fn leica_makernote_isolated(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     // The Leica6 Typ-006 `Condition` reads `$$self{Model}`; thread it. No Leica
     // leaf reads Make.
     captured_make: None,
@@ -11593,6 +11726,7 @@ pub(in crate::exif) fn canon_makernote_isolated(
     warnings: Vec::new(),
     warnings_ignorable: Vec::new(),
     maker_note: None,
+    printim_versions: Vec::new(),
     captured_make: None,
     // `$$self{Model}` (the conditional `SerialNumber` PrintConv is `-j`-only, but
     // the model also gates the 0x96 SerialInfo LIST + ShotInfo branches the `-n`
@@ -14740,6 +14874,132 @@ mod tests {
     );
   }
 
+  /// THROUGH-THE-WALKER (`#381` Codex [medium]): a malformed PrintIM
+  /// SubDirectory (`0xc4a5`) in IFD0 surfaces ExifTool's `ProcessPrintIM`
+  /// warning at its EXACT `sub Warn` severity on the document diagnostic
+  /// channel. ExifTool's empty-block guard is `$et->Warn('Empty PrintIM data',
+  /// 1)` (PrintIM.pm:52) — the trailing `1` ⇒ MINOR, so `run_diagnostics`
+  /// renders `[minor] Empty PrintIM data`; the other guards
+  /// (`$et->Warn('Invalid PrintIM header')`, PrintIM.pm:60) are plain `Warn` ⇒
+  /// NORMAL (no prefix). Drive the FULL TIFF walker (`parse_exif_block`) then
+  /// the document `run_diagnostics` drain (the `sub Warn` analogue that applies
+  /// the prefix), not just `parse_version`.
+  #[test]
+  #[cfg(feature = "alloc")]
+  fn printim_empty_block_warns_minor_through_the_walker() {
+    // A single IFD0 entry: PrintIM (0xc4a5), format undef (7), count 0 ⇒ size 0
+    // ⇒ INLINE, a zero-length value window. `ProcessPrintIM`'s `unless ($size)`
+    // fires ⇒ `$et->Warn('Empty PrintIM data', 1)` (minor).
+    let empty = entry(0xc4a5, 7 /* undef */, 0, [0u8; 4]);
+    let t = tiff_with_entries(&[empty]);
+    let meta = parse_exif_block(&t).expect("valid TIFF");
+    // The document drain applies the `[minor] ` prefix from the ignorable level.
+    let mut tm = crate::tagmap::TagMap::new();
+    crate::diagnostics::run_diagnostics(&meta, &mut tm);
+    assert_eq!(
+      tm.first_warning(),
+      Some("[minor] Empty PrintIM data"),
+      "the empty-block guard is `Warn(.., 1)` ⇒ a [minor] warning; warnings = {:?}",
+      tm.warnings()
+    );
+  }
+
+  /// THROUGH-THE-WALKER companion to the empty-block test: a `0xc4a5` block with
+  /// a bad header surfaces a NORMAL (unprefixed) `Invalid PrintIM header`
+  /// (PrintIM.pm:60, plain `$et->Warn(msg)`), confirming only the empty case is
+  /// minor.
+  #[test]
+  #[cfg(feature = "alloc")]
+  fn printim_bad_header_warns_normal_through_the_walker() {
+    // PrintIM (0xc4a5), format undef (7), count 20 ⇒ size 20 (> 4) ⇒ OUT-OF-LINE
+    // at offset 26 (header 8 + count 2 + entry 12 + nextIFD 4). The 20 bytes do
+    // NOT start with "PrintIM" ⇒ `Invalid PrintIM header`.
+    let val_off: u32 = 26;
+    let bad = entry(0xc4a5, 7 /* undef */, 20, val_off.to_be_bytes());
+    let mut t = tiff_with_entries(&[bad]);
+    assert_eq!(t.len(), val_off as usize, "out-of-line region starts at 26");
+    t.extend_from_slice(&[0u8; 20]); // 20 bytes, header "PrintIM" absent
+    let meta = parse_exif_block(&t).expect("valid TIFF");
+    let mut tm = crate::tagmap::TagMap::new();
+    crate::diagnostics::run_diagnostics(&meta, &mut tm);
+    assert_eq!(
+      tm.first_warning(),
+      Some("Invalid PrintIM header"),
+      "a bad-header block is a NORMAL `Warn(msg)` (no [minor]); warnings = {:?}",
+      tm.warnings()
+    );
+  }
+
+  /// GPS-IFD REGRESSION (`#381` Codex [medium]): the `0xc4a5` PrintIM
+  /// SubDirectory lives ONLY in `%Exif::Main` (Exif.pm:3280), NEVER in
+  /// `%GPS::Main` — so a `0xc4a5` entry walked under the GPS table
+  /// ([`TableRef::Gps`], via [`parse_gps_block`]) must be treated as an ordinary
+  /// unknown GPS tag, NOT parsed as PrintIM. The gate was previously
+  /// `is_core_ifd()`, which ALSO matches `TableRef::Gps`, so a crafted GPS
+  /// `0xc4a5` would mis-parse: an EMPTY (count 0) block ⇒ a spurious `[minor]
+  /// Empty PrintIM data`, and a structurally-valid block ⇒ a spurious
+  /// `PrintIM:PrintIMVersion`. Both must be absent now that the gate is the
+  /// `%Exif::Main` table scope (`TableRef::Exif | TableRef::Interop`).
+  #[test]
+  #[cfg(feature = "alloc")]
+  fn gps_ifd_c4a5_is_not_parsed_as_printim() {
+    // (a) A STRUCTURALLY-VALID PrintIM block (16 bytes: "PrintIM\0" header,
+    //     version "0300" at +8, num=0 at +14 ⇒ size 16 >= 16) at offset 26 in a
+    //     GPS top-level IFD. Under `%Exif::Main` this would push
+    //     `PrintIMVersion="0300"`; under `%GPS::Main` it must NOT (no PrintIM
+    //     SubDirectory there). `0xc4a5`, format undef (7), count 16 ⇒ OUT-OF-LINE.
+    let val_off: u32 = 26;
+    let valid = entry(0xc4a5, 7 /* undef */, 16, val_off.to_be_bytes());
+    let mut t = tiff_with_entries(&[valid]);
+    assert_eq!(t.len(), val_off as usize, "out-of-line region starts at 26");
+    t.extend_from_slice(b"PrintIM\0"); // 8-byte header
+    t.extend_from_slice(b"0300"); // version at +8
+    t.extend_from_slice(&[0u8, 0u8]); // +12 (unused)
+    t.extend_from_slice(&[0u8, 0u8]); // +14 num = 0 ⇒ size 16 >= 16 + 0
+    // Walk the TOP-LEVEL IFD as a GPS IFD (`TableRef::Gps`) — the CR3 `CMT4`
+    // path. Were the gate `is_core_ifd()`, this would parse as PrintIM.
+    let meta = parse_gps_block(&t).expect("valid TIFF");
+    assert!(
+      meta.printim_versions.is_empty(),
+      "a GPS-table 0xc4a5 must NOT be parsed as PrintIM (no PrintIMVersion); \
+       versions = {:?}",
+      meta.printim_versions
+    );
+    // No PrintIM warning either (the valid block emits none, but assert the
+    // channel is clear of any PrintIM diagnostic).
+    let mut tm = crate::tagmap::TagMap::new();
+    crate::diagnostics::run_diagnostics(&meta, &mut tm);
+    assert!(
+      !tm.warnings().iter().any(|w| w.contains("PrintIM")),
+      "no PrintIM diagnostic for a GPS-table 0xc4a5; warnings = {:?}",
+      tm.warnings()
+    );
+
+    // (b) An EMPTY (count 0 ⇒ inline, zero-length window) `0xc4a5` GPS entry —
+    //     the case that under the buggy `is_core_ifd()` gate hit
+    //     `ProcessPrintIM`'s `unless ($size)` ⇒ `$et->Warn('Empty PrintIM data',
+    //     1)`. The GPS table has no PrintIM SubDirectory ⇒ NO such warning.
+    let empty = entry(0xc4a5, 7 /* undef */, 0, [0u8; 4]);
+    let te = tiff_with_entries(&[empty]);
+    let meta_e = parse_gps_block(&te).expect("valid TIFF");
+    assert!(
+      meta_e.printim_versions.is_empty(),
+      "an empty GPS-table 0xc4a5 emits no PrintIMVersion; versions = {:?}",
+      meta_e.printim_versions
+    );
+    let mut tm_e = crate::tagmap::TagMap::new();
+    crate::diagnostics::run_diagnostics(&meta_e, &mut tm_e);
+    assert!(
+      !tm_e
+        .warnings()
+        .iter()
+        .any(|w| w.contains("Empty PrintIM data")),
+      "an empty GPS-table 0xc4a5 must NOT warn `[minor] Empty PrintIM data`; \
+       warnings = {:?}",
+      tm_e.warnings()
+    );
+  }
+
   #[test]
   #[cfg(feature = "alloc")]
   fn excessive_count_does_not_apply_to_string_or_undef() {
@@ -15008,6 +15268,7 @@ mod tests {
       warnings: Vec::new(),
       warnings_ignorable: Vec::new(),
       maker_note: None,
+      printim_versions: Vec::new(),
       captured_make: None,
       captured_model: None,
       chain_guard: ChainGuard::Owned(std::collections::HashSet::new()),

--- a/src/exif/printim/mod.rs
+++ b/src/exif/printim/mod.rs
@@ -1,0 +1,157 @@
+//! `Image::ExifTool::PrintIM` — the Print Image Matching directory reader
+//! (PrintIM.pm, a faithful transliteration of `ProcessPrintIM`).
+//!
+//! PrintIM is a small Epson-proprietary structure carried as the EXIF IFD0 tag
+//! `0xc4a5` (`Exif.pm:3280`, a `SubDirectory => { TagTable => PrintIM::Main }`)
+//! and, on some vendors, as a MakerNote sub-directory tag `0x0e00`
+//! (Sony/Panasonic/Nikon). Its `%PrintIM::Main` table emits ONE camera-relevant
+//! tag — `PrintIMVersion` (PrintIM.pm:24-27, `PrintConv => undef` so it stays
+//! the raw 4-char string) — under `GROUPS => { 0 => 'PrintIM', 1 => 'PrintIM',
+//! 2 => 'Printing' }`. The numbered records 9-13 (`PIMContrast`/… ) are
+//! commented out in `%PrintIM::Main`, so bundled emits NONE of them; this port
+//! emits the version alone.
+//!
+//! ## The `ProcessPrintIM` block (PrintIM.pm:43-93)
+//!
+//! ```text
+//! return 0 unless $size;                        # Warn 'Empty PrintIM data', 1 (MINOR)
+//! return 0 unless $size > 15;                   # Warn 'Bad PrintIM data'
+//! return 0 unless substr($dataPt,$off,7) eq 'PrintIM';  # 'Invalid PrintIM header'
+//! my $num = Get16u($dataPt, $off + 14);
+//! if ($size < 16 + $num * 6) {                  # size too big ⇒ wrong byte order
+//!     ToggleByteOrder();
+//!     $num = Get16u($dataPt, $off + 14);
+//!     return 0 if $size < 16 + $num * 6;        # 'Bad PrintIM size'
+//! }
+//! HandleTag(PrintIMVersion, substr($dataPt, $off + 8, 4));   # the 4 ASCII bytes
+//! # ... the numbered records (commented out — not emitted)
+//! ```
+//!
+//! The `PrintIMVersion` value is the four bytes at `$off + 8` read as text (the
+//! `substr` is byte-order-independent — it is the ASCII version like `"0300"`).
+//! The `$num`-validation `ToggleByteOrder` only affects how the (un-emitted)
+//! numbered records would be read; it does not change the version bytes, so the
+//! port keeps the size-validation guard for fidelity (a structurally-invalid
+//! block emits nothing) without needing the toggled order for the version.
+
+use crate::exif::ifd::{ByteOrder, get_u16};
+
+/// A `ProcessPrintIM` guard failure, carrying the FAITHFUL `$et->Warn(...)` text
+/// AND its `sub Warn` severity so the caller can surface it on the shared
+/// warning channel at ExifTool's exact level (`ExifTool.pm:5616-5630`):
+///
+/// * [`Minor`](Self::Minor) — `$et->Warn(msg, 1)`, the `,1` ignorable flag (→ a
+///   `[minor] ` prefix). The ONLY PrintIM minor guard is the empty-block case
+///   (`PrintIM.pm:52`, `$et->Warn('Empty PrintIM data', 1)`).
+/// * [`Normal`](Self::Normal) — a plain `$et->Warn(msg)` (level 0, no prefix):
+///   `'Bad PrintIM data'` (`PrintIM.pm:56`), `'Invalid PrintIM header'`
+///   (`PrintIM.pm:60`) and `'Bad PrintIM size'` (`PrintIM.pm:70`).
+///
+/// The message is always a `&'static str` (the literal `ProcessPrintIM` warns).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PrintImError {
+  /// A normal `$et->Warn(msg)` — `ignorable == 0`, no `[minor]` prefix.
+  Normal(&'static str),
+  /// A minor `$et->Warn(msg, 1)` — `ignorable == 1`, surfaced as `[minor] msg`.
+  Minor(&'static str),
+}
+
+impl PrintImError {
+  /// The bare `$et->Warn` message text (no `[minor]` prefix baked in — the
+  /// prefix is applied centrally by `run_diagnostics`).
+  pub(crate) const fn message(self) -> &'static str {
+    match self {
+      Self::Normal(m) | Self::Minor(m) => m,
+    }
+  }
+
+  /// Whether this is the minor (`$et->Warn(msg, 1)`) case — the caller routes a
+  /// `true` to the `[minor] ` (ignorable-`1`) warning path.
+  pub(crate) const fn is_minor(self) -> bool {
+    matches!(self, Self::Minor(_))
+  }
+}
+
+/// The byte order's opposite — ExifTool's `ToggleByteOrder()` (ExifTool.pm:6171)
+/// applied to the PrintIM `$num`-count re-read.
+const fn toggled(order: ByteOrder) -> ByteOrder {
+  match order {
+    ByteOrder::Little => ByteOrder::Big,
+    ByteOrder::Big => ByteOrder::Little,
+  }
+}
+
+/// The 4-character `PrintIMVersion` (`"0300"`/`"0250"`/…) parsed from a PrintIM
+/// block.
+///
+/// `Ok(version)` on a structurally-valid block; `Err(PrintImError)` carrying the
+/// FAITHFUL `ProcessPrintIM` `$et->Warn(...)` text AND its severity when a guard
+/// fails, so the caller can surface it on the shared warning channel at exactly
+/// ExifTool's level — a file-level Warning, `[minor] `-prefixed iff the Perl site
+/// passes the `,1` ignorable flag:
+///
+/// * [`Minor`](PrintImError::Minor)`("Empty PrintIM data")` (PrintIM.pm:52,
+///   `$et->Warn(..., 1)`) — a zero-length block.
+/// * [`Normal`](PrintImError::Normal)`("Bad PrintIM data")` (PrintIM.pm:56) —
+///   `1..=15` bytes (`unless $size > 15`).
+/// * [`Normal`](PrintImError::Normal)`("Invalid PrintIM header")` (PrintIM.pm:60)
+///   — a missing `"PrintIM"` header.
+/// * [`Normal`](PrintImError::Normal)`("Bad PrintIM size")` (PrintIM.pm:70) — a
+///   `$num`-count too large for the block even after the byte-order toggle.
+///
+/// `block` is the SubDirectory value (the `0xc4a5` / `0x0e00` tag bytes);
+/// `order` is the inherited TIFF byte order (`Get16u` reads the record count
+/// with it, then toggles on a size mismatch). The version itself is read from
+/// the fixed `block[8..12]` ASCII bytes — byte-order-independent.
+pub(crate) fn parse_version(
+  block: &[u8],
+  order: ByteOrder,
+) -> Result<smol_str::SmolStr, PrintImError> {
+  // `return 0 unless $size` (PrintIM.pm:51-52) — `$et->Warn('Empty PrintIM
+  // data', 1)` (the trailing `1` ⇒ MINOR/`[minor]`); then `return 0 unless
+  // $size > 15` (:55-56) — `$et->Warn('Bad PrintIM data')` (no flag ⇒ NORMAL).
+  // A zero-length block warns "empty" (minor); a non-empty but too-short one
+  // warns "bad data" (normal).
+  if block.is_empty() {
+    return Err(PrintImError::Minor("Empty PrintIM data"));
+  }
+  if block.len() <= 15 {
+    return Err(PrintImError::Normal("Bad PrintIM data"));
+  }
+  // `unless substr($$dataPt, $offset, 7) eq 'PrintIM'` (PrintIM.pm:59-60) — the
+  // 7-byte ASCII header; `$et->Warn('Invalid PrintIM header')` (NORMAL).
+  if block.get(0..7) != Some(b"PrintIM".as_slice()) {
+    return Err(PrintImError::Normal("Invalid PrintIM header"));
+  }
+  // `my $num = Get16u($dataPt, $offset + 14)` + the size-vs-`16 + $num*6` check,
+  // with a single byte-order toggle on overflow (PrintIM.pm:63-71). This
+  // validates the structure faithfully; the version bytes do not depend on the
+  // resolved order, so the toggle only gates the build.
+  let size = block.len();
+  let valid = |ord: ByteOrder| -> bool {
+    match get_u16(block, 14, ord) {
+      // `16 + $num * 6` in `usize` (the count is a `u16`, so the product cannot
+      // overflow `usize`); a block smaller than that is rejected.
+      Some(num) => size >= 16usize.saturating_add((num as usize).saturating_mul(6)),
+      None => false,
+    }
+  };
+  if !valid(order) && !valid(toggled(order)) {
+    // `return 0` — `$et->Warn('Bad PrintIM size')` (NORMAL; the structure is
+    // unusable in EITHER order).
+    return Err(PrintImError::Normal("Bad PrintIM size"));
+  }
+  // `HandleTag(PrintIMVersion, substr($$dataPt, $offset + 8, 4))` (PrintIM.pm:
+  // 72) — the four ASCII version bytes (`PrintConv => undef`, so raw text).
+  // ExifTool's `substr` yields whatever bytes are there; the version is ASCII
+  // digits in practice, read lossily into a `SmolStr`. The header + size guards
+  // above already proved the block carries `>= 16` bytes, so `block[8..12]` is
+  // in bounds.
+  let bytes = block.get(8..12).unwrap_or_default();
+  Ok(smol_str::SmolStr::from(
+    String::from_utf8_lossy(bytes).as_ref(),
+  ))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/exif/printim/tests.rs
+++ b/src/exif/printim/tests.rs
@@ -1,0 +1,100 @@
+use super::*;
+
+/// Build a minimal valid PrintIM block: the `"PrintIM"` header, a NUL, the
+/// 4-byte ASCII version at offset 8, two reserved bytes, and the `$num` count at
+/// offset 14, followed by `num * 6` record bytes (so the size check passes).
+fn block(version: &[u8; 4], num: u16, order: ByteOrder) -> Vec<u8> {
+  let mut b = Vec::new();
+  b.extend_from_slice(b"PrintIM\0"); // 0..8
+  b.extend_from_slice(version); // 8..12
+  b.extend_from_slice(&[0, 0]); // 12..14 reserved
+  b.extend_from_slice(&match order {
+    ByteOrder::Little => num.to_le_bytes(),
+    ByteOrder::Big => num.to_be_bytes(),
+  }); // 14..16
+  b.extend(std::iter::repeat_n(0u8, (num as usize) * 6)); // records
+  b
+}
+
+#[test]
+fn parses_the_four_ascii_version_bytes() {
+  let b = block(b"0300", 33, ByteOrder::Little);
+  assert_eq!(parse_version(&b, ByteOrder::Little).as_deref(), Ok("0300"));
+}
+
+#[test]
+fn version_is_byte_order_independent() {
+  // The version bytes are read from the fixed 8..12 ASCII span regardless of
+  // the inherited TIFF order (only the `$num` count is order-sensitive).
+  let b = block(b"0250", 5, ByteOrder::Big);
+  assert_eq!(parse_version(&b, ByteOrder::Big).as_deref(), Ok("0250"));
+}
+
+#[test]
+fn rejects_a_block_without_the_printim_header() {
+  // `unless substr($$dataPt, $offset, 7) eq 'PrintIM'` ⇒ 'Invalid PrintIM
+  // header' (PrintIM.pm:60), no version. `$et->Warn(msg)` with NO `,1` flag ⇒
+  // a NORMAL (level-0) warning.
+  let mut b = block(b"0300", 1, ByteOrder::Little);
+  b[0] = b'X'; // corrupt the "PrintIM" header
+  assert_eq!(
+    parse_version(&b, ByteOrder::Little),
+    Err(PrintImError::Normal("Invalid PrintIM header"))
+  );
+}
+
+#[test]
+fn rejects_an_empty_block_as_minor() {
+  // `return 0 unless $size` ⇒ `$et->Warn('Empty PrintIM data', 1)`
+  // (PrintIM.pm:52) — the trailing `1` is the `sub Warn` MINOR flag, so this
+  // surfaces as a `[minor]` warning (the ONLY PrintIM minor guard).
+  let err = parse_version(&[], ByteOrder::Little).unwrap_err();
+  assert_eq!(err, PrintImError::Minor("Empty PrintIM data"));
+  assert!(
+    err.is_minor(),
+    "the empty-block guard is `Warn(.., 1)` = minor"
+  );
+  assert_eq!(err.message(), "Empty PrintIM data");
+}
+
+#[test]
+fn rejects_a_block_of_15_or_fewer_bytes() {
+  // `unless $size > 15` ⇒ 'Bad PrintIM data' (PrintIM.pm:56) — exactly 15 bytes
+  // is too short. `$et->Warn(msg)` with no flag ⇒ a NORMAL warning.
+  let short = b"PrintIM\x000300\0\0\0";
+  assert_eq!(short.len(), 15);
+  let err = parse_version(short, ByteOrder::Little).unwrap_err();
+  assert_eq!(err, PrintImError::Normal("Bad PrintIM data"));
+  assert!(
+    !err.is_minor(),
+    "the bad-data guard is `Warn(msg)` = normal"
+  );
+}
+
+#[test]
+fn toggles_byte_order_when_the_count_overflows_the_block() {
+  // A `$num` written in the OPPOSITE order makes the first size check fail;
+  // `ProcessPrintIM` toggles and re-reads. Here a real `num=2` (12 record
+  // bytes) is written big-endian but the inherited order is little-endian: the
+  // little-endian read of `00 02` is `0x0200` (512) ⇒ size check fails ⇒ toggle
+  // to big-endian reads `2` ⇒ passes. The version still parses.
+  let b = block(b"0300", 2, ByteOrder::Big);
+  assert_eq!(parse_version(&b, ByteOrder::Little).as_deref(), Ok("0300"));
+}
+
+#[test]
+fn rejects_a_count_too_large_in_both_orders() {
+  // A `$num` so large the `16 + num*6` size requirement fails in BOTH orders
+  // (a 16-byte block claiming 0xffff records) ⇒ 'Bad PrintIM size' (PrintIM.pm:
+  // 70), no version. `$et->Warn(msg)` with no flag ⇒ a NORMAL warning.
+  let mut b = Vec::new();
+  // "PrintIM" + NUL, version "0300" (8..12), two reserved, count 0xffff (14..16).
+  b.extend_from_slice(b"PrintIM\x000300\0\0\xff\xff");
+  assert_eq!(b.len(), 16);
+  let err = parse_version(&b, ByteOrder::Little).unwrap_err();
+  assert_eq!(err, PrintImError::Normal("Bad PrintIM size"));
+  assert!(
+    !err.is_minor(),
+    "the bad-size guard is `Warn(msg)` = normal"
+  );
+}

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -294,8 +294,19 @@ fn extract_info_budget(name: &str) -> (usize, usize) {
     // what enables the Sony SubDoc GPS Composites), NOT a redundant clone; the
     // `media_metadata` typed path is UNCHANGED (152) since it never runs the
     // Composite post-pass. Ceilings raised to (870, 990).
-    "MakerNotes_Apple.jpg" => (870, 990), // measured (835, 956) — #133 PR 5 family-0 carry
-    "ID3v2_4_big.mp3" => (130, 130),      // measured (118, 117)
+    // RE-BASELINED for #381 (the `Composite:Flash`/`LensID`/`DateTimeCreated`
+    // ports): the `BuildCompositeTags` fixpoint now evaluates THREE more defs
+    // per pass over BOTH views — none builds for Apple (no XMP flash field, no
+    // `LensType`, no IPTC date), but each attempt allocates its per-def
+    // `$val[]`/`$prt[]` scratch pair, so `-j` rises +6 and `-n` +6 (the
+    // engine-overhead cost the existing #133-PR-3 comment already flagged a
+    // future perf PR could shave by reusing the scratch Vecs). The prior `(870,
+    // 990)` ceiling was also already exceeded on the base (the measured drifted
+    // to (884, 1002) before #381 without a re-baseline); the new ceilings cover
+    // BOTH the drift and the #381 +6. `media_metadata` is UNCHANGED by the new
+    // Composites (163, never runs the post-pass).
+    "MakerNotes_Apple.jpg" => (910, 1030), // measured (890, 1008) — #381 +3 Composite defs
+    "ID3v2_4_big.mp3" => (130, 130),       // measured (118, 117)
     // RE-BASELINED for #133 PR 5: a `video/*` QuickTime now RUNS the Composite
     // post-pass (the full-video flip), building `Composite:AvgBitrate`/`ImageSize`/
     // `Megapixels`/`Rotation` + re-emitting the opposite view — `-j` 135 → 195,

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -11278,11 +11278,12 @@ fn mpeg2_ts_pruveeo_d90_conformance() {
 // `*_DEFERRED` residuals are dropped from BOTH sides (the goldens keep the
 // faithful full 13.59 dump).
 //
-// EVERY `*_DEFERRED` list shares the FOUR cross-cutting subsystems KS-2 also
-// drops (minus `Composite:DateTimeCreated` — these bodies carry no IPTC date):
-//   * `Composite:Flash`           — the multi-field flash Composite (unported);
-//   * `Composite:LensID`          — the lens-resolution Composite (unported);
-//   * `PrintIM:PrintIMVersion`    — exifast parses no PrintIM IFD;
+// `Composite:Flash` (the XMP-Flash bitmask Composite), `Composite:LensID` (the
+// unambiguous-Pentax-LensType resolution Composite) and `PrintIM:PrintIMVersion`
+// (the IFD0 `0xc4a5` PrintIM directory) are NOW PORTED (#381) — emitted
+// byte-exact for these bodies, so they are NO LONGER in the `*_DEFERRED` lists.
+// EVERY `*_DEFERRED` list still shares ONE cross-cutting deferral (plus KS-2's
+// `Composite:DateTimeCreated`, which needs an IPTC date these bodies lack):
 //   * `XMP-tiff:YCbCrSubSampling` — the unported `RawJoin`/`%JPEG::
 //                                   yCbCrSubSampling` PrintConv (`xmp/tables.rs`).
 //
@@ -11328,9 +11329,6 @@ fn mpeg2_ts_pruveeo_d90_conformance() {
 // Contrast/ISOAutoMinSpeed/ShutterType/SkinToneCorrection/ExposureCompensation
 // residuals.
 const K1_DEFERRED: &[&str] = &[
-  "Composite:Flash",
-  "Composite:LensID",
-  "PrintIM:PrintIMVersion",
   "XMP-tiff:YCbCrSubSampling",
   "Pentax:AFPointSelected",
   "Pentax:AFPointsInFocus",
@@ -11350,9 +11348,6 @@ const K1_DEFERRED: &[&str] = &[
 // K-3: the K-3 AFPointSelected model variant + TempInfo (SensorTemperature) +
 // Contrast/ISOAutoMinSpeed residuals.
 const K3_DEFERRED: &[&str] = &[
-  "Composite:Flash",
-  "Composite:LensID",
-  "PrintIM:PrintIMVersion",
   "XMP-tiff:YCbCrSubSampling",
   "Pentax:AFPointSelected",
   "Pentax:ContrastHighlight",
@@ -11368,9 +11363,6 @@ const K3_DEFERRED: &[&str] = &[
 // TempInfo) + the AFPointInfo/PixelShiftInfo/Contrast residuals + the IsOffset
 // PreviewImageStart.
 const K5_II_DEFERRED: &[&str] = &[
-  "Composite:Flash",
-  "Composite:LensID",
-  "PrintIM:PrintIMVersion",
   "XMP-tiff:YCbCrSubSampling",
   "Pentax:BodyBatteryVoltage3",
   "Pentax:BodyBatteryVoltage4",
@@ -11411,9 +11403,6 @@ const K5_II_DEFERRED: &[&str] = &[
 // AFPointInfo/PixelShiftInfo/Contrast/ISOAutoMinSpeed/ShutterType/
 // SkinToneCorrection/ExposureCompensation).
 const KP_DEFERRED: &[&str] = &[
-  "Composite:Flash",
-  "Composite:LensID",
-  "PrintIM:PrintIMVersion",
   "XMP-tiff:YCbCrSubSampling",
   "Pentax:AFPointSelected",
   "Pentax:AFPointsInFocus",
@@ -11445,9 +11434,6 @@ const KP_DEFERRED: &[&str] = &[
 // propagates byte-exact to the two Composites. The remaining entries are only
 // unimplemented Pentax leaves, so K-70 now activates honestly.
 const K70_DEFERRED: &[&str] = &[
-  "Composite:Flash",
-  "Composite:LensID",
-  "PrintIM:PrintIMVersion",
   "XMP-tiff:YCbCrSubSampling",
   "Pentax:AFPointsInFocus",
   "Pentax:AFPointsSelected",
@@ -11567,25 +11553,19 @@ fn jpeg_pentax_k70_conformance() {
 // FaceDetect/ColorMatrixA2/B2/AFPointSelected[2-element]/AFPointsInFocus/
 // FlashExposureComp[int8s array]/… + ExtenderStatus).
 //
-// The excluded keys are DEFERRED SUBSYSTEMS exifast does not implement (NOT
-// Pentax-specific — none is emitted byte-exact by any other active fixture
-// either): the `Composite:Flash` (the multi-field flash Composite, see
-// `xmp/tables.rs:41`), `Composite:LensID` (the lens-resolution Composite),
-// `Composite:DateTimeCreated` (the IPTC date Composite), `PrintIM:PrintIMVersion`
-// (exifast parses no PrintIM IFD), and `XMP-tiff:YCbCrSubSampling` (exifast emits
-// the raw `[2,1]` — the `tiff:YCbCrSubSampling` field is DOCUMENTED as needing the
-// unported `RawJoin` + `%JPEG::yCbCrSubSampling` PrintConv, `xmp/tables.rs:47`).
-// The golden keeps them (faithful 242-tag 13.59 dump); they are dropped from BOTH
-// sides so the Pentax set + the rest are verified byte-exact.
+// `Composite:Flash` (the XMP-Flash bitmask Composite), `Composite:LensID` (the
+// unambiguous-Pentax-LensType resolution Composite), `Composite:DateTimeCreated`
+// (the IPTC `DateCreated`+`TimeCreated` Composite) and `PrintIM:PrintIMVersion`
+// (the IFD0 `0xc4a5` PrintIM directory) are NOW PORTED (#381) — emitted
+// byte-exact, so they are NO LONGER excluded. The sole remaining deferral is
+// `XMP-tiff:YCbCrSubSampling` (exifast emits the raw `[2,1]` — the
+// `tiff:YCbCrSubSampling` field is DOCUMENTED as needing the unported `RawJoin`
+// + `%JPEG::yCbCrSubSampling` PrintConv, `xmp/tables.rs:47`). The golden keeps
+// it (faithful 242-tag 13.59 dump); it is dropped from BOTH sides so the Pentax
+// set + the four newly-emitted cross-cutting tags + the rest verify byte-exact.
 #[test]
 fn jpeg_pentax_ks2_conformance() {
-  const DEFERRED: &[&str] = &[
-    "Composite:Flash",
-    "Composite:LensID",
-    "Composite:DateTimeCreated",
-    "PrintIM:PrintIMVersion",
-    "XMP-tiff:YCbCrSubSampling",
-  ];
+  const DEFERRED: &[&str] = &["XMP-tiff:YCbCrSubSampling"];
   check_excluding(
     "JPEG_pentax_ks2.jpg",
     "JPEG_pentax_ks2.jpg.json",

--- a/tests/golden/Pentax.avi.json
+++ b/tests/golden/Pentax.avi.json
@@ -114,6 +114,7 @@
   "Pentax:Copyright": "",
   "Pentax:FirmwareVersion": "K-x Ver 1.00           ",
   "Composite:ImageSize": "1280x720",
+  "Composite:LensID": "smc PENTAX-DA L 18-55mm F3.5-5.6",
   "Composite:Megapixels": 0.922,
   "Composite:Duration": "25.00 s"
 }]

--- a/tests/golden/Pentax.avi.n.json
+++ b/tests/golden/Pentax.avi.n.json
@@ -114,6 +114,7 @@
   "Pentax:Copyright": "",
   "Pentax:FirmwareVersion": "K-x Ver 1.00           ",
   "Composite:ImageSize": "1280 720",
+  "Composite:LensID": "7 222",
   "Composite:Megapixels": 0.9216,
   "Composite:Duration": 24.9996
 }]

--- a/tests/golden/Pentax.jpg.json
+++ b/tests/golden/Pentax.jpg.json
@@ -195,6 +195,7 @@
   "Pentax:WBShiftGM": 0,
   "InteropIFD:InteropIndex": "R98 - DCF basic file (sRGB)",
   "InteropIFD:InteropVersion": "0100",
+  "PrintIM:PrintIMVersion": "0300",
   "IFD1:Compression": "JPEG (old-style)",
   "IFD1:XResolution": 72,
   "IFD1:YResolution": 72,

--- a/tests/golden/Pentax.jpg.n.json
+++ b/tests/golden/Pentax.jpg.n.json
@@ -195,6 +195,7 @@
   "Pentax:WBShiftGM": 0,
   "InteropIFD:InteropIndex": "R98",
   "InteropIFD:InteropVersion": "0100",
+  "PrintIM:PrintIMVersion": "0300",
   "IFD1:Compression": 6,
   "IFD1:XResolution": 72,
   "IFD1:YResolution": 72,

--- a/tests/golden/SamsungNX1.srw.json
+++ b/tests/golden/SamsungNX1.srw.json
@@ -93,5 +93,6 @@
   "Composite:FOV": "37.5 deg",
   "Composite:FocalLength35efl": "35.0 mm (35 mm equivalent: 53.0 mm)",
   "Composite:HyperfocalDistance": "7.72 m",
+  "Composite:LensID": "Samsung NX 16-50mm F2-2.8 S ED OIS",
   "Composite:LightValue": 15.3
 }]

--- a/tests/golden/SamsungNX1.srw.n.json
+++ b/tests/golden/SamsungNX1.srw.n.json
@@ -93,5 +93,6 @@
   "Composite:FOV": 37.5173323852195,
   "Composite:FocalLength35efl": 52.9999999999999,
   "Composite:HyperfocalDistance": 7.7172664799835,
+  "Composite:LensID": 13,
   "Composite:LightValue": 15.2877123795494
 }]

--- a/tests/golden/SamsungNX500.srw.json
+++ b/tests/golden/SamsungNX500.srw.json
@@ -93,5 +93,6 @@
   "Composite:FOV": "29.2 deg",
   "Composite:FocalLength35efl": "45.0 mm (35 mm equivalent: 69.0 mm)",
   "Composite:HyperfocalDistance": "11.48 m",
+  "Composite:LensID": "Samsung NX 45mm F1.8",
   "Composite:LightValue": 6.0
 }]

--- a/tests/golden/SamsungNX500.srw.n.json
+++ b/tests/golden/SamsungNX500.srw.n.json
@@ -93,5 +93,6 @@
   "Composite:FOV": 29.2417726767321,
   "Composite:FocalLength35efl": 68.9999999999999,
   "Composite:HyperfocalDistance": 11.4822940618623,
+  "Composite:LensID": 10,
   "Composite:LightValue": 6.01792190799726
 }]

--- a/tests/golden/XMP.xmp.json
+++ b/tests/golden/XMP.xmp.json
@@ -72,5 +72,6 @@
   "Composite:Aperture": 2.8,
   "Composite:ImageSize": "1136x852",
   "Composite:Megapixels": 0.968,
-  "Composite:ShutterSpeed": 0.4
+  "Composite:ShutterSpeed": 0.4,
+  "Composite:Flash": "Off, Did not fire"
 }]

--- a/tests/golden/XMP.xmp.n.json
+++ b/tests/golden/XMP.xmp.n.json
@@ -72,5 +72,6 @@
   "Composite:Aperture": 2.8,
   "Composite:ImageSize": "1136 852",
   "Composite:Megapixels": 0.967872,
-  "Composite:ShutterSpeed": 0.4
+  "Composite:ShutterSpeed": 0.4,
+  "Composite:Flash": 16
 }]

--- a/tests/golden/XMP_exif_printconv.xmp.json
+++ b/tests/golden/XMP_exif_printconv.xmp.json
@@ -8,5 +8,6 @@
   "XMP-tiff:PhotometricInterpretation": "YCbCr",
   "XMP-exif:LightSource": "Cloudy",
   "XMP-exif:MeteringMode": "Multi-segment",
-  "XMP-exif:Flash": 5
+  "XMP-exif:Flash": 5,
+  "Composite:Flash": "No Flash"
 }]

--- a/tests/golden/XMP_exif_printconv.xmp.n.json
+++ b/tests/golden/XMP_exif_printconv.xmp.n.json
@@ -8,5 +8,6 @@
   "XMP-tiff:PhotometricInterpretation": 6,
   "XMP-exif:LightSource": 10,
   "XMP-exif:MeteringMode": 5,
-  "XMP-exif:Flash": 5
+  "XMP-exif:Flash": 5,
+  "Composite:Flash": 0
 }]

--- a/tests/golden/XMP_nodeid_flash.xmp.json
+++ b/tests/golden/XMP_nodeid_flash.xmp.json
@@ -7,5 +7,6 @@
   "XMP-exif:Flash": {
     "Fired": true,
     "Mode": "On"
-  }
+  },
+  "Composite:Flash": "On, Fired"
 }]

--- a/tests/golden/XMP_nodeid_flash.xmp.n.json
+++ b/tests/golden/XMP_nodeid_flash.xmp.n.json
@@ -7,5 +7,6 @@
   "XMP-exif:Flash": {
     "Fired": true,
     "Mode": 1
-  }
+  },
+  "Composite:Flash": 9
 }]

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -276,24 +276,16 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
       "Composite:GPSPosition",
     ],
   ),
-  // #311 — the K-S2 deferred subsystems exifast does not emit (NOT Pentax — the
-  // `Composite:Flash`/`LensID`/`DateTimeCreated` Composites, the `PrintIM` IFD,
-  // and the `tiff:YCbCrSubSampling` `RawJoin`). Mirrors `conformance.rs::
+  // #311 — the K-S2. #381 ported the four cross-cutting Composites/IFD
+  // (`Composite:Flash`/`LensID`/`DateTimeCreated` + `PrintIM:PrintIMVersion`) —
+  // now emitted byte-exact, so they are NO LONGER excluded. The sole remaining
+  // deferral is the `tiff:YCbCrSubSampling` `RawJoin`. Mirrors `conformance.rs::
   // jpeg_pentax_ks2_conformance`. The golden keeps the faithful 13.59 dump.
-  (
-    "JPEG_pentax_ks2.jpg",
-    &[
-      "Composite:Flash",
-      "Composite:LensID",
-      "Composite:DateTimeCreated",
-      "PrintIM:PrintIMVersion",
-      "XMP-tiff:YCbCrSubSampling",
-    ],
-  ),
-  // #311/#318 — the 5 additional Pentax body fixtures. Each shares KS-2's
-  // cross-cutting deferred subsystems (`Composite:Flash`/`LensID`,
-  // `PrintIM:PrintIMVersion`, `XMP-tiff:YCbCrSubSampling`) MINUS the body-absent
-  // `Composite:DateTimeCreated`, PLUS the per-body `Pentax:*` model-variant /
+  ("JPEG_pentax_ks2.jpg", &["XMP-tiff:YCbCrSubSampling"]),
+  // #311/#318 — the 5 additional Pentax body fixtures. #381 ported their
+  // `Composite:Flash`/`LensID` + `PrintIM:PrintIMVersion` (now emitted
+  // byte-exact, no longer excluded); the remaining exclusions are
+  // `XMP-tiff:YCbCrSubSampling` PLUS the per-body `Pentax:*` model-variant /
   // `$count`-gated SubDirectory residuals the #379 port does not yet emit for
   // these bodies (deferred, NOT mis-decoded — exifast emits nothing, the golden
   // keeps the bundled value). These lists MIRROR EXACTLY the per-fixture
@@ -302,9 +294,6 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   (
     "JPEG_pentax_k1.jpg",
     &[
-      "Composite:Flash",
-      "Composite:LensID",
-      "PrintIM:PrintIMVersion",
       "XMP-tiff:YCbCrSubSampling",
       "Pentax:AFPointSelected",
       "Pentax:AFPointsInFocus",
@@ -324,9 +313,6 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   (
     "JPEG_pentax_k3.jpg",
     &[
-      "Composite:Flash",
-      "Composite:LensID",
-      "PrintIM:PrintIMVersion",
       "XMP-tiff:YCbCrSubSampling",
       "Pentax:AFPointSelected",
       "Pentax:ContrastHighlight",
@@ -340,9 +326,6 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   (
     "JPEG_pentax_k5_ii.jpg",
     &[
-      "Composite:Flash",
-      "Composite:LensID",
-      "PrintIM:PrintIMVersion",
       "XMP-tiff:YCbCrSubSampling",
       "Pentax:BodyBatteryVoltage3",
       "Pentax:BodyBatteryVoltage4",
@@ -388,9 +371,6 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   (
     "JPEG_pentax_k70.jpg",
     &[
-      "Composite:Flash",
-      "Composite:LensID",
-      "PrintIM:PrintIMVersion",
       "XMP-tiff:YCbCrSubSampling",
       "Pentax:AFPointsInFocus",
       "Pentax:AFPointsSelected",
@@ -408,9 +388,6 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   (
     "JPEG_pentax_kp.jpg",
     &[
-      "Composite:Flash",
-      "Composite:LensID",
-      "PrintIM:PrintIMVersion",
       "XMP-tiff:YCbCrSubSampling",
       "Pentax:AFPointSelected",
       "Pentax:AFPointsInFocus",

--- a/tools/gen_golden.sh
+++ b/tools/gen_golden.sh
@@ -103,10 +103,22 @@ case "$FIX" in
   # its derived composites (`CircleOfConfusion`/`FOV`/`FocalLength35efl`/
   # `HyperfocalDistance`) stay excluded with it. Drop only the unported lens/
   # MakerNote Composites by name (NOT `Composite:all`). Precede the generic `XMP*`.
+  # #381: `Composite:Flash` is NOW emitted (the XMP-Flash bitmask from the
+  # structured `XMP-exif:Flash` `{Mode=2,…}` ⇒ 16 ⇒ "Off, Did not fire") — no
+  # longer excluded. The unported lens chain (`ScaleFactor35efl` +
+  # `CircleOfConfusion`/`FOV`/`FocalLength35efl`/`HyperfocalDistance`) stays
+  # dropped (the Canon-rational ScaleFactor deferral above).
   XMP.xmp)
-    EXCLUDE_ARR+=(-x Composite:ScaleFactor35efl -x Composite:Flash \
+    EXCLUDE_ARR+=(-x Composite:ScaleFactor35efl \
                   -x Composite:CircleOfConfusion -x Composite:FOV \
                   -x Composite:FocalLength35efl -x Composite:HyperfocalDistance) ;;
+  # #381: `XMP_exif_printconv.xmp` / `XMP_nodeid_flash.xmp` carry ONLY a
+  # `Composite:Flash` (no other composite) — bundled emits it from the XMP flash
+  # fields ("No Flash" from the scalar `exif:Flash=5`; "On, Fired" from the
+  # `{Fired=True,Mode=1}` nodeID-recombined struct). exifast now emits the same,
+  # so these two keep `Composite:Flash` (NOT the generic `XMP*` `Composite:all`
+  # strip). They must precede the generic `XMP*` arm (first match wins).
+  XMP_exif_printconv.xmp | XMP_nodeid_flash.xmp) : ;;
   XMP*) EXCLUDE_ARR+=(-x Composite:all) ;;
   # The PNG raw-profile fixtures (#179): #133 PR 5 flips PNG into the Composite
   # allow-list, so exifast NOW emits `Composite:ImageSize`/`Megapixels` (from the
@@ -139,11 +151,12 @@ case "$FIX" in
   # position-3 `ExtenderStatus` (the K-x AVI record is 4 bytes ⇒ 'Not attached'),
   # so it is NO LONGER excluded either. Still deferred (binary SubDirectory /
   # `$$self{AEInfoSize}==24`-conditional, P2/P3): the AEInfo size-24 leaves
-  # `AEMeteringMode2`/`AEWhiteBalance`/`LevelIndicator`. The MakerNote-derived
-  # `Composite:LensID` stays the engine-wide deferral. The ported
-  # ImageSize/Megapixels/Duration are kept.
+  # `AEMeteringMode2`/`AEWhiteBalance`/`LevelIndicator`. #381: `Composite:LensID`
+  # is NOW emitted (the unambiguous K-x LensType `7 222` ⇒ "smc PENTAX-DA L
+  # 18-55mm F3.5-5.6" IS the resolved name `$prt[0]`) — no longer excluded. The
+  # ported ImageSize/Megapixels/Duration are kept.
   Pentax.avi)
-    EXCLUDE_ARR+=(-x Composite:LensID -x Pentax:AEMeteringMode2 -x Pentax:AEWhiteBalance \
+    EXCLUDE_ARR+=(-x Pentax:AEMeteringMode2 -x Pentax:AEWhiteBalance \
                   -x Pentax:LevelIndicator) ;;
   # `QuickTime_gopro_gpmf.mp4`: the `LocationInformation`-derived QuickTime GPS
   # Composites (the same `%QuickTime::Composite` deferral as the SP2/anafi arms).
@@ -347,15 +360,19 @@ case "$FIX" in
                   -x Composite:BlueBalance -x Composite:RedBalance \
                   -x Composite:AutoFocus -x Composite:LensID -x Composite:LensSpec) ;;
   # Pentax also drops `Pentax:PreviewImageStart`/`PreviewImage` (IsOffset binary
-  # extraction, unported) + `PrintIM:PrintIMVersion`. `IFD1:ThumbnailImage` is
-  # NOW emitted via the #331 EXIF `DataTag` channel (no longer excluded; the
-  # Pentax:PreviewImage IsOffset binary stays deferred — P2/P3 of #331).
+  # extraction, unported). `IFD1:ThumbnailImage` is NOW emitted via the #331 EXIF
+  # `DataTag` channel (no longer excluded; the Pentax:PreviewImage IsOffset binary
+  # stays deferred — P2/P3 of #331). `PrintIM:PrintIMVersion` is NOW emitted (the
+  # IFD0 `0xc4a5` PrintIM directory, #381) — no longer excluded.
   # PR 4: the full lens chain now builds (PENTAX, NOT Canon — the simple
-  # `$foc35/$focal` ScaleFactor path: 15/10 = 1.5). The MakerNote `Composite:
-  # LensID` + the non-Composite port deferrals remain.
+  # `$foc35/$focal` ScaleFactor path: 15/10 = 1.5). `Composite:LensID` STAYS
+  # excluded: the K10D LensType `3 44` is the AMBIGUOUS `%pentaxLensTypes` "Sigma
+  # or Tamron Lens (3 44)" — bundled disambiguates to "Sigma AF 10-20mm F4-5.6 EX
+  # DC" via `PrintLensID`'s focal-length matching, which the #381 unambiguous-
+  # LensType subset DEFERS (exifast emits no LensID here). The non-Composite port
+  # deferrals remain.
   Pentax.jpg)
     EXCLUDE_ARR+=(-x Pentax:PreviewImageStart -x Pentax:PreviewImage \
-                  -x PrintIM:PrintIMVersion \
                   -x Composite:LensID) ;;
   # DJI_Matrice30T.jpg: PR 4's full lens chain builds (DJI, NOT Canon — the
   # simple `$foc35/$focal` ScaleFactor path: 40/9.1 = 4.3956043956044), no
@@ -425,9 +442,15 @@ case "$FIX" in
   # `ImageSize`/`Megapixels`, whose `Require`d ImageWidth/Height live in the
   # deferred `SubIFD1`). exifast emits the residual (IFD0/ExifIFD/Samsung/
   # PreviewIFD/the 8 ported Composites) byte-exact vs bundled ExifTool 13.59.
+  # #381: `Composite:LensID` is NOW emitted (the unambiguous Samsung LensType —
+  # `Samsung NX 45mm F1.8` / `Samsung NX 16-50mm F2-2.8 S ED OIS` — IS the
+  # resolved name `$prt[0]`, no disambiguation needed), so it is NO LONGER
+  # excluded. The other MakerNote-derived Composites (`WB_RGGBLevels`/`RedBalance`/
+  # `BlueBalance`/`CFAPattern`) + the `SubIFD1`-deferred `ImageSize`/`Megapixels`
+  # stay dropped.
   SamsungNX500.srw | SamsungNX1.srw)
     EXCLUDE_ARR+=(-x SubIFD:all -x SubIFD1:all \
-                  -x Composite:LensID -x Composite:WB_RGGBLevels \
+                  -x Composite:WB_RGGBLevels \
                   -x Composite:RedBalance -x Composite:BlueBalance \
                   -x Composite:CFAPattern -x Composite:ImageSize \
                   -x Composite:Megapixels) ;;


### PR DESCRIPTION
Ports the cross-cutting tags previously excluded from the 6 Pentax fixtures (and benefits the whole suite — Composite:Flash + PrintIM are widespread):

- **Composite:Flash** (the XMP Composite, XMP.pm:2808) — assembles the EXIF bitmask from the XMP:Flash struct/flat Desires; ExifTool's `$found` gate replicated (early-None so flash-less files don't synthesize 'No Flash').
- **Composite:LensID** (Exif.pm:5303) — for an unambiguous LensType, `PrintLensID` returns the LensType's own PrintConv, so this reuses exifast's existing lens tables (no new DB). **Defers** (None) when a vendor disambiguator is active — Sony LensType2 (`&0x8000||==0`), Canon RFLensType (truthy), Pentax converter (LensFocalLength/FocalLength > 1.1) — mirroring `PrintLensID`'s branches.
- **Composite:DateTimeCreated** (IPTC.pm:943) — concat of IPTC:DateCreated + TimeCreated.
- **PrintIM:PrintIMVersion** — a new `src/exif/printim/` parser for the 0xc4a5 `%Exif::Main` SubDirectory (gated to Exif/Interop, **not** GPS), with faithful `ProcessPrintIM` warnings (`[minor] Empty PrintIM data` vs normal `Bad PrintIM data`/`Invalid PrintIM header`/`Bad PrintIM size`).

Un-excluded the 4 tags from all 6 Pentax fixtures (ks2 also DateTimeCreated); 14 goldens gained the tags byte-exact vs 13.59 (Pentax.jpg/Samsung NX/Pentax.avi/XMP fixtures). Ambiguous Pentax 'X or Y' + Canon/Nikon/Apple LensID deferred (a clear scope note). `build(-Dwarnings)=0 conformance=453/0 typed_serde=573 lib=3627/0 xtask=26/0`. **Codex: 4 rounds to APPROVE** (LensID vendor-defer + ratio guard, PrintIM warnings + severity + table-scope). Closes #381.