### PR TITLE
feat(m2ts): MPEG-2 video PES decoder — activate the MPEG2_TS_mpeg2video fixture (#128)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ id3        = []
 # `GetTagTable('Image::ExifTool::QuickTime::Stream')` — exifast's `LigoGPS`
 # walker (`process_ligogps`) and the shared `QuickTime::Stream` emitter
 # (`emit_ligogps`) both live behind the `quicktime` gate.
-m2ts       = ["h264", "quicktime"]
+m2ts       = ["h264", "quicktime", "mpeg-audio"]
 # `matroska` — engine-only per FORMATS.md row 23. Leaf format (no
 # cross-format chains); ports the entire EBML walker + tag table.
 matroska   = []

--- a/src/composite/table.rs
+++ b/src/composite/table.rs
@@ -73,6 +73,11 @@ pub(crate) struct CompositeContext {
   /// `vide`-track rotation angle in degrees, or `None` when there is no video
   /// track / matrix (then `Composite:Rotation`'s ValueConv is `undef`).
   pub(crate) rotation: Option<f64>,
+  /// `$$self{VALUE}{FileSize}` — the input byte length, threaded for the
+  /// `%MPEG::Composite` `Duration` derive (MPEG.pm:386-415, `Require =>
+  /// FileSize`). `None` for every format that does not supply it (only M2TS
+  /// does, via [`crate::format_parser::AnyMeta::composite_file_size`]).
+  pub(crate) file_size: Option<u64>,
 }
 
 impl CompositeContext {
@@ -80,13 +85,25 @@ impl CompositeContext {
   /// total for `AvgBitrate`, and the pre-computed `CalcRotation` angle). The
   /// non-QuickTime / no-`mdat` / no-video cases pass `None`s. (`AvgBitrate` does
   /// NOT divide by `$$self{TimeScale}` — see [`avg_bitrate`] — so the TimeScale
-  /// is not threaded.)
+  /// is not threaded.) `file_size` defaults to `None`; set it with
+  /// [`Self::with_file_size`] on the MPEG/M2TS path.
   #[cfg(feature = "alloc")]
   pub(crate) const fn new(media_data_total: Option<u64>, rotation: Option<f64>) -> Self {
     Self {
       media_data_total,
       rotation,
+      file_size: None,
     }
+  }
+
+  /// Set `$$self{VALUE}{FileSize}` for the `%MPEG::Composite` `Duration` derive
+  /// (MPEG.pm:413). A builder so the 22 non-MPEG `new(…, …)` call sites stay
+  /// unchanged.
+  #[cfg(feature = "alloc")]
+  #[must_use]
+  pub(crate) const fn with_file_size(mut self, file_size: Option<u64>) -> Self {
+    self.file_size = file_size;
+    self
   }
 }
 
@@ -286,6 +303,16 @@ pub(crate) enum CompositePrintConv {
   /// the bare raw scalar under `-n`, the quoted Perl string for a non-finite
   /// value in both modes ([`crate::composite::convs::duration_value`]).
   ConvertDuration,
+  /// `%MPEG::Composite` `Duration` PrintConv (`ConvertDuration($val) . " (approx)"`,
+  /// MPEG.pm:414) — identical to [`ConvertDuration`](Self::ConvertDuration) under
+  /// `-j` but with the literal `" (approx)"` suffix appended (e.g. `"1.68 s
+  /// (approx)"`); the bare numeric `$val` (the `8 * FileSize / TotalBitrate`
+  /// seconds) under `-n` (the suffix is a PrintConv-only string concatenation,
+  /// so `-n` carries no `(approx)`). A non-finite `$val` would stringify via
+  /// `ConvertDuration` (titlecase `Inf`/`NaN`) and STILL gain the suffix —
+  /// faithful to the Perl `.` string concat (unreachable for the M2TS path,
+  /// whose `FileSize`/bitrate are always finite-positive).
+  MpegDuration,
   /// `PrintConv => 'Image::ExifTool::GPS::ToDMS($self, $val, 1, $ref)'` — the
   /// `Composite:GPSLatitude`/`GPSLongitude` PrintConv. Under `-j` the DMS string
   /// (`48 deg 51' 29.34" N`); under `-n` the bare signed decimal `$val`. The
@@ -408,6 +435,21 @@ impl CompositePrintConv {
         // finite/non-finite-aware renderer.
         let n = raw.as_num().unwrap_or(f64::NAN);
         crate::composite::convs::duration_value(n, mode)
+      }
+      CompositePrintConv::MpegDuration => {
+        // `%MPEG::Composite` Duration (MPEG.pm:414): `ConvertDuration($val) .
+        // " (approx)"`. `$val` is the numeric `8 * FileSize / TotalBitrate`
+        // seconds. Under `-n` the bare ValueConv number (no suffix — the suffix
+        // is a PrintConv string concat). Under `-j` the `ConvertDuration`
+        // rendering (a finite value via the shared renderer, a non-finite value
+        // its titlecase Perl string) with the literal ` (approx)` appended.
+        let n = raw.as_num().unwrap_or(f64::NAN);
+        match mode {
+          ConvMode::ValueConv => crate::composite::convs::duration_value(n, mode),
+          ConvMode::PrintConv => TagValue::Str(
+            std::format!("{} (approx)", crate::composite::convs::convert_duration(n)).into(),
+          ),
+        }
       }
       CompositePrintConv::GpsCoordinate(ref_pos) => {
         let n = raw.as_num().unwrap_or(f64::NAN);
@@ -981,6 +1023,107 @@ fn aiff_duration(
   }
   Some(CompositeRaw::Num(
     frames_raw.coerce_numeric()? / sr_raw.coerce_numeric()?,
+  ))
+}
+
+/// `$val[i] =~ /^\d+$/` — the `%MPEG::Composite` Duration ValueConv bitrate
+/// guard (MPEG.pm:410-411). A PRESENT bitrate input ([`MPEG:AudioBitrate`] /
+/// [`MPEG:VideoBitrate`]) is admissible only if its ValueConv value stringifies
+/// to a run of ASCII digits — an `Variable`-sentinel `Str` (the all-ones VBR
+/// VideoBitrate) does NOT match, so the whole Duration aborts (`return undef`).
+/// An ABSENT input vacuously passes (the Perl `$val[i] and …` short-circuits on
+/// the undef), mirrored by [`CompositeValue::is_present`] short-circuiting here.
+#[cfg(feature = "m2ts")]
+fn mpeg_bitrate_is_decimal(input: &CompositeValue) -> bool {
+  match input.as_text() {
+    Some(s) => !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()),
+    None => true, // absent ⇒ the `$val[i] and ...` guard is vacuously satisfied
+  }
+}
+
+/// `%MPEG::Composite` `Duration` ValueConv (MPEG.pm:400-413). Inputs (index =
+/// ExifTool hash position): `0`=FileSize (Require), `1`=ID3Size, `2`=MPEG:
+/// AudioBitrate, `3`=MPEG:VideoBitrate, `4`=MPEG:VBRFrames, `5`=MPEG:SampleRate,
+/// `6`=MPEG:MPEGAudioVersion (all Desire). Two branches:
+///
+/// * VBR (`$val[4] and defined $val[5] and defined $val[6]`): compute from the
+///   VBR audio-frame count — `$mfs = $prt[5] / ($val[6] == 3 ? 144 : 72)` (the
+///   PrintConv SampleRate over the MPEG-version frame-size divisor), then
+///   `8 * $val[4] / $mfs`. `$prt[5]` is the SampleRate PrintConv value (its
+///   numeric coercion equals the raw rate at exifast's option set).
+/// * Total-bitrate (`return undef unless $val[2] or $val[3]`): the file size in
+///   bits divided by the summed audio+video bitrate — `8 * (FileSize - (ID3Size
+///   ||0)) / ((AudioBitrate||0) + (VideoBitrate||0))`, guarded by the two
+///   `/^\d+$/` bitrate checks (a `Variable` VideoBitrate ⇒ undef). This is the
+///   `(approx)` path the M2TS MPEG-2-video fixture takes (no VBR audio):
+///   `8 * 3989924 / 19000000 = 1.679968`.
+#[cfg(feature = "m2ts")]
+fn mpeg_duration(
+  v: &[CompositeValue],
+  prts: &[Option<TagValue>],
+  ctx: &CompositeContext,
+) -> Option<CompositeRaw> {
+  // `$val[0]` — ExifTool's `Require => FileSize` resolves `$$self{VALUE}{FileSize}`
+  // (the pseudo-tag ExifTool always carries). exifast does not EMIT `File:FileSize`
+  // (the goldens exclude it), so the input byte length is THREADED via
+  // [`CompositeContext::file_size`] instead (set by the M2TS path's
+  // `with_file_size`); absent ⇒ no composite (only M2TS supplies it).
+  let file_size = ctx.file_size? as f64;
+  let id3_size = v.get(1).and_then(CompositeValue::coerce_numeric);
+  let audio = v.get(2);
+  let video = v.get(3);
+  let vbr_frames = v.get(4);
+  let sample_rate = v.get(5);
+  let mpeg_version = v.get(6);
+
+  // VBR branch: `$val[4] and defined $val[5] and defined $val[6]`. `$val[4]`
+  // (VBRFrames) is a Perl-truthy test on the RAW value; the other two are
+  // `defined` (presence).
+  let vbr_frames_truthy = vbr_frames.is_some_and(CompositeValue::is_truthy);
+  let sr_present = sample_rate.is_some_and(CompositeValue::is_present);
+  let ver_present = mpeg_version.is_some_and(CompositeValue::is_present);
+  if vbr_frames_truthy && sr_present && ver_present {
+    // `$mfs = $prt[5] / ($val[6] == 3 ? 144 : 72)`; `8 * $val[4] / $mfs`.
+    let prt_sr = prts
+      .get(5)
+      .and_then(Option::as_ref)
+      .map(crate::composite::value_text)
+      .map(|s| crate::convert::perl_str_to_f64(&s))?;
+    let ver = mpeg_version?.coerce_numeric()?;
+    let divisor = if ver == 3.0 { 144.0 } else { 72.0 };
+    let mfs = prt_sr / divisor;
+    let frames = vbr_frames?.coerce_numeric()?;
+    return Some(CompositeRaw::Num(8.0 * frames / mfs));
+  }
+
+  // Total-bitrate branch. `return undef unless $val[2] or $val[3]` — at least
+  // one bitrate must be Perl-truthy.
+  let audio_truthy = audio.is_some_and(CompositeValue::is_truthy);
+  let video_truthy = video.is_some_and(CompositeValue::is_truthy);
+  if !audio_truthy && !video_truthy {
+    return None;
+  }
+  // `return undef if $val[2] and not $val[2] =~ /^\d+$/` (and likewise $val[3]).
+  // The guard fires only for a PRESENT non-decimal bitrate (e.g. a `Variable`
+  // VideoBitrate); an absent input passes.
+  if audio.is_some_and(CompositeValue::is_present) && !mpeg_bitrate_is_decimal(audio?) {
+    return None;
+  }
+  if video.is_some_and(CompositeValue::is_present) && !mpeg_bitrate_is_decimal(video?) {
+    return None;
+  }
+  // `(8 * ($val[0] - ($val[1]||0))) / (($val[2]||0) + ($val[3]||0))`.
+  let total_bitrate = audio
+    .and_then(CompositeValue::coerce_numeric)
+    .unwrap_or(0.0)
+    + video
+      .and_then(CompositeValue::coerce_numeric)
+      .unwrap_or(0.0);
+  if total_bitrate == 0.0 {
+    return None; // a present-but-zero bitrate would divide by zero (Perl dies; we abort)
+  }
+  Some(CompositeRaw::Num(
+    8.0 * (file_size - id3_size.unwrap_or(0.0)) / total_bitrate,
   ))
 }
 
@@ -2119,6 +2262,44 @@ const AIFF_DURATION: CompositeDef = CompositeDef {
   sort_key: "AIFF-Duration",
 };
 
+/// `%MPEG::Composite` `Duration` (MPEG.pm:386-415) — Group2 `Video`,
+/// `Priority => -1`. Registered only when `m2ts` is on (the sole exifast path
+/// that emits the `%MPEG::Video` bitrate tags AND threads the input byte length
+/// via [`CompositeContext::file_size`]).
+///
+/// **Index alignment.** ExifTool's `Require => { 0 => FileSize }` resolves the
+/// `$$self{VALUE}{FileSize}` pseudo-tag, which exifast does not emit; the derive
+/// reads it from `ctx.file_size` instead. Index 0 stays a (never-resolving,
+/// `Desire`-kind) `FileSize` placeholder so the remaining `$val[1..6]` line up
+/// 1:1 with `mpeg_duration`'s transliterated arithmetic. Making the placeholder
+/// `Desire` (not `Require`) keeps the engine from aborting on the always-Missing
+/// stream FileSize — observationally identical to ExifTool, whose `Require`d
+/// FileSize is always satisfied. The bitrate/VBR inputs carry the `MPEG:` group
+/// (family-1 `MPEG`); `ID3Size`/`FileSize` are bare-name (any group).
+///
+/// `Priority => -1` ("don't replace any other Duration tag") is moot here:
+/// `Composite:Duration` is keyed under family-1 `Composite` and never collides
+/// with the format `M2TS:Duration` / `MPEG:Duration` (distinct family-1), so the
+/// duplicate-override rule is never exercised — stored as the default `1`.
+#[cfg(feature = "m2ts")]
+const MPEG_DURATION: CompositeDef = CompositeDef {
+  name: "Duration",
+  inputs: &[
+    des(&[], "FileSize"), // index 0 — supplied via ctx.file_size (placeholder)
+    des(&[], "ID3Size"),
+    des(&["MPEG"], "AudioBitrate"),
+    des(&["MPEG"], "VideoBitrate"),
+    des(&["MPEG"], "VBRFrames"),
+    des(&["MPEG"], "SampleRate"),
+    des(&["MPEG"], "MPEGAudioVersion"),
+  ],
+  derive: mpeg_duration,
+  print_conv: CompositePrintConv::MpegDuration,
+  sub_doc: SubDoc::No,
+  priority: 1,
+  sort_key: "MPEG-Duration",
+};
+
 /// `Composite:GPSLatitude` (GPS.pm:368). Group2 `Location`. The composite name
 /// matches the GPS-main `GPSLatitude`, but resolves from `GPS:GPSLatitude` (the
 /// decimal-degrees ValueConv) — the family-1 `GPS` group keeps them distinct.
@@ -2662,6 +2843,8 @@ pub(crate) const REGISTRY: &[CompositeDef] = &[
   FLAC_DURATION,
   #[cfg(feature = "aiff")]
   AIFF_DURATION,
+  #[cfg(feature = "m2ts")]
+  MPEG_DURATION,
   #[cfg(feature = "exif")]
   GPS_LATITUDE,
   #[cfg(feature = "exif")]

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -805,7 +805,8 @@ impl AnyMeta<'_> {
           .iter()
           .map(|t| (t.group_ref().family1(), t.name(), t.value_ref())),
       );
-      let ctx = crate::composite::CompositeContext::new(mdat_total, rotation);
+      let ctx = crate::composite::CompositeContext::new(mdat_total, rotation)
+        .with_file_size(self.composite_file_size());
       crate::composite::build_composites_into_tags(
         &mut out,
         Some(&mut other_view),
@@ -985,6 +986,7 @@ impl AnyMeta<'_> {
           crate::emit::ConvMode::PrintConv => &other_view,
         };
         crate::composite::make_context(mdat_total, value_view)
+          .with_file_size(self.composite_file_size())
       };
       crate::composite::build_composites(out, Some(&mut other_view), mode, doc_count, &ctx);
     }
