### PR TITLE
perf(fmt): write! per-byte hex/text builders into a pre-sized String (#48, FU-3)

### DIFF
--- a/src/formats/id3/v2_process.rs
+++ b/src/formats/id3/v2_process.rs
@@ -409,12 +409,13 @@ fn bytes_to_decimal_string(bytes: &[u8]) -> String {
     }
   }
   // Serialize most-significant first; interior limbs zero-pad to 9.
+  use core::fmt::Write as _;
   let mut out = String::with_capacity(limbs.len() * 9);
   if let Some(last) = limbs.last() {
     out.push_str(&last.to_string());
   }
   for limb in limbs.iter().rev().skip(1) {
-    out.push_str(&format!("{:09}", limb));
+    let _ = write!(&mut out, "{limb:09}");
   }
   out
 }

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -16182,16 +16182,18 @@ fn camm_gps_measure_mode_value(mode: u32, print_conv: bool) -> crate::value::Tag
 fn media_uid_value(raw: &str, print_conv: bool) -> crate::value::TagValue {
   use crate::value::TagValue;
   if print_conv {
+    use core::fmt::Write as _;
     // Hex-concatenate the parsed u32s. A non-numeric element falls back to a
     // bare `0` slot only if `parse` fails — but the parser always emits
     // decimal u32s, so every element parses. Faithful `sprintf('%.8x',$_)`.
-    let mut hex = std::string::String::new();
+    // Each u32 renders to exactly 8 hex chars.
+    let mut hex = std::string::String::with_capacity(raw.len());
     for tok in raw.split(' ') {
       if tok.is_empty() {
         continue;
       }
       let v: u32 = tok.parse().unwrap_or(0);
-      hex.push_str(&std::format!("{v:08x}"));
+      let _ = write!(&mut hex, "{v:08x}");
     }
     TagValue::Str(hex.into())
   } else {

--- a/src/formats/riff.rs
+++ b/src/formats/riff.rs
@@ -2476,12 +2476,14 @@ fn emit_bmp_video_format(payload: &[u8], entries: &mut Vec<RiffEntry>) {
 /// Non-printable bytes are replaced with `\xNN` escapes; bundled also trims
 /// trailing whitespace via `unpack("A4", ...)`.
 fn render_fourcc(bytes: &[u8; 4]) -> String {
+  use core::fmt::Write as _;
   // bundled: `$val =~ s/([\0-\x1f\x7f-\xff])/sprintf('\\x%.2x',ord $1)/eg`,
   // then implicit `unpack("A4")` trims trailing ASCII spaces.
-  let mut s = String::new();
+  // Worst case is 4 escaped bytes (`\xNN` each = 4 chars).
+  let mut s = String::with_capacity(bytes.len() * 4);
   for &b in bytes.iter() {
     if !(0x20..0x7f).contains(&b) {
-      s.push_str(&std::format!("\\x{b:02x}"));
+      let _ = write!(&mut s, "\\x{b:02x}");
     } else {
       s.push(b as char);
     }


### PR DESCRIPTION
Sweeps the 3 remaining production per-element hex/text string builders that allocated a tiny String per iteration (`push_str(&format!(...))`) → `String::with_capacity(...)` + `write!` via `core::fmt::Write`:
- `riff.rs:2478` render_fourcc (per non-printable byte → `\x{b:02x}`, lowercase + prefix preserved)
- `quicktime.rs:16182` media_uid_value (GoPro MUID, per u32 → `{v:08x}`, lowercase width-8)
- `id3/v2_process.rs:417` big-int decimal (per limb → `{limb:09}`, 9-wide zero-pad)

The FLAC MD5 source was already on the pattern in-tree. **Output byte-identical** (format specifiers + loop behavior preserved exactly); no new dependency. 0 golden files changed. `build(-Dwarnings)=0 conformance=471/0 timed_metadata=157/0 typed_serde=598 lib=3706/0 xtask=26/0`. **Codex: APPROVE.** Closes #48.