### PR TITLE
docs(gopro): correct stale pre-#211 per-track-grouping comments + #189 regression guard

### DIFF
--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -7594,14 +7594,15 @@ fn parse_inner<'a>(data: &'a [u8], ext: Option<&str>) -> Option<Meta<'a>> {
   // reaches a `udta/GPMF` when it descends that `udta` child
   // (`ProcessDirectory`, QuickTime.pm:10359) and a `trak`'s `gpmd` samples when
   // that `trak`'s `stbl` box exits (QuickTime.pm:10369-10371) — so they
-  // interleave by atom layout, and the flat `gopro_meta` accumulates in walk
-  // order instead of the prior fixed "all `gpmd` then all `udta/GPMF`" post-
-  // pass. NOTE (oracle-verified, ExifTool 13.59): when a `moov` carries BOTH
-  // sources ExifTool keeps them in DIFFERENT groups (`Track<N>:` for `gpmd`
-  // vs `GoPro:` for `udta/GPMF`), so there is no single cross-source last-wins
-  // to match — the flat `GoProMeta` collapses both, a divergence this ordered
-  // walk does not by itself resolve (see `walk_moov` doc). The walk completes
-  // BEFORE the `mdat` scan, and a visited `udta/GPMF` (like a
+  // interleave by atom layout. #189 (oracle-verified, ExifTool 13.59): a `moov`
+  // carrying BOTH sources keeps them in DIFFERENT family-1 groups (`Track<N>:`
+  // for `gpmd` — the `trak`'s `SET_GROUP1`, GoPro.pm:826 — vs `GoPro:` for
+  // `udta/GPMF`), so both survive with no cross-source collision. exifast mirrors
+  // that by source: the `udta/GPMF` atom fills this flat `gopro_meta` (→ `GoPro:`,
+  // no-`ee`), while each `gpmd` `DEVC` sample is a per-`Doc<N>` entry in the
+  // SEPARATE `gopro_timed_meta` ([`GoProTimedMeta`]) stamped with its `Track<N>`
+  // index (→ `Track<N>:`, `-ee` only — see `walk_moov` + `emit_gopro_doc`). The
+  // walk completes BEFORE the `mdat` scan, and a visited `udta/GPMF` (like a
   // `gpmd` sample) folds into `found_embedded`, so the `mdat` scan is still
   // suppressed by the mere PRESENCE of any dispatched GoPro source
   // (`return if $$et{FoundEmbedded}`, QuickTimeStream.pl:3689). A direct