@@ -1008,6 +1010,22 @@ impl AnyMeta<'_> {
     match self {
       #[cfg(feature = "quicktime")]
       AnyMeta::QuickTime(m) => m.quicktime().media_data_total(),
+      _ => None,
+    }
+  }
+
+  /// `$$self{VALUE}{FileSize}` — the input byte length the `%MPEG::Composite`
+  /// `Duration` derive divides by (MPEG.pm:412-413, `Require => FileSize`). Only
+  /// the `M2ts` Meta supplies it (the sole exifast path emitting the `%MPEG::
+  /// Video` bitrate tags); every other Meta returns `None` (their composites
+  /// never read FileSize). exifast does not emit `File:FileSize` as a tag, so
+  /// this is threaded into the Composite engine via
+  /// [`CompositeContext::with_file_size`] rather than resolved from the stream.
+  #[cfg(feature = "alloc")]
+  fn composite_file_size(&self) -> Option<u64> {
+    match self {
+      #[cfg(feature = "m2ts")]
+      AnyMeta::M2ts(m) => Some(m.file_size()),
       _ => None,
     }
   }

--- a/src/formats/m2ts.rs
+++ b/src/formats/m2ts.rs
@@ -432,6 +432,17 @@ pub struct Meta<'a> {
   /// Stored as the RAW index byte; PrintConv lookup at emit. Bundled `-n`
   /// emits the raw index (a fixture shows `0` for 48000).
   ac3_audio_sample_rate: Option<u8>,
