### PR TITLE
feat(exif/pentax): multi-model Main conditional branches — un-exclude per-body variants from the 6 fixtures (#311)

### DIFF
--- a/src/exif/makernotes/vendors/pentax/printconv.rs
+++ b/src/exif/makernotes/vendors/pentax/printconv.rs
@@ -379,30 +379,84 @@ fn flash_exposure_comp(raw: &RawValue, print_conv: bool) -> TagValue {
   TagValue::Str(SmolStr::from(parts.join("; ")))
 }
 
-/// `0x000e AFPointSelected` "other models" variant (`Pentax.pm:1375-1408`) —
-/// int16u[2], a 2-element ARRAY PrintConv: element 0 via the 18-entry
-/// [`AF_POINT_SELECTED`](super::tags::AF_POINT_SELECTED) hash (incl. the `0xfff*`
-/// special keys), element 1 via `{0=>'Single Point', 1=>'Expanded Area'}`, joined
-/// `"; "`. A miss renders `Unknown (N)` (no `PrintHex`). `-n` ⇒ the space-joined
-/// raw run.
-fn af_point_selected(raw: &RawValue, print_conv: bool) -> TagValue {
+/// `0x000e AFPointSelected` — a MODEL-VARIANT `int16u[N]` 2-element ARRAY PrintConv
+/// (`Pentax.pm:1219-1408`). The element-0 + element-1 PrintConv hashes are selected
+/// by `$$self{Model}` (the ExifTool array-of-`Condition`-variants):
+///   * `/(K-1|645Z)\b/` ⇒ [`AF_POINT_SELECTED_K1`] + [`AF_POINT_SELECTED_K1_AREA`]
+///     (`33-point (L)`);
+///   * `/(K-3|KP)\b/`   ⇒ [`AF_POINT_SELECTED_K3`] + [`AF_POINT_SELECTED_K3_AREA`]
+///     (`27-point (L)`);
+///   * everything else (K10D / K-x / K-5 II / K-70 / K-S2, INCLUDING a `None`
+///     model) ⇒ [`AF_POINT_SELECTED`] + [`AF_POINT_SELECTED_AREA`].
+/// Each element renders via its positional hash (element 0 the point hash, every
+/// later element the area hash — the Perl `$$convList[-1]` reuse), joined `"; "`.
+/// A miss renders `Unknown (N)` (no `PrintHex`). `-n` ⇒ the space-joined raw run.
+pub(crate) fn af_point_selected_for_model(
+  raw: &RawValue,
+  print_conv: bool,
+  model: Option<&str>,
+) -> TagValue {
+  use super::tags::{
+    AF_POINT_SELECTED, AF_POINT_SELECTED_AREA, AF_POINT_SELECTED_K1, AF_POINT_SELECTED_K1_AREA,
+    AF_POINT_SELECTED_K3, AF_POINT_SELECTED_K3_AREA,
+  };
   if !print_conv {
     return TagValue::Str(SmolStr::from(space_join(raw)));
   }
   let Some(elems) = numeric_elems(raw) else {
     return raw_to_tag_value(raw);
   };
-  const AREA: &[(i64, &str)] = &[(0, "Single Point"), (1, "Expanded Area")];
-  let tables: [&[(i64, &str)]; 2] = [super::tags::AF_POINT_SELECTED, AREA];
+  // Mirror `conditional_leaf`'s `(K-1|645Z)` / `(K-3|KP)` model-word gate.
+  let (point, area): (&[(i64, &str)], &[(i64, &str)]) =
+    if model.is_some_and(|m| af_model_word(m, "K-1") || af_model_word(m, "645Z")) {
+      (AF_POINT_SELECTED_K1, AF_POINT_SELECTED_K1_AREA)
+    } else if model.is_some_and(|m| af_model_word(m, "K-3") || af_model_word(m, "KP")) {
+      (AF_POINT_SELECTED_K3, AF_POINT_SELECTED_K3_AREA)
+    } else {
+      (AF_POINT_SELECTED, AF_POINT_SELECTED_AREA)
+    };
   let mut parts: std::vec::Vec<std::string::String> = std::vec::Vec::new();
   for (i, &n) in elems.iter().enumerate() {
-    let table = *tables.get(i).or_else(|| tables.last()).unwrap_or(&AREA);
+    // Element 0 ⇒ the point hash; every later element ⇒ the area hash (the Perl
+    // `$$convList[-1]` reuse for the trailing positions).
+    let table = if i == 0 { point } else { area };
     match hash_get(table, n) {
       Some(l) => parts.push(l.to_string()),
       None => parts.push(std::format!("Unknown ({n})")),
     }
   }
   TagValue::Str(SmolStr::from(parts.join("; ")))
+}
+
+/// The `PentaxPrintConv::AfPointSelected` `apply` arm has no `$$self{Model}`
+/// context (the conv is `Copy` and dispatched by value), so it renders the "other
+/// models" variant. The model-keyed K-1 / K-3 variants render through
+/// [`af_point_selected_for_model`] at the emit site (which DOES have `model`); the
+/// 0x000e leaf is routed there, not here, so this only serves a defensive
+/// `emit_entry` of a 0x000e with no model in scope.
+fn af_point_selected(raw: &RawValue, print_conv: bool) -> TagValue {
+  af_point_selected_for_model(raw, print_conv, None)
+}
+
+/// `true` when `model` contains `needle` followed by a Perl `\b` word boundary —
+/// the same ASCII `\b` test [`tags::model_word_match`](super::tags) uses for the
+/// `0x000e` model gate, duplicated here to keep `printconv` free of a `tags`
+/// cross-import for one predicate.
+fn af_model_word(model: &str, needle: &str) -> bool {
+  let mut from = 0;
+  while let Some(rel) = model.get(from..).and_then(|sub| sub.find(needle)) {
+    let start = from + rel;
+    let end = start + needle.len();
+    let boundary_ok = model
+      .get(end..)
+      .and_then(|sub| sub.chars().next())
+      .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+    if boundary_ok {
+      return true;
+    }
+    from = end;
+  }
+  false
 }
 
 /// `0x000f AFPointsInFocus` for `/K-(3|S1|S2)\b/` (`Pentax.pm:1409-1446`) — int32u,

--- a/src/exif/makernotes/vendors/pentax/printconv/tests.rs
+++ b/src/exif/makernotes/vendors/pentax/printconv/tests.rs
@@ -351,3 +351,93 @@ fn af_points_in_focus_ks2_bottom_row_bits() {
   // `-n`: the raw int.
   assert_eq!(conv.apply(&u(&[1 << 24]), false), TagValue::I64(1 << 24));
 }
+
+#[test]
+fn af_point_selected_model_special_high_values() {
+  // 0x000e AFPointSelected — the model-keyed element-0 hashes carry the
+  // `0xfffb`-`0xffff` SPECIAL selections (Pentax.pm:1225-1230 K-1, 1302-1306
+  // K-3/KP, 1382-1387 "other models"). The 6 body fixtures only ever exercise a
+  // normal point (the K-3/KP fixture is raw 14 = "Center"), so these specials are
+  // unexercised by the goldens — assert them directly via the model dispatcher.
+  // Same defect class as `af_points_in_focus_ks2_bottom_row_bits` (a PrintConv
+  // table missing the high values the fixtures don't hit).
+
+  // K-3 / KP variant (AF_POINT_SELECTED_K3): the five specials previously MISSING
+  // from the table rendered "Unknown (6553x)"; they now resolve.
+  let kp = Some("PENTAX KP");
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xffff]), true, kp),
+    TagValue::Str("Auto".into())
+  );
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xfffe]), true, kp),
+    TagValue::Str("Fixed Center".into())
+  );
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xfffc]), true, Some("PENTAX K-3 Mark III")),
+    TagValue::Str("Face Detect AF".into())
+  );
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xfffb]), true, Some("PENTAX K-3")),
+    TagValue::Str("AF Select".into())
+  );
+  // The K-3/KP fixture value (raw 14 = the normal "Center" point) is UNCHANGED by
+  // the appended specials — the golden stays byte-identical.
+  assert_eq!(
+    af_point_selected_for_model(&u(&[14]), true, kp),
+    TagValue::Str("Center".into())
+  );
+  // The K-3/KP hash has NO `0xfffa` (that is the "other models" 'Auto 2' only) ⇒
+  // a K-3 raw 0xfffa misses ⇒ decimal "Unknown (N)" (no PrintHex on this leaf).
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xfffa]), true, kp),
+    TagValue::Str("Unknown (65530)".into())
+  );
+
+  // K-1 / 645Z variant (AF_POINT_SELECTED_K1): the same five specials, plus its
+  // own 33-point geometry (raw 17 = "Center" here, NOT 14).
+  let k1 = Some("PENTAX K-1");
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xffff]), true, k1),
+    TagValue::Str("Auto".into())
+  );
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xfffd]), true, Some("PENTAX 645Z")),
+    TagValue::Str("Automatic Tracking AF".into())
+  );
+  assert_eq!(
+    af_point_selected_for_model(&u(&[17]), true, k1),
+    TagValue::Str("Center".into())
+  );
+
+  // "other models" variant (AF_POINT_SELECTED): already had all six specials,
+  // INCLUDING `0xfffa` 'Auto 2'. The K10D fixture is the single-element record.
+  let k10d = Some("PENTAX K10D");
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xfffa]), true, k10d),
+    TagValue::Str("Auto 2".into())
+  );
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xffff]), true, k10d),
+    TagValue::Str("Auto".into())
+  );
+
+  // The count-2 record threads the element-1 AREA hash (a special in element 0,
+  // an Expanded-Area size in element 1, joined "; "). K-3/KP element 1 = the
+  // 27-point ladder; K-1 element 1 = the 33-point ladder.
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xffff, 5]), true, kp),
+    TagValue::Str("Auto; Expanded Area 27-point (L)".into())
+  );
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xfffe, 5]), true, k1),
+    TagValue::Str("Fixed Center; Expanded Area 33-point (L)".into())
+  );
+
+  // `-n` (print_conv = false) is the space-joined raw run for every model, so a
+  // special value is NOT label-decoded.
+  assert_eq!(
+    af_point_selected_for_model(&u(&[0xffff]), false, kp),
+    TagValue::Str("65535".into())
+  );
+}