--- a/src/formats/quicktime_stream.rs
+++ b/src/formats/quicktime_stream.rs
@@ -3191,9 +3191,11 @@ fn process_moov_gps_box(
 /// `ProcessMOV` `for(;;)` loop (QuickTime.pm:10032) reaches them:
 ///
 ///   - `trak` — the timed-metadata samples (a `gpmd` GoPro track dispatches
-///     into [`crate::formats::gopro::process_gopro`]). ExifTool runs
-///     `ProcessSamples` when the track's `stbl` box EXITS (QuickTime.pm:10369-
-///     10371), i.e. at that `trak`'s position in the walk.
+///     into [`crate::formats::gopro::process_gopro`], each `DEVC` sample landing
+///     as a per-`Doc<N>` [`crate::metadata::GoProDocSample`] in `gopro_timed_out`
+///     stamped with the `trak`'s `Track<N>` index — NOT the flat `gopro_out`;
+///     #189). ExifTool runs `ProcessSamples` when the track's `stbl` box EXITS
+///     (QuickTime.pm:10369-10371), i.e. at that `trak`'s position in the walk.
 ///   - `udta/GPMF` — the GoPro GPMF atom (QuickTime.pm:2132-2135). ExifTool
 ///     dispatches it via `$et->ProcessDirectory` (QuickTime.pm:10359) the
 ///     instant the walk descends the `udta` child, i.e. at that `udta`'s
@@ -3208,24 +3210,26 @@ fn process_moov_gps_box(
 ///     own child position (its freeGPS rows land in the SEPARATE `out`
 ///     accumulator, so they never interleave with GoPro's `gopro_out`).
 ///
-/// Processing each source AT its atom position (rather than draining all
-/// `gpmd` samples then all `udta/GPMF` in a fixed post-pass) makes the
-/// accumulation into the single flat `gopro_out` follow ExifTool's `for(;;)`
-/// walk ORDER — so GoPro scalar tags (last-wins `set_*`) and GPS rows (append
-/// `push_*`) land in walk order. This holds across EVERY top-level `moov`
-/// (the caller invokes `walk_moov` per `moov` in file order, R7 multi-moov).
+/// Processing each `udta/GPMF` atom AT its atom position (rather than in a fixed
+/// post-pass) makes the accumulation into the flat `gopro_out` follow ExifTool's
+/// `for(;;)` walk ORDER — so the moov-level GoPro scalar tags (last-wins `set_*`)
+/// and GPS rows (append `push_*`) land in walk order. This holds across EVERY
+/// top-level `moov` (the caller invokes `walk_moov` per `moov` in file order, R7
+/// multi-moov).
 ///
-/// NOTE (oracle-verified, ExifTool 13.59): a file carrying BOTH a `gpmd` trak
-/// AND a `udta/GPMF` is NOT a clean last-wins collision in ExifTool — the
-/// `gpmd` GoPro tags inherit the track's `SET_GROUP1 = Track<N>` group
-/// (GoPro.pm:826 leaves `SET_GROUP0` alone when `SET_GROUP1` is set) while the
-/// `udta/GPMF` tags emit at the moov level (`GoPro:`/`QuickTime:`), so the two
-/// sources occupy DIFFERENT groups and BOTH survive regardless of sibling
-/// order. exifast's flat [`crate::metadata::GoProMeta`] cannot represent that
-/// per-track grouping, so it collapses both into one `GoPro:` namespace; this
-/// ordered walk only controls WHICH source wins that single flat slot. The
-/// group-faithful behaviour (per-track GoPro tags) is a separate, larger
-/// change tracked outside this walk — see the module-level note.
+/// #189 (oracle-verified, ExifTool 13.59): a file carrying BOTH a `gpmd` trak
+/// AND a `udta/GPMF` is NOT a last-wins collision — the `gpmd` GoPro tags inherit
+/// the track's `SET_GROUP1 = Track<N>` group (GoPro.pm:826 leaves `SET_GROUP0`
+/// alone when `SET_GROUP1` is set) while the `udta/GPMF` tags emit at the moov
+/// level (`GoPro:`/`QuickTime:`), so the two sources occupy DIFFERENT family-1
+/// groups and BOTH survive regardless of sibling order. exifast mirrors that by
+/// SOURCE, not by collapsing: the `udta/GPMF` atom fills the flat
+/// [`crate::metadata::GoProMeta`] (`gopro_out` → `GoPro:`), while each `gpmd`
+/// `DEVC` sample is a per-`Doc<N>` [`crate::metadata::GoProDocSample`] in
+/// `gopro_timed_out` stamped with the `trak`'s `Track<N>` index (→ `Track<N>:`,
+/// `-ee` only — [`crate::formats::quicktime::emit_gopro_doc`]). So the two
+/// sources never share a slot, and a duplicate scalar name (e.g. `DeviceName`)
+/// survives in BOTH groups.
 ///
 /// Returns `true` iff ANY GoPro source was DISPATCHED — a `gpmd` GoPro sample
 /// in a `trak` OR a `udta/GPMF` atom — mirroring ExifTool's
@@ -3328,10 +3332,12 @@ fn walk_moov(
       // (processed at the `trak` position) and the `gps ` box above. Running
       // it here (rather than in a fixed post-pass after every `trak`) makes
       // the accumulation into the flat `gopro_out` follow ExifTool's walk
-      // ORDER. (See the fn doc: in ExifTool the two sources land in different
-      // GROUPS — `Track<N>:` vs `GoPro:` — so this ordering only decides which
-      // wins exifast's single flat slot; full group fidelity is a separate
-      // change.)
+      // ORDER. (See the fn doc: the two sources land in DIFFERENT family-1
+      // groups — `Track<N>:` for `gpmd` vs `GoPro:` for `udta/GPMF` — and
+      // exifast keeps them separate by source, #189: `gpmd` → the per-`Doc<N>`
+      // `gopro_timed_out`, this `udta/GPMF` → the flat `gopro_out`. So this
+      // ordering only sequences the moov-level `udta/GPMF` and `gps ` sources;
+      // it never collides with the `Track<N>:` `gpmd` stream.)
       //
       // `GPMF` lives ONLY in the `udta`/UserData table, so it is reached as a
       // DIRECT child of `udta`; a direct `moov/GPMF` child is NOT an ExifTool

--- a/tests/timed_metadata_conformance.rs
+++ b/tests/timed_metadata_conformance.rs
@@ -272,6 +272,17 @@ fn gsen_ee_byte_exact() {
 /// adds: with `-ee` the per-sample GPMF timed block is what changes, and it IS
 /// byte-exact. With those two frame rates now emitted, the FULL hero8 document
 /// (container + gpmd/fdsc `Doc<N>`) is byte-exact at `-ee` with NO exclusions.
+///
+/// This is also the **#189 per-track-grouping guard**: hero8 is a DUAL-SOURCE
+/// GoPro file — a `udta/GPMF` box AND a `gpmd` `trak` — so the `-ee -G1` golden
+/// pins BOTH family-1 groups at once: the `udta/GPMF` device tags under `GoPro:`
+/// (`GoPro:DeviceName` = "Highlights", `GoPro:CameraSerialNumber`) and the gpmd
+/// stream's tags under `Track4:` (`Track4:DeviceName` = "HERO8 Black",
+/// `Track4:Accelerometer`, `Track4:GPSDateTime`). The SAME scalar name
+/// (`DeviceName`) survives in BOTH groups with different values — the exact
+/// divergence #189 fixes (a flat collapse would drop one). A regression that
+/// re-collapsed the `gpmd` trak into `GoPro:` would delete every `Track4:*` key
+/// here and fail this byte-exact check.
 #[test]
 fn gopro_hero8_gpmd_ee_byte_exact() {
   // `-ee -G1`: the doc axis collapsed first-wins — Track4's first `DEVC` block


### PR DESCRIPTION
#189 (per-track GoPro `Track<N>:` vs `GoPro:` grouping) was already **resolved under #211** (commit 98343f5): gpmd-trak GoPro → `GoProTimedMeta`/`emit_gopro_doc` (`Track<N>:`), moov/udta/GPMF → flat `GoProMeta` (`GoPro:`) — the bounded source-track thread, not a #185-scale redesign. Verified vs bundled 13.59: the real-device `QuickTime_gopro_hero8/hero6_gpmf` fixtures carry both sources and bundled emits udta as `GoPro:` + gpmd as `Track4:`, which exifast matches (already pinned by `gopro_hero8/hero6_gpmd_ee_byte_exact`).

This is comment-only: three doc blocks (`quicktime.rs`, `quicktime_stream.rs`) still narrated the pre-#211 "flat collapse" model, contradicting the dispatch code. Corrected to the current by-source split + documented `gopro_hero8_gpmd_ee_byte_exact` as the explicit #189 regression guard. Zero code tokens changed. `build(-Dwarnings)=0 conformance=470/0 timed_metadata=157/0 typed_serde=597 xtask=26/0`. Closes #189.