+  /// `MPEG:ImageWidth/Height/AspectRatio/FrameRate/VideoBitrate` — the
+  /// `%MPEG::Video` sequence-header decode of a stream-type-0x01/0x02 PES
+  /// (M2TS.pm:300-307 → `MPEG::ParseMPEGAudioVideo`). `None` for an MPEG-2-
+  /// video-free stream (the canonical H.264 `M2TS.mts`).
+  mpeg_video: Option<crate::formats::mpeg::VideoMeta>,
+  /// `$$self{VALUE}{FileSize}` (ExifTool.pm `SetFileType`) — the input byte
+  /// length, threaded into the Composite engine for the `%MPEG::Composite`
+  /// `Duration` def (MPEG.pm:386-415 `Require => FileSize`). Not emitted as a
+  /// tag (the goldens exclude `File:FileSize`); carried only for the Composite
+  /// `Duration = 8 * FileSize / (Audio+VideoBitrate)` derive.
+  file_size: u64,
   /// Nested H.264 Meta when an H.264 PES payload was forwarded to the
   /// H.264 decoder. The H.264 Meta is fully owned (`'a` is a phantom in
   /// `H264Meta<'a>`), but is stored at the Meta's own `'a` for GAT
@@ -548,6 +559,23 @@ impl<'a> Meta<'a> {
   #[inline(always)]
   pub const fn ac3_audio_sample_rate(&self) -> Option<u8> {
     self.ac3_audio_sample_rate
+  }
+
+  /// The MPEG-1/2 video sequence-header decode (`%MPEG::Video`,
+  /// M2TS.pm:300-307). `None` when no MPEG-2-video PES was decoded.
+  #[must_use]
+  #[inline(always)]
+  pub const fn mpeg_video(&self) -> Option<&crate::formats::mpeg::VideoMeta> {
+    self.mpeg_video.as_ref()
+  }
+
+  /// The input byte length (`$$self{VALUE}{FileSize}`), used by the Composite
+  /// `%MPEG::Composite` `Duration` derive (MPEG.pm:386-415). `0` only for an
+  /// empty input (never produced — `probe` rejects sub-`MIN_INITIAL_BYTES`).
+  #[must_use]
+  #[inline(always)]
+  pub const fn file_size(&self) -> u64 {
+    self.file_size
   }
 
   /// The H.264 sub-Meta when an H.264 PES payload was forwarded. Borrowed
@@ -777,6 +805,13 @@ struct Walker<'a> {
   ac3_audio_channels: Option<u8>,
   /// AC-3 PES payload decode (M2TS.pm:253-261).
   ac3_audio_sample_rate: Option<u8>,
+  /// MPEG-1/2 video sequence-header decode (M2TS.pm:300-307 →
+  /// `MPEG::ParseMPEGAudioVideo`). The `%MPEG::Video` tags
+  /// (`ImageWidth`/`Height`/`AspectRatio`/`FrameRate`/`VideoBitrate`) extracted
+  /// from the FIRST stream-type-0x01/0x02 PES whose payload carries a valid
+  /// `\0\0\x01\xb3` sequence header. `HandleTag`s are last-wins, so the LAST
+  /// successfully-decoded video PES survives (the inner `if let Some`).
+  mpeg_video: Option<crate::formats::mpeg::VideoMeta>,
   /// Nested H.264 Meta when an H.264 PES payload was forwarded.
   h264: Option<crate::formats::h264::H264Meta<'a>>,
   /// `$$et{ParsedH264}` (H264.pm:1102-1103) — set once the first H.264 frame
@@ -903,6 +938,7 @@ impl<'a> Walker<'a> {
       ac3_surround_mode: None,
       ac3_audio_channels: None,
       ac3_audio_sample_rate: None,
+      mpeg_video: None,
       h264: None,
       parsed_h264: false,
       h264_frame_state: crate::formats::h264::H264FrameState::new(),
@@ -1656,10 +1692,25 @@ impl<'a> Walker<'a> {
       return ParseOutcome::Unknown;
     };
     match t {
-      // M2TS.pm:300-307 — MPEG-1/2 Video / Audio. Routed to `MPEG::*` —
-      // deferred; the canonical fixture exercises 0x1b H.264 only. Bundled
-      // `$more` stays 0 (these `ParseMPEG*` helpers don't set it).
-      0x01..=0x04 => ParseOutcome::Done,
+      // M2TS.pm:300-303 — MPEG-1/2 Video. `ParseMPEGAudioVideo` scans the
+      // ≤256-byte PES payload for the `\0\0\x01\xb3` sequence-header start code
+      // and bit-extracts the `%MPEG::Video` tags (`ImageWidth`/`Height`/
+      // `AspectRatio`/`FrameRate`/`VideoBitrate`, MPEG.pm:258-313) into the
+      // typed [`crate::formats::mpeg::VideoMeta`]. `HandleTag` is last-wins, so a
+      // later valid sequence header overwrites (the inner `if let Some`); a PES
+      // with no valid header leaves the prior decode intact. Bundled `$more`
+      // stays 0 (`ParseMPEGAudioVideo` never sets it).
+      0x01 | 0x02 => {
+        if let Some(v) = crate::formats::mpeg::parse_mpeg_audio_video(payload) {
+          self.mpeg_video = Some(v);
+        }
+        ParseOutcome::Done
+      }
+      // M2TS.pm:304-307 — MPEG-1/2 Audio (`MPEG::ParseMPEGAudio`). Deferred:
+      // the embedded MPEG-audio-in-PES decode produces no tags for the camera/
+      // dashcam M2TS references (which carry AC-3 / AAC audio on 0x81/0x0f, not
+      // MPEG-1/2 audio on 0x03/0x04). Filed as the MPEG-audio-in-PES follow-up.
+      0x03 | 0x04 => ParseOutcome::Done,
       // M2TS.pm:342-351 — H.264.
       0x1b => {
         let prev = self.h264.take();
@@ -1970,6 +2021,11 @@ impl<'a> Walker<'a> {
       ac3_surround_mode: self.ac3_surround_mode,
       ac3_audio_channels: self.ac3_audio_channels,
       ac3_audio_sample_rate: self.ac3_audio_sample_rate,
+      mpeg_video: self.mpeg_video,
+      // `$$self{VALUE}{FileSize}` — the input length (ExifTool sets FileSize at
+      // SetFileType). The Composite `%MPEG::Composite` `Duration` derive divides
+      // by it (MPEG.pm:413); not emitted as a tag.
+      file_size: self.data.len() as u64,
       h264: self.h264,
       warnings: self.warnings,
       ligogps: self.ligogps,
@@ -2245,6 +2301,75 @@ impl crate::emit::Taggable for Meta<'_> {
         ac3(),
         "AudioSampleRate".into(),
         value,
+        false,
+      ));
+    }
+
+    // MPEG-1/2 video (`%MPEG::Video`, M2TS.pm:300-307 → MPEG.pm:258-313) — emit
+    // in `%MPEG::Video` `ProcessFrameHeader` sort order (the `BitNN` keys sort
+    // ImageWidth, ImageHeight, AspectRatio, FrameRate, VideoBitrate). Family-0 =
+    // family-1 = `"MPEG"` (MPEG.pm:259 `GROUPS{2} => 'Video'` ⇒ family-0
+    // defaults to the table name `"MPEG"`; the `-G1` key is `"MPEG"`).
+    if let Some(v) = &self.mpeg_video {
+      let mpeg = || Group::new("MPEG", "MPEG");
+      // MPEG.pm:260/261 — ImageWidth / ImageHeight: no ValueConv/PrintConv,
+      // raw integer in both modes.
+      tags.push(EmittedTag::new(
+        mpeg(),
+        "ImageWidth".into(),
+        TagValue::U64(u64::from(v.image_width())),
+        false,
+      ));
+      tags.push(EmittedTag::new(
+        mpeg(),
+        "ImageHeight".into(),
+        TagValue::U64(u64::from(v.image_height())),
+        false,
+      ));
+      // MPEG.pm:262-295 — AspectRatio: ValueConv hash (raw idx → float) then
+      // PrintConv hash (float → name). `-n` emits the ValueConv float; `-j` the
+      // named string.
+      let aspect = if print_conv {
+        TagValue::Str(v.aspect_ratio_print().into())
+      } else {
+        TagValue::F64(v.aspect_ratio_value())
+      };
+      tags.push(EmittedTag::new(mpeg(), "AspectRatio".into(), aspect, false));
+      // MPEG.pm:296-308 — FrameRate: ValueConv hash (raw idx → fps) then
+      // `PrintConv => '"$val fps"'` (the ValueConv float interpolated, %.15g
+      // NV stringification, e.g. `59.94 fps`).
+      let frame_rate = if print_conv {
+        TagValue::Str(format!("{} fps", crate::value::format_g(v.frame_rate_value(), 15)).into())
+      } else {
+        TagValue::F64(v.frame_rate_value())
+      };
+      tags.push(EmittedTag::new(
+        mpeg(),
+        "FrameRate".into(),
+        frame_rate,
+        false,
+      ));
+      // MPEG.pm:309-313 — VideoBitrate: `ValueConv => '$val eq 0x3ffff ?
+      // "Variable" : $val * 400'`, `PrintConv => 'ConvertBitrate($val)'`. `-n`
+      // emits the post-ValueConv integer (or the "Variable" string); `-j` the
+      // ConvertBitrate text (or "Variable" passed through unchanged — it is not
+      // `IsFloat`, so `ConvertBitrate` returns it verbatim).
+      let bitrate = match v.video_bitrate() {
+        crate::formats::mpeg::VideoBitrate::Variable => TagValue::Str("Variable".into()),
+        crate::formats::mpeg::VideoBitrate::Bps(bps) => {
+          if print_conv {
+            let mut s = String::new();
+            let _ = crate::formats::mpeg::write_convert_bitrate(&mut s, f64::from(bps));
+            TagValue::Str(s.into())
+          } else {
+            TagValue::U64(u64::from(bps))
+          }
+        }
+      };
+      tags.push(EmittedTag::new(
+        mpeg(),
+        "VideoBitrate".into(),
+        bitrate,
         false,
       ));
     }

--- a/src/formats/mpeg.rs
+++ b/src/formats/mpeg.rs
@@ -2071,6 +2071,294 @@ pub(crate) const fn id3_process_mp3_scan_len(ext_is_mp3: bool) -> usize {
 }
 
 // ===========================================================================
+// MPEG video — `%MPEG::Video` / `ProcessMPEGVideo` / `ParseMPEGAudioVideo`
+// (MPEG.pm:258-321 + 583-681)
+// ===========================================================================
+
+/// `%MPEG::Video` AspectRatio ValueConv hash (MPEG.pm:262-279) — the 4-bit
+/// `aspect_ratio_information` index (1-14) → the decimal aspect value. Index 0
+/// and 15 are rejected by [`process_mpeg_video`] (forbidden / reserved), so the
+/// table is keyed 1..=14. `-n` emits the float; `-j` runs [`ASPECT_PRINT`].
+const ASPECT_VALUE: [(u8, f64); 14] = [
+  (1, 1.0),
+  (2, 0.6735),
+  (3, 0.7031),
+  (4, 0.7615),
+  (5, 0.8055),
+  (6, 0.8437),
+  (7, 0.8935),
+  (8, 0.9157),
+  (9, 0.9815),
+  (10, 1.0255),
+  (11, 1.0695),
+  (12, 1.0950),
+  (13, 1.1575),
+  (14, 1.2015),
+];
+
+/// `%MPEG::Video` AspectRatio PrintConv hash (MPEG.pm:280-295) — keyed by the
+/// ValueConv'd float (matching ExifTool's `PrintConv` lookup against `$val`).
+/// A value with no named hit prints the bare float string (ExifTool's
+/// `PrintInverseLookup` passthrough — every numeric float in the table has an
+/// explicit PrintConv entry, so the named hits below are exhaustive).
+const ASPECT_PRINT: [(u8, &str); 14] = [
+  (1, "1:1"),
+  (2, "0.6735"),
+  (3, "16:9, 625 line, PAL"),
+  (4, "0.7615"),
+  (5, "0.8055"),
+  (6, "16:9, 525 line, NTSC"),
+  (7, "0.8935"),
+  (8, "4:3, 625 line, PAL, CCIR601"),
+  (9, "0.9815"),
+  (10, "1.0255"),
+  (11, "1.0695"),
+  (12, "4:3, 525 line, NTSC, CCIR601"),
+  (13, "1.1575"),
+  (14, "1.2015"),
+];
+
+/// `%MPEG::Video` FrameRate ValueConv hash (MPEG.pm:298-307) — the 4-bit
+/// `frame_rate_code` index (1-8) → fps. Index 0 and >8 are rejected by
+/// [`process_mpeg_video`]. `-n` emits the float; `-j` appends `" fps"`
+/// (MPEG.pm:308 `PrintConv => '"$val fps"'`).
+const FRAME_RATE_VALUE: [(u8, f64); 8] = [
+  (1, 23.976),
+  (2, 24.0),
+  (3, 25.0),
+  (4, 29.97),
+  (5, 30.0),
+  (6, 50.0),
+  (7, 59.94),
+  (8, 60.0),
+];
+
+/// `0x3ffff` — `%MPEG::Video` VideoBitrate "Variable" sentinel (MPEG.pm:312
+/// `$val eq 0x3ffff ? "Variable" : $val * 400`). The raw 18-bit `bit_rate_value`
+/// all-ones means VBR.
+const VIDEO_BITRATE_VBR: u32 = 0x3_ffff;
+
+/// The post-ValueConv `MPEG:VideoBitrate` (MPEG.pm:312). `Variable` (the
+/// all-ones VBR sentinel) or `bit_rate_value * 400` bits/s.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoBitrate {
+  /// `0x3ffff` ⇒ `"Variable"` (`-n` AND `-j`).
+  Variable,
+  /// `bit_rate_value * 400` bits/s (`-n` raw integer; `-j` ConvertBitrate).
+  Bps(u32),
+}
+
+/// Typed MPEG-2 video sequence-header metadata — the output of
+/// [`parse_mpeg_audio_video`] (the video side of `ParseMPEGAudioVideo`,
+/// MPEG.pm:627-666, which dispatches a `\0\0\x01\xb3` sequence-header start
+/// code to `ProcessMPEGVideo`, MPEG.pm:587-606). Carries the five
+/// fixture-visible `%MPEG::Video` tags.
+///
+/// **D8 — no public fields, accessors only.** Construct only via
+/// [`parse_mpeg_audio_video`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VideoMeta {
+  /// `MPEG:ImageWidth` — Bit00-11 of `$w1` = the 12-bit `horizontal_size`
+  /// (MPEG.pm:260).
+  image_width: u16,
+  /// `MPEG:ImageHeight` — Bit12-23 of `$w1` = the 12-bit `vertical_size`
+  /// (MPEG.pm:261).
+  image_height: u16,
+  /// `MPEG:AspectRatio` — the raw 4-bit `aspect_ratio_information` index
+  /// (Bit24-27 of `$w1`, MPEG.pm:262); 1..=14 (0/15 rejected). ValueConv/
+  /// PrintConv applied at emit via [`ASPECT_VALUE`] / [`ASPECT_PRINT`].
+  aspect_ratio_idx: u8,
+  /// `MPEG:FrameRate` — the raw 4-bit `frame_rate_code` index (Bit28-31 of
+  /// `$w1`, MPEG.pm:296); 1..=8. ValueConv/PrintConv via [`FRAME_RATE_VALUE`].
+  frame_rate_idx: u8,
+  /// `MPEG:VideoBitrate` — the post-ValueConv form (Bit32-49 of `$w2`,
+  /// MPEG.pm:309-313): the 18-bit `bit_rate_value * 400`, or `Variable`.
+  video_bitrate: VideoBitrate,
+}
+
+impl VideoMeta {
+  /// `MPEG:ImageWidth` (MPEG.pm:260).
+  #[must_use]
+  #[inline(always)]
+  pub const fn image_width(&self) -> u16 {
+    self.image_width
+  }
+
+  /// `MPEG:ImageHeight` (MPEG.pm:261).
+  #[must_use]
+  #[inline(always)]
+  pub const fn image_height(&self) -> u16 {
+    self.image_height
+  }
+
+  /// `MPEG:AspectRatio` ValueConv float (MPEG.pm:262-279) — the decimal aspect
+  /// value for the raw 4-bit index, used by `-n` and as the PrintConv key.
+  #[must_use]
+  #[inline(always)]
+  pub fn aspect_ratio_value(&self) -> f64 {
+    ASPECT_VALUE
+      .iter()
+      .find(|(k, _)| *k == self.aspect_ratio_idx)
+      .map_or(f64::from(self.aspect_ratio_idx), |(_, v)| *v)
+  }
+
+  /// `MPEG:AspectRatio` PrintConv string (MPEG.pm:280-295) — the named ratio
+  /// (e.g. `"16:9, 625 line, PAL"`) for the raw 4-bit index.
+  #[must_use]
+  #[inline(always)]
+  pub fn aspect_ratio_print(&self) -> &'static str {
+    ASPECT_PRINT
+      .iter()
+      .find(|(k, _)| *k == self.aspect_ratio_idx)
+      .map_or("", |(_, s)| *s)
+  }
+
+  /// `MPEG:FrameRate` ValueConv fps (MPEG.pm:298-307) — the fps for the raw
+  /// 4-bit code. `-j` appends `" fps"`.
+  #[must_use]
+  #[inline(always)]
+  pub fn frame_rate_value(&self) -> f64 {
+    FRAME_RATE_VALUE
+      .iter()
+      .find(|(k, _)| *k == self.frame_rate_idx)
+      .map_or(f64::from(self.frame_rate_idx), |(_, v)| *v)
+  }
+
+  /// `MPEG:VideoBitrate` post-ValueConv form (MPEG.pm:309-313).
+  #[must_use]
+  #[inline(always)]
+  pub const fn video_bitrate(&self) -> VideoBitrate {
+    self.video_bitrate
+  }
+}
+
+/// `ProcessMPEGVideo` (MPEG.pm:587-606) — read the two big-endian header words
+/// `$w1`/`$w2` that FOLLOW a `\0\0\x01\xb3` sequence-header start code, validate
+/// the aspect-ratio + frame-rate nibbles, and bit-extract the `%MPEG::Video`
+/// fields via the `ProcessFrameHeader` masks (MPEG.pm:441-457).
+///
+/// `buff` begins at the byte AFTER the `\xb3` start code (the position Perl's
+/// `substr($$buffPt, pos(...))` slices from). Returns `None` when fewer than 4
+/// bytes are available (MPEG.pm:591 `return 0 unless length $$buffPt >= 4`) or
+/// the aspect/frame-rate validation fails (MPEG.pm:593-598 `return 0`) — exactly
+/// the cases Perl rejects.
+///
+/// **Per-field gating (4-7 byte tail).** MPEG.pm:592 `my ($w1, $w2) =
+/// unpack('N2', $$buffPt)` — Perl's `unpack` silently drops an INCOMPLETE second
+/// 4-byte group, so a 4-7 byte tail leaves `$w2` **undef**. `ProcessFrameHeader`
+/// then reads `$word = $data[1] = undef` for `Bit32-49 VideoBitrate` and
+/// computes `(undef >> 14) & 0x3FFFF` = `0` (Perl warns to STDERR but emits the
+/// tag). So bundled extracts the FIRST-word tags (ImageWidth/ImageHeight/
+/// AspectRatio/FrameRate) at >=4 bytes and emits `VideoBitrate => 0` (PrintConv
+/// `"0 bps"`) when the second word is absent — it is NOT omitted. We mirror this
+/// by defaulting the missing second word to `0`. The downstream
+/// `%MPEG::Composite` `Duration` derive (`mpeg_duration`) then suppresses itself
+/// via its `$val[3]` truthiness guard (a `0` VideoBitrate is Perl-falsy), so no
+/// `Composite:Duration` appears for a partial header — byte-identical to bundled
+/// ExifTool 13.59.
+#[must_use]
+fn process_mpeg_video(buff: &[u8]) -> Option<VideoMeta> {
+  // MPEG.pm:591 `return 0 unless length $$buffPt >= 4` — the FIRST word ($w1)
+  // alone carries ImageWidth/Height/AspectRatio/FrameRate, so the gate is >=4.
+  let w1_bytes: [u8; 4] = buff.get(..4)?.try_into().ok()?;
+  let w1 = u32::from_be_bytes(w1_bytes);
+  // MPEG.pm:592 `unpack('N2', ...)` — the SECOND word ($w2 = VideoBitrate) is
+  // present only at >=8 bytes; an incomplete group leaves `$w2` undef, which
+  // `ProcessFrameHeader` treats as 0 (`undef >> 14 & mask`). Default to 0.
+  let w2 = buff
+    .get(4..8)
+    .and_then(|b| <[u8; 4]>::try_from(b).ok())
+    .map_or(0, u32::from_be_bytes);
+  // MPEG.pm:592-599 — validate as much as possible:
+  //   ($w1 & 0xf0) == 0x00 → 0000 forbidden aspect ratio
+  //   ($w1 & 0xf0) == 0xf0 → 1111 reserved aspect ratio
+  //   ($w1 & 0x0f) == 0    → frame rate must be 1-8
+  //   ($w1 & 0x0f) > 8
+  let aspect_nibble = ((w1 >> 4) & 0x0f) as u8;
+  let frame_rate_idx = (w1 & 0x0f) as u8;
+  if aspect_nibble == 0x00 || aspect_nibble == 0x0f || frame_rate_idx == 0 || frame_rate_idx > 8 {
+    return None;
+  }
+  // `ProcessFrameHeader` masks (MPEG.pm:441-457) for `%MPEG::Video`:
+  //   Bit00-11 ImageWidth  = ($w1 >> (31 - 11)) & 0xFFF = ($w1 >> 20) & 0xFFF
+  //   Bit12-23 ImageHeight = ($w1 >> (31 - 23)) & 0xFFF = ($w1 >> 8)  & 0xFFF
+  //   Bit24-27 AspectRatio = ($w1 >> (31 - 27)) & 0x0F  = ($w1 >> 4)  & 0x0F
+  //   Bit28-31 FrameRate   = ($w1 >> (31 - 31)) & 0x0F  =  $w1        & 0x0F
+  //   Bit32-49 VideoBitrate= ($w2 >> (31 + 32 - 49)) & 0x3FFFF = ($w2 >> 14) & 0x3FFFF
+  let image_width = ((w1 >> 20) & 0x0fff) as u16;
+  let image_height = ((w1 >> 8) & 0x0fff) as u16;
+  let aspect_ratio_idx = aspect_nibble;
+  let bit_rate_value = (w2 >> 14) & 0x3_ffff;
+  let video_bitrate = if bit_rate_value == VIDEO_BITRATE_VBR {
+    VideoBitrate::Variable
+  } else {
+    VideoBitrate::Bps(bit_rate_value.saturating_mul(400))
+  };
+  Some(VideoMeta {
+    image_width,
+    image_height,
+    aspect_ratio_idx,
+    frame_rate_idx,
+    video_bitrate,
+  })
+}
+
+/// `ParseMPEGAudioVideo` (MPEG.pm:627-666) — the video side. Scan `buff` for the
+/// MPEG-2 sequence-header start code `\0\0\x01\xb3` and, on the first match,
+/// hand the ≤256-byte tail (starting AFTER the `\xb3`) to [`process_mpeg_video`].
+///
+/// Returns the decoded [`VideoMeta`] for the first valid sequence header, or
+/// `None` when no `\xb3` header is present / validates. Faithful scope: the
+/// MPEG-1/2 **audio** side of `ParseMPEGAudioVideo` (the `\xc0` audio start code
+/// + the leading-frame `ParseMPEGAudio` MP3-sync probe, MPEG.pm:639-645/650) is
+/// the [`AudioMeta`] domain and produces no tags for an MPEG-2 video elementary
+/// stream (M2TS routes MPEG audio via stream types 0x03/0x04, not 0x02) — it is
+/// the deferred MPEG-audio-in-PES item, not exercised by the video fixture.
+#[must_use]
+pub fn parse_mpeg_audio_video(buff: &[u8]) -> Option<VideoMeta> {
+  // MPEG.pm:636 `while ($$buffPt =~ /\0\0\x01(\xb3|\xc0)/g)`. We only dispatch
+  // the `\xb3` (video) branch; iterate every sequence-start candidate so a
+  // leading non-`\xb3` (`\xc0`) match does not abort the scan.
+  let mut pos = 0usize;
+  while let Some(rel) = find_subslice(buff.get(pos..)?, &[0x00, 0x00, 0x01]) {
+    let sc_pos = pos + rel; // start of `00 00 01`
+    let marker = buff.get(sc_pos + 3).copied();
+    // Advance past this `00 00 01` for the next iteration regardless.
+    pos = sc_pos + 3;
+    if marker == Some(0xb3) {
+      // MPEG.pm:642-647 — `substr($$buffPt, pos(...), $len)` with `$len`
+      // clamped to 256; `pos(...)` is one past the matched `\xb3`.
+      let after = sc_pos + 4;
+      let tail = buff.get(after..)?;
+      let bounded = tail.get(..256.min(tail.len()))?;
+      if let Some(meta) = process_mpeg_video(bounded) {
+        return Some(meta);
+      }
+      // MPEG.pm:648-649 `$len = length - pos; last if $len < 4` — a tail of
+      // fewer than 4 bytes after the `\xb3` cannot hold the first word, so
+      // `process_mpeg_video` returns `None` (its >=4 gate). A 4-7 byte tail now
+      // DECODES the first-word tags (`$w2` defaults to 0 ⇒ `VideoBitrate => 0`),
+      // matching bundled. On an invalid header (bad aspect/frame-rate) keep
+      // scanning for a later sequence header (faithful: the Perl loop continues
+      // to the next `/g` match while `found{video}` is unset).
+    }
+  }
+  None
+}
+
+/// Find the first occurrence of `needle` in `haystack` (a small two/three-byte
+/// start-code search; `memchr`-free to keep the dependency surface minimal and
+/// the `#![deny(clippy::indexing_slicing)]` contract checked).
+#[inline]
+#[must_use]
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+  if needle.is_empty() || haystack.len() < needle.len() {
+    return None;
+  }
+  haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+// ===========================================================================
 // Tests
 // ===========================================================================
 
