### PR TITLE
fix(serialize): replace silent unwrap_or("") with faithful EscapeJSON rendering + expect-invariants (#53, FU-12)

### DIFF
--- a/src/composite/convs/lens/mod.rs
+++ b/src/composite/convs/lens/mod.rs
@@ -701,10 +701,14 @@ pub(crate) fn print_hyperfocal(val: f64) -> String {
   if val.is_finite() {
     format!("{val:.2} m")
   } else {
-    format!(
-      "{} m",
-      crate::value::perl_nonfinite_str(val).unwrap_or("NaN")
-    )
+    // The `else` arm is reached ONLY for a non-finite `val`, so
+    // `perl_nonfinite_str` returns `Some` by construction (it is `None` ONLY
+    // for finite inputs). `expect` the invariant rather than silently degrade
+    // to a wrong "NaN" token — a `None` here would be a programming-logic bug,
+    // never a data edge (#53/FU-12).
+    let non_finite = crate::value::perl_nonfinite_str(val)
+      .expect("perl_nonfinite_str is Some for every non-finite f64 (is_finite-guarded)");
+    format!("{non_finite} m")
   }
 }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -923,7 +923,15 @@ pub fn write_convert_bitrate<W: core::fmt::Write + ?Sized>(
   // Perl's NV default — titlecase `Inf`/`-Inf`/`NaN` (NOT Rust's lowercase
   // `inf`/`-inf` from `{}`). `perl_nonfinite_str` produces Perl's casing.
   if !bitrate.is_finite() {
-    return w.write_str(crate::value::perl_nonfinite_str(bitrate).unwrap_or("NaN"));
+    // The `!is_finite()` guard above means `bitrate` is NaN/±Inf, so
+    // `perl_nonfinite_str` returns `Some` by construction (it yields `None`
+    // ONLY for finite inputs). A panic here would be a programming-logic bug
+    // (the guard and the helper's None-condition diverged), never a data
+    // edge — so `expect` an invariant rather than silently degrade a finite
+    // value to a wrong "NaN" token (#53/FU-12).
+    let non_finite = crate::value::perl_nonfinite_str(bitrate)
+      .expect("perl_nonfinite_str is Some for every non-finite f64 (is_finite-guarded)");
+    return w.write_str(non_finite);
   }
   const UNITS: &[&str] = &["bps", "kbps", "Mbps", "Gbps"];
   let mut b = bitrate;
@@ -1368,6 +1376,20 @@ pub(crate) enum EscapedJson {
   /// JSON string ([`crate::value::TagValue::JsonStr`]) so it is NOT re-coerced to
   /// a bare token by the serializer's number/boolean gate.
   Quoted(SmolStr),
+}
+
+impl EscapedJson {
+  /// The RENDERED content of either verdict — the bare token ([`Self::Bare`]) or
+  /// the escaped, NUL-stripped, `FixUTF8`'d string ([`Self::Quoted`]). The
+  /// classify verdict (which way the value serializes to JSON) lives in the
+  /// variant; this is the plain UTF-8 text a typed/domain consumer wants.
+  #[must_use]
+  #[inline(always)]
+  pub(crate) fn as_str(&self) -> &str {
+    match self {
+      Self::Bare(s) | Self::Quoted(s) => s,
+    }
+  }
 }
 
 /// Replicate ExifTool's COMPLETE `EscapeJSON` order (`exiftool:3804-3824`, the

--- a/src/formats/insta360.rs
+++ b/src/formats/insta360.rs
@@ -503,20 +503,55 @@ fn decode_identity(buff: &[u8]) -> Insta360Identity {
       break;
     };
     // QuickTimeStream.pl:3434 `$et->HandleTag($tagTablePtr, $t, $val)`.
+    // These INSV maker-note values are raw byte substrings (QuickTimeStream.pl
+    // :3433 `substr` + HandleTag — no Format/charset/RawConv), so bundled emits
+    // them through the FULL JSON `EscapeJSON` order: it first CLASSIFIES the
+    // ORIGINAL value (NULs and all) against the boolean/number gate
+    // (exiftool:3805/3810) and, ONLY for a non-match, DELETES every NUL
+    // (`tr/\0//d`, exiftool:3820) and THEN runs `FixUTF8` (exiftool:3824). The
+    // classify PRECEDES the NUL-strip, so a NUL-bearing original always fails
+    // the anchored gate → it is a QUOTED string, NOT a bare token: a NUL-split
+    // numeric `31 00 32 00` → `"12"` (NOT bare `12`) and `74 00 72 00 75 00
+    // 65 00` → `"true"` (NOT bare `true`). The NUL-strip-before-`FixUTF8` order
+    // also rejoins a NUL-SPLIT UTF-8 sequence (`C2 00 A9` → `©`, not `??`). A
+    // NUL-free clean-number/boolean original DOES pass the gate → BARE.
+    //
+    // `escape_json_raw_bytes_classified` returns that verdict
+    // ([`EscapedJson::Bare`]/[`EscapedJson::Quoted`]); we store it via the
+    // `*_json` setters so the emit can map `Bare`→`TagValue::Str` (the
+    // serializer renders it bare) and `Quoted`→`TagValue::JsonStr` (forced
+    // quoted, bypassing the serializer's re-run of the gate on the
+    // ALREADY-NUL-stripped text). For the real all-ASCII device strings (no
+    // NUL, valid UTF-8) the verdict is `Quoted` and the content is identity —
+    // byte-identical to bundled's quoted output (#53/FU-12).
+    use crate::convert::escape_json_raw_bytes_classified;
     match t {
       TAG_SERIAL_NUMBER => {
-        out.set_serial_number(Some(SmolStr::new(core::str::from_utf8(val).unwrap_or(""))));
+        out.set_serial_number_json(Some(escape_json_raw_bytes_classified(val, false)));
       }
       TAG_MODEL => {
-        out.set_model(Some(SmolStr::new(core::str::from_utf8(val).unwrap_or(""))));
+        out.set_model_json(Some(escape_json_raw_bytes_classified(val, false)));
       }
       TAG_FIRMWARE => {
-        out.set_firmware(Some(SmolStr::new(core::str::from_utf8(val).unwrap_or(""))));
+        out.set_firmware_json(Some(escape_json_raw_bytes_classified(val, false)));
       }
       TAG_PARAMETERS => {
-        // QuickTimeStream.pl:705 `ValueConv => '$val =~ tr/_/ /; $val'`.
-        let s = core::str::from_utf8(val).unwrap_or("");
-        out.set_parameters(Some(SmolStr::new(s.replace('_', " "))));
+        // QuickTimeStream.pl:705 `ValueConv => '$val =~ tr/_/ /; $val'`. The
+        // `tr/_/ /` runs on the RAW `$val` BEFORE the `EscapeJSON` classify, so
+        // map `_`→` ` on the raw bytes first, then classify the result — a
+        // value that becomes number-shaped only after the `tr` is judged on the
+        // post-`tr` lexeme exactly as ExifTool does (the `_`→` ` is ASCII and
+        // commutes with the later NUL-strip + `FixUTF8`). No `_` ⇒ classify the
+        // value in place (no allocation).
+        if val.contains(&b'_') {
+          let mapped: std::vec::Vec<u8> = val
+            .iter()
+            .map(|&b| if b == b'_' { b' ' } else { b })
+            .collect();
+          out.set_parameters_json(Some(escape_json_raw_bytes_classified(&mapped, false)));
+        } else {
+          out.set_parameters_json(Some(escape_json_raw_bytes_classified(val, false)));
+        }
       }
       _ => {} // Unknown tag; bundled HandleTag with no-table-entry is a no-op.
     }
@@ -1856,6 +1891,152 @@ mod tests {
     assert_eq!(id.serial_number(), Some("S"));
     assert_eq!(id.parameters(), Some("P"));
     // The 5th tag (0xff) was outside the cap; nothing extra to verify.
+  }
+
+  #[test]
+  fn decode_identity_nul_split_utf8_reassembles_via_escapejson_order() {
+    // A crafted identity value whose UTF-8 sequence is SPLIT by an embedded NUL:
+    // `C2 00 A9` is `©` (`C2 A9`) with a NUL between the leader and continuation.
+    // Bundled's `EscapeJSON` deletes NULs FIRST (`tr/\0//d`, exiftool:3820) then
+    // runs `FixUTF8` (exiftool:3824), so the NUL-strip rejoins `C2 A9` → `©`.
+    // A `FixUTF8`-first order would instead flag the `C2`/`A9` halves separately
+    // (the NUL breaks the sequence) → `??`, and the trailing NUL of the
+    // round-tripped `Str` would then be stripped → still `??`. The fix routes
+    // through `escape_json_raw_bytes` (NUL-strip → `FixUTF8`), so each field is
+    // the faithful `©`.
+    let split = b"\xc2\x00\xa9"; // © split by a NUL
+    let id = decode_identity(&identity_body(&[
+      (TAG_SERIAL_NUMBER, split),
+      (TAG_MODEL, split),
+      (TAG_FIRMWARE, split),
+      // Parameters additionally runs `tr/_/ /`; `_` is absent here, so the
+      // EscapeJSON repair alone applies (still `©`).
+      (TAG_PARAMETERS, split),
+    ]));
+    assert_eq!(id.serial_number(), Some("©"));
+    assert_eq!(id.model(), Some("©"));
+    assert_eq!(id.firmware(), Some("©"));
+    assert_eq!(id.parameters(), Some("©"));
+  }
+
+  #[test]
+  fn decode_identity_real_ascii_is_byte_identical_under_escapejson() {
+    // Real all-ASCII device strings carry no NUL and are valid UTF-8, so
+    // `escape_json_raw_bytes` is identity on them — byte-identical to the prior
+    // `fix_utf8` path (no golden change). Underscores in Parameters still map to
+    // spaces (QuickTimeStream.pl:705 `tr/_/ /`).
+    let id = decode_identity(&identity_body(&[
+      (TAG_SERIAL_NUMBER, b"IXX00123"),
+      (TAG_MODEL, b"Insta360 X3"),
+      (TAG_FIRMWARE, b"1.0.07"),
+      (TAG_PARAMETERS, b"2_6_4032_3024"),
+    ]));
+    assert_eq!(id.serial_number(), Some("IXX00123"));
+    assert_eq!(id.model(), Some("Insta360 X3"));
+    assert_eq!(id.firmware(), Some("1.0.07"));
+    assert_eq!(id.parameters(), Some("2 6 4032 3024"));
+    // Every real device string fails the number/boolean gate (letters, dots,
+    // spaces) → QUOTED. Emit renders each as `TagValue::JsonStr` ⇒ the SAME
+    // quoted token the prior `TagValue::Str` produced (byte-identical golden).
+    use crate::convert::EscapedJson;
+    assert!(matches!(id.serial_number_json(), Some(EscapedJson::Quoted(s)) if s == "IXX00123"));
+    assert!(matches!(id.model_json(), Some(EscapedJson::Quoted(s)) if s == "Insta360 X3"));
+    assert!(matches!(id.firmware_json(), Some(EscapedJson::Quoted(s)) if s == "1.0.07"));
+    assert!(matches!(id.parameters_json(), Some(EscapedJson::Quoted(s)) if s == "2 6 4032 3024"));
+  }
+
+  #[test]
+  fn decode_identity_nul_split_numeric_is_quoted_not_bare() {
+    // The #53 finding: a NUL-SPLIT numeric `31 00 32 00` (`"1\02\0"`). ExifTool's
+    // `EscapeJSON` CLASSIFIES the ORIGINAL (NULs and all) FIRST — the anchored
+    // number regex rejects the embedded NUL — so it is a QUOTED string, and the
+    // `tr/\0//d` that follows yields the lexeme `"12"`: bundled emits `"12"`, NOT
+    // a bare `12`. Classifying AFTER the NUL-strip (the bug) would see `12` and
+    // wrongly emit it bare. The fix carries the `Quoted` verdict so emit forces
+    // `TagValue::JsonStr` ⇒ `"12"`.
+    let nul_split_num = b"1\x002\x00";
+    let id = decode_identity(&identity_body(&[
+      (TAG_SERIAL_NUMBER, nul_split_num),
+      (TAG_MODEL, nul_split_num),
+      (TAG_FIRMWARE, nul_split_num),
+      (TAG_PARAMETERS, nul_split_num),
+    ]));
+    use crate::convert::EscapedJson;
+    // Content (NUL-stripped) is `12`, but the verdict is QUOTED (the original
+    // failed the gate), so it must NOT be coerced to a bare number.
+    for v in [
+      id.serial_number_json(),
+      id.model_json(),
+      id.firmware_json(),
+      id.parameters_json(),
+    ] {
+      assert!(
+        matches!(v, Some(EscapedJson::Quoted(s)) if s == "12"),
+        "NUL-split numeric must be Quoted(\"12\"), got {v:?}"
+      );
+    }
+    assert_eq!(id.serial_number(), Some("12")); // content accessor sees `12`
+  }
+
+  #[test]
+  fn decode_identity_nul_split_boolean_is_quoted_not_bare() {
+    // The boolean half of #53: `74 00 72 00 75 00 65 00` (`"t\0r\0u\0e\0"`). The
+    // NUL-bearing original fails `/^(true|false)$/i` (anchored, no NUL), so it is
+    // a QUOTED string; `tr/\0//d` then yields `"true"`. Bundled emits `"true"`,
+    // NOT a bare `true`. The `Quoted` verdict ⇒ `TagValue::JsonStr` ⇒ `"true"`.
+    let nul_split_bool = b"t\x00r\x00u\x00e\x00";
+    let id = decode_identity(&identity_body(&[
+      (TAG_SERIAL_NUMBER, nul_split_bool),
+      (TAG_MODEL, nul_split_bool),
+    ]));
+    use crate::convert::EscapedJson;
+    assert!(matches!(id.serial_number_json(), Some(EscapedJson::Quoted(s)) if s == "true"));
+    assert!(matches!(id.model_json(), Some(EscapedJson::Quoted(s)) if s == "true"));
+    assert_eq!(id.serial_number(), Some("true"));
+  }
+
+  #[test]
+  fn decode_identity_clean_numeric_no_nul_is_bare() {
+    // The complement: a CLEAN number original (no NUL) `31 32 33 34` (`"1234"`)
+    // DOES pass the gate, so `EscapeJSON` returns it VERBATIM as a BARE token —
+    // `escape_json_raw_bytes` is identity on it. The `Bare` verdict ⇒
+    // `TagValue::Str` ⇒ the serializer's own gate renders it bare `1234`.
+    let id = decode_identity(&identity_body(&[(TAG_SERIAL_NUMBER, b"1234")]));
+    use crate::convert::EscapedJson;
+    assert!(matches!(id.serial_number_json(), Some(EscapedJson::Bare(s)) if s == "1234"));
+    assert_eq!(id.serial_number(), Some("1234"));
+  }
+
+  #[test]
+  fn decode_identity_nul_split_utf8_is_quoted() {
+    // The R2 NUL-split UTF-8 `C2 00 A9` → `©` now flows via the verdict path:
+    // the NUL-bearing original fails the number/boolean gate → QUOTED, and the
+    // NUL-strip-then-`FixUTF8` order reassembles `C2 A9` → `©`. Emit forces
+    // `TagValue::JsonStr` ⇒ the quoted `"©"` (byte-identical to the prior
+    // `TagValue::Str("©")` rendering — `©` is non-numeric either way).
+    let split = b"\xc2\x00\xa9";
+    let id = decode_identity(&identity_body(&[
+      (TAG_SERIAL_NUMBER, split),
+      (TAG_PARAMETERS, split),
+    ]));
+    use crate::convert::EscapedJson;
+    assert!(matches!(id.serial_number_json(), Some(EscapedJson::Quoted(s)) if s == "©"));
+    assert!(matches!(id.parameters_json(), Some(EscapedJson::Quoted(s)) if s == "©"));
+    assert_eq!(id.serial_number(), Some("©"));
+  }
+
+  #[test]
+  fn decode_identity_parameters_tr_underscore_before_classify() {
+    // Parameters runs `tr/_/ /` (QuickTimeStream.pl:705) on the RAW `$val`
+    // BEFORE `EscapeJSON` classifies. A value that is number-shaped ONLY before
+    // the `tr` (`"1_2"`) becomes `"1 2"` (a space → fails the number gate) →
+    // QUOTED `"1 2"`, matching ExifTool's `tr`-then-classify order. A value that
+    // stays a clean number after the (absent) `tr` (`"12"`, no `_`/NUL) is BARE.
+    let id_underscore = decode_identity(&identity_body(&[(TAG_PARAMETERS, b"1_2")]));
+    use crate::convert::EscapedJson;
+    assert!(matches!(id_underscore.parameters_json(), Some(EscapedJson::Quoted(s)) if s == "1 2"));
+    let id_clean = decode_identity(&identity_body(&[(TAG_PARAMETERS, b"12")]));
+    assert!(matches!(id_clean.parameters_json(), Some(EscapedJson::Bare(s)) if s == "12"));
   }
 
   #[test]

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -12553,21 +12553,27 @@ fn push_insta360_identity_tags(
   group: &crate::value::Group,
   out: &mut std::vec::Vec<crate::emit::EmittedTag>,
 ) {
+  use crate::convert::EscapedJson;
   use crate::emit::EmittedTag;
   use crate::value::TagValue;
   for (val, name) in [
-    (id.serial_number(), "SerialNumber"),
-    (id.model(), "Model"),
-    (id.firmware(), "Firmware"),
-    (id.parameters(), "Parameters"),
+    (id.serial_number_json(), "SerialNumber"),
+    (id.model_json(), "Model"),
+    (id.firmware_json(), "Firmware"),
+    (id.parameters_json(), "Parameters"),
   ] {
     if let Some(v) = val {
-      out.push(EmittedTag::new(
-        group.clone(),
-        name.into(),
-        TagValue::Str(v.into()),
-        false,
-      ));
+      // The `EscapeJSON` verdict decides the JSON shape: a value the gate
+      // accepted (the NUL-FREE clean number/boolean original) is a BARE token
+      // via `TagValue::Str` (the serializer renders it bare, identity on
+      // NUL-free ASCII); everything else — every real device string, and a
+      // NUL-split numeric/boolean whose post-strip lexeme would otherwise be
+      // mis-coerced — is forced-quoted via `TagValue::JsonStr` (#53).
+      let value = match v {
+        EscapedJson::Bare(s) => TagValue::Str(s.clone()),
+        EscapedJson::Quoted(s) => TagValue::JsonStr(s.clone()),
+      };
+      out.push(EmittedTag::new(group.clone(), name.into(), value, false));
     }
   }
 }
@@ -16578,6 +16584,53 @@ mod tests {
     );
     assert_eq!(unpack_h_star(&[0xca, 0xfe, 0xf0, 0x0d]), "cafef00d");
     assert_eq!(unpack_h_star(&[]), "");
+  }
+
+  /// `push_insta360_identity_tags` maps each field's `EscapeJSON` verdict to the
+  /// right `TagValue` (#53): `Quoted`→`JsonStr` (forced-quoted, the serializer
+  /// does NOT re-coerce the NUL-stripped text to a bare token) and `Bare`→`Str`
+  /// (the gate renders it bare). The NUL-split numeric `"12"` must serialize as
+  /// the QUOTED `"12"`, a clean number `1234` as the BARE `1234`.
+  #[cfg(feature = "alloc")]
+  #[test]
+  fn insta360_identity_emit_quoted_vs_bare_tagvalue() {
+    use crate::convert::EscapedJson;
+    use crate::metadata::Insta360Identity;
+    use crate::value::{Group, TagValue};
+
+    let mut id = Insta360Identity::new();
+    // A NUL-split numeric serial (`31 00 32 00`) classified QUOTED → content
+    // `"12"`; a clean numeric model (`1234`, no NUL) classified BARE; a normal
+    // string firmware QUOTED.
+    id.set_serial_number_json(Some(EscapedJson::Quoted("12".into())));
+    id.set_model_json(Some(EscapedJson::Bare("1234".into())));
+    id.set_firmware_json(Some(EscapedJson::Quoted("1.0.07".into())));
+
+    let group = Group::new("Trailer", "Insta360");
+    let mut out = std::vec::Vec::new();
+    push_insta360_identity_tags(&id, &group, &mut out);
+
+    let find = |name: &str| {
+      out
+        .iter()
+        .find(|t| t.tag().name() == name)
+        .map(|t| t.tag().value_ref().clone())
+    };
+    // QUOTED serial → JsonStr (forced quoted), NOT bare.
+    assert_eq!(find("SerialNumber"), Some(TagValue::JsonStr("12".into())));
+    // BARE clean number → Str (gate renders bare).
+    assert_eq!(find("Model"), Some(TagValue::Str("1234".into())));
+    assert_eq!(find("Firmware"), Some(TagValue::JsonStr("1.0.07".into())));
+
+    // End-to-end JSON shape: JsonStr forces quotes (`"12"`), Str's clean number
+    // renders bare (`1234`) through the serializer's own gate.
+    #[cfg(feature = "json")]
+    {
+      let json_of = |v: &TagValue| serde_json::to_string(v).expect("serialize");
+      assert_eq!(json_of(&find("SerialNumber").unwrap()), "\"12\"");
+      assert_eq!(json_of(&find("Model").unwrap()), "1234");
+      assert_eq!(json_of(&find("Firmware").unwrap()), "\"1.0.07\"");
+    }
   }
 
   /// The GENERATED conv-less maps resolve only their verified-allowlist atoms

--- a/src/formats/riff.rs
+++ b/src/formats/riff.rs
@@ -1151,7 +1151,18 @@ impl<'a> Walker<'a> {
           if let Some(sty) = stype
             && let Some(stream) = self.streams.get_mut(stream_idx)
           {
-            let sty_str = SmolStr::new(core::str::from_utf8(&sty).unwrap_or(""));
+            // `strh` StreamType is a raw 4-byte FourCC (`auds`/`vids`/…),
+            // captured here UNTRIMMED (the raw `fourcc_at` bytes). Decode via
+            // the `EscapeJSON` tail order — DELETE NULs (`tr/\0//d`,
+            // exiftool:3820) THEN run `FixUTF8` (exiftool:3824) — rather than the
+            // prior bare `fix_utf8` (which repaired before the NUL deletion) or
+            // silently dropping a non-UTF-8 FourCC to "". The NUL-strip precedes
+            // the repair, so a trailing-NUL / NUL-split non-UTF-8 FourCC
+            // reassembles faithfully (`C2 00 A9` → `©`, not `??`), and a trailing
+            // NUL is removed before the `TrackKind` match. For the real all-ASCII
+            // 4-byte FourCCs (no NUL, valid UTF-8) `escape_json_raw_bytes` is
+            // identity → byte-identical (#53/FU-12).
+            let sty_str = SmolStr::new(crate::convert::escape_json_raw_bytes(&sty));
             stream.stream_type = Some(sty_str);
           }
           // The codec FourCC at offset 4 is captured by `emit_stream_header`
@@ -4293,6 +4304,82 @@ mod tests {
       RiffValue::Str(s) => assert_eq!(s.as_str(), "2003:03:10 15:04:43"),
       v => panic!("{v:?}"),
     }
+  }
+
+  #[test]
+  fn strl_stream_type_nul_bearing_fourcc_reassembles_via_escapejson_order() {
+    // A crafted `strh` StreamType FourCC whose UTF-8 is SPLIT by an embedded NUL
+    // and trailed by a NUL: `C2 00 A9 00`. The raw `strh` StreamType is captured
+    // UNTRIMMED (`fourcc_at`, the 4 raw bytes) into `RiffStream::stream_type`.
+    // Bundled emits raw on-disk strings through `EscapeJSON`, which DELETES NULs
+    // FIRST (`tr/\0//d`, exiftool:3820) then runs `FixUTF8` (exiftool:3824): the
+    // NUL-strip rejoins `C2 A9` → `©`. The prior bare `fix_utf8(b"\xc2\x00\xa9\x00")`
+    // ran the repair BEFORE the NUL deletion → it flagged the `C2`/`A9` halves
+    // separately (the NULs break the sequence) → `"?\0?\0"`. The fix routes
+    // through `escape_json_raw_bytes` (NUL-strip → `FixUTF8`) → the faithful `©`.
+    //
+    // Drive `process_chunks_strl` directly (the `body` it expects begins at the
+    // first sub-chunk header, AFTER the `strl` LIST type).
+    let mut body = Vec::new();
+    body.extend_from_slice(b"strh");
+    body.extend_from_slice(&48u32.to_le_bytes());
+    body.extend_from_slice(b"\xc2\x00\xa9\x00"); // 0: StreamType (© split + trailed by NUL)
+    body.extend_from_slice(&[0u8; 44]); // remaining 44 bytes of the 48-byte strh
+    let mut walker = Walker {
+      data: &body,
+      pos: 0,
+      entries: Vec::new(),
+      streams: Vec::new(),
+      current_stream_type: None,
+      charset: Charset::Latin,
+      unsupported_charset: None,
+      err: false,
+      pentax_makernote: None,
+      base_file_type: "RIFF",
+      form_is_webp: false,
+      webp_file_type_override: None,
+      webp_ext_override: false,
+      webp_meta: Vec::new(),
+    };
+    walker.process_chunks_strl(&body);
+    assert_eq!(walker.streams.len(), 1, "one strl → one stream record");
+    assert_eq!(
+      walker.streams[0].stream_type(),
+      Some("©"),
+      "NUL-split StreamType is repaired in EscapeJSON order (NUL-strip then FixUTF8)"
+    );
+  }
+
+  #[test]
+  fn strl_stream_type_real_fourcc_is_byte_identical_under_escapejson() {
+    // The real all-ASCII 4-byte FourCCs (`vids`/`auds`/…) carry no NUL and are
+    // valid UTF-8, so `escape_json_raw_bytes` is identity on them — the captured
+    // `stream_type` is byte-identical to the prior `fix_utf8` path (no behavior
+    // change for real data), keeping the downstream `TrackKind` match intact.
+    let mut body = Vec::new();
+    body.extend_from_slice(b"strh");
+    body.extend_from_slice(&48u32.to_le_bytes());
+    body.extend_from_slice(b"vids"); // 0: StreamType
+    body.extend_from_slice(&[0u8; 44]);
+    let mut walker = Walker {
+      data: &body,
+      pos: 0,
+      entries: Vec::new(),
+      streams: Vec::new(),
+      current_stream_type: None,
+      charset: Charset::Latin,
+      unsupported_charset: None,
+      err: false,
+      pentax_makernote: None,
+      base_file_type: "RIFF",
+      form_is_webp: false,
+      webp_file_type_override: None,
+      webp_ext_override: false,
+      webp_meta: Vec::new(),
+    };
+    walker.process_chunks_strl(&body);
+    assert_eq!(walker.streams.len(), 1);
+    assert_eq!(walker.streams[0].stream_type(), Some("vids"));
   }
 
   #[test]

--- a/src/metadata/insta360.rs
+++ b/src/metadata/insta360.rs
@@ -79,6 +79,8 @@
 
 use smol_str::SmolStr;
 
+use crate::convert::EscapedJson;
+
 use crate::metadata::{CameraInfo, CaptureSettings, GpsLocation, MediaMetadata};
 
 // ===========================================================================
@@ -92,20 +94,25 @@ use crate::metadata::{CameraInfo, CaptureSettings, GpsLocation, MediaMetadata};
 /// Every field is optional; a real-world INSV trailer always carries at
 /// least Model + Firmware. SerialNumber is missing on some firmware
 /// (GO 2 early builds).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Insta360Identity {
-  /// `0x0a SerialNumber` (QuickTimeStream.pl:698).
-  serial_number: Option<SmolStr>,
+  /// `0x0a SerialNumber` (QuickTimeStream.pl:698). Stored as the FULL
+  /// `EscapeJSON` verdict ([`EscapedJson`]): the content plus whether the
+  /// ORIGINAL raw-byte value classified as a BARE JSON token or a QUOTED
+  /// string. A plainly-set value (the `set_*` API) is a quoted string; the
+  /// decode path (`*_json` setters) carries the classify decision so a
+  /// NUL-split numeric/boolean serial renders quoted, not bare (#53).
+  serial_number: Option<EscapedJson>,
   /// `0x12 Model` (QuickTimeStream.pl:699) — e.g. `"Insta360 X3"`,
   /// `"Insta360 ONE RS"`, `"Insta360 Ace Pro"`.
-  model: Option<SmolStr>,
+  model: Option<EscapedJson>,
   /// `0x1a Firmware` (QuickTimeStream.pl:700).
-  firmware: Option<SmolStr>,
+  firmware: Option<EscapedJson>,
   /// `0x2a Parameters` (QuickTimeStream.pl:701-706) after the bundled
   /// `$val =~ tr/_/ /` substitution. The string encodes the
   /// "number of lenses, 6-axis orientation of each lens, raw resolution"
   /// (bundled note).
-  parameters: Option<SmolStr>,
+  parameters: Option<EscapedJson>,
   /// The STICKY `DOC_NUM` the `0x101` record inherits. `ProcessInsta360`
   /// walks the identity record LAST (it is first in file, walked last) and
   /// does NOT `++$$et{DOC_NUM}` for it — so its tags ride whatever the last
@@ -129,32 +136,65 @@ impl Insta360Identity {
     }
   }
 