--- a/src/exif/makernotes/vendors/pentax/subtables.rs
+++ b/src/exif/makernotes/vendors/pentax/subtables.rs
@@ -1397,6 +1397,30 @@ pub(crate) fn emit_battery_info(
       push(out, "GripBatteryADLoad", int_value(i64::from(v)));
     }
   }
+  // 6: BodyBatteryVoltage3 (int16u, BigEndian) — `/(K-5|K-r|645D)\b/`
+  // (`Pentax.pm:4941-4950`). `$val / 100`; PrintConv `sprintf("%.2f V", $val)`.
+  // The K-5 II matches (`K-5\b`); offset 6/7 is out of the 6-byte K10D record so a
+  // non-voltage body never reads here.
+  if is_body_voltage3(model) {
+    if let Some(v) = read_u16(block, 6, ByteOrder::Big) {
+      push(
+        out,
+        "BodyBatteryVoltage3",
+        battery_voltage(i64::from(v), print_conv),
+      );
+    }
+  }
+  // 8: BodyBatteryVoltage4 (int16u, BigEndian) — `/(K-5|K-r)\b/`
+  // (`Pentax.pm:4951-4960`). The K-5 II matches.
+  if is_body_voltage4(model) {
+    if let Some(v) = read_u16(block, 8, ByteOrder::Big) {
+      push(
+        out,
+        "BodyBatteryVoltage4",
+        battery_voltage(i64::from(v), print_conv),
+      );
+    }
+  }
 }
 
 /// `true` when `model` matches `/K-3 Mark III/` (a plain substring — ExifTool's
@@ -1459,6 +1483,18 @@ fn is_body_voltage(model: Option<&str>) -> bool {
       "K-x", "K-S1", "K-S2", "KP",
     ],
   )
+}
+
+/// `true` for the BatteryInfo `6 BodyBatteryVoltage3` `/(K-5|K-r|645D)\b/`
+/// (`Pentax.pm:4943`). The K-5 II matches via `K-5\b`.
+fn is_body_voltage3(model: Option<&str>) -> bool {
+  model_matches_any(model, &["K-5", "K-r", "645D"])
+}
+
+/// `true` for the BatteryInfo `8 BodyBatteryVoltage4` `/(K-5|K-r)\b/`
+/// (`Pentax.pm:4953`). The K-5 II matches via `K-5\b`.
+fn is_body_voltage4(model: Option<&str>) -> bool {
+  model_matches_any(model, &["K-5", "K-r"])
 }
 
 /// `BodyBatteryVoltage1`/`Voltage2` value: `$val / 100`; PrintConv
