### PR TITLE
fix(audio): debug-assert on unknown staged-tag lift dispatch arms (#51, FU-10)

### DIFF
--- a/src/formats/aac.rs
+++ b/src/formats/aac.rs
@@ -310,7 +310,12 @@ fn parse_inner(data: &[u8]) -> Option<Meta<'_>> {
           channels = (*n as u64) as u8;
         }
       }
-      _ => {}
+      // `process_bit_stream` only ever pushes the `def.name()` of an
+      // `AAC_BIT_KEYS` entry resolved through `aac_get` (a closed set:
+      // ProfileType/SampleRate/Channels). Any other name means the keys,
+      // the table, and this lift loop have drifted — a programming bug.
+      // Debug-only signal; release behavior unchanged (silent no-op).
+      other => debug_assert!(false, "aac lift: unknown staged tag {other:?}"),
     }
   }
 

--- a/src/formats/aiff.rs
+++ b/src/formats/aiff.rs
@@ -1356,7 +1356,12 @@ fn stage_common(body: &[u8]) -> Option<Common> {
           compressor_name = Some(s.to_string());
         }
       }
-      _ => {}
+      // `process_binary_data` only ever pushes the `def.name()` of an
+      // `AIFF_COMMON_KEYS` entry resolved through `AIFF_COMMON` (a closed set:
+      // the 6 `%AIFF::Common` fields matched above). Any other name means the
+      // keys, the table, and this lift loop have drifted — a programming bug.
+      // Debug-only signal; release behavior unchanged (silent no-op).
+      other => debug_assert!(false, "aiff COMM lift: unknown staged tag {other:?}"),
     }
   }
 

--- a/src/formats/mpc.rs
+++ b/src/formats/mpc.rs
@@ -844,7 +844,12 @@ fn extract_sv7_header(hdr: &[u8]) -> Sv7Header {
       "FastSeek" => h.fast_seek = n as u8,
       "Gapless" => h.gapless = n as u8,
       "EncoderVersion" => h.encoder_version = n as u8,
-      _ => {}
+      // `process_bit_stream` only ever pushes the `def.name()` of an
+      // `MPC_BIT_KEYS` entry resolved through `mpc_get` (a closed set: the 11
+      // `%MPC::Main` SV7 fields matched above). Any other name means the keys,
+      // the table, and this lift loop have drifted — a programming bug.
+      // Debug-only signal; release behavior unchanged (silent no-op).
+      other => debug_assert!(false, "mpc lift: unknown staged tag {other:?}"),
     }
   }
   h


### PR DESCRIPTION
Spreads PR #4's FrameState::set debug-assert pattern: the aac/aiff(COMM)/mpc tag-lift dispatch had a silent fall-through for an unknown STAGED tag name — a closed internal set (the lift maps hard-coded AAC/MPC bit-key arrays / AIFF COMM integer keys to outputs; an unknown name is a programming bug, not input-driven). Added `debug_assert!(false, "...: unknown staged tag {other:?}")` on each.

Faithful ExifTool unknown-TAG fallbacks (unknown input tag → emit raw/Unknown) are left silent. `debug_assert` is compiled out in release → **zero runtime/output change**; all goldens byte-identical (conformance 471/0); the asserts do not fire on any valid fixture (lib 3706/0 in debug). `build(-Dwarnings)=0 timed_metadata=157/0 typed_serde=598 xtask=26/0`. **Codex: APPROVE.** Closes #51.