-  /// `SerialNumber` (QuickTimeStream.pl:698).
+  /// `SerialNumber` (QuickTimeStream.pl:698) — the rendered text content.
   #[inline(always)]
   #[must_use]
   pub fn serial_number(&self) -> Option<&str> {
-    self.serial_number.as_deref()
+    self.serial_number.as_ref().map(EscapedJson::as_str)
   }
 
-  /// `Model` (QuickTimeStream.pl:699).
+  /// `Model` (QuickTimeStream.pl:699) — the rendered text content.
   #[inline(always)]
   #[must_use]
   pub fn model(&self) -> Option<&str> {
-    self.model.as_deref()
+    self.model.as_ref().map(EscapedJson::as_str)
   }
 
-  /// `Firmware` (QuickTimeStream.pl:700).
+  /// `Firmware` (QuickTimeStream.pl:700) — the rendered text content.
   #[inline(always)]
   #[must_use]
   pub fn firmware(&self) -> Option<&str> {
-    self.firmware.as_deref()
+    self.firmware.as_ref().map(EscapedJson::as_str)
   }
 
-  /// `Parameters` (QuickTimeStream.pl:701-706).
+  /// `Parameters` (QuickTimeStream.pl:701-706) — the rendered text content.
   #[inline(always)]
   #[must_use]
   pub fn parameters(&self) -> Option<&str> {
-    self.parameters.as_deref()
+    self.parameters.as_ref().map(EscapedJson::as_str)
+  }
+
+  /// `SerialNumber` with its [`EscapedJson`] classify verdict — the emit path
+  /// maps `Bare`→[`crate::value::TagValue::Str`] (gate renders it bare) and
+  /// `Quoted`→[`crate::value::TagValue::JsonStr`] (forced-quoted, #53).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn serial_number_json(&self) -> Option<&EscapedJson> {
+    self.serial_number.as_ref()
+  }
+
+  /// `Model` with its [`EscapedJson`] classify verdict (see
+  /// [`Self::serial_number_json`]).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn model_json(&self) -> Option<&EscapedJson> {
+    self.model.as_ref()
+  }
+
+  /// `Firmware` with its [`EscapedJson`] classify verdict (see
+  /// [`Self::serial_number_json`]).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn firmware_json(&self) -> Option<&EscapedJson> {
+    self.firmware.as_ref()
+  }
+
+  /// `Parameters` with its [`EscapedJson`] classify verdict (see
+  /// [`Self::serial_number_json`]).
+  #[inline(always)]
+  #[must_use]
+  pub(crate) fn parameters_json(&self) -> Option<&EscapedJson> {
+    self.parameters.as_ref()
   }
 
   /// The sticky `DOC_NUM` this identity record inherits (see field doc).