@@ -2115,12 +2151,19 @@ pub(crate) fn emit_caf_point_info(
   // space-joined run (empty when `num == 0`).
   let n_bytes = ((num.max(0) as usize) + 3) / 4;
   let slice: &[u8] = block.get(2..2 + n_bytes).unwrap_or(&[]);
-  for (name, bit_val) in [("CAFPointsInFocus", 0x02u8), ("CAFPointsSelected", 0x03u8)] {
+  // CAFPointsInFocus: `DecodeAFPoints($val,$num,2,0x02)`; CAFPointsSelected:
+  // `DecodeAFPoints($val,$num,2,0x03)` — both with `$bitVal` undef (mask-truthy).
+  for (name, point_mask) in [
+    ("CAFPointsInFocus", 0x02i64),
+    ("CAFPointsSelected", 0x03i64),
+  ] {
     if print_conv {
       push(
         out,
         name,
-        TagValue::Str(SmolStr::from(decode_af_points(slice, num, 2, bit_val))),
+        TagValue::Str(SmolStr::from(decode_af_points(
+          slice, num, 2, point_mask, None,
+        ))),
       );
     } else {
       // `-n`: the default space-joined int8u run.
@@ -2134,13 +2177,95 @@ pub(crate) fn emit_caf_point_info(
   }
 }
 
+/// `true` when `model` matches the AFPointInfo offset-4 regex `/K(P|-1|-70)\b/`
+/// (`Pentax.pm:6081`/`:6088`/`:6095`) — the K-1, K-70 and KP. The Perl alternation
+/// is `K` then `(P|-1|-70)` pinned by a trailing `\b`: `KP\b`, `K-1\b`, `K-70\b`
+/// (so `K-1` matches `"PENTAX K-1"` but the embedded `K-1` of a longer token is
+/// boundary-checked). No other model writes these three leaves.
+fn is_af_point_info_decoded(model: Option<&str>) -> bool {
+  model_matches_any(model, &["KP", "K-1", "K-70"])
+}
+
+/// Decode `%Pentax::AFPointInfo` (`0x0245`, `Pentax.pm:6067-6100`) — the K-1-style
+/// AF-point info (`FORMAT` default `int8u`, inherits the resolved MakerNote byte
+/// order for the int16u `NumAFPoints`). Emits NumAFPoints (@2, int16u, a
+/// `DATAMEMBER`) and — for the `/K(P|-1|-70)\b/` bodies — AFPointsInFocus (@4),
+/// AFPointsSelected (@4.1) and AFPointsSpecial (@4.2), each a `DecodeAFPoints` over
+/// the same `int8u[int((NumAFPoints+3)/4)]` slice at byte 4:
+///   * AFPointsInFocus  — `DecodeAFPoints($val,$num,2,0x02)`      (mask-truthy)
+///   * AFPointsSelected — `DecodeAFPoints($val,$num,2,0x03)`      (mask-truthy)
+///   * AFPointsSpecial  — `DecodeAFPoints($val,$num,2,0x03,0x03)` (== 0x03)
+/// The offset-0 int16u (a version?) is undocumented and not emitted. A model NOT
+/// in the `/K(P|-1|-70)\b/` list still emits the UNCONDITIONAL NumAFPoints but none
+/// of the three decoded leaves; no active fixture carries that case (only K-1/KP/
+/// K-70 write a 0x0245 subdir), but the gate is faithful to the per-leaf Condition.
+pub(crate) fn emit_af_point_info(
+  block: &[u8],
+  order: ByteOrder,
+  model: Option<&str>,
+  print_conv: bool,
+  out: &mut std::vec::Vec<VendorEmission>,
+) {
+  // 2: NumAFPoints — `Format => 'int16u'`, `RawConv => '$$self{NumAFPoints} =
+  // $val'`. UNCONDITIONAL. Read in the inherited MakerNote order. No PrintConv.
+  let Some(num_u) = read_u16(block, 2, order) else {
+    return;
+  };
+  let num = i64::from(num_u);
+  push(out, "NumAFPoints", int_value(num));
+  // 4/4.1/4.2: AFPointsInFocus / AFPointsSelected / AFPointsSpecial — the
+  // `/K(P|-1|-70)\b/`-gated `int8u[int((NumAFPoints+3)/4)]` slice at byte 4.
+  if !is_af_point_info_decoded(model) {
+    return;
+  }
+  let n_bytes = ((num.max(0) as usize) + 3) / 4;
+  let slice: &[u8] = block.get(4..4 + n_bytes).unwrap_or(&[]);
+  for (name, point_mask, bit_val) in [
+    ("AFPointsInFocus", 0x02i64, None),
+    ("AFPointsSelected", 0x03i64, None),
+    ("AFPointsSpecial", 0x03i64, Some(0x03i64)),
+  ] {
+    if print_conv {
+      push(
+        out,
+        name,
+        TagValue::Str(SmolStr::from(decode_af_points(
+          slice, num, 2, point_mask, bit_val,
+        ))),
+      );
+    } else {
+      // `-n`: the default space-joined int8u run (the Writable=>0 leaves still
+      // print their raw bytes under `-n`, matching ExifTool's `-G1 -n`).
+      let joined = slice
+        .iter()
+        .map(u8::to_string)
+        .collect::<std::vec::Vec<_>>()
+        .join(" ");
+      push(out, name, TagValue::Str(SmolStr::from(joined)));
+    }
+  }
+}
+
 /// `Image::ExifTool::Pentax::DecodeAFPoints` (`Pentax.pm:6730-6754`): walk `num`
 /// AF points packed `bits`-per-point across `bytes`, listing the 1-based index of
-/// each point whose `bits`-wide field (high bits first) equals `bit_val`. An
-/// EMPTY byte slice returns `'(none)'`; otherwise a comma-joined index list (also
-/// `'(none)'`-displayed by the join when empty? — no, ExifTool joins to `''`, but
-/// the empty-slice early-return covers the K-S2's `num == 0`).
-fn decode_af_points(bytes: &[u8], num: i64, bits: u32, bit_val: u8) -> std::string::String {
+/// each point whose `bits`-wide field (high bits first), `mask`ed, matches.
+///
+/// Faithful to the Perl `($val,$num,$bits,$mask,$bitVal)` signature: when
+/// `bit_val` is `Some(v)`, a point is listed iff `(($byte >> $shift) & $mask) ==
+/// v` (the `AFPointsSpecial` `0x03,0x03` call); when `None`, iff `($byte >>
+/// $shift) & $mask` is non-zero (the `AFPointsInFocus 0x02` / `AFPointsSelected
+/// 0x03` calls, where `$bitVal` is `undef`). `mask` is the explicit Perl `$mask`
+/// — NOT `(1<<bits)-1` — because the `0x02` calls mask a single bit out of the
+/// 2-bit field. An EMPTY byte slice returns `'(none)'`; otherwise a comma-joined
+/// 1-based index list (empty-displayed as `''`, which the empty-slice early-return
+/// only short-circuits for `num == 0`).
+fn decode_af_points(
+  bytes: &[u8],
+  num: i64,
+  bits: u32,
+  mask: i64,
+  bit_val: Option<i64>,
+) -> std::string::String {
   let Some(&first) = bytes.first() else {
     return "(none)".to_string();
   };
@@ -2149,10 +2274,14 @@ fn decode_af_points(bytes: &[u8], num: i64, bits: u32, bit_val: u8) -> std::stri
   let mut idx = 0usize;
   let mut byte = i64::from(first);
   let mut shift = shift0;
-  let mask_bits = (1i64 << bits) - 1;
   let mut bit_list: std::vec::Vec<std::string::String> = std::vec::Vec::new();
   loop {
-    if ((byte >> shift) & mask_bits) == i64::from(bit_val) {
+    let field = (byte >> shift) & mask;
+    let hit = match bit_val {
+      Some(v) => field == v,
+      None => field != 0,
+    };
+    if hit {
       bit_list.push(i.to_string());
     }
     i += 1;

--- a/src/exif/makernotes/vendors/pentax/tags.rs
+++ b/src/exif/makernotes/vendors/pentax/tags.rs
@@ -224,6 +224,16 @@ pub enum SubTable {
   /// SourceDirectoryIndex (@byte 0) + SourceFileIndex (@byte 2); the 20
   /// `DigitalFilterNN` blobs are deferred.
   FilterInfo,
+  /// `%Pentax::AFPointInfo` at `0x0245` (`Pentax.pm:3117-3120`, `:6067-6100`) —
+  /// the K-1-style AF-point info (`int8u`/`FIRST_ENTRY 0`; the int16u NumAFPoints
+  /// inherits the resolved MakerNote order). The Main `0x0245` row is
+  /// UNCONDITIONAL (a plain SubDirectory). Emits NumAFPoints (@2) and — for the
+  /// `/K(P|-1|-70)\b/` bodies — AFPointsInFocus / AFPointsSelected /
+  /// AFPointsSpecial (@4, each `DecodeAFPoints` over an `int8u[(NumAFPoints+3)/4]`
+  /// slice). Only the K-1, KP and K-70 write a 0x0245 subdir; the K-3 III
+  /// `AFPointValues` belongs to the separate `0x021f AFInfo` table and is deferred
+  /// (no K-3 III fixture).
+  AfPointInfo,
 }
 
 /// The ported `%Pentax::Main` rows — sorted by `id` for binary search.
@@ -1128,6 +1138,17 @@ pub const PENTAX_TAGS: &[PentaxTag] = &[
     unknown: false,
     format: None,
   },
+  // `0x0245 AFPointInfo` (`Pentax.pm:3117-3120`) — a plain SubDirectory (no
+  // explicit `Format` ⇒ implicit-`undef`, the whole block reaches the child).
+  // Written only by the K-1, KP and K-70.
+  PentaxTag {
+    id: 0x0245,
+    name: "AFPointInfo",
+    conv: PentaxPrintConv::None,
+    sub_table: Some(SubTable::AfPointInfo),
+    unknown: false,
+    format: None,
+  },
 ];
 
 /// Look up a `%Pentax::Main` tag by ID. Returns `None` for an unported /
@@ -1175,8 +1196,8 @@ pub fn format_override(id: u16) -> Option<Format> {
 /// repeated across many entries would otherwise force. Mirrors
 /// [`nikon::is_implicit_undef_subdir`](super::super::nikon::is_implicit_undef_subdir);
 /// matches the implicit-`undef` SubDirectory rows `0x003f LensRec`, `0x0205`
-/// CameraSettings, `0x0206` AEInfo, `0x0207` LensInfo, `0x0208` FlashInfo and
-/// `0x0215` CameraInfo.
+/// CameraSettings, `0x0206` AEInfo, `0x0207` LensInfo, `0x0208` FlashInfo,
+/// `0x0215` CameraInfo and `0x0245` AFPointInfo.
 #[must_use]
 pub fn is_implicit_undef_subdir(id: u16) -> bool {
   lookup(id).is_some_and(|tag| tag.format_override().is_none() && tag.sub_table().is_some())
@@ -1427,25 +1448,29 @@ pub fn conditional_leaf(
       ConditionalLeaf::Suppress
     }
   }
+  // `count` (ExifTool's `$count`) is one of the four Condition axes this fn maps;
+  // none of the CURRENTLY-ported gated leaves branches on it (the `0x0016` / `0x004d`
+  // `$count` variants are now both ported and select inside the PrintConv, not
+  // here), but it stays in the signature as a documented Condition input a future
+  // `$count`-gated leaf would consult. Discard it explicitly to keep the unused
+  // axis visible rather than silently dropped.
+  let _ = count;
   match id {
     // ---- GATED #173 leaves ----
     // `$$self{Make} !~ /^Asahi/` selects the ported "Pentax models" variant; an
     // Asahi body (the deferred "Asahi models" hash) ⇒ suppress. A `None` Make
     // (videos) is `!~ /^Asahi/` ⇒ emit.
     0x000d => gate(make.is_none_or(|m| !make_prefix_match(m, "Asahi"))),
-    // The "other models" variant — selected when the model is NOT K-1/645Z and
-    // NOT K-3/KP (those use the deferred model-keyed 0x000e arms). The
-    // [`PentaxPrintConv::AfPointSelected`] conv now renders the FULL int16u[N]
-    // array (element 0 the 11-point hash, element 1 the Single-Point/Expanded-Area
-    // hash), so BOTH the K10D single-element (`'Center'`) and the K-S2
-    // two-element (`'Center; Single Point'`) records emit. A `None` model can only
-    // be the non-K-1/3 arm.
-    0x000e => {
-      let is_k1_645z =
-        model.is_some_and(|m| model_word_match(m, "K-1") || model_word_match(m, "645Z"));
-      let is_k3_kp = model.is_some_and(|m| model_word_match(m, "K-3") || model_word_match(m, "KP"));
-      gate(!is_k1_645z && !is_k3_kp)
-    }
+    // `0x000e AFPointSelected` — ALL THREE model variants are now ported (#311):
+    // the `/(K-1|645Z)\b/` 33-point hash, the `/(K-3|KP)\b/` 27-point hash and the
+    // "other models" 11-point hash. The emit site routes 0x000e through
+    // [`printconv::af_point_selected_for_model`](super::printconv) (which selects
+    // the element-0/element-1 hashes by `$$self{Model}`), so the leaf emits
+    // unconditionally — every record matches exactly one model variant and renders
+    // the FULL int16u[N] array (element 0 the point hash, element 1 the
+    // Single-Point/Expanded-Area hash). A `None` model takes the "other models"
+    // arm.
+    0x000e => ConditionalLeaf::Emit,
     // `0x000f AFPointsInFocus` (`Pentax.pm:1409-1465`) — TWO variants selected by
     // `Condition`. The port implements variant 1, the int32u 27-bit BITMASK
     // (`PrintHex`, `{0=>'(none)', BITMASK=>{...}}`), whose `Condition` is
@@ -1460,9 +1485,14 @@ pub fn conditional_leaf(
     // 0x000f — their `AFPointsInFocus` is the separate `0x021f AFInfo` leaf), so
     // this gate is byte-identical across every active and held fixture.
     0x000f => gate(model.is_some_and(is_afpoints_in_focus_bitmask)),
-    // `$count == 1` selects the ported int16u variant; the count-2 variant is
-    // deferred.
-    0x0016 => gate(count == 1),
+    // `0x0016 ExposureCompensation` — BOTH variants are ported (#311): the
+    // `$count == 1` int16u (`($val-50)/10`) and the `Count => 2` variant. The
+    // count-2 ValueConv is `$val =~ s/ .*//; ($val-50)/10` — it strips everything
+    // after the first space, i.e. takes ELEMENT 0 ONLY, so it produces the SAME
+    // scalar as the count-1 path. [`PentaxPrintConv::ExposureCompensation`] reads
+    // element 0 via `first_i64`, so the leaf emits for either count (the 2nd
+    // element, meaning-unknown, is correctly ignored).
+    0x0016 => ConditionalLeaf::Emit,
     // `$val/100` (variant 2) is the ported FocalLength; an Optio body in the
     // `/^PENTAX Optio (30|33WR|43WR|450|550|555|750Z|X)\b/` list uses the
     // deferred `$val/10` variant ⇒ suppress (10× different).
@@ -1773,10 +1803,10 @@ pub const FOCUS_MODE: &[(i64, &str)] = &[
 ];
 
 /// `0x000e AFPointSelected` element-0 PrintConv (the "other models" K10D
-/// variant, `Pentax.pm:1380-1399`) — sorted by key for binary search. The value
-/// is a single `int16u`, so only this (element-0) hash applies; the element-1
-/// hash (extended tracking, `Pentax.pm:1400-1407`) is unreachable for a
-/// one-element value and is not ported.
+/// variant, `Pentax.pm:1380-1399`) — sorted by key for binary search. Used for
+/// every body NOT matching `/(K-1|645Z)\b/` or `/(K-3|KP)\b/` (the K10D / K-x /
+/// K-5 II / K-70 / K-S2). For a TWO-element record (the K-5 II(s), K-S2) element 1
+/// resolves via [`AF_POINT_SELECTED_AREA`].
 pub const AF_POINT_SELECTED: &[(i64, &str)] = &[
   (0, "None"),
   (1, "Upper-left"),
@@ -1796,6 +1826,165 @@ pub const AF_POINT_SELECTED: &[(i64, &str)] = &[
   (0xfffd, "Automatic Tracking AF"),
   (0xfffe, "Fixed Center"),
   (0xffff, "Auto"),
+];
+
+/// `0x000e AFPointSelected` element-1 PrintConv for the "other models" variant
+/// (`Pentax.pm:1400-1407`, the K-5 II(s) / K-70 / K-S2 etc. extended-tracking
+/// flag): `{0=>'Single Point', 1=>'Expanded Area'}`. Sorted by key.
+pub const AF_POINT_SELECTED_AREA: &[(i64, &str)] = &[(0, "Single Point"), (1, "Expanded Area")];
+
+/// `0x000e AFPointSelected` element-0 PrintConv for the K-1 / 645Z variant
+/// (`Condition => '$$self{Model} =~ /(K-1|645Z)\b/'`, `Pentax.pm:1225-1287`) — the
+/// 33-point pattern plus the Zone-Select labels and the `0xfffb`-`0xffff` special
+/// selections (AF Select / Face Detect AF / Automatic Tracking AF / Fixed Center /
+/// Auto; like the K-3/KP hash, NO `0xfffa` 'Auto 2'). Sorted by key for binary
+/// search.
+pub const AF_POINT_SELECTED_K1: &[(i64, &str)] = &[
+  (0, "None"),
+  (1, "Top-left"),
+  (2, "Top Near-left"),
+  (3, "Top"),
+  (4, "Top Near-right"),
+  (5, "Top-right"),
+  (6, "Upper Far-left"),
+  (7, "Upper-left"),
+  (8, "Upper Near-left"),
+  (9, "Upper-middle"),
+  (10, "Upper Near-right"),
+  (11, "Upper-right"),
+  (12, "Upper Far-right"),
+  (13, "Far Far Left"),
+  (14, "Far Left"),
+  (15, "Left"),
+  (16, "Near-left"),
+  (17, "Center"),
+  (18, "Near-right"),
+  (19, "Right"),
+  (20, "Far Right"),
+  (21, "Far Far Right"),
+  (22, "Lower Far-left"),
+  (23, "Lower-left"),
+  (24, "Lower Near-left"),
+  (25, "Lower-middle"),
+  (26, "Lower Near-right"),
+  (27, "Lower-right"),
+  (28, "Lower Far-right"),
+  (29, "Bottom-left"),
+  (30, "Bottom Near-left"),
+  (31, "Bottom"),
+  (32, "Bottom Near-right"),
+  (33, "Bottom-right"),
+  (263, "Zone Select Upper-left"),
+  (264, "Zone Select Upper Near-left"),
+  (265, "Zone Select Upper Middle"),
+  (266, "Zone Select Upper Near-right"),
+  (267, "Zone Select Upper-right"),
+  (270, "Zone Select Far Left"),
+  (271, "Zone Select Left"),
+  (272, "Zone Select Near-left"),
+  (273, "Zone Select Center"),
+  (274, "Zone Select Near-right"),
+  (275, "Zone Select Right"),
+  (276, "Zone Select Far Right"),
+  (279, "Zone Select Lower-left"),
+  (280, "Zone Select Lower Near-left"),
+  (281, "Zone Select Lower-middle"),
+  (282, "Zone Select Lower Near-right"),
+  (283, "Zone Select Lower-right"),
+  (0xfffb, "AF Select"),
+  (0xfffc, "Face Detect AF"),
+  (0xfffd, "Automatic Tracking AF"),
+  (0xfffe, "Fixed Center"),
+  (0xffff, "Auto"),
+];
+
+/// `0x000e AFPointSelected` element-1 PrintConv for the K-1 / 645Z variant
+/// (`Pentax.pm:1288-1293`): the Expanded-Area sizes ending in `33-point (L)`.
+/// Sorted by key.
+pub const AF_POINT_SELECTED_K1_AREA: &[(i64, &str)] = &[
+  (0, "Single Point"),
+  (1, "Expanded Area 9-point (S)"),
+  (3, "Expanded Area 25-point (M)"),
+  (5, "Expanded Area 33-point (L)"),
+];
+
+/// `0x000e AFPointSelected` element-0 PrintConv for the K-3 / KP variant
+/// (`Condition => '$$self{Model} =~ /(K-3|KP)\b/'`, `Pentax.pm:1300-1368`) — the
+/// 27-point pattern plus the Zone-Select labels and the `0xfffb`-`0xffff` special
+/// selections (AF Select / Face Detect AF / Automatic Tracking AF / Fixed Center /
+/// Auto; the K-3/KP hash has NO `0xfffa` 'Auto 2', unlike the "other models"
+/// hash). Sorted by key for binary search.
+pub const AF_POINT_SELECTED_K3: &[(i64, &str)] = &[
+  (0, "None"),
+  (1, "Top-left"),
+  (2, "Top Near-left"),
+  (3, "Top"),
+  (4, "Top Near-right"),
+  (5, "Top-right"),
+  (6, "Upper-left"),
+  (7, "Upper Near-left"),
+  (8, "Upper-middle"),
+  (9, "Upper Near-right"),
+  (10, "Upper-right"),
+  (11, "Far Left"),
+  (12, "Left"),
+  (13, "Near-left"),
+  (14, "Center"),
+  (15, "Near-right"),
+  (16, "Right"),
+  (17, "Far Right"),
+  (18, "Lower-left"),
+  (19, "Lower Near-left"),
+  (20, "Lower-middle"),
+  (21, "Lower Near-right"),
+  (22, "Lower-right"),
+  (23, "Bottom-left"),
+  (24, "Bottom Near-left"),
+  (25, "Bottom"),
+  (26, "Bottom Near-right"),
+  (27, "Bottom-right"),
+  (257, "Zone Select Top-left"),
+  (258, "Zone Select Top Near-left"),
+  (259, "Zone Select Top"),
+  (260, "Zone Select Top Near-right"),
+  (261, "Zone Select Top-right"),
+  (262, "Zone Select Upper-left"),
+  (263, "Zone Select Upper Near-left"),
+  (264, "Zone Select Upper-middle"),
+  (265, "Zone Select Upper Near-right"),
+  (266, "Zone Select Upper-right"),
+  (267, "Zone Select Far Left"),
+  (268, "Zone Select Left"),
+  (269, "Zone Select Near-left"),
+  (270, "Zone Select Center"),
+  (271, "Zone Select Near-right"),
+  (272, "Zone Select Right"),
+  (273, "Zone Select Far Right"),
+  (274, "Zone Select Lower-left"),
+  (275, "Zone Select Lower Near-left"),
+  (276, "Zone Select Lower-middle"),
+  (277, "Zone Select Lower Near-right"),
+  (278, "Zone Select Lower-right"),
+  (279, "Zone Select Bottom-left"),
+  (280, "Zone Select Bottom Near-left"),
+  (281, "Zone Select Bottom"),
+  (282, "Zone Select Bottom Near-right"),
+  (283, "Zone Select Bottom-right"),
+  (0xfffb, "AF Select"),
+  (0xfffc, "Face Detect AF"),
+  (0xfffd, "Automatic Tracking AF"),
+  (0xfffe, "Fixed Center"),
+  (0xffff, "Auto"),
+];
+
+/// `0x000e AFPointSelected` element-1 PrintConv for the K-3 / KP variant
+/// (`Pentax.pm:1369-1373`): the Expanded-Area sizes ending in `27-point (L)`
+/// (NOT the K-1's `33-point`). Sorted by key.
+pub const AF_POINT_SELECTED_K3_AREA: &[(i64, &str)] = &[
+  (0, "Single Point"),
+  (1, "Expanded Area 9-point (S)"),
+  (3, "Expanded Area 25-point (M)"),
+  (5, "Expanded Area 27-point (L)"),
 ];
 
 /// `0x0062 RawDevelopmentProcess` PrintConv (`Pentax.pm:2302-2323`) — sorted by

--- a/src/exif/makernotes/vendors/pentax/tags/tests.rs
+++ b/src/exif/makernotes/vendors/pentax/tags/tests.rs
@@ -198,20 +198,18 @@ const K10D_MODEL: Option<&str> = Some("PENTAX K10D");
 
 #[test]
 fn conditional_leaf_count_gated_leaves() {
-  // 0x0016 ExposureCompensation: `$count == 1` emits; the count-2 variant is
-  // deferred ⇒ Suppress.
-  assert_eq!(
-    conditional_leaf(0x0016, 1, K10D_MODEL, K10D_MAKE, Format::Int16u),
-    ConditionalLeaf::Emit,
-    "0x0016 count==1 must emit"
-  );
-  assert_eq!(
-    conditional_leaf(0x0016, 2, K10D_MODEL, K10D_MAKE, Format::Int16u),
-    ConditionalLeaf::Suppress,
-    "0x0016 count==2 must suppress (deferred variant)"
-  );
-  assert!(conditional_leaf(0x0016, 0, K10D_MODEL, K10D_MAKE, Format::Int16u).is_suppressed());
-  // 0x004d FlashExposureComp: BOTH variants are now ported (the count==1 int32s
+  // 0x0016 ExposureCompensation: BOTH variants are now ported (#311) — the
+  // `$count == 1` int16u AND the `Count => 2` variant (whose ValueConv strips all
+  // but element 0, so it produces the same scalar). The leaf emits for either
+  // count; the PrintConv reads element 0.
+  for count in [1usize, 2] {
+    assert_eq!(
+      conditional_leaf(0x0016, count, K10D_MODEL, K10D_MAKE, Format::Int16u),
+      ConditionalLeaf::Emit,
+      "0x0016 count=={count} must emit (both variants ported)"
+    );
+  }
+  // 0x004d FlashExposureComp: BOTH variants are ported (the count==1 int32s
   // and the count==2 int8s array), so the leaf emits for either count (#311).
   for count in [1usize, 2] {
     assert_eq!(
@@ -224,10 +222,13 @@ fn conditional_leaf_count_gated_leaves() {
 
 #[test]
 fn conditional_leaf_af_point_selected_model_gated() {
-  // 0x000e AFPointSelected: the "other models" variant emits for a non-K-1/645Z,
-  // non-K-3/KP model, for EITHER count (the array conv now renders both the
-  // single-element K10D form `'Center'` and the two-element K-S2 form
-  // `'Center; Single Point'`, #311).
+  // 0x000e AFPointSelected: ALL THREE model variants are now ported (#311), so the
+  // leaf emits UNCONDITIONALLY for every model and count — the emit site routes it
+  // through `af_point_selected_for_model`, which selects the element-0/element-1
+  // hashes by `$$self{Model}` (the `/(K-1|645Z)\b/` 33-point hash, the
+  // `/(K-3|KP)\b/` 27-point hash, or the "other models" 11-point hash). The
+  // per-model SELECTION (the right labels per body) is covered in the printconv
+  // suite; here the structural gate must never SUPPRESS.
   for count in [1usize, 2] {
     assert_eq!(
       conditional_leaf(0x000e, count, K10D_MODEL, K10D_MAKE, Format::Int16u),
@@ -235,28 +236,20 @@ fn conditional_leaf_af_point_selected_model_gated() {
       "0x000e count=={count} (other-models body) must emit"
     );
   }
-  // The K-1/645Z and K-3/KP model variants are deferred (their own point hashes)
-  // ⇒ Suppress, never the "other models" hash flattened onto them.
   for m in [
     "PENTAX K-1",
     "PENTAX 645Z",
     "PENTAX K-3",
     "PENTAX K-3 Mark III",
     "PENTAX KP",
+    "PENTAX Optio S",
   ] {
     assert_eq!(
       conditional_leaf(0x000e, 1, Some(m), K10D_MAKE, Format::Int16u),
-      ConditionalLeaf::Suppress,
-      "{m} AFPointSelected must suppress (model-specific variant deferred)"
+      ConditionalLeaf::Emit,
+      "{m} AFPointSelected must emit (all model variants ported)"
     );
   }
-  // The `K-3` token must not false-match a non-K-3 model containing the bytes
-  // out of word-boundary (faithful `\b`); a plain Optio is the "other models"
-  // arm.
-  assert_eq!(
-    conditional_leaf(0x000e, 1, Some("PENTAX Optio S"), K10D_MAKE, Format::Int16u),
-    ConditionalLeaf::Emit
-  );
 }
 
 /// `0x000f AFPointsInFocus` (#311) — the ported variant 1 is the int32u 27-bit

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -9493,7 +9493,18 @@ fn emit_pentax_value<S: ExifSink>(
   {
     return Ok(());
   }
-  let value = pentax_tag.conv.apply(raw, print_conv);
+  // `0x000e AFPointSelected` (`Pentax.pm:1219-1408`) is a `$$self{Model}`-keyed
+  // array-of-variants: the element-0/element-1 PrintConv hashes differ for
+  // `/(K-1|645Z)\b/`, `/(K-3|KP)\b/` and the "other models". The `Copy` conv
+  // dispatched by `apply` has no model context, so 0x000e renders through the
+  // model-aware [`af_point_selected_for_model`](makernotes::vendors::pentax::printconv)
+  // here (where `model` is threaded), exactly as the encrypted `0x005d` shutter
+  // count is handled outside the conv. #311.
+  let value = if entry.tag_id == 0x000e {
+    makernotes::vendors::pentax::printconv::af_point_selected_for_model(raw, print_conv, model)
+  } else {
+    pentax_tag.conv.apply(raw, print_conv)
+  };
   // Thread the row's ExifTool `Priority => N` (`0` for the walked `0x0012
   // ExposureTime` / `0x0013 FNumber` rows, `1` otherwise) so a `Priority => 0`
   // leaf never overrides an earlier same-`(doc, family1, name)` value
@@ -11710,6 +11721,21 @@ pub(in crate::exif) fn pentax_makernote_isolated(
           // ⇒ LE; the K-5 II reports `"PENTAX"` ⇒ BE.)
           SubTable::FilterInfo => {
             pentax::subtables::emit_filter_info(block, make, &mut *sink.emissions);
+          }
+          // `%Pentax::AFPointInfo` (0x0245) — a plain SubDirectory (UNCONDITIONAL).
+          // The int16u NumAFPoints inherits the resolved MakerNote (`parent_order`)
+          // order; the offset-4 AFPointsInFocus/Selected/Special leaves are
+          // `/K(P|-1|-70)\b/`-model-gated (`emit_af_point_info` decides from the
+          // threaded `model` — the K-1/KP/K-70 fixtures emit them, no other body
+          // writes a 0x0245). #311.
+          SubTable::AfPointInfo => {
+            pentax::subtables::emit_af_point_info(
+              block,
+              parent_order,
+              model,
+              print_conv,
+              &mut *sink.emissions,
+            );
           }
         }
         continue;

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -11396,26 +11396,33 @@ fn mpeg2_ts_pruveeo_d90_conformance() {
 //   * `XMP-tiff:YCbCrSubSampling` — the unported `RawJoin`/`%JPEG::
 //                                   yCbCrSubSampling` PrintConv (`xmp/tables.rs`).
 //
-// PLUS the per-body `Pentax:*` residuals the #379 port does not yet emit for
-// THESE bodies (each a known DEFERRED `%Pentax::Main` model-variant leaf or
-// `$count`-gated SubDirectory variant — see `vendors/pentax/tags.rs::
-// conditional_leaf` and `subtables.rs`, which deliberately SUPPRESS the
-// unported variant rather than mis-decode it):
+// #311 PORTED the per-body multi-model `%Pentax::Main` conditional branches the
+// `#379` body-agnostic port had suppressed (see `vendors/pentax/tags.rs::
+// conditional_leaf`, `printconv.rs::af_point_selected_for_model` and
+// `subtables.rs::{emit_af_point_info,emit_battery_info}`), now emitted byte-exact:
 //
-//   * `AFPointSelected` (0x000e)   — the model-keyed K-1 (33-point + Zone Select)
-//        and K-3/KP variants (`Pentax.pm:1220/1295`); the port emits only the
-//        "other models" int16u[N] variant (the K-S2 one). K-1/K-3/KP suppressed.
-//   * `AFPointsInFocus` (0x000f)   — the int16u "other models" variant
-//        (`Pentax.pm:1448`); the port emits only the K-3/S1/S2 27-bit BITMASK.
-//   * `ExposureCompensation` (0x0016) — the `Count => 2` variant; the port emits
-//        only the `$count == 1` variant.
+//   * `AFPointSelected` (0x000e)   — the model-keyed K-1/645Z (33-point) and
+//        K-3/KP (27-point) element-0 hashes (`Pentax.pm:1219-1408`), routed by
+//        `$$self{Model}` + the count-2 second positional element. (K-5 II/K-70/K-S2
+//        keep the "other models" 11-point hash.)
+//   * `ExposureCompensation` (0x0016) — the `Count => 2` variant (`Pentax.pm:1605`):
+//        its ValueConv strips all but element 0, so it equals the `$count == 1`
+//        scalar. Now un-gated.
+//   * `NumAFPoints`/`AFPointsInFocus`/`AFPointsSelected`/`AFPointsSpecial` — the
+//        `%Pentax::AFPointInfo` (0x0245) SubDirectory + its `DecodeAFPoints`
+//        bit-mask decoder (`Pentax.pm:6067-6100`, K-1/KP/K-70). The
+//        `DecodeAFPoints` `$mask`/`$bitVal` separation is now faithful.
+//   * `BodyBatteryVoltage3`/`4` (`%Pentax::BatteryInfo` offsets 6/8,
+//        `Pentax.pm:4941-4960`, `/(K-5|K-r|645D)\b/` and `/(K-5|K-r)\b/`, K-5 II).
+//
+// PLUS the per-body `Pentax:*` residuals NOT in #311 scope (still DEFERRED — the
+// port emits nothing, so the golden retains the bundled value and the key is
+// dropped from both sides):
+//
 //   * `ContrastHighlight`/`ContrastShadow`/`ContrastHighlightShadowAdj`
 //        (0x006d/6e/6f), `ISOAutoMinSpeed` (0x007a), `ShutterType` (0x0087),
 //        `SkinToneCorrection` (0x0095), `SensorSize` (0x0064) — `%Pentax::Main`
 //        leaves not yet in `PENTAX_TAGS`.
-//   * `NumAFPoints`/`AFPointsInFocus`/`AFPointsSelected`/`AFPointsSpecial` —
-//        the `%Pentax::AFPointInfo` (0x0245) SubDirectory + its `DecodeAFPoints`
-//        bit-mask decoder (unported).
 //   * `PixelShiftResolution` — the `%Pentax::PixelShiftInfo` (0x0243)
 //        SubDirectory (unported).
 //   * `SensorTemperature`/`SensorTemperature2`/`CameraTemperature4`/`5` — the
@@ -11423,42 +11430,38 @@ fn mpeg2_ts_pruveeo_d90_conformance() {
 //   * (K-5 II only) the `$count`-91 `%Pentax::LensInfo3` variant
 //        (`LensFocalLength`/`MaxAperture`/`MinFocusDistance`/`NominalMax`/`Min
 //        Aperture`/`FocusRangeIndex`), the `%Pentax::WBLevels` (0x022d)
-//        `WB_RGGBLevels*` table, the K-5-II `%Pentax::BatteryInfo` leaves
-//        (`BodyBatteryVoltage3`/`4`), the `%Pentax::ShotInfo` `CameraOrientation`,
+//        `WB_RGGBLevels*` table, the `%Pentax::ShotInfo` `CameraOrientation`,
 //        the `%Pentax::AEInfo` `LevelIndicator`, the `%Pentax::CameraSettings`
 //        `ISOAuto`/`LinkAEToAFPoint`/`SensitivitySteps`, and the
 //        `Pentax:PreviewImageStart` IsOffset pointer — all deferred
 //        K-5-II-specific `$count`/offset SubDirectory variants.
 //
-// These are tracked DEFERRALS (the #311 follow-up to the body-specific variant
-// tables), NOT mis-decodes — exifast emits nothing for them, so the golden
-// retains the bundled value and the key is dropped from both sides.
+// (The K-3 Mark III `AFInfoK3III` `AFPointValues`/`AFPointsSelected` and the
+// *istD-family AFPointSelected variants are also deferred — no fixture.)
 
-// K-1: the K-1 AFPointSelected model variant + AFPointInfo/PixelShiftInfo/
-// Contrast/ISOAutoMinSpeed/ShutterType/SkinToneCorrection/ExposureCompensation
-// residuals.
+// K-1: #311 PORTED the K-1 (`/(K-1|645Z)\b/`) AFPointSelected model variant, the
+// count-2 ExposureCompensation, and the `%Pentax::AFPointInfo` (0x0245) subdir
+// (NumAFPoints + AFPointsInFocus/AFPointsSelected/AFPointsSpecial via
+// `DecodeAFPoints`) — all now byte-exact, so they are NO LONGER excluded. The
+// residual deferrals are NON-#311 `%Pentax::Main` leaves not yet in `PENTAX_TAGS`
+// (Contrast*/ISOAutoMinSpeed/ShutterType/SkinToneCorrection) and the `0x0243
+// PixelShiftInfo` subdir (PixelShiftResolution).
 const K1_DEFERRED: &[&str] = &[
   "XMP-tiff:YCbCrSubSampling",
-  "Pentax:AFPointSelected",
-  "Pentax:AFPointsInFocus",
-  "Pentax:AFPointsSelected",
-  "Pentax:AFPointsSpecial",
   "Pentax:ContrastHighlight",
   "Pentax:ContrastHighlightShadowAdj",
   "Pentax:ContrastShadow",
-  "Pentax:ExposureCompensation",
   "Pentax:ISOAutoMinSpeed",
-  "Pentax:NumAFPoints",
   "Pentax:PixelShiftResolution",
   "Pentax:ShutterType",
   "Pentax:SkinToneCorrection",
 ];
 
-// K-3: the K-3 AFPointSelected model variant + TempInfo (SensorTemperature) +
-// Contrast/ISOAutoMinSpeed residuals.
+// K-3: #311 PORTED the K-3 (`/(K-3|KP)\b/`) AFPointSelected model variant (now
+// byte-exact, no longer excluded). The residuals are the `0x03ff TempInfo` subdir
+// (SensorTemperature/2) and the non-#311 Contrast*/ISOAutoMinSpeed Main leaves.
 const K3_DEFERRED: &[&str] = &[
   "XMP-tiff:YCbCrSubSampling",
-  "Pentax:AFPointSelected",
   "Pentax:ContrastHighlight",
   "Pentax:ContrastHighlightShadowAdj",
   "Pentax:ContrastShadow",
@@ -11467,14 +11470,14 @@ const K3_DEFERRED: &[&str] = &[
   "Pentax:SensorTemperature2",
 ];
 
-// K-5 II (BIG-endian): the deferred K-5-II `$count`/offset SubDirectory variants
-// (LensInfo3 / WBLevels / BatteryInfo / ShotInfo / AEInfo / CameraSettings /
-// TempInfo) + the AFPointInfo/PixelShiftInfo/Contrast residuals + the IsOffset
-// PreviewImageStart.
+// K-5 II (BIG-endian): #311 PORTED the `%Pentax::BatteryInfo` `/(K-5|K-r|645D)\b/`
+// BodyBatteryVoltage3 (offset 6) and `/(K-5|K-r)\b/` BodyBatteryVoltage4 (offset
+// 8) — now byte-exact, no longer excluded. The remaining residuals are the
+// deferred K-5-II `$count`/offset SubDirectory variants (LensInfo3 / WBLevels /
+// ShotInfo / AEInfo / CameraSettings / TempInfo) + the Contrast/ISOAutoMinSpeed
+// Main leaves + the IsOffset PreviewImageStart — none of them #311.
 const K5_II_DEFERRED: &[&str] = &[
   "XMP-tiff:YCbCrSubSampling",
-  "Pentax:BodyBatteryVoltage3",
-  "Pentax:BodyBatteryVoltage4",
   "Pentax:CameraOrientation",
   "Pentax:CameraTemperature4",
   "Pentax:CameraTemperature5",
@@ -11508,21 +11511,18 @@ const K5_II_DEFERRED: &[&str] = &[
   "Pentax:WB_RGGBLevelsUserSelected",
 ];
 
-// KP: identical residual shape to K-1 (the K-3/KP AFPointSelected variant +
-// AFPointInfo/PixelShiftInfo/Contrast/ISOAutoMinSpeed/ShutterType/
-// SkinToneCorrection/ExposureCompensation).
+// KP: identical residual shape to K-1 after #311. PORTED: the KP (`/(K-3|KP)\b/`)
+// AFPointSelected variant, the count-2 ExposureCompensation, and the
+// `%Pentax::AFPointInfo` (0x0245) subdir (NumAFPoints + AFPointsInFocus/Selected/
+// Special) — all byte-exact, no longer excluded. The residuals are the non-#311
+// Contrast*/ISOAutoMinSpeed/ShutterType/SkinToneCorrection Main leaves and the
+// `0x0243 PixelShiftInfo` subdir.
 const KP_DEFERRED: &[&str] = &[
   "XMP-tiff:YCbCrSubSampling",
-  "Pentax:AFPointSelected",
-  "Pentax:AFPointsInFocus",
-  "Pentax:AFPointsSelected",
-  "Pentax:AFPointsSpecial",
   "Pentax:ContrastHighlight",
   "Pentax:ContrastHighlightShadowAdj",
   "Pentax:ContrastShadow",
-  "Pentax:ExposureCompensation",
   "Pentax:ISOAutoMinSpeed",
-  "Pentax:NumAFPoints",
   "Pentax:PixelShiftResolution",
   "Pentax:ShutterType",
   "Pentax:SkinToneCorrection",
@@ -11542,16 +11542,17 @@ const KP_DEFERRED: &[&str] = &[
 // `0.01666666667` (not full-f64 `0.0166666666666667`) and the rounded value
 // propagates byte-exact to the two Composites. The remaining entries are only
 // unimplemented Pentax leaves, so K-70 now activates honestly.
+// #311 PORTED the count-2 ExposureCompensation and the `%Pentax::AFPointInfo`
+// (0x0245) subdir (NumAFPoints + AFPointsInFocus/Selected/Special via
+// `DecodeAFPoints`) — byte-exact, no longer excluded. (K-70's 0x000e is the
+// unrelated CAFPointInfo internal, already emitted, so no AFPointSelected entry.)
+// The residuals are the non-#311 Contrast*/ShutterType/SkinToneCorrection Main
+// leaves and the `0x0243 PixelShiftInfo` subdir.
 const K70_DEFERRED: &[&str] = &[
   "XMP-tiff:YCbCrSubSampling",
-  "Pentax:AFPointsInFocus",
-  "Pentax:AFPointsSelected",
-  "Pentax:AFPointsSpecial",
   "Pentax:ContrastHighlight",
   "Pentax:ContrastHighlightShadowAdj",
   "Pentax:ContrastShadow",
-  "Pentax:ExposureCompensation",
-  "Pentax:NumAFPoints",
   "Pentax:PixelShiftResolution",
   "Pentax:ShutterType",
   "Pentax:SkinToneCorrection",

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -282,29 +282,28 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   // deferral is the `tiff:YCbCrSubSampling` `RawJoin`. Mirrors `conformance.rs::
   // jpeg_pentax_ks2_conformance`. The golden keeps the faithful 13.59 dump.
   ("JPEG_pentax_ks2.jpg", &["XMP-tiff:YCbCrSubSampling"]),
-  // #311/#318 — the 5 additional Pentax body fixtures. #381 ported their
-  // `Composite:Flash`/`LensID` + `PrintIM:PrintIMVersion` (now emitted
-  // byte-exact, no longer excluded); the remaining exclusions are
-  // `XMP-tiff:YCbCrSubSampling` PLUS the per-body `Pentax:*` model-variant /
-  // `$count`-gated SubDirectory residuals the #379 port does not yet emit for
-  // these bodies (deferred, NOT mis-decoded — exifast emits nothing, the golden
-  // keeps the bundled value). These lists MIRROR EXACTLY the per-fixture
-  // `*_DEFERRED` consts in `conformance.rs::jpeg_pentax_{k1,k3,k5_ii,k70,kp}_
-  // conformance` (see the detailed rationale there).
+  // #311/#318 — the 5 additional Pentax body fixtures. #311 ported the per-body
+  // multi-model Main conditional branches: the `/(K-1|645Z)\b/` + `/(K-3|KP)\b/`
+  // AFPointSelected (0x000e) model point-hashes, the count-2 ExposureCompensation
+  // (0x0016), the `%Pentax::BatteryInfo` BodyBatteryVoltage3/4 (K-5 II), and the
+  // `%Pentax::AFPointInfo` (0x0245) subdir (NumAFPoints + AFPointsInFocus/Selected/
+  // Special via `DecodeAFPoints`) — all now emitted byte-exact, no longer excluded.
+  // The remaining exclusions are `XMP-tiff:YCbCrSubSampling` PLUS the NON-#311
+  // per-body `Pentax:*` residuals the port does not yet emit (Contrast* /
+  // ISOAutoMinSpeed / ShutterType / SkinToneCorrection Main leaves; the `0x0243
+  // PixelShiftInfo`, `0x03ff TempInfo` and K-5-II `$count`/offset SubDirectory
+  // variants) — deferred, NOT mis-decoded (exifast emits nothing, the golden keeps
+  // the bundled value). These lists MIRROR EXACTLY the per-fixture `*_DEFERRED`
+  // consts in `conformance.rs::jpeg_pentax_{k1,k3,k5_ii,k70,kp}_conformance` (see
+  // the detailed rationale there).
   (
     "JPEG_pentax_k1.jpg",
     &[
       "XMP-tiff:YCbCrSubSampling",
-      "Pentax:AFPointSelected",
-      "Pentax:AFPointsInFocus",
-      "Pentax:AFPointsSelected",
-      "Pentax:AFPointsSpecial",
       "Pentax:ContrastHighlight",
       "Pentax:ContrastHighlightShadowAdj",
       "Pentax:ContrastShadow",
-      "Pentax:ExposureCompensation",
       "Pentax:ISOAutoMinSpeed",
-      "Pentax:NumAFPoints",
       "Pentax:PixelShiftResolution",
       "Pentax:ShutterType",
       "Pentax:SkinToneCorrection",
@@ -314,7 +313,6 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
     "JPEG_pentax_k3.jpg",
     &[
       "XMP-tiff:YCbCrSubSampling",
-      "Pentax:AFPointSelected",
       "Pentax:ContrastHighlight",
       "Pentax:ContrastHighlightShadowAdj",
       "Pentax:ContrastShadow",
@@ -327,8 +325,6 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
     "JPEG_pentax_k5_ii.jpg",
     &[
       "XMP-tiff:YCbCrSubSampling",
-      "Pentax:BodyBatteryVoltage3",
-      "Pentax:BodyBatteryVoltage4",
       "Pentax:CameraOrientation",
       "Pentax:CameraTemperature4",
       "Pentax:CameraTemperature5",
@@ -372,14 +368,9 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
     "JPEG_pentax_k70.jpg",
     &[
       "XMP-tiff:YCbCrSubSampling",
-      "Pentax:AFPointsInFocus",
-      "Pentax:AFPointsSelected",
-      "Pentax:AFPointsSpecial",
       "Pentax:ContrastHighlight",
       "Pentax:ContrastHighlightShadowAdj",
       "Pentax:ContrastShadow",
-      "Pentax:ExposureCompensation",
-      "Pentax:NumAFPoints",
       "Pentax:PixelShiftResolution",
       "Pentax:ShutterType",
       "Pentax:SkinToneCorrection",
@@ -389,16 +380,10 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
     "JPEG_pentax_kp.jpg",
     &[
       "XMP-tiff:YCbCrSubSampling",
-      "Pentax:AFPointSelected",
-      "Pentax:AFPointsInFocus",
-      "Pentax:AFPointsSelected",
-      "Pentax:AFPointsSpecial",
       "Pentax:ContrastHighlight",
       "Pentax:ContrastHighlightShadowAdj",
       "Pentax:ContrastShadow",
-      "Pentax:ExposureCompensation",
       "Pentax:ISOAutoMinSpeed",
-      "Pentax:NumAFPoints",
       "Pentax:PixelShiftResolution",
       "Pentax:ShutterType",
       "Pentax:SkinToneCorrection",


### PR DESCRIPTION
Now that the 6 Pentax body fixtures (k1/k3/k5_ii/k70/kp/ks2) are active, this ports the per-body Main conditional variants #173/#311 had suppressed pending fixtures, and un-excludes them:

- **AFPointSelected (0x000e)** — the (K-1|645Z) + (K-3|KP) element-0 model hashes (incl the K-3/KP special selections 0xfffb-0xffff: AF Select/Face Detect AF/Tracking/Fixed Center/Auto) + the count-2 element-1 area hashes. All 6 AFPointSelected tables verified == ExifTool source.
- **AFPointInfo (0x0245)** for K-1/KP/K-70 — corrected from the issue's '0x021f' after / ground-truth — with a **fixed ** (threads `$mask`/`$bitVal` separately; the prior collapsed API would have mis-decoded AFPointsSelected).
- **ExposureCompensation** count-2 + **BodyBatteryVoltage3/4** (BatteryInfo offsets 6/8) for k5_ii.

Un-excluded those from the 6 fixtures' FIXTURE_EXCLUDED_KEYS (byte-exact). **Kept deferred (no fixture):** K-3 Mark III AFInfoK3III/AFPointValues + the *istD-family, plus the non-#311 leaves (PixelShiftInfo/TempInfo/the K-5-II $count variants/PreviewImageStart). `build(-Dwarnings)=0 conformance=455/0 typed_serde=575 lib=3637/0 xtask=26/0`. **Codex: APPROVE (R2).** Closes #311 (modulo the noted no-fixture K-3III/*istD variants).