### PR TITLE
fix: restore normal-float rendering regressed by #203 + defer #401 PEF fixtures (main green)

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1284,23 +1284,39 @@ const _: () = {
         }
         // A FINITE float: ExifTool stringifies it with `%.15g` (its default NV
         // stringification), then runs the SAME unconditional `EscapeJSON`
-        // `return $str` (`exiftool:3810`). So an in-gate `%.15g` rendering is
-        // emitted BARE, byte-for-byte — even when the rendered token's MAGNITUDE
-        // over-ranges finite-f64 (a finite double near `f64::MAX` renders to
-        // `1.79769313486232e+308`, which the gate ADMITS and bundled emits
-        // unquoted, #203). The generic `TagValue::F64` arm reparses that token and
+        // `return $str` (`exiftool:3810`). This renderer arm exists ONLY to fix
+        // the ONE case the generic `TagValue::F64` arm renders DIFFERENTLY from
+        // bundled: a finite double near `f64::MAX` whose `%.15g` token
+        // (`1.79769313486232e+308`) is in-gate yet reparses to `±INFINITY`. The
+        // gate ADMITS it and bundled emits it UNQUOTED (#203), but the generic arm
         // QUOTES it for `to_value` soundness (a `RawValue` of an over-range token
         // errors `NumberOutOfRange` through `to_value`); here, on the
         // `to_string`/`to_writer`-only render path, the bare ExifTool token is
-        // both faithful AND sound. An out-of-gate rendering (a `>16`-fraction
-        // float such as a `DV:Duration` `0.00122222222222222`) and every
-        // NON-finite f64 (the titlecase `Inf`/`-Inf`/`NaN` quoted word) fail the
-        // gate and delegate to the generic arm, which quotes them identically.
+        // both faithful AND sound, so emit it VERBATIM.
+        //
+        // For EVERY OTHER finite double — i.e. one whose `%.15g` token reparses to
+        // a FAITHFUL finite f64 ([`f64_token_is_faithful`]) — the generic arm
+        // already produces bundled's exact bytes (via `serialize_f64`, which
+        // renders a whole-valued double WITH its `.0`: a `Track1:GPSLatitude` of
+        // `12.0` → `12.0`, NOT the `.0`-stripped `%.15g` token `12`). Delegating
+        // there preserves that, so this arm must NOT route a faithful token through
+        // the `%.15g`-verbatim path (which would drop the `.0` and emit a bare
+        // integer, diverging from bundled — #203's over-reach). An out-of-gate
+        // rendering (a `>16`-fraction `DV:Duration` `0.00122222222222222`) and
+        // every NON-finite f64 (the titlecase `Inf`/`-Inf`/`NaN` quoted word) also
+        // delegate to the generic arm, which quotes them identically to bundled.
         TagValue::F64(n) if n.is_finite() => {
           #[cfg(feature = "json")]
           {
             let rounded = crate::value::format_g(*n, 15);
-            if escape_json_is_number(&rounded) {
+            // ONLY the over-range case (in-gate token, NOT a faithful finite f64)
+            // needs the bare-verbatim path bundled emits but the generic arm
+            // quotes; everything faithful is rendered correctly by the generic arm.
+            if escape_json_is_number(&rounded)
+              && rounded
+                .parse::<f64>()
+                .is_ok_and(|f| !crate::value::f64_token_is_faithful(f, &rounded))
+            {
               return serialize_in_gate_number_str_verbatim(&rounded, s);
             }
             self.0.serialize(s)

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -12124,14 +12124,22 @@ fn makernotes_samsung_nx1_conformance() {
 #[test]
 #[ignore]
 fn pef_pentax_k3_mark_iii_conformance() {
-    check("PEF_pentax_k3_mark_iii.pef", "PEF_pentax_k3_mark_iii.pef.json", true);
-    check("PEF_pentax_k3_mark_iii.pef", "PEF_pentax_k3_mark_iii.pef.n.json", false);
+  check(
+    "PEF_pentax_k3_mark_iii.pef",
+    "PEF_pentax_k3_mark_iii.pef.json",
+    true,
+  );
+  check(
+    "PEF_pentax_k3_mark_iii.pef",
+    "PEF_pentax_k3_mark_iii.pef.n.json",
+    false,
+  );
 }
 
 // #393 — Pentax *ist D: raw BatteryInfo variant, AFPointSelected variants
 #[test]
 #[ignore]
 fn pef_pentax_istd_conformance() {
-    check("PEF_pentax_istd.pef", "PEF_pentax_istd.pef.json", true);
-    check("PEF_pentax_istd.pef", "PEF_pentax_istd.pef.n.json", false);
+  check("PEF_pentax_istd.pef", "PEF_pentax_istd.pef.json", true);
+  check("PEF_pentax_istd.pef", "PEF_pentax_istd.pef.n.json", false);
 }

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -227,6 +227,14 @@ const NOT_ACTIVE: &[&str] = &[
   // `-G1` golden is not byte-exact. Accept-deferred to #352 (the SubIFD walk);
   // the CR2 + ARW members of this set ARE active (the IFD0:PreviewImage proof).
   "DNG_preview_image.dng",
+  // The two Pentax PEF (`.pef`) RAW fixtures (#393/#401) ship with paired
+  // `.json`/`.n.json` goldens but their conformance tests are `#[ignore]`d pending
+  // the PEF/Pentax-variant decode port — exifast does not yet emit the full tag
+  // set bundled extracts from these bodies. Accept-deferred here so the auto-
+  // discovered active set stays at `EXPECTED_ACTIVE_FIXTURES`; the in-flight #393
+  // port will move them to active once the variants decode byte-exact.
+  "PEF_pentax_k3_mark_iii.pef",
+  "PEF_pentax_istd.pef",
 ];
 
 /// ACTIVE fixtures that emit a tag whose VALUE diverges from bundled because a


### PR DESCRIPTION
Hotfix for two regressions found on main via #221's gate (which runs timed_metadata, the suite the regressing PRs skipped).

**Regression 1 — #203 f64 over-reach (value):** the merged #203 (f64 bare-token) routed *every* finite double through `serialize_in_gate_number_str_verbatim(format_g(*n,15))`. `%g` strips a whole-valued double's `.0` (`12.0`→`"12"`), so exifast emitted `Number(12)` where bundled emits `12.0` — breaking `sony_rtmd_partialgps_n` (a 12-degree GPSLatitude). It slipped through because #203's gate never ran `timed_metadata_conformance`. Fix: gate the verbatim path on the **not-faithful** condition only — a faithful token (`"12"`) falls through to the generic `serialize_f64` → `"12.0"`; the near-`f64::MAX` over-range token (which reparses to INFINITY, so is not-faithful) still goes bare `1.79…e+308` (#203's win preserved); NaN/Inf still quoted. Only the near-MAX case is not-faithful among finite doubles, so the branch fires exactly for #203's scenario.

**Regression 2 — #401 PEF fixtures (typed_serde):** the teammate added `PEF_pentax_k3_mark_iii`/`PEF_pentax_istd` with goldens but not in `NOT_ACTIVE`; the auto-discovery counted them active (found 587 vs 585). Deferred both in `NOT_ACTIVE` (their conformance tests are `#[ignore]`d); #393 will activate them. + a fmt-only normalization of the #401 `#[ignore]`d tests.

**Full gate incl timed_metadata:** `build(-Dwarnings)=0 conformance=459/0 timed_metadata=157/0 (sony_rtmd green) typed_serde=585 lib=3642/0 (#203 tests green) xtask=26/0`. **Codex: APPROVE.** Restores main to fully green.