@@ -175,30 +215,63 @@ impl Insta360Identity {
       && self.parameters.is_none()
   }
 
-  /// Assign `SerialNumber`.
+  /// Assign `SerialNumber` from plain text. A plainly-set value is a QUOTED
+  /// JSON string (`EscapeJSON` would never coerce a typed-in value to a bare
+  /// token without re-running its gate); the decode path uses
+  /// [`Self::set_serial_number_json`] to carry the classify verdict instead.
   #[inline(always)]
   pub fn set_serial_number(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.serial_number = v.map(EscapedJson::Quoted);
+    self
+  }
+
+  /// Assign `Model` from plain text (QUOTED; see [`Self::set_serial_number`]).
+  #[inline(always)]
+  pub fn set_model(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.model = v.map(EscapedJson::Quoted);
+    self
+  }
+
+  /// Assign `Firmware` from plain text (QUOTED; see [`Self::set_serial_number`]).
+  #[inline(always)]
+  pub fn set_firmware(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.firmware = v.map(EscapedJson::Quoted);
+    self
+  }
+
+  /// Assign `Parameters` from plain text (QUOTED; see
+  /// [`Self::set_serial_number`]).
+  #[inline(always)]
+  pub fn set_parameters(&mut self, v: Option<SmolStr>) -> &mut Self {
+    self.parameters = v.map(EscapedJson::Quoted);
+    self
+  }
+
+  /// Assign `SerialNumber` with its [`EscapedJson`] classify verdict (the
+  /// decode path — `escape_json_raw_bytes_classified`).
+  #[inline(always)]
+  pub(crate) fn set_serial_number_json(&mut self, v: Option<EscapedJson>) -> &mut Self {
     self.serial_number = v;
     self
   }
 