@@ -2696,5 +2984,117 @@ mod tests {
     assert!(ChannelMode::Stereo.is_stereo());
     assert!(ChannelMode::SingleChannel.is_single_channel());
     assert!(Emphasis::None.is_none() && Emphasis::Reserved.is_reserved());
+  }
+
+  // ──────────────────── MPEG-2 video per-field gating ────────────────────
+  //
+  // Oracle: bundled ExifTool 13.59 (`exiftool -G1 -j`) on a raw `.mpg` whose
+  // bytes are `00 00 01 b3` + the tail under test. The first word
+  // `w1 = 0x2D01E034` decodes to ImageWidth=720 (0x2D0), ImageHeight=480
+  // (0x1E0), AspectRatio idx 3 ("16:9, 625 line, PAL"), FrameRate idx 4
+  // (29.97 fps); the second word `w2 = 0x00190000` yields VideoBitrate
+  // `(0x19_0000 >> 14) & 0x3FFFF = 100`, ValueConv `100 * 400 = 40000` bps.
+  //
+  // Bundled per-length behavior (`MPEG.pm:591` gate `>= 4`; `unpack('N2')`
+  // drops the incomplete 2nd group ⇒ `$w2` undef ⇒ `VideoBitrate => 0`):
+  //   4-byte tail: ImageWidth/Height/AspectRatio/FrameRate + `VideoBitrate 0`
+  //   7-byte tail: identical to the 4-byte tail (still no full 2nd word)
+  //   8-byte tail: + the real `VideoBitrate 40000`
+  const VID_W1: [u8; 4] = [0x2D, 0x01, 0xE0, 0x34];
+  const VID_W2: [u8; 4] = [0x00, 0x19, 0x00, 0x00];
+
+  fn mpeg2_video_buf(tail: &[u8]) -> std::vec::Vec<u8> {
+    let mut b = std::vec![0x00u8, 0x00, 0x01, 0xb3];
+    b.extend_from_slice(tail);
+    b
+  }
+
+  #[test]
+  fn mpeg2_video_first_word_only_4_byte_tail() {
+    // MPEG.pm:591 gate is `>= 4`: the first word alone decodes. Bundled emits
+    // the first-word tags + `VideoBitrate => 0` (NOT omitted).
+    let buf = mpeg2_video_buf(&VID_W1);
+    let v = parse_mpeg_audio_video(&buf).expect("4-byte tail decodes the first word");
+    assert_eq!(v.image_width(), 720);
+    assert_eq!(v.image_height(), 480);
+    assert_eq!(v.aspect_ratio_print(), "16:9, 625 line, PAL");
+    assert_eq!(format_g(v.frame_rate_value(), 15), "29.97");
+    // `$w2` undef ⇒ `(undef >> 14) & 0x3FFFF` = 0 ⇒ Bps(0) (= bundled "0 bps").
+    assert_eq!(v.video_bitrate(), VideoBitrate::Bps(0));
+  }
+
+  #[test]
+  fn mpeg2_video_partial_second_word_7_byte_tail() {
+    // 7 bytes = first word + 3 of the 4 second-word bytes. `unpack('N2')` drops
+    // the incomplete group, so this is byte-for-byte identical to the 4-byte
+    // tail: first-word tags + `VideoBitrate => 0`.
+    let mut tail = VID_W1.to_vec();
+    tail.extend_from_slice(&VID_W2[..3]);
+    let buf = mpeg2_video_buf(&tail);
+    let v = parse_mpeg_audio_video(&buf).expect("7-byte tail decodes the first word");
+    assert_eq!(v.image_width(), 720);
+    assert_eq!(v.image_height(), 480);
+    assert_eq!(v.aspect_ratio_print(), "16:9, 625 line, PAL");
+    assert_eq!(format_g(v.frame_rate_value(), 15), "29.97");
+    assert_eq!(v.video_bitrate(), VideoBitrate::Bps(0));
+  }
+
+  #[test]
+  fn mpeg2_video_full_8_byte_tail_emits_bitrate() {
+    // 8 bytes = both words. Bundled emits the real VideoBitrate (40000 bps).
+    let mut tail = VID_W1.to_vec();
+    tail.extend_from_slice(&VID_W2);
+    let buf = mpeg2_video_buf(&tail);
+    let v = parse_mpeg_audio_video(&buf).expect("8-byte tail decodes both words");
+    assert_eq!(v.image_width(), 720);
+    assert_eq!(v.image_height(), 480);
+    assert_eq!(v.video_bitrate(), VideoBitrate::Bps(40_000));
+  }
+
+  #[test]
+  fn mpeg2_video_zero_vs_full_bitrate_differ() {
+    // Guard the regression directly: the 4-byte (partial) decode must NOT equal
+    // the 8-byte (full) decode — the partial one carries Bps(0), the full one
+    // Bps(40000). Both still emit the SAME first-word tags.
+    let four = parse_mpeg_audio_video(&mpeg2_video_buf(&VID_W1)).expect("4-byte decodes");
+    let mut full_tail = VID_W1.to_vec();
+    full_tail.extend_from_slice(&VID_W2);
+    let eight = parse_mpeg_audio_video(&mpeg2_video_buf(&full_tail)).expect("8-byte decodes");
+    assert_eq!(four.image_width(), eight.image_width());
+    assert_eq!(four.image_height(), eight.image_height());
+    assert_ne!(four.video_bitrate(), eight.video_bitrate());
+    assert_eq!(four.video_bitrate(), VideoBitrate::Bps(0));
+    assert_eq!(eight.video_bitrate(), VideoBitrate::Bps(40_000));
+  }
+
+  #[test]
+  fn mpeg2_video_start_code_near_end_of_window() {
+    // The `\xb3` lands within <4 bytes of the buffer end: the tail cannot hold
+    // even the first word, so `process_mpeg_video`'s >=4 gate rejects (None),
+    // matching MPEG.pm:649 `last if $len < 4`. (1, 2, and 3 trailing bytes.)
+    for partial in 1..4usize {
+      let buf = mpeg2_video_buf(&VID_W1[..partial]);
+      assert!(
+        parse_mpeg_audio_video(&buf).is_none(),
+        "a {partial}-byte tail after \\xb3 is below the >=4 first-word gate"
+      );
+    }
+  }
+
+  #[test]
+  fn mpeg2_video_invalid_header_keeps_scanning() {
+    // A first `\xb3` with a forbidden aspect-ratio nibble (0) is rejected, but a
+    // later VALID sequence header in the same buffer is still found (the loop
+    // continues to the next `/g` match, MPEG.pm:637).
+    let mut bad_w1 = VID_W1;
+    bad_w1[3] = 0x04; // aspect nibble (high) -> 0 (forbidden), frame rate 4
+    let mut buf = mpeg2_video_buf(&bad_w1);
+    // Append a second, valid full header.
+    buf.extend_from_slice(&[0x00, 0x00, 0x01, 0xb3]);
+    buf.extend_from_slice(&VID_W1);
+    buf.extend_from_slice(&VID_W2);
+    let v = parse_mpeg_audio_video(&buf).expect("the second valid header is found");
+    assert_eq!(v.image_width(), 720);
+    assert_eq!(v.video_bitrate(), VideoBitrate::Bps(40_000));
   }
 }

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -12337,10 +12337,9 @@ fn mpeg2_ts_misb_klv_conformance() {
 // teammate fixture (#408) re-added the (now-active, see below) Pentax PEF test
 // stubs from a pre-#393 base; those duplicates are dropped here — #393's
 // `check_excluding` versions remain the canonical ones. The MPEG2 video PES
-// decode (`MPEG:ImageWidth/Height/FrameRate/VideoBitrate`) is deferred (#128),
-// so this fixture stays `#[ignore]`d + NOT_ACTIVE until the decoder lands.
+// decode (`MPEG:ImageWidth/Height/AspectRatio/FrameRate/VideoBitrate`) +
+// `%MPEG::Composite` `Duration` landed (#128), so the fixture is active.
 #[test]
-#[ignore]
 fn mpeg2_ts_mpeg2video_conformance() {
   check(
     "MPEG2_TS_mpeg2video.ts",

--- a/tests/golden/MPEG2_TS_mpeg2video.ts.json
+++ b/tests/golden/MPEG2_TS_mpeg2video.ts.json
@@ -1,26 +1,18 @@
-[
-  {
-    "ExifTool:ExifToolVersion": 13.55,
-    "File:FileName": "MPEG2_TS_mpeg2video.ts",
-    "File:Directory": "tests/fixtures",
-    "File:FileSize": 3989924,
-    "File:FileModifyDate": "2026:06:24 12:35:45+09:00",
-    "File:FileAccessDate": "2026:06:24 12:35:45+09:00",
-    "File:FileInodeChangeDate": "2026:06:24 12:35:45+09:00",
-    "File:FilePermissions": 100644,
-    "File:FileType": "M2T",
-    "File:FileTypeExtension": "M2T",
-    "File:MIMEType": "video/mpeg",
-    "M2TS:AudioStreamType": 129,
-    "M2TS:AudioSampleRate": 0,
-    "M2TS:Duration": 4.42108888888889,
-    "MPEG:ImageWidth": 1280,
-    "MPEG:ImageHeight": 720,
-    "MPEG:AspectRatio": 0.7031,
-    "MPEG:FrameRate": 59.94,
-    "MPEG:VideoBitrate": 19000000,
-    "Composite:ImageSize": "1280 720",
-    "Composite:Megapixels": 0.9216,
-    "Composite:Duration": 1.679968
-  }
-]
+[{
+  "SourceFile": "MPEG2_TS_mpeg2video.ts",
+  "ExifTool:ExifToolVersion": 13.59,
+  "File:FileType": "M2T",
+  "File:FileTypeExtension": "m2t",
+  "File:MIMEType": "video/mpeg",
+  "M2TS:AudioStreamType": "A52/AC-3 Audio",
+  "M2TS:Duration": "4.42 s",
+  "AC3:AudioSampleRate": 48000,
+  "MPEG:ImageWidth": 1280,
+  "MPEG:ImageHeight": 720,
+  "MPEG:AspectRatio": "16:9, 625 line, PAL",
+  "MPEG:FrameRate": "59.94 fps",
+  "MPEG:VideoBitrate": "19 Mbps",
+  "Composite:ImageSize": "1280x720",
+  "Composite:Megapixels": 0.922,
+  "Composite:Duration": "1.68 s (approx)"
+}]

--- a/tests/golden/MPEG2_TS_mpeg2video.ts.n.json
+++ b/tests/golden/MPEG2_TS_mpeg2video.ts.n.json
@@ -1,26 +1,18 @@
-[
-  {
-    "ExifTool:ExifToolVersion": 13.55,
-    "File:FileName": "MPEG2_TS_mpeg2video.ts",
-    "File:Directory": "tests/fixtures",
-    "File:FileSize": 3989924,
-    "File:FileModifyDate": "2026:06:24 12:35:45+09:00",
-    "File:FileAccessDate": "2026:06:24 12:35:45+09:00",
-    "File:FileInodeChangeDate": "2026:06:24 12:35:45+09:00",
-    "File:FilePermissions": 100644,
-    "File:FileType": "M2T",
-    "File:FileTypeExtension": "M2T",
-    "File:MIMEType": "video/mpeg",
-    "M2TS:AudioStreamType": 129,
-    "M2TS:AudioSampleRate": 0,
-    "M2TS:Duration": 4.42108888888889,
-    "MPEG:ImageWidth": 1280,
-    "MPEG:ImageHeight": 720,
-    "MPEG:AspectRatio": 0.7031,
-    "MPEG:FrameRate": 59.94,
-    "MPEG:VideoBitrate": 19000000,
-    "Composite:ImageSize": "1280 720",
-    "Composite:Megapixels": 0.9216,
-    "Composite:Duration": 1.679968
-  }
-]
+[{
+  "SourceFile": "MPEG2_TS_mpeg2video.ts",
+  "ExifTool:ExifToolVersion": 13.59,
+  "File:FileType": "M2T",
+  "File:FileTypeExtension": "M2T",
+  "File:MIMEType": "video/mpeg",
+  "M2TS:AudioStreamType": 129,
+  "M2TS:Duration": 4.42108888888889,
+  "AC3:AudioSampleRate": 0,
+  "MPEG:ImageWidth": 1280,
+  "MPEG:ImageHeight": 720,
+  "MPEG:AspectRatio": 0.7031,
+  "MPEG:FrameRate": 59.94,
+  "MPEG:VideoBitrate": 19000000,
+  "Composite:ImageSize": "1280 720",
+  "Composite:Megapixels": 0.9216,
+  "Composite:Duration": 1.679968
+}]

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -231,11 +231,6 @@ const NOT_ACTIVE: &[&str] = &[
   // ACTIVE: #393 ported their MakerNote variants byte-exact, so they moved out of
   // NOT_ACTIVE into the active set with per-fixture FIXTURE_EXCLUDED_KEYS for the
   // non-MakerNote residuals.)
-  // #128 / #408 — the teammate added this MPEG-2 video transport-stream fixture
-  // with bundled goldens, but the `MPEG:ImageWidth/Height/FrameRate/VideoBitrate`
-  // video-PES decode is deferred (#128), so exifast does not yet emit the golden's
-  // tag set. Accept-deferred until the MPEG-2 video PES decoder lands + activates.
-  "MPEG2_TS_mpeg2video.ts",
 ];
 
 /// ACTIVE fixtures that emit a tag whose VALUE diverges from bundled because a
@@ -1356,7 +1351,7 @@ fn drop_keys(doc: &str, exact_keys: &[&str]) -> String {
 ///   * `Exif_filesource_nulnum.tif` — the same `31 00 32 00` on the `FileSource`
 ///     HASH-miss path → "Unknown (12)" / quoted "12".
 /// Additive — every PRE-EXISTING golden stays byte-identical.
-const EXPECTED_ACTIVE_FIXTURES: usize = 597;
+const EXPECTED_ACTIVE_FIXTURES: usize = 598;
 
 /// Every `tests/fixtures/<f>` that has both `tests/golden/<f>.json` and
 /// `tests/golden/<f>.n.json`, MINUS the [`NOT_ACTIVE`] formally-accept-


### PR DESCRIPTION
Ports the MPEG-2 video sequence-header decode for the MPEG-TS path, activating the teammate's MPEG2_TS_mpeg2video.ts fixture (#408).

- **MPEG-2 sequence header** (`process_mpeg_video`, faithful to MPEG.pm:591 `ProcessMPEGVideo`/`ProcessFrameHeader`): `MPEG:ImageWidth`/`ImageHeight` (12-bit), `AspectRatio` (aspect_ratio_information table), `FrameRate` (frame_rate_code table), `VideoBitrate` (18-bit ×400). Mirrors Perl's `unpack('N2')`: the gate is **≥4 bytes** (first word), the missing 2nd word defaults to 0 (so a 4-7 byte tail emits `VideoBitrate=0 bps`, exactly bundled) — panic-safe slicing.
- **M2TS audio** (`AudioStreamType`/`Duration`, `AC3:AudioSampleRate`) + **Composite:ImageSize/Megapixels/Duration**. `Composite:Duration` = `8*FileSize/(Audio+VideoBitrate)` `(approx)` (MPEG.pm:400-413, VBR/Variable-aborts guards), auto-suppressed when VideoBitrate is falsy.

16/16 keys byte-exact vs bundled 13.59 (-j + -n); 6 oracle-pinned truncation tests (4/7/8-byte tails, near-end-of-window, invalid-header-keeps-scanning). All existing m2ts/mpeg goldens byte-identical. `build(-Dwarnings)=0 conformance=471/0 timed_metadata=157/0 typed_serde=598 lib=3706/0 xtask=26/0`. **Codex: APPROVE (R2).** EXPECTED_ACTIVE 597→598. Closes #128.