-  /// Assign `Model`.
+  /// Assign `Model` with its [`EscapedJson`] classify verdict.
   #[inline(always)]
-  pub fn set_model(&mut self, v: Option<SmolStr>) -> &mut Self {
+  pub(crate) fn set_model_json(&mut self, v: Option<EscapedJson>) -> &mut Self {
     self.model = v;
     self
   }
 
-  /// Assign `Firmware`.
+  /// Assign `Firmware` with its [`EscapedJson`] classify verdict.
   #[inline(always)]
-  pub fn set_firmware(&mut self, v: Option<SmolStr>) -> &mut Self {
+  pub(crate) fn set_firmware_json(&mut self, v: Option<EscapedJson>) -> &mut Self {
     self.firmware = v;
     self
   }
 
-  /// Assign `Parameters`.
+  /// Assign `Parameters` with its [`EscapedJson`] classify verdict.
   #[inline(always)]
-  pub fn set_parameters(&mut self, v: Option<SmolStr>) -> &mut Self {
+  pub(crate) fn set_parameters_json(&mut self, v: Option<EscapedJson>) -> &mut Self {
     self.parameters = v;
     self
   }
@@ -215,6 +288,41 @@ impl Default for Insta360Identity {
   #[inline(always)]
   fn default() -> Self {
     Self::new()
+  }
+}
+
+/// Value equality on each field's OBSERVABLE/CANONICAL form, never its raw
+/// private representation. Every field of [`Insta360Identity`] is compared this
+/// way, so no construction-path bookkeeping can leak into equality (#53):
+///
+///  - the four identity fields (`serial_number` / `model` / `firmware` /
+///    `parameters`, each [`EscapedJson`]) carry a private `Bare`/`Quoted`
+///    JSON-rendering verdict that is serialization bookkeeping, NOT identity — a
+///    clean numeric serial the decode path stores as `Bare("1234")` is the SAME
+///    identity as one a `set_serial_number(Some("1234"))` caller stores as
+///    `Quoted("1234")` (external callers cannot construct `Bare`). Each is
+///    compared via its `*()` accessor (the inner `&str`), so the derived
+///    [`EscapedJson`] `PartialEq` (which also discriminates the variant) is
+///    deliberately NOT used.
+///  - [`Self::doc`] is the sticky `DOC_NUM` walk stamp, compared via its emit
+///    canonical form `doc.unwrap_or(0)`: `None` and `Some(0)` both denote the
+///    flat (Main) document — emit collapses them with `id.doc().unwrap_or(0)`
+///    (`quicktime.rs` `Group::with_doc(.., id.doc().unwrap_or(0))`), so a record
+///    the decode path stamps `Some(0)` and the same content left `None` by
+///    public construction are observably identical. `Some(nonzero)` stays a
+///    distinct `Doc<N>`.
+///
+/// With all five fields observable-compared, the equality-leak class is closed:
+/// no field carries a raw representation into `eq`. `Eq`/`Hash` are not derived,
+/// so there is no consistency obligation to uphold.
+impl PartialEq for Insta360Identity {
+  #[inline]
+  fn eq(&self, other: &Self) -> bool {
+    self.serial_number() == other.serial_number()
+      && self.model() == other.model()
+      && self.firmware() == other.firmware()
+      && self.parameters() == other.parameters()
+      && self.doc.unwrap_or(0) == other.doc.unwrap_or(0)
   }
 }
 
@@ -1039,6 +1147,63 @@ mod tests {
     assert_eq!(id.serial_number(), Some("IXX00123"));
     assert_eq!(id.parameters(), Some("2 6 4032 3024"));
     assert!(!id.is_empty());
+  }
+
+  #[test]
+  fn identity_eq_compares_content_not_json_verdict() {
+    // #53: the decode path can store a clean numeric ORIGINAL as the bare JSON
+    // verdict (`escape_json_raw_bytes_classified("1234")` → `Bare("1234")`),
+    // while the public `set_*` API stores the SAME visible text as `Quoted`.
+    // The classify verdict is JSON-rendering bookkeeping, not identity, so the
+    // two must compare EQUAL on their public content.
+    let mut decoded = Insta360Identity::new();
+    decoded.set_serial_number_json(Some(EscapedJson::Bare(SmolStr::new("1234"))));
+    assert_eq!(decoded.serial_number(), Some("1234"));
+
+    let mut via_setter = Insta360Identity::new();
+    via_setter.set_serial_number(Some(SmolStr::new("1234")));
+    // Confirm the setter took the quoted verdict (the private leak the bug is
+    // about) — yet equality ignores it.
+    assert!(matches!(
+      via_setter.serial_number_json(),
+      Some(EscapedJson::Quoted(_))
+    ));
+
+    assert_eq!(
+      decoded, via_setter,
+      "Bare(\"1234\") and Quoted(\"1234\") must be equal (same content)"
+    );
+
+    // Sanity: genuinely different content is still NOT equal.
+    let mut other = Insta360Identity::new();
+    other.set_serial_number(Some(SmolStr::new("5678")));
+    assert_ne!(decoded, other);
+
+    // #53 R5: the `doc` walk stamp is compared by its emit canonical form
+    // `doc.unwrap_or(0)`. `None` and `Some(0)` both denote the flat (Main)
+    // document (emit collapses them via `id.doc().unwrap_or(0)`), so identical
+    // content under either must compare EQUAL — the construction path must not
+    // leak through `doc`.
+    let mut doc_none = Insta360Identity::new();
+    doc_none.set_serial_number(Some(SmolStr::new("1234")));
+    assert_eq!(doc_none.doc(), None);
+    let mut doc_zero = doc_none.clone();
+    doc_zero.set_doc(Some(0));
+    assert_eq!(doc_zero.doc(), Some(0));
+    assert_eq!(
+      doc_none, doc_zero,
+      "doc None and Some(0) are the SAME Main-doc state (unwrap_or(0))"
+    );
+
+    // A nonzero `Doc<N>` stays distinct from the Main document (and from a
+    // different nonzero doc): same content, different sticky doc ⇒ NOT equal.
+    let mut doc_one = doc_none.clone();
+    doc_one.set_doc(Some(1));
+    assert_ne!(
+      doc_zero, doc_one,
+      "Some(0) (Main) and Some(1) (Doc1) are distinct documents"
+    );
+    assert_ne!(doc_none, doc_one);
   }
 
   #[test]


### PR DESCRIPTION
Audits all `unwrap_or("")`/`unwrap_or_default` on `Option<String>` in serialization paths and replaces silent empty-string degradation:

- **expect-invariants** (convert.rs:926, composite lens) — `perl_nonfinite_str` is always-`Some` on the non-finite branch, so the `"NaN"` fallback was dead; now `expect()` on the impossible `None`.
- **visible-faithful fallbacks** (insta360 Serial/Model/Firmware/Parameters, riff strh FourCC) — were `from_utf8(...).unwrap_or("")` (dropping a non-UTF-8 value to `""`); now route through the **#399 EscapeJSON pipeline** (`escape_json_raw_bytes_classified` + `TagValue::JsonStr`): classify the **original** NUL-bearing bytes → NUL-strip → FixUTF8, so `\xC2\x00\xA9` reassembles to `©` and NUL-split numerics stay quoted, matching bundled. The insta360 identity verdict is carried struct-side (`EscapedJson`); a **manual `PartialEq`** compares every field by its observable value (content accessors + `doc.unwrap_or(0)`) so equality never leaks the JSON/construction representation.

**Output-neutral for all real cases** — every real serial/FourCC is byte-identical; only crafted non-UTF-8 / NUL-split inputs change (now faithful). 0 golden files changed. `build(-Dwarnings)=0 conformance=471/0 timed_metadata=157/0 typed_serde=598 lib=3717/0 xtask=26/0`. **Codex: APPROVE (R5 — 5-round drive: real fidelity → UTF-8 order → classify-before-strip → PartialEq verdict → doc normalization).** Closes #53.