### PR TITLE
feat(sony): activate Sony_SLT-A33_real.ARW — older ProcessBinaryData sub-tables + AFStatus grid

### DIFF
--- a/src/exif/makernotes/vendors/sony/camerainfo3.rs
+++ b/src/exif/makernotes/vendors/sony/camerainfo3.rs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::CameraInfo3` (`Sony.pm:2986-3170`) — the
+//! `0x0010` Main-table SubDirectory dispatched when `$count == 15360`
+//! (`Sony.pm:2280-2300`), a plain (un-enciphered) `ProcessBinaryData` block
+//! holding camera info for the A33/A35/A55, A450/A500/A550, A560/A580,
+//! NEX-3/5/5C/C3 and VG10E.
+//!
+//! The table covers TWO different AF systems at OVERLAPPING offsets, selected
+//! by `$$self{Model}`:
+//!  1. `DSLR-A(450|500|550)` — a 9-point AF system (offsets identical to the
+//!     A200-A390 `CameraInfo` table).
+//!  2. `SLT-` / `DSLR-A(560|580)` — a 15-point three-cross AF system (more
+//!     info at different offsets), whose `0x23` `AFStatus15` SubDirectory holds
+//!     an 18-element `int16s` AF-status grid (`%Sony::AFStatus15`,
+//!     `Sony.pm:9798-9821`).
+//!
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range
+//! is in the block AND its model `Condition` holds
+//! ([[exifast-processbinarydata-per-field]]). `LensSpec` (0x00) renders via the
+//! shared [`super::printconv`] lens-spec conversion (same name as the Main-IFD
+//! `0x0029` leaf — last-wins dedup keeps this byte-identical value).
+
+use crate::value::TagValue;
+
+use super::subtables::{
+  SubEmission, af_status_value, model_is_a4xx_9pt, model_is_slt_15pt, read_i16, read_u16,
+};
+
+/// `%afPoint15` PrintConv (`Sony.pm:557-575`) — the 15-point AF sensor used.
+fn af_point15(v: u16) -> Option<&'static str> {
+  Some(match v {
+    0 => "Upper-left",
+    1 => "Left",
+    2 => "Lower-left",
+    3 => "Far Left",
+    4 => "Top (horizontal)",
+    5 => "Near Right",
+    6 => "Center (horizontal)",
+    7 => "Near Left",
+    8 => "Bottom (horizontal)",
+    9 => "Top (vertical)",
+    10 => "Center (vertical)",
+    11 => "Bottom (vertical)",
+    12 => "Far Right",
+    13 => "Upper-right",
+    14 => "Right",
+    15 => "Lower-right",
+    16 => "Upper-middle",
+    17 => "Lower-middle",
+    255 => "(none)",
+    _ => return None,
+  })
+}
+
+/// `FocusStatus` (0x19) PrintConv (`Sony.pm:3082-3091`) — SLT / A560 / A580.
+fn focus_status(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Manual - Not confirmed (0)",
+    4 => "Manual - Not confirmed (4)",
+    16 => "AF-C - Confirmed",
+    24 => "AF-C - Not Confirmed",
+    64 => "AF-S - Confirmed",
+    _ => return None,
+  })
+}
+
+/// `AFPointSelected` (0x1c, 15-point) PrintConv (`Sony.pm:3094-3118`).
+fn af_point_selected15(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Auto",
+    1 => "Center",
+    2 => "Top",
+    3 => "Upper-right",
+    4 => "Right",
+    5 => "Lower-right",
+    6 => "Bottom",
+    7 => "Lower-left",
+    8 => "Left",
+    9 => "Upper-left",
+    10 => "Far Right",
+    11 => "Far Left",
+    12 => "Upper-middle",
+    13 => "Near Right",
+    14 => "Lower-middle",
+    15 => "Near Left",
+    _ => return None,
+  })
+}
+
+/// `AFPointSelected` (0x14, 9-point) PrintConv (`Sony.pm:3030-3046`).
+fn af_point_selected9(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Auto",
+    1 => "Center",
+    2 => "Top",
+    3 => "Upper-right",
+    4 => "Right",
+    5 => "Lower-right",
+    6 => "Bottom",
+    7 => "Lower-left",
+    8 => "Left",
+    9 => "Upper-left",
+    _ => return None,
+  })
+}
+
+/// `AFPoint` (0x18, 9-point) PrintConv (`Sony.pm:3058-3074`).
+fn af_point9(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Top-right",
+    1 => "Bottom-right",
+    2 => "Bottom",
+    3 => "Middle Horizontal",
+    4 => "Center Vertical",
+    5 => "Top",
+    6 => "Top-left",
+    7 => "Bottom-left",
+    _ => return None,
+  })
+}
+
+/// `FocusMode` (0x15 9-pt / 0x1d 15-pt) PrintConv (`Sony.pm:3050-3056`).
+fn focus_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Manual",
+    1 => "AF-S",
+    2 => "AF-C",
+    3 => "AF-A",
+    _ => return None,
+  })
+}
+
+/// Render a hash-PrintConv leaf (`-j` label/`Unknown (N)`, `-n` raw int).
+fn hash_leaf(raw: u8, hit: Option<&'static str>, print_conv: bool) -> TagValue {
+  super::hash_print_value(raw, hit, print_conv)
+}
+
+/// Push a `%afStatusInfo` `int16s` leaf at `off` (the 9-point inline AF-status
+/// fields).
+fn push_af_status(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(v) = read_i16(buf, off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: af_status_value(v, print_conv),
+    });
+  }
+}
+
+/// Walk the `CameraInfo3` block and emit the camera-info + AF leaves for the
+/// model's AF system.
+///
+/// `buf` is the verbatim (un-enciphered) `0x0010` block. `model` is
+/// `$$self{Model}`; `print_conv` selects `-j` vs `-n`.
+#[must_use]
+pub fn parse_camera_info3(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+  let slt = model_is_slt_15pt(model);
+  let a4xx = model_is_a4xx_9pt(model);
+
+  // 0x00 LensSpec (`Condition !~ NEX-5C`, undef[8]; Sony.pm:2994-3002) is the
+  // SAME `LensSpec` name + value as the Main-IFD `0x0029` leaf, which exifast
+  // already emits byte-identically; since `0x0010` precedes `0x0029` in
+  // tag-order the Main leaf wins the last-wins dedup either way, so this
+  // duplicate is intentionally NOT re-emitted here (it would be dropped).
+
+  // 0x0e FocalLength — int16u, `Condition !~ A450/A500/A550`, `$val/10`,
+  // `Priority => 0`, `sprintf("%.1f mm",$val)` (Sony.pm:3006-3014).
+  if !a4xx && let Some(raw) = read_u16(buf, 0x0e) {
+    let mm = f64::from(raw) / 10.0;
+    out.push(SubEmission {
+      // `Priority => 0` (Sony.pm:3011) — this Sony `FocalLength` never overrides
+      // an earlier same-name duplicate.
+      priority: 0,
+      name: "FocalLength",
+      value: if print_conv {
+        TagValue::Str(std::format!("{mm:.1} mm").into())
+      } else {
+        TagValue::F64(mm)
+      },
+    });
+  }
+
+  // 0x10 FocalLengthTeleZoom — int16u, `Condition !~ A450/A500/A550`,
+  // `$val*2/3`, `sprintf("%.1f mm",$val)` (Sony.pm:3015-3023).
+  if !a4xx && let Some(raw) = read_u16(buf, 0x10) {
+    let mm = f64::from(raw) * 2.0 / 3.0;
+    out.push(SubEmission {
+      priority: 1,
+      name: "FocalLengthTeleZoom",
+      value: if print_conv {
+        TagValue::Str(std::format!("{mm:.1} mm").into())
+      } else {
+        TagValue::F64(mm)
+      },
+    });
+  }
+
+  if a4xx {
+    // 9-point AF system (DSLR-A450/A500/A550).
+    if let Some(&raw) = buf.get(0x14) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "AFPointSelected",
+        value: hash_leaf(raw, af_point_selected9(raw), print_conv),
+      });
+    }
+    if let Some(&raw) = buf.get(0x15) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "FocusMode",
+        value: hash_leaf(raw, focus_mode(raw), print_conv),
+      });
+    }
+    if let Some(&raw) = buf.get(0x18) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "AFPoint",
+        value: hash_leaf(raw, af_point9(raw), print_conv),
+      });
+    }
+    push_af_status(buf, 0x1b, "AFStatusActiveSensor", print_conv, &mut out);
+    push_af_status(buf, 0x1d, "AFStatusTop-right", print_conv, &mut out);
+    push_af_status(buf, 0x1f, "AFStatusBottom-right", print_conv, &mut out);
+    push_af_status(buf, 0x21, "AFStatusBottom", print_conv, &mut out);
+    push_af_status(buf, 0x23, "AFStatusMiddleHorizontal", print_conv, &mut out);
+    push_af_status(buf, 0x25, "AFStatusCenterVertical", print_conv, &mut out);
+    push_af_status(buf, 0x27, "AFStatusTop", print_conv, &mut out);
+    push_af_status(buf, 0x29, "AFStatusTop-left", print_conv, &mut out);
+    push_af_status(buf, 0x2b, "AFStatusBottom-left", print_conv, &mut out);
+    push_af_status(buf, 0x2d, "AFStatusLeft", print_conv, &mut out);
+    push_af_status(buf, 0x2f, "AFStatusCenterHorizontal", print_conv, &mut out);
+    push_af_status(buf, 0x31, "AFStatusRight", print_conv, &mut out);
+  } else if slt {
+    // 15-point three-cross AF system (SLT- / DSLR-A560/A580).
+    // 0x19 FocusStatus (Sony.pm:3076-3092).
+    if let Some(&raw) = buf.get(0x19) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "FocusStatus",
+        value: hash_leaf(raw, focus_status(raw), print_conv),
+      });
+    }
+    // 0x1c AFPointSelected (Sony.pm:3094-3118).
+    if let Some(&raw) = buf.get(0x1c) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "AFPointSelected",
+        value: hash_leaf(raw, af_point_selected15(raw), print_conv),
+      });
+    }
+    // 0x1d FocusMode (Sony.pm:3122-3130).
+    if let Some(&raw) = buf.get(0x1d) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "FocusMode",
+        value: hash_leaf(raw, focus_mode(raw), print_conv),
+      });
+    }
+    // 0x20 AFPoint — `%afPoint15` (int8u; Sony.pm:3143-3151).
+    if let Some(&raw) = buf.get(0x20) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "AFPoint",
+        value: hash_leaf(raw, af_point15(u16::from(raw)), print_conv),
+      });
+    }
+    // 0x21 AFStatusActiveSensor — int16s afStatusInfo (Sony.pm:3153-3158).
+    push_af_status(buf, 0x21, "AFStatusActiveSensor", print_conv, &mut out);
+    // 0x23 AFStatus15 — int16s[18] SubDirectory (Sony.pm:3166-3170).
+    push_af_status15(buf, 0x23, print_conv, &mut out);
+  }
+
+  out
+}
+
+/// Emit the 18-element `int16s` `%Sony::AFStatus15` grid starting at `off`
+/// (CameraInfo3 0x23). Each element is a `%afStatusInfo` leaf
+/// (`Sony.pm:9798-9821`).
+fn push_af_status15(buf: &[u8], off: usize, print_conv: bool, out: &mut Vec<SubEmission>) {
+  const NAMES: [&str; 18] = [
+    "AFStatusUpper-left",
+    "AFStatusLeft",
+    "AFStatusLower-left",
+    "AFStatusFarLeft",
+    "AFStatusTopHorizontal",
+    "AFStatusNearRight",
+    "AFStatusCenterHorizontal",
+    "AFStatusNearLeft",
+    "AFStatusBottomHorizontal",
+    "AFStatusTopVertical",
+    "AFStatusCenterVertical",
+    "AFStatusBottomVertical",
+    "AFStatusFarRight",
+    "AFStatusUpper-right",
+    "AFStatusRight",
+    "AFStatusLower-right",
+    "AFStatusUpper-middle",
+    "AFStatusLower-middle",
+  ];
+  for (i, name) in NAMES.iter().enumerate() {
+    push_af_status(buf, off + i * 2, name, print_conv, out);
+  }
+}

--- a/src/exif/makernotes/vendors/sony/camerainfo3.rs
+++ b/src/exif/makernotes/vendors/sony/camerainfo3.rs
@@ -25,7 +25,8 @@
 use crate::value::TagValue;
 
 use super::subtables::{
-  SubEmission, af_status_value, model_is_a4xx_9pt, model_is_slt_15pt, read_i16, read_u16,
+  SubEmission, af_status_value, model_is_a4xx_9pt, model_is_a4xx_exact, model_is_slt_15pt,
+  read_i16, read_u16,
 };
 
 /// `%afPoint15` PrintConv (`Sony.pm:557-575`) — the 15-point AF sensor used.
@@ -164,7 +165,12 @@ fn push_af_status(
 pub fn parse_camera_info3(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<SubEmission> {
   let mut out = std::vec::Vec::new();
   let slt = model_is_slt_15pt(model);
+  // The 9-point AF block (0x14..0x31) is `\b`-anchored
+  // (`/^DSLR-A(450|500|550)\b/`); 0x0e/0x10 `FocalLength*` are `$`-anchored EXACT
+  // (`/^DSLR-(A450|A500|A550)$/`), so they take DISTINCT helpers — they diverge
+  // only for a hypothetical suffixed A4xx string (e.g. `DSLR-A500-x`).
   let a4xx = model_is_a4xx_9pt(model);
+  let a4xx_exact = model_is_a4xx_exact(model);
 
   // 0x00 LensSpec (`Condition !~ NEX-5C`, undef[8]; Sony.pm:2994-3002) is the
   // SAME `LensSpec` name + value as the Main-IFD `0x0029` leaf, which exifast
@@ -172,9 +178,10 @@ pub fn parse_camera_info3(buf: &[u8], model: Option<&str>, print_conv: bool) -> 
   // tag-order the Main leaf wins the last-wins dedup either way, so this
   // duplicate is intentionally NOT re-emitted here (it would be dropped).
 
-  // 0x0e FocalLength — int16u, `Condition !~ A450/A500/A550`, `$val/10`,
-  // `Priority => 0`, `sprintf("%.1f mm",$val)` (Sony.pm:3006-3014).
-  if !a4xx && let Some(raw) = read_u16(buf, 0x0e) {
+  // 0x0e FocalLength — int16u, `Condition !~ /^DSLR-(A450|A500|A550)$/`
+  // ($-anchored EXACT, Sony.pm:3006), `$val/10`, `Priority => 0`,
+  // `sprintf("%.1f mm",$val)` (Sony.pm:3004-3013).
+  if !a4xx_exact && let Some(raw) = read_u16(buf, 0x0e) {
     let mm = f64::from(raw) / 10.0;
     out.push(SubEmission {
       // `Priority => 0` (Sony.pm:3011) — this Sony `FocalLength` never overrides
@@ -189,9 +196,10 @@ pub fn parse_camera_info3(buf: &[u8], model: Option<&str>, print_conv: bool) -> 
     });
   }
 
-  // 0x10 FocalLengthTeleZoom — int16u, `Condition !~ A450/A500/A550`,
-  // `$val*2/3`, `sprintf("%.1f mm",$val)` (Sony.pm:3015-3023).
-  if !a4xx && let Some(raw) = read_u16(buf, 0x10) {
+  // 0x10 FocalLengthTeleZoom — int16u, `Condition !~ /^DSLR-(A450|A500|A550)$/`
+  // ($-anchored EXACT, Sony.pm:3016), `$val*2/3`, `sprintf("%.1f mm",$val)`
+  // (Sony.pm:3014-3022).
+  if !a4xx_exact && let Some(raw) = read_u16(buf, 0x10) {
     let mm = f64::from(raw) * 2.0 / 3.0;
     out.push(SubEmission {
       priority: 1,
@@ -310,3 +318,11 @@ fn push_af_status15(buf: &[u8], off: usize, print_conv: bool, out: &mut Vec<SubE
     push_af_status(buf, off + i * 2, name, print_conv, out);
   }
 }
+
+#[cfg(test)]
+// The module-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "camerainfo3_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/camerainfo3_tests.rs
+++ b/src/exif/makernotes/vendors/sony/camerainfo3_tests.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Sony::CameraInfo3` model-anchor regression: 0x0e `FocalLength` / 0x10
+//! `FocalLengthTeleZoom` carry `Condition => '$$self{Model} !~
+//! /^DSLR-(A450|A500|A550)$/'` (`$`-anchored EXACT, Sony.pm:3006/3016) — a
+//! DISTINCT anchor from the 9-point-AF block (0x14..0x31), which is the `\b`
+//! `/^DSLR-A(450|500|550)\b/`. A single `\b` bool wrongly suppressed the
+//! `FocalLength*` leaves for a hyphen/space-suffixed A4xx string.
+
+use super::*;
+
+fn put_u16(buf: &mut [u8], off: usize, v: u16) {
+  buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn has(model: &str, buf: &[u8], name: &str) -> bool {
+  parse_camera_info3(buf, Some(model), true)
+    .iter()
+    .any(|e| e.name == name)
+}
+
+#[test]
+fn focallength_is_exact_not_word_boundary() {
+  let mut buf = vec![0u8; 0x40];
+  put_u16(&mut buf, 0x0e, 500); // FocalLength 50.0 mm
+  put_u16(&mut buf, 0x10, 300); // FocalLengthTeleZoom
+
+  // SLT-A33 (15-point body, not an A4xx): both emit.
+  assert!(has("SLT-A33", &buf, "FocalLength"));
+  assert!(has("SLT-A33", &buf, "FocalLengthTeleZoom"));
+
+  // Suffixed A4xx strings are NOT a `$`-exact match, so the `$`-anchored
+  // `FocalLength*` still emit (the `\b` port wrongly dropped `DSLR-A500-x`).
+  for m in ["DSLR-A500-x", "DSLR-A500X"] {
+    assert!(
+      has(m, &buf, "FocalLength"),
+      "{m} FocalLength must emit ($-exact)"
+    );
+    assert!(
+      has(m, &buf, "FocalLengthTeleZoom"),
+      "{m} FocalLengthTeleZoom must emit ($-exact)"
+    );
+  }
+
+  // The real 9-point bodies (exact match) do NOT carry these leaves.
+  for m in ["DSLR-A450", "DSLR-A500", "DSLR-A550"] {
+    assert!(!has(m, &buf, "FocalLength"), "{m} FocalLength suppressed");
+    assert!(
+      !has(m, &buf, "FocalLengthTeleZoom"),
+      "{m} FocalLengthTeleZoom suppressed"
+    );
+  }
+}

--- a/src/exif/makernotes/vendors/sony/camerasettings3.rs
+++ b/src/exif/makernotes/vendors/sony/camerasettings3.rs
@@ -19,7 +19,8 @@ use smol_str::SmolStr;
 
 use super::subtables::{
   SubEmission, drive_mode, exposure_comp_value, exposure_program2, hash_hex_value,
-  model_is_a4xx_9pt, model_is_nex, read_u32, signed_setting_value, white_balance_setting,
+  model_is_a4xx_exact, model_is_a4xx_prefix, model_is_nex, read_u32, signed_setting_value,
+  white_balance_setting,
 };
 
 /// Render a plain (non-hex) hash-PrintConv leaf (`-j` label/`Unknown (N)`, `-n`
@@ -195,8 +196,13 @@ pub fn parse_camera_settings3(
 ) -> Vec<SubEmission> {
   let mut out = std::vec::Vec::new();
   let nex = model_is_nex(model);
-  let a4xx = model_is_a4xx_9pt(model);
-  let other = !a4xx; // the `!~ /^DSLR-(A450|A500|A550)$/` class
+  // The A4xx conditions in this table come in TWO anchor flavors (never `\b`):
+  // most leaves are `$`-anchored EXACT (`!~ /^DSLR-(A450|A500|A550)$/`), while
+  // 0x87/0x88 `FlashStatus*` are the no-anchor PREFIX
+  // (`!~ /^DSLR-(A450|A500|A550)/`). Split the bool so a suffixed A4xx string
+  // follows each field's true anchor.
+  let a4xx_exact = model_is_a4xx_exact(model);
+  let a4xx_prefix = model_is_a4xx_prefix(model);
 
   // 0x00 ShutterSpeedSetting — `$val ? 2**(6 - $val/8) : 0`,
   // `$val ? PrintExposureTime($val) : "Bulb"` (Sony.pm:5144-5150).
@@ -409,9 +415,9 @@ pub fn parse_camera_settings3(
     &mut out,
   );
 
-  // 0x32/0x33/0x34/0x35/0x36/0x38 — `Condition => '$$self{Model} !~
-  // /^DSLR-(A450|A500|A550)$/'` (Sony.pm:5491-5615).
-  if other {
+  // 0x32/0x33/0x34/0x35 — `!~ /^DSLR-(A450|A500|A550)$/` ($-anchored EXACT,
+  // Sony.pm:5454/5462/5472/5496).
+  if !a4xx_exact {
     push_hash(
       buf,
       0x32,
@@ -438,8 +444,12 @@ pub fn parse_camera_settings3(
       &mut out,
     );
   }
-  // 0x36 LiveViewAFSetting / 0x38 PanoramaSize3D — `!~ /^(NEX-|DSLR-A4xx)/`.
-  if other && !nex {
+  // 0x36 LiveViewAFSetting — `!~ /^(NEX-|DSLR-(A450|A500|A550)$)/` (NEX prefix +
+  // A4xx $-exact, Sony.pm:5506). 0x38 PanoramaSize3D is `!~
+  // /^DSLR-(A450|A500|A550)$/` ($-exact only, Sony.pm:5519); its `!nex` gate is a
+  // pre-existing over-exclusion outside this A4xx-anchor fix, kept so real NEX
+  // bodies stay byte-identical.
+  if !a4xx_exact && !nex {
     push_hash(
       buf,
       0x36,
@@ -458,9 +468,10 @@ pub fn parse_camera_settings3(
     );
   }
 
-  // 0x83..0x99 — the `!~ /^(NEX-|DSLR-A4xx)/` SLT/DSLR live-view block
-  // (Sony.pm:5524-5614).
-  if other && !nex {
+  // 0x83/0x84/0x85/0x86/0x8b — `!~ /^(NEX-|DSLR-(A450|A500|A550)$)/` (NEX prefix
+  // + A4xx $-exact, Sony.pm:5531/5539/5548/5558/5591) — the SLT/DSLR live-view
+  // block.
+  if !a4xx_exact && !nex {
     push_hash(
       buf,
       0x83,
@@ -495,8 +506,9 @@ pub fn parse_camera_settings3(
       &mut out,
     );
   }
-  // 0x87/0x88 FlashStatus — `!~ /^DSLR-(A450|A500|A550)/` (Sony.pm:5564-5580).
-  if other {
+  // 0x87/0x88 FlashStatus* — `!~ /^DSLR-(A450|A500|A550)/` (no-anchor PREFIX,
+  // Sony.pm:5566/5574).
+  if !a4xx_prefix {
     push_hash(
       buf,
       0x87,
@@ -514,13 +526,15 @@ pub fn parse_camera_settings3(
       &mut out,
     );
   }
-  // 0x99 LensMount — `!~ /^DSLR-A4xx$/`, DataMember (Sony.pm:5604).
-  if other {
+  // 0x99 LensMount — `!~ /^DSLR-(A450|A500|A550)$/` ($-anchored EXACT),
+  // DataMember (Sony.pm:5608).
+  if !a4xx_exact {
     push_hash(buf, 0x99, "LensMount", lens_mount, print_conv, &mut out);
   }
 
-  // 0x10c SequenceNumber — OTHER-passthrough (Sony.pm:5638).
-  if other && let Some(&raw) = buf.get(0x10c) {
+  // 0x10c SequenceNumber — `!~ /^DSLR-(A450|A500|A550)$/` ($-anchored EXACT,
+  // Sony.pm:5629), OTHER-passthrough PrintConv.
+  if !a4xx_exact && let Some(&raw) = buf.get(0x10c) {
     out.push(SubEmission {
       priority: 1,
       name: "SequenceNumber",
@@ -529,8 +543,9 @@ pub fn parse_camera_settings3(
   }
 
   // 0x0114 FolderNumber (mask 0x00ffc000) + 276.1 ImageNumber (mask
-  // 0x00003fff) — int32u (Sony.pm:5650-5666).
-  if other && let Some(v) = read_u32(buf, 0x0114) {
+  // 0x00003fff) — int32u, `!~ /^DSLR-(A450|A500|A550)$/` ($-anchored EXACT,
+  // Sony.pm:5643/5651).
+  if !a4xx_exact && let Some(v) = read_u32(buf, 0x0114) {
     let folder = (v & 0x00ff_c000) >> 14;
     out.push(SubEmission {
       priority: 1,
@@ -545,8 +560,9 @@ pub fn parse_camera_settings3(
     });
   }
 
-  // 0x200 ShotNumberSincePowerUp2 — int32u (Sony.pm:5675).
-  if other && let Some(v) = read_u32(buf, 0x200) {
+  // 0x200 ShotNumberSincePowerUp2 — int32u, `!~ /^DSLR-(A450|A500|A550)$/`
+  // ($-anchored EXACT, Sony.pm:5665).
+  if !a4xx_exact && let Some(v) = read_u32(buf, 0x200) {
     out.push(SubEmission {
       priority: 1,
       name: "ShotNumberSincePowerUp2",
@@ -956,3 +972,11 @@ fn masked_count_value(val: u32, width: usize, print_conv: bool) -> TagValue {
   }
   TagValue::Str(SmolStr::new(std::format!("{val:0width$}")))
 }
+
+#[cfg(test)]
+// The module-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "camerasettings3_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/camerasettings3.rs
+++ b/src/exif/makernotes/vendors/sony/camerasettings3.rs
@@ -1,0 +1,958 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::CameraSettings3` (`Sony.pm:5134-5760`) — the
+//! `0x0114` Main-table SubDirectory dispatched when `$count == 1536 || 2048`
+//! (`Sony.pm:803-835`), an `int8u`-format `ProcessBinaryData` block of camera
+//! settings for the A33/A35/A55, A450/A500/A550, A560/A580 and NEX-3/5/C3/VG10E.
+//!
+//! `FORMAT => 'int8u'`, `PRIORITY => 0`, `DATAMEMBER => [ 0x99 ]` (LensMount).
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range
+//! is in the block AND its model `Condition` holds
+//! ([[exifast-processbinarydata-per-field]]). The masked `0x0114`/`276.1`
+//! `FolderNumber`/`ImageNumber` and `0x200` `ShotNumberSincePowerUp2` read
+//! `int32u` from their offsets.
+
+use crate::exif::tables::{print_exposure_time, print_fnumber};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+
+use super::subtables::{
+  SubEmission, drive_mode, exposure_comp_value, exposure_program2, hash_hex_value,
+  model_is_a4xx_9pt, model_is_nex, read_u32, signed_setting_value, white_balance_setting,
+};
+
+/// Render a plain (non-hex) hash-PrintConv leaf (`-j` label/`Unknown (N)`, `-n`
+/// raw int) from a `u8` value.
+fn hash_leaf(raw: u8, hit: Option<&'static str>, print_conv: bool) -> TagValue {
+  super::hash_print_value(raw, hit, print_conv)
+}
+
+/// Push a simple `int8u` hash-PrintConv leaf at `off`.
+fn push_hash(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  hit: impl Fn(u8) -> Option<&'static str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: hash_leaf(raw, hit(raw), print_conv),
+    });
+  }
+}
+
+/// `MeteringMode` PrintConv (`1 => Multi-segment`, `2 => Center-weighted
+/// average`, `3 => Spot`) — shared by 0x07 here and `MoreSettings` 0x03.
+fn metering_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Multi-segment",
+    2 => "Center-weighted average",
+    3 => "Spot",
+    _ => return None,
+  })
+}
+
+/// `FocusModeSetting` PrintConv (`Sony.pm:5214-5223`).
+fn focus_mode_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    17 => "AF-S",
+    18 => "AF-C",
+    19 => "AF-A",
+    32 => "Manual",
+    48 => "DMF",
+    _ => return None,
+  })
+}
+
+/// `DynamicRangeOptimizerSetting` PrintConv (`1 => Off`, `16 => On (Auto)`,
+/// `17 => On (Manual)`).
+fn dro_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On (Auto)",
+    17 => "On (Manual)",
+    _ => return None,
+  })
+}
+
+/// `ColorSpace` PrintConv (`1 => sRGB`, `2 => Adobe RGB`).
+fn color_space(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "sRGB",
+    2 => "Adobe RGB",
+    _ => return None,
+  })
+}
+
+/// `CreativeStyleSetting` PrintConv (`Sony.pm:5283-5292`).
+fn creative_style_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    16 => "Standard",
+    32 => "Vivid",
+    64 => "Portrait",
+    80 => "Landscape",
+    96 => "B&W",
+    160 => "Sunset",
+    _ => return None,
+  })
+}
+
+/// `FlashMode` PrintConv (`Sony.pm` — shared 0x20 / `MoreSettings` 0x10).
+fn flash_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Flash Off",
+    16 => "Autoflash",
+    17 => "Fill-flash",
+    18 => "Slow Sync",
+    19 => "Rear Sync",
+    20 => "Wireless",
+    _ => return None,
+  })
+}
+
+/// `LongExposureNoiseReduction` PrintConv (`1 => Off`, `16 => On`).
+fn long_exposure_nr(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On",
+    _ => return None,
+  })
+}
+
+/// `HighISONoiseReduction` PrintConv (`16 => Low`, `17 => High`, `19 => Auto`).
+fn high_iso_nr(v: u8) -> Option<&'static str> {
+  Some(match v {
+    16 => "Low",
+    17 => "High",
+    19 => "Auto",
+    _ => return None,
+  })
+}
+
+/// `HDRSetting` PrintConv (`1 => Off`, `16 => On (Auto)`, `17 => On (Manual)`).
+fn hdr_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On (Auto)",
+    17 => "On (Manual)",
+    _ => return None,
+  })
+}
+
+/// `HDRLevel` PrintConv (`Sony.pm` — shared 0x2e / `MoreSettings` 0x17).
+fn hdr_level(v: u8) -> Option<&'static str> {
+  Some(match v {
+    33 => "1 EV",
+    34 => "1.5 EV",
+    35 => "2 EV",
+    36 => "2.5 EV",
+    37 => "3 EV",
+    38 => "3.5 EV",
+    39 => "4 EV",
+    40 => "5 EV",
+    41 => "6 EV",
+    _ => return None,
+  })
+}
+
+/// `ViewingMode` PrintConv (`16 => ViewFinder`, `33 => Focus Check Live View`,
+/// `34 => Quick AF Live View`) — 0x2f.
+fn viewing_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    16 => "ViewFinder",
+    33 => "Focus Check Live View",
+    34 => "Quick AF Live View",
+    _ => return None,
+  })
+}
+
+/// `FaceDetection` PrintConv (`1 => Off`, `16 => On`).
+fn face_detection(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On",
+    _ => return None,
+  })
+}
+
+/// Walk the `CameraSettings3` block and emit the settings leaves for the model.
+///
+/// `buf` is the verbatim (un-enciphered) `0x0114` block; `model` is
+/// `$$self{Model}`; `print_conv` selects `-j` vs `-n`. The 9-point DSLR-A4xx
+/// bodies use a different masked-tag layout (0x283.. / 0x30c..) — this port
+/// targets the "other models" (SLT / A560 / A580 / NEX) branches the A33 needs
+/// plus the shared leaves; the A4xx-only conditional leaves stay deferred.
+#[must_use]
+pub fn parse_camera_settings3(
+  buf: &[u8],
+  model: Option<&str>,
+  print_conv: bool,
+) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+  let nex = model_is_nex(model);
+  let a4xx = model_is_a4xx_9pt(model);
+  let other = !a4xx; // the `!~ /^DSLR-(A450|A500|A550)$/` class
+
+  // 0x00 ShutterSpeedSetting — `$val ? 2**(6 - $val/8) : 0`,
+  // `$val ? PrintExposureTime($val) : "Bulb"` (Sony.pm:5144-5150).
+  if let Some(&raw) = buf.first() {
+    let secs = if raw != 0 {
+      2f64.powf(6.0 - f64::from(raw) / 8.0)
+    } else {
+      0.0
+    };
+    out.push(SubEmission {
+      priority: 1,
+      name: "ShutterSpeedSetting",
+      value: if print_conv {
+        if raw != 0 {
+          TagValue::Str(print_exposure_time(secs).into())
+        } else {
+          TagValue::Str("Bulb".into())
+        }
+      } else {
+        TagValue::F64(secs)
+      },
+    });
+  }
+
+  // 0x01 ApertureSetting — `2**(($val/8 - 1)/2)`, PrintFNumber (Sony.pm:5152).
+  push_fnumber_leaf(buf, 0x01, "ApertureSetting", print_conv, &mut out);
+
+  // 0x02 ISOSetting — special hash + `int($val+0.5)` OTHER (Sony.pm:5160-5172).
+  if let Some(&raw) = buf.get(0x02) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ISOSetting",
+      value: iso_setting_value(raw, print_conv),
+    });
+  }
+
+  // 0x03 ExposureCompensationSet — `($val-128)/24`, `%+.1f`|0 (Sony.pm:5174).
+  if let Some(&raw) = buf.get(0x03) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ExposureCompensationSet",
+      value: exposure_comp_value(raw, print_conv),
+    });
+  }
+
+  // 0x04 DriveModeSetting — `PrintHex`, %sonyDriveMode (Sony.pm:5181).
+  push_drive_mode(buf, 0x04, "DriveModeSetting", false, print_conv, &mut out);
+
+  // 0x05 ExposureProgram — %sonyExposureProgram2 (Sony.pm:5206).
+  push_hash(
+    buf,
+    0x05,
+    "ExposureProgram",
+    exposure_program2_u8,
+    print_conv,
+    &mut out,
+  );
+
+  push_hash(
+    buf,
+    0x06,
+    "FocusModeSetting",
+    focus_mode_setting,
+    print_conv,
+    &mut out,
+  );
+  push_hash(
+    buf,
+    0x07,
+    "MeteringMode",
+    metering_mode,
+    print_conv,
+    &mut out,
+  );
+  push_hash(
+    buf,
+    0x09,
+    "SonyImageSize",
+    sony_image_size,
+    print_conv,
+    &mut out,
+  );
+  push_hash(buf, 0x0a, "AspectRatio", aspect_ratio, print_conv, &mut out);
+  push_hash(buf, 0x0b, "Quality", quality, print_conv, &mut out);
+  push_hash(
+    buf,
+    0x0c,
+    "DynamicRangeOptimizerSetting",
+    dro_setting,
+    print_conv,
+    &mut out,
+  );
+
+  // 0x0d DynamicRangeOptimizerLevel — plain int8u (no PrintConv).
+  push_plain(
+    buf,
+    0x0d,
+    "DynamicRangeOptimizerLevel",
+    print_conv,
+    &mut out,
+  );
+
+  push_hash(buf, 0x0e, "ColorSpace", color_space, print_conv, &mut out);
+  push_hash(
+    buf,
+    0x0f,
+    "CreativeStyleSetting",
+    creative_style_setting,
+    print_conv,
+    &mut out,
+  );
+  push_signed(buf, 0x10, "ContrastSetting", print_conv, &mut out);
+  push_signed(buf, 0x11, "SaturationSetting", print_conv, &mut out);
+  push_signed(buf, 0x12, "SharpnessSetting", print_conv, &mut out);
+
+  // 0x16 WhiteBalanceSetting — `PrintHex`, %whiteBalanceSetting (Sony.pm:5306).
+  push_hash_hex(
+    buf,
+    0x16,
+    "WhiteBalanceSetting",
+    white_balance_setting,
+    print_conv,
+    &mut out,
+  );
+
+  // 0x17 ColorTemperatureSetting — `$val*100`, "$val K" (Sony.pm:5314).
+  push_color_temp(buf, 0x17, print_conv, &mut out);
+
+  // 0x18 ColorCompensationFilterSet — int8s `+$val`|$val (Sony.pm:5322).
+  push_signed(
+    buf,
+    0x18,
+    "ColorCompensationFilterSet",
+    print_conv,
+    &mut out,
+  );
+
+  // 0x19 CustomWB_RGBLevels — int16uRev[3] (Sony.pm:5332).
+  push_custom_wb_rgb(buf, 0x19, print_conv, &mut out);
+
+  push_hash(buf, 0x20, "FlashMode", flash_mode, print_conv, &mut out);
+  push_hash(
+    buf,
+    0x21,
+    "FlashControl",
+    flash_control,
+    print_conv,
+    &mut out,
+  );
+
+  // 0x23 FlashExposureCompSet — `($val-128)/24` (Sony.pm:5402).
+  if let Some(&raw) = buf.get(0x23) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "FlashExposureCompSet",
+      value: exposure_comp_value(raw, print_conv),
+    });
+  }
+
+  push_hash(buf, 0x24, "AFAreaMode", af_area_mode, print_conv, &mut out);
+  push_hash(
+    buf,
+    0x25,
+    "LongExposureNoiseReduction",
+    long_exposure_nr,
+    print_conv,
+    &mut out,
+  );
+  push_hash(
+    buf,
+    0x26,
+    "HighISONoiseReduction",
+    high_iso_nr,
+    print_conv,
+    &mut out,
+  );
+  push_hash(
+    buf,
+    0x27,
+    "SmileShutterMode",
+    smile_shutter_mode,
+    print_conv,
+    &mut out,
+  );
+  push_hash(
+    buf,
+    0x28,
+    "RedEyeReduction",
+    red_eye_reduction,
+    print_conv,
+    &mut out,
+  );
+  push_hash(buf, 0x2d, "HDRSetting", hdr_setting, print_conv, &mut out);
+  push_hash(buf, 0x2e, "HDRLevel", hdr_level, print_conv, &mut out);
+  push_hash(buf, 0x2f, "ViewingMode", viewing_mode, print_conv, &mut out);
+  push_hash(
+    buf,
+    0x30,
+    "FaceDetection",
+    face_detection,
+    print_conv,
+    &mut out,
+  );
+  push_hash(
+    buf,
+    0x31,
+    "SmileShutter",
+    smile_shutter,
+    print_conv,
+    &mut out,
+  );
+
+  // 0x32/0x33/0x34/0x35/0x36/0x38 — `Condition => '$$self{Model} !~
+  // /^DSLR-(A450|A500|A550)$/'` (Sony.pm:5491-5615).
+  if other {
+    push_hash(
+      buf,
+      0x32,
+      "SweepPanoramaSize",
+      sweep_panorama_size,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x33,
+      "SweepPanoramaDirection",
+      sweep_panorama_dir,
+      print_conv,
+      &mut out,
+    );
+    push_drive_mode(buf, 0x34, "DriveMode", true, print_conv, &mut out);
+    push_hash(
+      buf,
+      0x35,
+      "MultiFrameNoiseReduction",
+      multi_frame_nr,
+      print_conv,
+      &mut out,
+    );
+  }
+  // 0x36 LiveViewAFSetting / 0x38 PanoramaSize3D — `!~ /^(NEX-|DSLR-A4xx)/`.
+  if other && !nex {
+    push_hash(
+      buf,
+      0x36,
+      "LiveViewAFSetting",
+      live_view_af,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x38,
+      "PanoramaSize3D",
+      panorama_size_3d,
+      print_conv,
+      &mut out,
+    );
+  }
+
+  // 0x83..0x99 — the `!~ /^(NEX-|DSLR-A4xx)/` SLT/DSLR live-view block
+  // (Sony.pm:5524-5614).
+  if other && !nex {
+    push_hash(
+      buf,
+      0x83,
+      "AFButtonPressed",
+      af_button_pressed,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x84,
+      "LiveViewMetering",
+      live_view_metering,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x85,
+      "ViewingMode2",
+      viewing_mode2,
+      print_conv,
+      &mut out,
+    );
+    push_hash(buf, 0x86, "AELock", ae_lock, print_conv, &mut out);
+    push_hash(
+      buf,
+      0x8b,
+      "LiveViewFocusMode",
+      live_view_focus_mode,
+      print_conv,
+      &mut out,
+    );
+  }
+  // 0x87/0x88 FlashStatus — `!~ /^DSLR-(A450|A500|A550)/` (Sony.pm:5564-5580).
+  if other {
+    push_hash(
+      buf,
+      0x87,
+      "FlashStatusBuilt-in",
+      flash_status_builtin,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x88,
+      "FlashStatusExternal",
+      flash_status_external,
+      print_conv,
+      &mut out,
+    );
+  }
+  // 0x99 LensMount — `!~ /^DSLR-A4xx$/`, DataMember (Sony.pm:5604).
+  if other {
+    push_hash(buf, 0x99, "LensMount", lens_mount, print_conv, &mut out);
+  }
+
+  // 0x10c SequenceNumber — OTHER-passthrough (Sony.pm:5638).
+  if other && let Some(&raw) = buf.get(0x10c) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "SequenceNumber",
+      value: sequence_number_value(raw, print_conv),
+    });
+  }
+
+  // 0x0114 FolderNumber (mask 0x00ffc000) + 276.1 ImageNumber (mask
+  // 0x00003fff) — int32u (Sony.pm:5650-5666).
+  if other && let Some(v) = read_u32(buf, 0x0114) {
+    let folder = (v & 0x00ff_c000) >> 14;
+    out.push(SubEmission {
+      priority: 1,
+      name: "FolderNumber",
+      value: masked_count_value(folder, 3, print_conv),
+    });
+    let image = v & 0x0000_3fff;
+    out.push(SubEmission {
+      priority: 1,
+      name: "ImageNumber",
+      value: masked_count_value(image, 4, print_conv),
+    });
+  }
+
+  // 0x200 ShotNumberSincePowerUp2 — int32u (Sony.pm:5675).
+  if other && let Some(v) = read_u32(buf, 0x200) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ShotNumberSincePowerUp2",
+      value: TagValue::I64(i64::from(v)),
+    });
+  }
+
+  // `%CameraSettings3` is `PRIORITY => 0` (Sony.pm:5139): every leaf here is a
+  // `Priority => 0` duplicate, so a higher-priority Main-IFD leaf of the same
+  // name (e.g. the `0x0102` `Quality` = `RAW + JPEG/HEIF`) is NOT overridden.
+  for e in &mut out {
+    e.priority = 0;
+  }
+  out
+}
+
+/// `ExposureProgram` adaptor — `%sonyExposureProgram2` keyed by a `u8`.
+fn exposure_program2_u8(v: u8) -> Option<&'static str> {
+  exposure_program2(u32::from(v))
+}
+
+/// Push a `2**(($val/8 - 1)/2)` + PrintFNumber leaf at `off`.
+fn push_fnumber_leaf(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    let fnum = 2f64.powf((f64::from(raw) / 8.0 - 1.0) / 2.0);
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: if print_conv {
+        TagValue::Str(print_fnumber(fnum).into())
+      } else {
+        TagValue::F64(fnum)
+      },
+    });
+  }
+}
+
+/// Push a plain `int8u` leaf (no conversion) at `off`.
+fn push_plain(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  _print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: TagValue::I64(i64::from(raw)),
+    });
+  }
+}
+
+/// Push an `int8s` `+$val`/$val signed-setting leaf at `off`.
+fn push_signed(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: signed_setting_value(raw as i8, print_conv),
+    });
+  }
+}
+
+/// Push a `PrintHex` hash leaf honouring the `Unknown (0x%x)` miss.
+fn push_hash_hex(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  hit: impl Fn(u32) -> Option<&'static str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: hash_hex_value(u32::from(raw), hit(u32::from(raw)), print_conv),
+    });
+  }
+}
+
+/// Push the `DriveMode`-family `PrintHex` hash leaf.
+fn push_drive_mode(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  extended: bool,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: hash_hex_value(
+        u32::from(raw),
+        drive_mode(u32::from(raw), extended),
+        print_conv,
+      ),
+    });
+  }
+}
+
+/// Push the `ColorTemperatureSetting` (`$val*100`, `"$val K"`) leaf.
+fn push_color_temp(buf: &[u8], off: usize, print_conv: bool, out: &mut Vec<SubEmission>) {
+  if let Some(&raw) = buf.get(off) {
+    let k = u32::from(raw) * 100;
+    out.push(SubEmission {
+      priority: 1,
+      name: "ColorTemperatureSetting",
+      value: if print_conv {
+        TagValue::Str(SmolStr::new(std::format!("{k} K")))
+      } else {
+        TagValue::I64(i64::from(k))
+      },
+    });
+  }
+}
+
+/// Push `CustomWB_RGBLevels` — `int16uRev[3]` (big-endian `int16u` triple,
+/// space-joined). `-n` is the same space-joined string (no ValueConv).
+fn push_custom_wb_rgb(buf: &[u8], off: usize, _print_conv: bool, out: &mut Vec<SubEmission>) {
+  if let Some(&[a0, a1, b0, b1, c0, c1]) = buf.get(off..off + 6) {
+    let a = u16::from_be_bytes([a0, a1]);
+    let b = u16::from_be_bytes([b0, b1]);
+    let c = u16::from_be_bytes([c0, c1]);
+    out.push(SubEmission {
+      priority: 1,
+      name: "CustomWB_RGBLevels",
+      value: TagValue::Str(SmolStr::new(std::format!("{a} {b} {c}"))),
+    });
+  }
+}
+
+/// `ISOSetting` value (`Sony.pm:5160-5172`): `ValueConv` `($val and $val<254) ?
+/// exp(...)*100 : $val`, PrintConv hash with `0 => Auto`, `254 => n/a`, OTHER
+/// `int($val+0.5)`.
+fn iso_setting_value(raw: u8, print_conv: bool) -> TagValue {
+  let vc = if raw != 0 && raw < 254 {
+    (((f64::from(raw) / 8.0 - 6.0) * core::f64::consts::LN_2).exp()) * 100.0
+  } else {
+    f64::from(raw)
+  };
+  if !print_conv {
+    // `-n`: the ValueConv result. For 0 / 254 it is the raw integer.
+    return if raw != 0 && raw < 254 {
+      TagValue::F64(vc)
+    } else {
+      TagValue::I64(i64::from(raw))
+    };
+  }
+  match raw {
+    0 => TagValue::Str("Auto".into()),
+    254 => TagValue::Str("n/a".into()),
+    _ => TagValue::I64((vc + 0.5) as i64),
+  }
+}
+
+/// `SonyImageSize` PrintConv (`Sony.pm:5235-5244`).
+fn sony_image_size(v: u8) -> Option<&'static str> {
+  Some(match v {
+    21 => "Large (3:2)",
+    22 => "Medium (3:2)",
+    23 => "Small (3:2)",
+    25 => "Large (16:9)",
+    26 => "Medium (16:9)",
+    27 => "Small (16:9)",
+    _ => return None,
+  })
+}
+
+/// `AspectRatio` PrintConv (`4 => 3:2`, `8 => 16:9`).
+fn aspect_ratio(v: u8) -> Option<&'static str> {
+  Some(match v {
+    4 => "3:2",
+    8 => "16:9",
+    _ => return None,
+  })
+}
+
+/// `Quality` PrintConv (`2 => RAW`, `4 => RAW + JPEG`, `6 => Fine`,
+/// `7 => Standard`).
+fn quality(v: u8) -> Option<&'static str> {
+  Some(match v {
+    2 => "RAW",
+    4 => "RAW + JPEG",
+    6 => "Fine",
+    7 => "Standard",
+    _ => return None,
+  })
+}
+
+/// `FlashControl` PrintConv (`1 => ADI Flash`, `2 => Pre-flash TTL`).
+fn flash_control(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "ADI Flash",
+    2 => "Pre-flash TTL",
+    _ => return None,
+  })
+}
+
+/// `AFAreaMode` PrintConv (`Sony.pm:5413-5420`).
+fn af_area_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Wide",
+    2 => "Spot",
+    3 => "Local",
+    4 => "Flexible",
+    _ => return None,
+  })
+}
+
+/// `SmileShutterMode` PrintConv (`17 => Slight Smile`, `18 => Normal Smile`,
+/// `19 => Big Smile`).
+fn smile_shutter_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    17 => "Slight Smile",
+    18 => "Normal Smile",
+    19 => "Big Smile",
+    _ => return None,
+  })
+}
+
+/// `RedEyeReduction` PrintConv (`1 => Off`, `16 => On`).
+fn red_eye_reduction(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On",
+    _ => return None,
+  })
+}
+
+/// `SmileShutter` PrintConv (`1 => Off`, `16 => On`).
+fn smile_shutter(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On",
+    _ => return None,
+  })
+}
+
+/// `SweepPanoramaSize` PrintConv (`1 => Standard`, `2 => Wide`).
+fn sweep_panorama_size(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Standard",
+    2 => "Wide",
+    _ => return None,
+  })
+}
+
+/// `SweepPanoramaDirection` PrintConv (`1 => Right`, `2 => Left`, `3 => Up`,
+/// `4 => Down`).
+fn sweep_panorama_dir(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Right",
+    2 => "Left",
+    3 => "Up",
+    4 => "Down",
+    _ => return None,
+  })
+}
+
+/// `MultiFrameNoiseReduction` PrintConv (`Sony.pm:5481-5489`).
+fn multi_frame_nr(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    1 => "Off",
+    16 => "On",
+    255 => "None",
+    _ => return None,
+  })
+}
+
+/// `LiveViewAFSetting` PrintConv (`0 => n/a`, `1 => Phase-detect AF`,
+/// `2 => Contrast AF`).
+fn live_view_af(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    1 => "Phase-detect AF",
+    2 => "Contrast AF",
+    _ => return None,
+  })
+}
+
+/// `PanoramaSize3D` PrintConv (`Sony.pm:5512-5519`).
+fn panorama_size_3d(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    1 => "Standard",
+    2 => "Wide",
+    3 => "16:9",
+    _ => return None,
+  })
+}
+
+/// `AFButtonPressed` PrintConv (`1 => No`, `16 => Yes`).
+fn af_button_pressed(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "No",
+    16 => "Yes",
+    _ => return None,
+  })
+}
+
+/// `LiveViewMetering` PrintConv (`0 => n/a`, `16 => 40 Segment`,
+/// `32 => 1200-zone Evaluative`).
+fn live_view_metering(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    16 => "40 Segment",
+    32 => "1200-zone Evaluative",
+    _ => return None,
+  })
+}
+
+/// `ViewingMode2` PrintConv (`Sony.pm:5547-5553`).
+fn viewing_mode2(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    16 => "Viewfinder",
+    33 => "Focus Check Live View",
+    34 => "Quick AF Live View",
+    _ => return None,
+  })
+}
+
+/// `AELock` PrintConv (`1 => On`, `2 => Off`).
+fn ae_lock(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "On",
+    2 => "Off",
+    _ => return None,
+  })
+}
+
+/// `FlashStatusBuilt-in` PrintConv (`1 => Off`, `2 => On`).
+fn flash_status_builtin(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    2 => "On",
+    _ => return None,
+  })
+}
+
+/// `FlashStatusExternal` PrintConv (`1 => None`, `2 => Off`, `3 => On`).
+fn flash_status_external(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "None",
+    2 => "Off",
+    3 => "On",
+    _ => return None,
+  })
+}
+
+/// `LiveViewFocusMode` PrintConv (`0 => n/a`, `1 => AF`, `16 => Manual`).
+fn live_view_focus_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    1 => "AF",
+    16 => "Manual",
+    _ => return None,
+  })
+}
+
+/// `LensMount` PrintConv (`1 => Unknown`, `16 => A-mount`, `17 => E-mount`).
+fn lens_mount(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Unknown",
+    16 => "A-mount",
+    17 => "E-mount",
+    _ => return None,
+  })
+}
+
+/// `SequenceNumber` value (`Sony.pm:5621-5644`): `0 => Single`, `255 => n/a`,
+/// OTHER passthrough. `-n` is the raw integer.
+fn sequence_number_value(raw: u8, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(raw));
+  }
+  match raw {
+    0 => TagValue::Str("Single".into()),
+    255 => TagValue::Str("n/a".into()),
+    n => TagValue::I64(i64::from(n)),
+  }
+}
+
+/// A masked count (`FolderNumber`/`ImageNumber`): `sprintf("%.Nd", $val)` in
+/// `-j`; the raw masked integer in `-n`.
+fn masked_count_value(val: u32, width: usize, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(val));
+  }
+  TagValue::Str(SmolStr::new(std::format!("{val:0width$}")))
+}

--- a/src/exif/makernotes/vendors/sony/camerasettings3_tests.rs
+++ b/src/exif/makernotes/vendors/sony/camerasettings3_tests.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Sony::CameraSettings3` model-anchor regression. The A4xx conditions in this
+//! table come in TWO anchor flavors (never `\b`): most leaves are `$`-anchored
+//! EXACT (`!~ /^DSLR-(A450|A500|A550)$/`, e.g. 0x32 `SweepPanoramaSize`, 0x99
+//! `LensMount`) while 0x87/0x88 `FlashStatus*` are the no-anchor PREFIX
+//! (`!~ /^DSLR-(A450|A500|A550)/`). A single `\b` bool was wrong in OPPOSITE
+//! directions for a suffixed A4xx string.
+
+use super::*;
+
+fn has(model: &str, buf: &[u8], name: &str) -> bool {
+  parse_camera_settings3(buf, Some(model), true)
+    .iter()
+    .any(|e| e.name == name)
+}
+
+#[test]
+fn a4xx_anchors_split_exact_vs_prefix() {
+  let mut buf = vec![0u8; 0x210];
+  buf[0x32] = 1; // SweepPanoramaSize = Standard  ($-exact)
+  buf[0x87] = 1; // FlashStatusBuilt-in = Off      (prefix)
+  buf[0x99] = 16; // LensMount = A-mount            ($-exact)
+
+  // SLT-A33 (not an A4xx): every probed leaf present.
+  assert!(has("SLT-A33", &buf, "SweepPanoramaSize"));
+  assert!(has("SLT-A33", &buf, "FlashStatusBuilt-in"));
+  assert!(has("SLT-A33", &buf, "LensMount"));
+
+  // Real exact A4xx bodies: ALL anchors exclude them.
+  for m in ["DSLR-A450", "DSLR-A500", "DSLR-A550"] {
+    assert!(!has(m, &buf, "SweepPanoramaSize"), "{m} 0x32 ($-exact)");
+    assert!(!has(m, &buf, "FlashStatusBuilt-in"), "{m} 0x87 (prefix)");
+    assert!(!has(m, &buf, "LensMount"), "{m} 0x99 ($-exact)");
+  }
+
+  // Suffixed A4xx strings: the `$`-exact leaves EMIT (not an exact match — the
+  // `\b` port wrongly dropped the hyphen form), but the PREFIX 0x87/0x88 are
+  // EXCLUDED (a prefix match — the `\b` port wrongly emitted the alnum form).
+  for m in ["DSLR-A500-x", "DSLR-A500X"] {
+    assert!(
+      has(m, &buf, "SweepPanoramaSize"),
+      "{m} 0x32 must emit ($-exact)"
+    );
+    assert!(has(m, &buf, "LensMount"), "{m} 0x99 must emit ($-exact)");
+    assert!(
+      !has(m, &buf, "FlashStatusBuilt-in"),
+      "{m} 0x87 must be excluded (prefix)"
+    );
+  }
+}

--- a/src/exif/makernotes/vendors/sony/extrainfo3.rs
+++ b/src/exif/makernotes/vendors/sony/extrainfo3.rs
@@ -15,7 +15,7 @@ use crate::value::TagValue;
 use smol_str::SmolStr;
 
 use super::subtables::{
-  SubEmission, model_is_dslr, model_is_nex_battery_excl, model_is_slt, read_u16,
+  SubEmission, model_is_a4xx_9pt, model_is_dslr, model_is_nex_battery_excl, model_is_slt, read_u16,
 };
 
 /// Walk the `ExtraInfo3` block and emit the battery/orientation leaves.
@@ -72,14 +72,26 @@ pub fn parse_extra_info3(buf: &[u8], model: Option<&str>, print_conv: bool) -> V
     });
   }
 
-  // 0x0014 — conditional ARRAY: BatteryState (SLT), ExposureProgram (A4xx),
-  // ModeDialPosition (other DSLR) (Sony.pm:5992-6038).
+  // 0x0014 — conditional ARRAY (`Sony.pm:5989-6035`), evaluated in table order
+  // (first match wins):
+  //   BatteryState     — `Model =~ /^SLT-/`
+  //   ExposureProgram  — `Model =~ /^DSLR-(A450|A500|A550)\b/` (`Priority => 0`)
+  //   ModeDialPosition — `Model =~ /^DSLR-/` (the other DSLR bodies)
+  // The A4xx branch must precede the generic DSLR branch: ExifTool reads this
+  // byte as ExposureProgram for the A450/A500/A550, NOT ModeDialPosition.
   if let Some(&raw) = buf.get(0x0014) {
     if model_is_slt(model) {
       out.push(SubEmission {
         priority: 1,
         name: "BatteryState",
         value: super::hash_print_value(raw, battery_state(raw), print_conv),
+      });
+    } else if model_is_a4xx_9pt(model) {
+      // `Priority => 0` (`Sony.pm:6006` — "some unknown values").
+      out.push(SubEmission {
+        priority: 0,
+        name: "ExposureProgram",
+        value: super::hash_print_value(raw, exposure_program_a4xx(raw), print_conv),
       });
     } else if model_is_dslr(model) {
       out.push(SubEmission {
@@ -147,6 +159,25 @@ fn battery_state(v: u8) -> Option<&'static str> {
   })
 }
 
+/// `ExposureProgram` PrintConv (A450/A500/A550 only; `Sony.pm:6007-6018`). The
+/// `Priority => 0` 0x0014 branch for the 9-point DSLR bodies — a DISTINCT table
+/// from `%sonyExposureProgram2` (the `MoreSettings`/`CameraSettings3`
+/// `ExposureProgram`).
+fn exposure_program_a4xx(v: u8) -> Option<&'static str> {
+  Some(match v {
+    241 => "Landscape",
+    243 => "Aperture-priority AE",
+    245 => "Portrait",
+    246 => "Auto",
+    247 => "Program AE",
+    249 => "Macro",
+    252 => "Sunset",
+    253 => "Sports",
+    255 => "Manual",
+    _ => return None,
+  })
+}
+
 /// `ModeDialPosition` PrintConv (other DSLR models; `Sony.pm:6024-6034`).
 fn mode_dial_position(v: u8) -> Option<&'static str> {
   Some(match v {
@@ -172,3 +203,11 @@ fn camera_orientation(v: u32) -> Option<&'static str> {
     _ => return None,
   })
 }
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "extrainfo3_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/extrainfo3.rs
+++ b/src/exif/makernotes/vendors/sony/extrainfo3.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::ExtraInfo3` (`Sony.pm:5919-6090`) — the `0x0116`
+//! Main-table SubDirectory holding extra hardware (battery) info for the
+//! A33/A35/A55, A450/A500/A550, A560/A580 and NEX-3/5/C3/VG10.
+//!
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range
+//! is in the block AND its model `Condition` holds
+//! ([[exifast-processbinarydata-per-field]]). The `BatteryUnknown` (0x0000) leaf
+//! carries `Unknown => 1`, so it is suppressed at default verbosity (matching
+//! the golden, which omits it).
+
+use crate::value::TagValue;
+use smol_str::SmolStr;
+
+use super::subtables::{
+  SubEmission, model_is_dslr, model_is_nex_battery_excl, model_is_slt, read_u16,
+};
+
+/// Walk the `ExtraInfo3` block and emit the battery/orientation leaves.
+///
+/// `buf` is the verbatim (un-enciphered) `0x0116` block; `model` is
+/// `$$self{Model}`; `print_conv` selects `-j` vs `-n`.
+#[must_use]
+pub fn parse_extra_info3(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+  let nex_excl = model_is_nex_battery_excl(model);
+
+  // 0x0002 BatteryTemperature — int8u (no Format ⇒ the `%binaryDataAttrs`
+  // default), `($val-32)/1.8`, `%.1f C` (Sony.pm:5932-5938).
+  if let Some(&raw) = buf.get(0x0002) {
+    let celsius = (f64::from(raw) - 32.0) / 1.8;
+    out.push(SubEmission {
+      priority: 1,
+      name: "BatteryTemperature",
+      value: if print_conv {
+        TagValue::Str(SmolStr::new(std::format!("{celsius:.1} C")))
+      } else {
+        TagValue::F64(celsius)
+      },
+    });
+  }
+
+  // 0x0004 BatteryLevel — int8u (no Format), `"$val%"` (Sony.pm:5940).
+  if let Some(&raw) = buf.get(0x0004) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "BatteryLevel",
+      value: if print_conv {
+        TagValue::Str(SmolStr::new(std::format!("{raw}%")))
+      } else {
+        TagValue::I64(i64::from(raw))
+      },
+    });
+  }
+
+  // 0x0006 BatteryVoltage1 / 0x0008 BatteryVoltage2 — int16u, `$val/128`,
+  // `%.2f V`; `Condition !~ NEX-(3|5|5C|C3|VG10|VG10E)` (Sony.pm:5954-5970).
+  if !nex_excl {
+    push_voltage(buf, 0x0006, "BatteryVoltage1", print_conv, &mut out);
+    push_voltage(buf, 0x0008, "BatteryVoltage2", print_conv, &mut out);
+  }
+
+  // 0x0011 ImageStabilization — int8u, `0 => Off`, `64 => On`;
+  // `Condition !~ NEX-...` (Sony.pm:5982-5990).
+  if !nex_excl && let Some(&raw) = buf.get(0x0011) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ImageStabilization",
+      value: super::hash_print_value(raw, image_stabilization(raw), print_conv),
+    });
+  }
+
+  // 0x0014 — conditional ARRAY: BatteryState (SLT), ExposureProgram (A4xx),
+  // ModeDialPosition (other DSLR) (Sony.pm:5992-6038).
+  if let Some(&raw) = buf.get(0x0014) {
+    if model_is_slt(model) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "BatteryState",
+        value: super::hash_print_value(raw, battery_state(raw), print_conv),
+      });
+    } else if model_is_dslr(model) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "ModeDialPosition",
+        value: super::hash_print_value(raw, mode_dial_position(raw), print_conv),
+      });
+    }
+  }
+
+  // 0x0018 CameraOrientation — int8u, Mask 0x30 (>> 4), plain hash, `!~ NEX-...`
+  // (Sony.pm:6079-6090). `-n` emits the masked integer.
+  if !nex_excl && let Some(&raw) = buf.get(0x0018) {
+    let masked = (raw & 0x30) >> 4;
+    out.push(SubEmission {
+      priority: 1,
+      name: "CameraOrientation",
+      value: super::hash_print_value(masked, camera_orientation(u32::from(masked)), print_conv),
+    });
+  }
+
+  out
+}
+
+/// Push a `$val/128` → `%.2f V` int16u battery-voltage leaf at `off`.
+fn push_voltage(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(raw) = read_u16(buf, off) {
+    let v = f64::from(raw) / 128.0;
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: if print_conv {
+        TagValue::Str(SmolStr::new(std::format!("{v:.2} V")))
+      } else {
+        TagValue::F64(v)
+      },
+    });
+  }
+}
+
+/// `ImageStabilization` PrintConv (`0 => Off`, `64 => On`).
+fn image_stabilization(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    64 => "On",
+    _ => return None,
+  })
+}
+
+/// `BatteryState` PrintConv (SLT models; `Sony.pm:6001-6007`).
+fn battery_state(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Empty",
+    2 => "Low",
+    3 => "Half full",
+    4 => "Almost full",
+    5 => "Full",
+    _ => return None,
+  })
+}
+
+/// `ModeDialPosition` PrintConv (other DSLR models; `Sony.pm:6024-6034`).
+fn mode_dial_position(v: u8) -> Option<&'static str> {
+  Some(match v {
+    248 => "No Flash",
+    249 => "Aperture-priority AE",
+    250 => "SCN",
+    251 => "Shutter speed priority AE",
+    252 => "Auto",
+    253 => "Program AE",
+    254 => "Panorama",
+    255 => "Manual",
+    _ => return None,
+  })
+}
+
+/// `CameraOrientation` PrintConv (`Sony.pm:6083-6088`).
+fn camera_orientation(v: u32) -> Option<&'static str> {
+  Some(match v {
+    0 => "Horizontal (normal)",
+    1 => "Rotate 90 CW",
+    2 => "Rotate 270 CW",
+    3 => "Rotate 180",
+    _ => return None,
+  })
+}

--- a/src/exif/makernotes/vendors/sony/extrainfo3_tests.rs
+++ b/src/exif/makernotes/vendors/sony/extrainfo3_tests.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `ExtraInfo3` 0x0014 conditional-array routing (`Sony.pm:5989-6035`):
+//! `BatteryState` (SLT), `ExposureProgram` (A450/A500/A550, `Priority => 0`),
+//! `ModeDialPosition` (the other DSLR bodies).
+
+use super::*;
+
+/// A minimal `ExtraInfo3` block (`int8u` default format ⇒ key = byte offset)
+/// with the 0x0014 byte set to `v`; everything else zero.
+fn block_with_0x14(v: u8) -> Vec<u8> {
+  let mut buf = vec![0u8; 0x20];
+  buf[0x14] = v;
+  buf
+}
+
+fn find<'a>(out: &'a [SubEmission], name: &str) -> Option<&'a SubEmission> {
+  out.iter().find(|e| e.name == name)
+}
+
+/// The A4xx (DSLR-A500) routes 0x0014 to `ExposureProgram` (NOT
+/// `ModeDialPosition`): 247 => 'Program AE', carried at `Priority => 0`.
+#[test]
+fn a4xx_routes_0x14_to_exposure_program() {
+  let buf = block_with_0x14(247);
+  let out = parse_extra_info3(&buf, Some("DSLR-A500"), true);
+  let ep = find(&out, "ExposureProgram").expect("ExposureProgram emitted");
+  assert_eq!(ep.value, TagValue::Str("Program AE".into()));
+  assert_eq!(ep.priority, 0, "Sony.pm Priority => 0");
+  assert!(
+    find(&out, "ModeDialPosition").is_none(),
+    "A4xx must NOT fabricate a ModeDialPosition"
+  );
+  assert!(find(&out, "BatteryState").is_none());
+}
+
+/// `-n` keeps the raw byte for the A4xx ExposureProgram.
+#[test]
+fn a4xx_exposure_program_numeric() {
+  let buf = block_with_0x14(247);
+  let out = parse_extra_info3(&buf, Some("DSLR-A500"), false);
+  assert_eq!(
+    find(&out, "ExposureProgram").map(|e| &e.value),
+    Some(&TagValue::I64(247))
+  );
+}
+
+/// An A4xx ExposureProgram value not in the table renders the hash-miss
+/// `"Unknown (N)"` (decimal; no `PrintHex`).
+#[test]
+fn a4xx_exposure_program_unknown_value() {
+  let buf = block_with_0x14(242);
+  let out = parse_extra_info3(&buf, Some("DSLR-A550"), true);
+  assert_eq!(
+    find(&out, "ExposureProgram").map(|e| &e.value),
+    Some(&TagValue::Str("Unknown (242)".into()))
+  );
+}
+
+/// Each A4xx body (A450/A500/A550, with the `\b` boundary) takes the
+/// ExposureProgram branch.
+#[test]
+fn all_a4xx_bodies_route_to_exposure_program() {
+  for model in ["DSLR-A450", "DSLR-A500", "DSLR-A550"] {
+    let buf = block_with_0x14(255); // 255 => 'Manual'
+    let out = parse_extra_info3(&buf, Some(model), true);
+    assert_eq!(
+      find(&out, "ExposureProgram").map(|e| &e.value),
+      Some(&TagValue::Str("Manual".into())),
+      "model={model}"
+    );
+    assert!(find(&out, "ModeDialPosition").is_none(), "model={model}");
+  }
+}
+
+/// The SLT body (A33) still routes 0x0014 to `BatteryState` — the activation
+/// golden's path, unchanged.
+#[test]
+fn slt_routes_0x14_to_battery_state() {
+  let buf = block_with_0x14(5); // 5 => 'Full'
+  let out = parse_extra_info3(&buf, Some("SLT-A33"), true);
+  let bs = find(&out, "BatteryState").expect("BatteryState emitted");
+  assert_eq!(bs.value, TagValue::Str("Full".into()));
+  assert_eq!(bs.priority, 1);
+  assert!(find(&out, "ExposureProgram").is_none());
+  assert!(find(&out, "ModeDialPosition").is_none());
+}
+
+/// A non-A4xx DSLR (A580) routes 0x0014 to `ModeDialPosition`.
+#[test]
+fn other_dslr_routes_0x14_to_mode_dial_position() {
+  let buf = block_with_0x14(252); // 252 => 'Auto'
+  let out = parse_extra_info3(&buf, Some("DSLR-A580"), true);
+  let md = find(&out, "ModeDialPosition").expect("ModeDialPosition emitted");
+  assert_eq!(md.value, TagValue::Str("Auto".into()));
+  assert_eq!(md.priority, 1);
+  assert!(find(&out, "ExposureProgram").is_none());
+  assert!(find(&out, "BatteryState").is_none());
+}

--- a/src/exif/makernotes/vendors/sony/mod.rs
+++ b/src/exif/makernotes/vendors/sony/mod.rs
@@ -71,12 +71,18 @@
 #![deny(clippy::indexing_slicing)]
 
 pub mod amount_lens_types;
+pub mod camerainfo3;
+pub mod camerasettings3;
 pub mod decipher;
+pub mod extrainfo3;
 pub mod lens_types;
 pub mod model_ids;
+pub mod moreinfo;
 pub mod printconv;
 pub mod sr2;
+pub mod subtables;
 pub mod tag202a;
+pub mod tag900b;
 pub mod tag9050;
 pub mod tag9400;
 pub mod tag9401;

--- a/src/exif/makernotes/vendors/sony/moreinfo.rs
+++ b/src/exif/makernotes/vendors/sony/moreinfo.rs
@@ -26,8 +26,8 @@ use smol_str::SmolStr;
 
 use super::subtables::{
   SubEmission, drive_mode, exposure_comp_value, exposure_comp2_value, exposure_program2,
-  hash_hex_value, model_is_a4xx_9pt, model_is_nex355c, read_i16, read_u16, read_u32,
-  signed_setting_value, white_balance_setting,
+  hash_hex_value, model_is_a4xx_9pt, model_is_a4xx_exact, model_is_nex355c, read_i16, read_u16,
+  read_u32, signed_setting_value, white_balance_setting,
 };
 
 /// Walk the `MoreInfo` index directory and emit the leaves of the four ported
@@ -105,7 +105,12 @@ pub fn parse_more_info(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec
         parse_more_settings(block, model, print_conv, &mut out);
         0
       }
-      0x0002 if !model_is_a4xx_9pt(model) => {
+      // FaceInfo vs FaceInfoA is the `$`-anchored EXACT selector
+      // (`Sony.pm:3398`/`3402`): `FaceInfoA` only for a model EQUAL to
+      // DSLR-A450/A500/A550, else this non-A4xx `FaceInfo` — so a suffixed body
+      // still parses FaceInfo. This is NOT the `\b` `model_is_a4xx_9pt` used for
+      // the ExtraInfo3 0x0014 / MoreSettings conditions.
+      0x0002 if !model_is_a4xx_exact(model) => {
         parse_face_info(block, print_conv, &mut out);
         1
       }
@@ -301,29 +306,77 @@ fn parse_more_settings(
   }
 }
 
-/// `%Sony::FaceInfo` (`Sony.pm:4062-4123`) — FORMAT int16u; 0x00 FacesDetected
-/// (int16s RawConv). Only the count leaf is camera-metadata-relevant for the
-/// activation golden (the per-face position rects are gated by FacesDetected and
-/// not present when 0).
+/// `%Sony::FaceInfo` (`Sony.pm:4062-4122`) — the non-A4xx `FaceInfo` variant the
+/// A33-class dispatches (`MoreInfo` 0x0002 when
+/// `Model !~ /^DSLR-(A450|A500|A550)$/`; the A4xx `FaceInfoA` is deferred).
+///
+/// `FORMAT => 'int16u'` ⇒ the `ProcessBinaryData` increment is 2, so a table key
+/// `K` addresses BYTE `K*2` (`ExifTool.pm:9933`). 0x00 `FacesDetected` is
+/// `int16s` with `RawConv => '$$self{FacesDetected} = ($val == -1 ? 0 : $val);
+/// $val'` — the emitted value is the original `$val` (`-1 => 'n/a'` in `-j`),
+/// while the per-face DataMember gate folds `-1` to `0`. Keys
+/// 0x01/0x06/0x0b/0x10/0x15/0x1a/0x1f/0x24 are `Face1..8Position` (`int16u[4]`),
+/// each emitted IFF `FacesDetected >= N` AND its full 8-byte range is in-block
+/// ([[exifast-processbinarydata-per-field]]).
 fn parse_face_info(buf: &[u8], print_conv: bool, out: &mut Vec<SubEmission>) {
-  // 0x00 FacesDetected — int16s, RawConv `($val == -1 ? 0 : $val)`, PrintConv
-  // `-1 => 'n/a'`, OTHER passthrough.
-  if let Some(raw) = read_i16(buf, 0x00) {
-    let value = if print_conv {
-      if raw == -1 {
-        TagValue::Str("n/a".into())
-      } else {
-        TagValue::I64(i64::from(raw))
-      }
-    } else {
-      TagValue::I64(i64::from(raw))
-    };
-    out.push(SubEmission {
-      priority: 1,
-      name: "FacesDetected",
-      value,
-    });
+  // 0x00 FacesDetected — int16s at byte 0 (key 0x00 × 2).
+  let Some(raw) = read_i16(buf, 0x00) else {
+    return;
+  };
+  let value = if print_conv && raw == -1 {
+    TagValue::Str("n/a".into())
+  } else {
+    TagValue::I64(i64::from(raw))
+  };
+  out.push(SubEmission {
+    priority: 1,
+    name: "FacesDetected",
+    value,
+  });
+
+  // DataMember gate for the per-face rows: `($val == -1 ? 0 : $val)`.
+  let faces = if raw == -1 { 0 } else { raw };
+
+  // Face1..8Position — `int16u[4]` at byte (key × 2), gated by
+  // `FacesDetected >= N`. `%faceInfo` has no PrintConv, so `-j` and `-n` render
+  // the same re-ordered/scaled string.
+  const FACES: [(i16, &str, usize); 8] = [
+    (1, "Face1Position", 0x01),
+    (2, "Face2Position", 0x06),
+    (3, "Face3Position", 0x0b),
+    (4, "Face4Position", 0x10),
+    (5, "Face5Position", 0x15),
+    (6, "Face6Position", 0x1a),
+    (7, "Face7Position", 0x1f),
+    (8, "Face8Position", 0x24),
+  ];
+  for (n, name, key) in FACES {
+    if faces < n {
+      continue;
+    }
+    if let Some(value) = face_position_value(buf, key * 2) {
+      out.push(SubEmission {
+        priority: 1,
+        name,
+        value,
+      });
+    }
   }
+}
+
+/// `%faceInfo` (`Sony.pm:4056-4061`) — read the `int16u[4]` rectangle at `byte`
+/// (LE), then `ValueConv => 'my @v=split(" ",$val); $_*=15 foreach @v;
+/// "$v[1] $v[0] $v[3] $v[2]"'`: scale each ×15 and re-order to top, left,
+/// height, width. `None` when the full 8-byte range is not in-block.
+fn face_position_value(buf: &[u8], byte: usize) -> Option<TagValue> {
+  let v0 = u32::from(read_u16(buf, byte)?);
+  let v1 = u32::from(read_u16(buf, byte + 2)?);
+  let v2 = u32::from(read_u16(buf, byte + 4)?);
+  let v3 = u32::from(read_u16(buf, byte + 6)?);
+  let (top, left, height, width) = (v1 * 15, v0 * 15, v3 * 15, v2 * 15);
+  Some(TagValue::Str(SmolStr::new(std::format!(
+    "{top} {left} {height} {width}"
+  ))))
 }
 
 /// `%Sony::MoreInfo0201` (`Sony.pm:3457-3497`) — ImageCount (0x011b) +
@@ -792,3 +845,11 @@ fn push_focal_length2(buf: &[u8], off: usize, out: &mut Vec<SubEmission>, print_
     });
   }
 }
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "moreinfo_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/moreinfo.rs
+++ b/src/exif/makernotes/vendors/sony/moreinfo.rs
@@ -26,7 +26,7 @@ use smol_str::SmolStr;
 
 use super::subtables::{
   SubEmission, drive_mode, exposure_comp_value, exposure_comp2_value, exposure_program2,
-  hash_hex_value, model_is_a4xx_9pt, model_is_a4xx_exact, model_is_nex355c, read_i16, read_u16,
+  hash_hex_value, model_is_a4xx_exact, model_is_a4xx_prefix, model_is_nex355c, read_i16, read_u16,
   read_u32, signed_setting_value, white_balance_setting,
 };
 
@@ -108,8 +108,8 @@ pub fn parse_more_info(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec
       // FaceInfo vs FaceInfoA is the `$`-anchored EXACT selector
       // (`Sony.pm:3398`/`3402`): `FaceInfoA` only for a model EQUAL to
       // DSLR-A450/A500/A550, else this non-A4xx `FaceInfo` — so a suffixed body
-      // still parses FaceInfo. This is NOT the `\b` `model_is_a4xx_9pt` used for
-      // the ExtraInfo3 0x0014 / MoreSettings conditions.
+      // still parses FaceInfo. This is NOT the `\b` `model_is_a4xx_9pt` (the
+      // ExtraInfo3 0x0014 / CameraInfo3 9-point-AF condition).
       0x0002 if !model_is_a4xx_exact(model) => {
         parse_face_info(block, print_conv, &mut out);
         1
@@ -155,9 +155,17 @@ fn parse_more_settings(
   print_conv: bool,
   out: &mut Vec<SubEmission>,
 ) {
-  let a4xx = model_is_a4xx_9pt(model);
+  // Two A4xx anchor flavors live in this table: 0x13/0x15 are `$`-anchored EXACT
+  // (`/^DSLR-(A450|A500|A550)$/`), while every overlapping-offset `other` leaf
+  // (0x1e..0x86) is the no-anchor PREFIX (`/^DSLR-(A450|A500|A550)/`). A single
+  // `\b` bool is wrong in OPPOSITE directions for a suffixed A4xx string, so
+  // split them.
+  let a4xx_exact = model_is_a4xx_exact(model);
+  let a4xx_prefix = model_is_a4xx_prefix(model);
   let nex355c = model_is_nex355c(model);
-  let other = !a4xx && !nex355c; // the `!~ NEX-(3|5|5C)|DSLR-A4xx` class
+  // `!~ /^NEX-(3|5|5C)|DSLR-(A450|A500|A550)/` — the prefix-A4xx + NEX-3/5/5C
+  // exclusion shared by the 0x1e..0x86 overlapping leaves.
+  let other = !a4xx_prefix && !nex355c;
 
   // 0x01 DriveMode2 — PrintHex, %sonyDriveMode (Sony.pm:3534).
   push_hash_hex(
@@ -228,8 +236,9 @@ fn parse_more_settings(
     print_conv,
     out,
   );
-  // 0x13 FocusMode — `!~ DSLR-A4xx` (Sony.pm:3650).
-  if !a4xx {
+  // 0x13 FocusMode — `!~ /^DSLR-(A450|A500|A550)$/` ($-anchored EXACT,
+  // Sony.pm:3662).
+  if !a4xx_exact {
     push_hash(
       buf,
       0x13,
@@ -239,8 +248,9 @@ fn parse_more_settings(
       out,
     );
   }
-  // 0x15 MultiFrameNoiseReduction — `!~ DSLR-A4xx` (Sony.pm:3664).
-  if !a4xx {
+  // 0x15 MultiFrameNoiseReduction — `!~ /^DSLR-(A450|A500|A550)$/` ($-anchored
+  // EXACT, Sony.pm:3673).
+  if !a4xx_exact {
     push_hash(
       buf,
       0x15,
@@ -272,9 +282,11 @@ fn parse_more_settings(
       print_conv,
       out,
     );
-    // 0x25 ISO — `!~ DSLR-A4xx` (Sony.pm:3784).
+    // 0x25 ISO — variant 2, `!~ /^DSLR-(A450|A500|A550)/` (no-anchor PREFIX,
+    // Sony.pm:3843).
     push_iso(buf, 0x25, out, print_conv);
-    // 0x26 FNumber — "other models" (Sony.pm:3800).
+    // 0x26 FNumber — "other models" fallback after the A4xx-prefix / NEX-prefix
+    // variants (Sony.pm:3870).
     push_fnumber(buf, 0x26, "FNumber", print_conv, out);
     // 0x27 ExposureTime — `!~ NEX-(3|5|5C)|DSLR-A4xx` (Sony.pm:3819).
     push_exposure_time(buf, 0x27, "ExposureTime", print_conv, out);
@@ -379,16 +391,21 @@ fn face_position_value(buf: &[u8], byte: usize) -> Option<TagValue> {
   ))))
 }
 
-/// `%Sony::MoreInfo0201` (`Sony.pm:3457-3497`) — ImageCount (0x011b) +
-/// ShutterCount (0x0125), int32u `& 0x00ffffff`, `!~ DSLR-A4xx`.
+/// `%Sony::MoreInfo0201` (`Sony.pm:3457-3496`) — ImageCount (0x011b) +
+/// ShutterCount (0x0125), int32u `& 0x00ffffff`,
+/// `!~ /^DSLR-A(450|500|550)$/` ($-anchored EXACT).
 fn parse_more_info0201(
   buf: &[u8],
   model: Option<&str>,
   print_conv: bool,
   out: &mut Vec<SubEmission>,
 ) {
-  if model_is_a4xx_9pt(model) {
-    return; // A4xx uses 0x014a ShutterCount (deferred — not the A33 path)
+  // `Condition => '$$self{Model} !~ /^DSLR-A(450|500|550)$/'` ($-anchored EXACT,
+  // Sony.pm:3477/3484) — NOT the `\b` boundary, so a hyphen/space-suffixed A4xx
+  // body still emits ImageCount/ShutterCount. The exact A4xx bodies instead
+  // carry 0x014a ShutterCount (deferred — not the A33 path).
+  if model_is_a4xx_exact(model) {
+    return;
   }
   let _ = print_conv;
   if let Some(v) = read_u32(buf, 0x011b) {

--- a/src/exif/makernotes/vendors/sony/moreinfo.rs
+++ b/src/exif/makernotes/vendors/sony/moreinfo.rs
@@ -1,0 +1,794 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::MoreInfo` (`Sony.pm:3382-3456`) — the `0x0020`
+//! Main-table SubDirectory dispatched (over `FocusInfo`) when `$count` is NOT
+//! `19154`/`19148` (`Sony.pm:44-63`). Unlike the other older sub-tables, its
+//! `PROCESS_PROC` is the bespoke `ProcessMoreInfo` (`Sony.pm:11247-11360`): an
+//! INDEX directory, not a flat `ProcessBinaryData` block.
+//!
+//! ## `ProcessMoreInfo` index layout
+//! `[ num:int16u ][ len:int16u ][ num × (tagID:int16u, offset:int16u) ]`. Each
+//! index entry points at a block whose size is the gap to the next-higher
+//! offset (sorted), clamped to `len`. The four ported blocks dispatch to plain
+//! `ProcessBinaryData` sub-tables whose offsets are RELATIVE to the block start:
+//! `MoreSettings` (0x0001), `FaceInfo` (0x0002), `MoreInfo0201` (0x0201) and
+//! `MoreInfo0401` (0x0401).
+//!
+//! Per the `ProcessBinaryData` per-field contract each leaf is emitted IFF its
+//! byte range is in its block AND its model `Condition` holds
+//! ([[exifast-processbinarydata-per-field]]). The truncation/corruption guards
+//! (`dirLen < 4`, `dirLen < 4 + num*4`, `num > 50`) match `ProcessMoreInfo`.
+
+use crate::exif::tables::{print_exposure_time, print_fnumber};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+
+use super::subtables::{
+  SubEmission, drive_mode, exposure_comp_value, exposure_comp2_value, exposure_program2,
+  hash_hex_value, model_is_a4xx_9pt, model_is_nex355c, read_i16, read_u16, read_u32,
+  signed_setting_value, white_balance_setting,
+};
+
+/// Walk the `MoreInfo` index directory and emit the leaves of the four ported
+/// blocks.
+///
+/// `buf` is the verbatim `0x0020` block (`DirStart = 0`, `DirLen = buf.len()`).
+/// `model` is `$$self{Model}`; `print_conv` selects `-j` vs `-n`.
+#[must_use]
+pub fn parse_more_info(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+  // `ProcessMoreInfo`: `return if $dirLen < 4`.
+  let Some(num) = read_u16(buf, 0) else {
+    return out;
+  };
+  let num = usize::from(num);
+  let Some(len_hdr) = read_u16(buf, 2) else {
+    return out;
+  };
+  let dir_len = buf.len();
+  // `$dirLen < 4 + $num*4` ⇒ truncated; `$num > 50` ⇒ corrupted.
+  if dir_len < 4 + num * 4 || num > 50 {
+    return out;
+  }
+  let mut len = usize::from(len_hdr);
+  if len > dir_len {
+    len = dir_len;
+  }
+
+  // Read the index, then derive each block's size from the sorted offsets.
+  let mut index: std::vec::Vec<(u16, usize)> = std::vec::Vec::with_capacity(num);
+  for i in 0..num {
+    let entry = 4 + i * 4;
+    let Some(tag) = read_u16(buf, entry) else {
+      return out;
+    };
+    let Some(off) = read_u16(buf, entry + 2) else {
+      return out;
+    };
+    let off = usize::from(off);
+    index.push((tag, off));
+    if off > len && off <= dir_len {
+      len = dir_len;
+    }
+  }
+  // Block size = gap to the next-higher sorted offset, clamped to `len`.
+  let mut sorted: std::vec::Vec<usize> = index.iter().map(|&(_, off)| off).collect();
+  sorted.sort_unstable();
+  sorted.push(0xffff);
+  let mut block_size: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+  for pair in sorted.windows(2) {
+    let &[off, next] = pair else { continue };
+    let mut size = next.saturating_sub(off);
+    if size > len.saturating_sub(off) {
+      size = len.saturating_sub(off);
+    }
+    block_size.entry(off).or_insert(size);
+  }
+
+  // Dispatch each index entry to its block sub-table. `MoreSettings` /
+  // `MoreInfo0201` / `MoreInfo0401` are `PRIORITY => 0`; `FaceInfo` has no
+  // `PRIORITY` (default 1). The priority is applied to each block's freshly
+  // pushed leaves so a later `CameraSettings3` duplicate (also `PRIORITY => 0`)
+  // resolves last-wins, while a higher-priority Main leaf still wins.
+  for &(tag_id, off) in &index {
+    if off > dir_len {
+      continue; // ignore bad offsets
+    }
+    let size = block_size.get(&off).copied().unwrap_or(0);
+    let Some(block) = buf.get(off..off + size) else {
+      continue;
+    };
+    let start = out.len();
+    let block_priority = match tag_id {
+      0x0001 => {
+        parse_more_settings(block, model, print_conv, &mut out);
+        0
+      }
+      0x0002 if !model_is_a4xx_9pt(model) => {
+        parse_face_info(block, print_conv, &mut out);
+        1
+      }
+      // 0x0107 TiffMeteringImage — the 7200-byte (3×40×30 int16u) AE-metering
+      // block, ValueConv `\ "Binary data 7404 bytes"` (Sony.pm:3413-3437). The
+      // scalar-ref renders to the fixed `(Binary data 7404 bytes, …)`
+      // placeholder (`exiftool:3984-3986`) in BOTH `-j` and `-n`, emitted only
+      // when `length $val >= 7200`.
+      0x0107 if block.len() >= 7200 => {
+        out.push(SubEmission::new(
+          "TiffMeteringImage",
+          TagValue::Str("(Binary data 7404 bytes, use -b option to extract)".into()),
+        ));
+        1
+      }
+      0x0201 => {
+        parse_more_info0201(block, model, print_conv, &mut out);
+        0
+      }
+      0x0401 => {
+        parse_more_info0401(block, model, print_conv, &mut out);
+        0
+      }
+      _ => continue,
+    };
+    if let Some(fresh) = out.get_mut(start..) {
+      for e in fresh {
+        e.priority = block_priority;
+      }
+    }
+  }
+  out
+}
+
+/// `%Sony::MoreSettings` (`Sony.pm:3528-4006`) — the bulk of the older-body
+/// settings. This ports the "other models" (`!~ NEX-(3|5|5C)|DSLR-A4xx`)
+/// branches the A33 needs plus the shared leaves; the A4xx/NEX-only overlapping
+/// offsets stay deferred.
+fn parse_more_settings(
+  buf: &[u8],
+  model: Option<&str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  let a4xx = model_is_a4xx_9pt(model);
+  let nex355c = model_is_nex355c(model);
+  let other = !a4xx && !nex355c; // the `!~ NEX-(3|5|5C)|DSLR-A4xx` class
+
+  // 0x01 DriveMode2 — PrintHex, %sonyDriveMode (Sony.pm:3534).
+  push_hash_hex(
+    buf,
+    0x01,
+    "DriveMode2",
+    |v| drive_mode(v, false),
+    print_conv,
+    out,
+  );
+  // 0x02 ExposureProgram — %sonyExposureProgram2 (Sony.pm:3550).
+  push_hash(
+    buf,
+    0x02,
+    "ExposureProgram",
+    |v| exposure_program2(u32::from(v)),
+    print_conv,
+    out,
+  );
+  push_hash(buf, 0x03, "MeteringMode", metering_mode, print_conv, out);
+  push_hash(
+    buf,
+    0x04,
+    "DynamicRangeOptimizerSetting",
+    dro_setting,
+    print_conv,
+    out,
+  );
+  push_plain(buf, 0x05, "DynamicRangeOptimizerLevel", out);
+  push_hash(buf, 0x06, "ColorSpace", color_space, print_conv, out);
+  push_hash(
+    buf,
+    0x07,
+    "CreativeStyleSetting",
+    creative_style_setting,
+    print_conv,
+    out,
+  );
+  push_signed(buf, 0x08, "ContrastSetting", print_conv, out);
+  push_signed(buf, 0x09, "SaturationSetting", print_conv, out);
+  push_signed(buf, 0x0a, "SharpnessSetting", print_conv, out);
+  // 0x0d WhiteBalanceSetting — PrintHex, %whiteBalanceSetting (Sony.pm:3606).
+  push_hash_hex(
+    buf,
+    0x0d,
+    "WhiteBalanceSetting",
+    white_balance_setting,
+    print_conv,
+    out,
+  );
+  // 0x0e ColorTemperatureSetting — `$val*100`, "$val K" (Sony.pm:3614).
+  push_color_temp(buf, 0x0e, out, print_conv);
+  push_signed(buf, 0x0f, "ColorCompensationFilterSet", print_conv, out);
+  push_hash(buf, 0x10, "FlashMode", flash_mode, print_conv, out);
+  push_hash(
+    buf,
+    0x11,
+    "LongExposureNoiseReduction",
+    long_exposure_nr,
+    print_conv,
+    out,
+  );
+  push_hash(
+    buf,
+    0x12,
+    "HighISONoiseReduction",
+    high_iso_nr,
+    print_conv,
+    out,
+  );
+  // 0x13 FocusMode — `!~ DSLR-A4xx` (Sony.pm:3650).
+  if !a4xx {
+    push_hash(
+      buf,
+      0x13,
+      "FocusMode",
+      focus_mode_morsettings,
+      print_conv,
+      out,
+    );
+  }
+  // 0x15 MultiFrameNoiseReduction — `!~ DSLR-A4xx` (Sony.pm:3664).
+  if !a4xx {
+    push_hash(
+      buf,
+      0x15,
+      "MultiFrameNoiseReduction",
+      multi_frame_nr,
+      print_conv,
+      out,
+    );
+  }
+  push_hash(buf, 0x16, "HDRSetting", hdr_setting, print_conv, out);
+  push_hash(buf, 0x17, "HDRLevel", hdr_level, print_conv, out);
+  push_hash(buf, 0x18, "ViewingMode", viewing_mode, print_conv, out);
+  push_hash(buf, 0x19, "FaceDetection", face_detection, print_conv, out);
+  // 0x1a CustomWB_RBLevels — int16uRev[2] (Sony.pm:3697).
+  push_custom_wb_rb(buf, 0x1a, out);
+
+  // The overlapping exposure offsets — the A33 (other) branches.
+  if other {
+    // 0x1e ExposureCompensationSet (Sony.pm:3717).
+    push_exposure_comp(buf, 0x1e, "ExposureCompensationSet", print_conv, out);
+    // 0x1f FlashExposureCompSet (Sony.pm:3728).
+    push_exposure_comp(buf, 0x1f, "FlashExposureCompSet", print_conv, out);
+    // 0x20 LiveViewAFMethod — `!~ NEX-(3|5|5C)` (Sony.pm:3744).
+    push_hash(
+      buf,
+      0x20,
+      "LiveViewAFMethod",
+      live_view_af_method,
+      print_conv,
+      out,
+    );
+    // 0x25 ISO — `!~ DSLR-A4xx` (Sony.pm:3784).
+    push_iso(buf, 0x25, out, print_conv);
+    // 0x26 FNumber — "other models" (Sony.pm:3800).
+    push_fnumber(buf, 0x26, "FNumber", print_conv, out);
+    // 0x27 ExposureTime — `!~ NEX-(3|5|5C)|DSLR-A4xx` (Sony.pm:3819).
+    push_exposure_time(buf, 0x27, "ExposureTime", print_conv, out);
+    // 0x29 FocalLength2 — `!~ NEX-(3|5|5C)` (Sony.pm:3851).
+    push_focal_length2(buf, 0x29, out, print_conv);
+    // 0x2a ExposureCompensation2 — int16s `!~ NEX-(3|5|5C)` (Sony.pm:3868).
+    push_exposure_comp2(buf, 0x2a, "ExposureCompensation2", print_conv, out);
+    // 0x2c FlashExposureCompSet2 — int16s "other models" (Sony.pm:3902).
+    push_exposure_comp2(buf, 0x2c, "FlashExposureCompSet2", print_conv, out);
+    // 0x2e Orientation2 — `!~ DSLR-A4xx` (Sony.pm:3919).
+    push_hash(buf, 0x2e, "Orientation2", orientation2, print_conv, out);
+    // 0x2f FocusPosition2 — `!~ NEX-(3|5|5C)|DSLR-A4xx` (Sony.pm:3930).
+    push_plain(buf, 0x2f, "FocusPosition2", out);
+    // 0x30 FlashAction — `!~ NEX-(3|5|5C)|DSLR-A4xx` (Sony.pm:3936).
+    push_hash(buf, 0x30, "FlashAction", flash_action, print_conv, out);
+    // 0x32 FocusMode2 — `!~ NEX-(3|5|5C)|DSLR-A4xx` (Sony.pm:3947).
+    push_hash(buf, 0x32, "FocusMode2", focus_mode2, print_conv, out);
+    // 0x7c FlashActionExternal — `!~ NEX-(3|5|5C)|DSLR-A4xx` (Sony.pm:3974).
+    push_hash(
+      buf,
+      0x7c,
+      "FlashActionExternal",
+      flash_action_external,
+      print_conv,
+      out,
+    );
+    // 0x86 FlashStatus — `!~ NEX-(3|5|5C)|DSLR-A4xx` (Sony.pm:3997).
+    push_hash(buf, 0x86, "FlashStatus", flash_status, print_conv, out);
+  }
+}
+
+/// `%Sony::FaceInfo` (`Sony.pm:4062-4123`) — FORMAT int16u; 0x00 FacesDetected
+/// (int16s RawConv). Only the count leaf is camera-metadata-relevant for the
+/// activation golden (the per-face position rects are gated by FacesDetected and
+/// not present when 0).
+fn parse_face_info(buf: &[u8], print_conv: bool, out: &mut Vec<SubEmission>) {
+  // 0x00 FacesDetected — int16s, RawConv `($val == -1 ? 0 : $val)`, PrintConv
+  // `-1 => 'n/a'`, OTHER passthrough.
+  if let Some(raw) = read_i16(buf, 0x00) {
+    let value = if print_conv {
+      if raw == -1 {
+        TagValue::Str("n/a".into())
+      } else {
+        TagValue::I64(i64::from(raw))
+      }
+    } else {
+      TagValue::I64(i64::from(raw))
+    };
+    out.push(SubEmission {
+      priority: 1,
+      name: "FacesDetected",
+      value,
+    });
+  }
+}
+
+/// `%Sony::MoreInfo0201` (`Sony.pm:3457-3497`) — ImageCount (0x011b) +
+/// ShutterCount (0x0125), int32u `& 0x00ffffff`, `!~ DSLR-A4xx`.
+fn parse_more_info0201(
+  buf: &[u8],
+  model: Option<&str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if model_is_a4xx_9pt(model) {
+    return; // A4xx uses 0x014a ShutterCount (deferred — not the A33 path)
+  }
+  let _ = print_conv;
+  if let Some(v) = read_u32(buf, 0x011b) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ImageCount",
+      value: TagValue::I64(i64::from(v & 0x00ff_ffff)),
+    });
+  }
+  if let Some(v) = read_u32(buf, 0x0125) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ShutterCount",
+      value: TagValue::I64(i64::from(v & 0x00ff_ffff)),
+    });
+  }
+}
+
+/// `%Sony::MoreInfo0401` (`Sony.pm:3498-3527`) — ShotNumberSincePowerUp
+/// (0x044e), int32u `& 0x00ffffff`, `!~ NEX-(3|5)`.
+fn parse_more_info0401(
+  buf: &[u8],
+  model: Option<&str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  let _ = print_conv;
+  // `Condition => '$$self{Model} !~ /^NEX-(3|5)$/'` — a `$`-anchored exact
+  // match (NEX-3 / NEX-5 only, NOT NEX-5C).
+  if model.is_some_and(|m| m == "NEX-3" || m == "NEX-5") {
+    return;
+  }
+  if let Some(v) = read_u32(buf, 0x044e) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ShotNumberSincePowerUp",
+      value: TagValue::I64(i64::from(v & 0x00ff_ffff)),
+    });
+  }
+}
+
+// ---- shared MoreSettings PrintConv hashes ----
+
+fn metering_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Multi-segment",
+    2 => "Center-weighted average",
+    3 => "Spot",
+    _ => return None,
+  })
+}
+
+fn dro_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On (Auto)",
+    17 => "On (Manual)",
+    _ => return None,
+  })
+}
+
+fn color_space(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "sRGB",
+    2 => "Adobe RGB",
+    _ => return None,
+  })
+}
+
+fn creative_style_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    16 => "Standard",
+    32 => "Vivid",
+    64 => "Portrait",
+    80 => "Landscape",
+    96 => "B&W",
+    160 => "Sunset",
+    _ => return None,
+  })
+}
+
+fn flash_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Flash Off",
+    16 => "Autoflash",
+    17 => "Fill-flash",
+    18 => "Slow Sync",
+    19 => "Rear Sync",
+    20 => "Wireless",
+    _ => return None,
+  })
+}
+
+fn long_exposure_nr(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On",
+    _ => return None,
+  })
+}
+
+fn high_iso_nr(v: u8) -> Option<&'static str> {
+  Some(match v {
+    16 => "Low",
+    17 => "High",
+    19 => "Auto",
+    _ => return None,
+  })
+}
+
+/// `FocusMode` (MoreSettings 0x13) PrintConv (`Sony.pm:3652-3658`).
+fn focus_mode_morsettings(v: u8) -> Option<&'static str> {
+  Some(match v {
+    17 => "AF-S",
+    18 => "AF-C",
+    19 => "AF-A",
+    32 => "Manual",
+    48 => "DMF",
+    _ => return None,
+  })
+}
+
+fn multi_frame_nr(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    1 => "Off",
+    16 => "On",
+    255 => "None",
+    _ => return None,
+  })
+}
+
+fn hdr_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On (Auto)",
+    17 => "On (Manual)",
+    _ => return None,
+  })
+}
+
+fn hdr_level(v: u8) -> Option<&'static str> {
+  Some(match v {
+    33 => "1 EV",
+    34 => "1.5 EV",
+    35 => "2 EV",
+    36 => "2.5 EV",
+    37 => "3 EV",
+    38 => "3.5 EV",
+    39 => "4 EV",
+    40 => "5 EV",
+    41 => "6 EV",
+    _ => return None,
+  })
+}
+
+fn viewing_mode(v: u8) -> Option<&'static str> {
+  Some(match v {
+    16 => "ViewFinder",
+    33 => "Focus Check Live View",
+    34 => "Quick AF Live View",
+    _ => return None,
+  })
+}
+
+fn face_detection(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Off",
+    16 => "On",
+    _ => return None,
+  })
+}
+
+fn live_view_af_method(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    1 => "Phase-detect AF",
+    2 => "Contrast AF",
+    _ => return None,
+  })
+}
+
+fn orientation2(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "Horizontal (normal)",
+    2 => "Rotate 180",
+    6 => "Rotate 90 CW",
+    8 => "Rotate 270 CW",
+    _ => return None,
+  })
+}
+
+fn flash_action(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Did not fire",
+    1 => "Fired",
+    _ => return None,
+  })
+}
+
+fn focus_mode2(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "AF",
+    1 => "MF",
+    _ => return None,
+  })
+}
+
+/// `FlashActionExternal` (MoreSettings 0x7c) PrintConv (`Sony.pm:3984-3989`).
+fn flash_action_external(v: u8) -> Option<&'static str> {
+  Some(match v {
+    136 => "Did not fire",
+    167 => "Fired",
+    182 => "Fired, HSS",
+    _ => return None,
+  })
+}
+
+/// `FlashStatus` (MoreSettings 0x86) PrintConv (`Sony.pm:4000-4005`).
+fn flash_status(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "None",
+    1 => "Built-in",
+    2 => "External",
+    _ => return None,
+  })
+}
+
+// ---- push helpers ----
+
+fn push_hash(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  hit: impl Fn(u8) -> Option<&'static str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: super::hash_print_value(raw, hit(raw), print_conv),
+    });
+  }
+}
+
+fn push_hash_hex(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  hit: impl Fn(u32) -> Option<&'static str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: hash_hex_value(u32::from(raw), hit(u32::from(raw)), print_conv),
+    });
+  }
+}
+
+fn push_plain(buf: &[u8], off: usize, name: &'static str, out: &mut Vec<SubEmission>) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: TagValue::I64(i64::from(raw)),
+    });
+  }
+}
+
+fn push_signed(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: signed_setting_value(raw as i8, print_conv),
+    });
+  }
+}
+
+fn push_exposure_comp(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: exposure_comp_value(raw, print_conv),
+    });
+  }
+}
+
+fn push_exposure_comp2(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(raw) = read_i16(buf, off) {
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: exposure_comp2_value(raw, print_conv),
+    });
+  }
+}
+
+fn push_color_temp(buf: &[u8], off: usize, out: &mut Vec<SubEmission>, print_conv: bool) {
+  if let Some(&raw) = buf.get(off) {
+    let k = u32::from(raw) * 100;
+    out.push(SubEmission {
+      priority: 1,
+      name: "ColorTemperatureSetting",
+      value: if print_conv {
+        TagValue::Str(SmolStr::new(std::format!("{k} K")))
+      } else {
+        TagValue::I64(i64::from(k))
+      },
+    });
+  }
+}
+
+/// `CustomWB_RBLevels` — int16uRev[2] (big-endian pair, space-joined). `-n` is
+/// the same string (no ValueConv).
+fn push_custom_wb_rb(buf: &[u8], off: usize, out: &mut Vec<SubEmission>) {
+  if let Some(&[a0, a1, b0, b1]) = buf.get(off..off + 4) {
+    let a = u16::from_be_bytes([a0, a1]);
+    let b = u16::from_be_bytes([b0, b1]);
+    out.push(SubEmission {
+      priority: 1,
+      name: "CustomWB_RBLevels",
+      value: TagValue::Str(SmolStr::new(std::format!("{a} {b}"))),
+    });
+  }
+}
+
+/// ISO (`$val ? exp(($val/8-6)*ln2)*100 : $val`, `$val ? %.0f : "Auto"`).
+fn push_iso(buf: &[u8], off: usize, out: &mut Vec<SubEmission>, print_conv: bool) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "ISO",
+      value: iso_value(raw, print_conv),
+    });
+  }
+}
+
+fn iso_value(raw: u8, print_conv: bool) -> TagValue {
+  let vc = if raw != 0 {
+    (((f64::from(raw) / 8.0 - 6.0) * core::f64::consts::LN_2).exp()) * 100.0
+  } else {
+    0.0
+  };
+  if !print_conv {
+    return if raw != 0 {
+      TagValue::F64(vc)
+    } else {
+      TagValue::I64(0)
+    };
+  }
+  if raw != 0 {
+    TagValue::I64(libm_round(vc))
+  } else {
+    TagValue::Str("Auto".into())
+  }
+}
+
+/// `sprintf("%.0f",$val)` — round-half-to-even is NOT Perl's behaviour; Perl's
+/// `sprintf %.0f` rounds half away from zero. For the positive ISO values here
+/// (always > 0) this is `floor(v + 0.5)`.
+fn libm_round(v: f64) -> i64 {
+  (v + 0.5).floor() as i64
+}
+
+/// FNumber (`2**(($val/8 - 1)/2)`, PrintFNumber).
+fn push_fnumber(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    let fnum = 2f64.powf((f64::from(raw) / 8.0 - 1.0) / 2.0);
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: if print_conv {
+        TagValue::Str(print_fnumber(fnum).into())
+      } else {
+        TagValue::F64(fnum)
+      },
+    });
+  }
+}
+
+/// ExposureTime (`$val ? 2**(6 - $val/8) : 0`, `$val ? PrintExposureTime : "Bulb"`).
+fn push_exposure_time(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    let secs = if raw != 0 {
+      2f64.powf(6.0 - f64::from(raw) / 8.0)
+    } else {
+      0.0
+    };
+    out.push(SubEmission {
+      priority: 1,
+      name,
+      value: if print_conv {
+        if raw != 0 {
+          TagValue::Str(print_exposure_time(secs).into())
+        } else {
+          TagValue::Str("Bulb".into())
+        }
+      } else {
+        TagValue::F64(secs)
+      },
+    });
+  }
+}
+
+/// FocalLength2 (`10 * 2**(($val-28)/16)`, `sprintf("%.1f mm",$val)`).
+fn push_focal_length2(buf: &[u8], off: usize, out: &mut Vec<SubEmission>, print_conv: bool) {
+  if let Some(&raw) = buf.get(off) {
+    let mm = 10.0 * 2f64.powf((f64::from(raw) - 28.0) / 16.0);
+    out.push(SubEmission {
+      priority: 1,
+      name: "FocalLength2",
+      value: if print_conv {
+        TagValue::Str(SmolStr::new(std::format!("{mm:.1} mm")))
+      } else {
+        TagValue::F64(mm)
+      },
+    });
+  }
+}

--- a/src/exif/makernotes/vendors/sony/moreinfo_tests.rs
+++ b/src/exif/makernotes/vendors/sony/moreinfo_tests.rs
@@ -158,3 +158,82 @@ fn faceinfo_dispatch_is_exact_match_not_word_boundary() {
     );
   }
 }
+
+/// `MoreSettings` carries TWO A4xx anchor flavors that a single `\b` bool got
+/// wrong in OPPOSITE directions: 0x13 `FocusMode` / 0x15
+/// `MultiFrameNoiseReduction` are `$`-anchored EXACT
+/// (`!~ /^DSLR-(A450|A500|A550)$/`, Sony.pm:3662/3673), while the overlapping
+/// `other` block (0x25 `ISO`, 0x26 `FNumber`, …) is the no-anchor PREFIX
+/// (`/^DSLR-(A450|A500|A550)/`).
+#[test]
+fn moresettings_a4xx_anchors_split_exact_vs_prefix() {
+  // A block long enough to reach 0x86, non-zero at the probed offsets.
+  let mut buf = vec![0u8; 0x90];
+  buf[0x13] = 17; // FocusMode = AF-S
+  buf[0x15] = 1; // MultiFrameNoiseReduction = Off
+  buf[0x25] = 64; // ISO (raw, non-zero)
+  buf[0x26] = 40; // FNumber (raw)
+
+  let has = |model: &str, name: &str| -> bool {
+    let mut out = Vec::new();
+    parse_more_settings(&buf, Some(model), true, &mut out);
+    names(&out).contains(&name)
+  };
+
+  // SLT-A33 (not an A4xx at all): every probed leaf present.
+  for n in ["FocusMode", "MultiFrameNoiseReduction", "ISO", "FNumber"] {
+    assert!(has("SLT-A33", n), "SLT-A33 {n}");
+  }
+
+  // Real exact A4xx bodies: EVERY anchor excludes them.
+  for m in ["DSLR-A450", "DSLR-A500", "DSLR-A550"] {
+    for n in ["FocusMode", "MultiFrameNoiseReduction", "ISO", "FNumber"] {
+      assert!(!has(m, n), "{m} {n} excluded (exact body)");
+    }
+  }
+
+  // Suffixed A4xx strings: NOT a `$`-exact match (so 0x13/0x15 EMIT — the `\b`
+  // port wrongly dropped the hyphen form) but ARE a PREFIX match (so the `other`
+  // block 0x25/0x26 are EXCLUDED — the `\b` port wrongly emitted the alnum
+  // form). Faithful to Sony.pm for BOTH suffix shapes.
+  for m in ["DSLR-A500-x", "DSLR-A500X"] {
+    assert!(has(m, "FocusMode"), "{m} FocusMode must emit ($-exact)");
+    assert!(
+      has(m, "MultiFrameNoiseReduction"),
+      "{m} MFNR must emit ($-exact)"
+    );
+    assert!(!has(m, "ISO"), "{m} ISO must be excluded (prefix)");
+    assert!(!has(m, "FNumber"), "{m} FNumber must be excluded (prefix)");
+  }
+}
+
+/// `MoreInfo0201` 0x011b `ImageCount` / 0x0125 `ShutterCount` carry
+/// `!~ /^DSLR-A(450|500|550)$/` (`$`-anchored EXACT, Sony.pm:3477/3484). A
+/// suffixed A4xx body is NOT an exact match, so it still emits both counts (the
+/// `\b` port wrongly suppressed the hyphen form).
+#[test]
+fn moreinfo0201_imagecount_is_exact_not_word_boundary() {
+  let mut buf = vec![0u8; 0x130];
+  put_u16(&mut buf, 0x011b, 0x1234); // low half of the int32u ImageCount
+  put_u16(&mut buf, 0x0125, 0x5678); // low half of the int32u ShutterCount
+
+  let collect = |model: &str| -> Vec<&'static str> {
+    let mut out = Vec::new();
+    parse_more_info0201(&buf, Some(model), false, &mut out);
+    names(&out)
+  };
+
+  assert_eq!(collect("SLT-A33"), ["ImageCount", "ShutterCount"]);
+  // Suffixed A4xx → still emitted (`$`-exact does not match).
+  for m in ["DSLR-A500-x", "DSLR-A500X"] {
+    assert_eq!(
+      collect(m),
+      ["ImageCount", "ShutterCount"],
+      "{m} 0201 counts"
+    );
+  }
+  // Real exact A4xx bodies use 0x014a (deferred) — 0201 emits nothing.
+  for m in ["DSLR-A450", "DSLR-A500", "DSLR-A550"] {
+    assert!(collect(m).is_empty(), "exact {m} suppresses 0201 counts");
+  }
+}

--- a/src/exif/makernotes/vendors/sony/moreinfo_tests.rs
+++ b/src/exif/makernotes/vendors/sony/moreinfo_tests.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Sony::FaceInfo` (`Sony.pm:4062-4122`) per-face rows: `FacesDetected`
+//! (int16s, `-1 => 'n/a'`) plus `Face1..8Position` (`int16u[4]`, key×2 byte
+//! offsets, ×15 re-ordered ValueConv, gated by `FacesDetected >= N`).
+
+use super::*;
+
+fn put_u16(buf: &mut [u8], off: usize, v: u16) {
+  buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn put_i16(buf: &mut [u8], off: usize, v: i16) {
+  buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn names(out: &[SubEmission]) -> Vec<&'static str> {
+  out.iter().map(|e| e.name).collect()
+}
+
+/// A crafted FaceInfo block with `FacesDetected = 2` and two rectangles emits
+/// `Face1Position`/`Face2Position` byte-exact (the ×15 re-ordered
+/// top,left,height,width ValueConv) and leaves Face3..8 gated out. There is no
+/// PrintConv, so `-j` and `-n` are identical.
+#[test]
+fn two_faces_emit_rectangles_identical_in_j_and_n() {
+  // FORMAT int16u ⇒ byte = key×2: FacesDetected@0, Face1@2, Face2@12, Face3@22.
+  let mut buf = vec![0u8; 100];
+  put_i16(&mut buf, 0, 2); // FacesDetected = 2
+  // Face1 int16u[4] = [v0,v1,v2,v3] = [2,3,8,12] at bytes 2,4,6,8.
+  put_u16(&mut buf, 2, 2);
+  put_u16(&mut buf, 4, 3);
+  put_u16(&mut buf, 6, 8);
+  put_u16(&mut buf, 8, 12);
+  // Face2 int16u[4] = [4,5,10,6] at bytes 12,14,16,18.
+  put_u16(&mut buf, 12, 4);
+  put_u16(&mut buf, 14, 5);
+  put_u16(&mut buf, 16, 10);
+  put_u16(&mut buf, 18, 6);
+  // A non-zero Face3 region (byte 22) that must stay gated out.
+  put_u16(&mut buf, 22, 9);
+
+  for print_conv in [true, false] {
+    let mut out = Vec::new();
+    parse_face_info(&buf, print_conv, &mut out);
+    assert_eq!(
+      names(&out),
+      ["FacesDetected", "Face1Position", "Face2Position"],
+      "print_conv={print_conv}"
+    );
+    assert_eq!(out[0].value, TagValue::I64(2));
+    // "$v[1]*15 $v[0]*15 $v[3]*15 $v[2]*15": Face1 [2,3,8,12] → top 45, left 30,
+    // height 180, width 120.
+    assert_eq!(out[1].value, TagValue::Str("45 30 180 120".into()));
+    // Face2 [4,5,10,6] → top 75, left 60, height 90, width 150.
+    assert_eq!(out[2].value, TagValue::Str("75 60 90 150".into()));
+  }
+}
+
+/// `FacesDetected = 0` (the A33 activation-golden path) emits only the count —
+/// no Face rows even when rectangle bytes are present.
+#[test]
+fn zero_faces_emits_only_the_count() {
+  let mut buf = vec![0u8; 100];
+  put_i16(&mut buf, 0, 0);
+  put_u16(&mut buf, 2, 99); // a rectangle that must NOT be emitted
+  let mut out = Vec::new();
+  parse_face_info(&buf, true, &mut out);
+  assert_eq!(names(&out), ["FacesDetected"]);
+  assert_eq!(out[0].value, TagValue::I64(0));
+}
+
+/// `FacesDetected = -1` folds to `'n/a'` (`-j`) / raw `-1` (`-n`); the DataMember
+/// gate folds to 0, so no Face rows.
+#[test]
+fn minus_one_is_na_and_gates_out_faces() {
+  let mut buf = vec![0u8; 100];
+  put_i16(&mut buf, 0, -1);
+  put_u16(&mut buf, 2, 7);
+  let mut j = Vec::new();
+  parse_face_info(&buf, true, &mut j);
+  assert_eq!(names(&j), ["FacesDetected"]);
+  assert_eq!(j[0].value, TagValue::Str("n/a".into()));
+  let mut n = Vec::new();
+  parse_face_info(&buf, false, &mut n);
+  assert_eq!(n[0].value, TagValue::I64(-1));
+}
+
+/// Per-field availability: `FacesDetected = 8` but the block only fits Face1 →
+/// only Face1Position emits (the higher faces fall out-of-range).
+#[test]
+fn per_field_availability_truncates_at_block_end() {
+  // 10-byte block: FacesDetected@0..2, Face1@2..10; Face2@12 is past the end.
+  let mut buf = vec![0u8; 10];
+  put_i16(&mut buf, 0, 8);
+  put_u16(&mut buf, 2, 1);
+  put_u16(&mut buf, 4, 1);
+  put_u16(&mut buf, 6, 1);
+  put_u16(&mut buf, 8, 1);
+  let mut out = Vec::new();
+  parse_face_info(&buf, true, &mut out);
+  assert_eq!(names(&out), ["FacesDetected", "Face1Position"]);
+  // [1,1,1,1] → "15 15 15 15".
+  assert_eq!(out[1].value, TagValue::Str("15 15 15 15".into()));
+}
+
+/// A minimal `MoreInfo` index directory (`[num=1][len][tag=0x0002][off=8]`) whose
+/// single block is a FaceInfo block with `FacesDetected = 1` and one rectangle.
+fn more_info_with_face_block() -> Vec<u8> {
+  let mut buf = vec![0u8; 40];
+  put_u16(&mut buf, 0, 1); // num = 1 index entry
+  put_u16(&mut buf, 2, 40); // len = whole directory
+  put_u16(&mut buf, 4, 0x0002); // tagID = FaceInfo block
+  put_u16(&mut buf, 6, 8); // block offset
+  // FaceInfo block at byte 8: FacesDetected@block-0, Face1@block-2 = [2,3,8,12].
+  put_i16(&mut buf, 8, 1);
+  put_u16(&mut buf, 10, 2);
+  put_u16(&mut buf, 12, 3);
+  put_u16(&mut buf, 14, 8);
+  put_u16(&mut buf, 16, 12);
+  buf
+}
+
+/// `MoreInfo` 0x0002 routes via the `$`-anchored EXACT `/^DSLR-(A450|A500|A550)$/`
+/// (`Sony.pm:3398`/`3402`), NOT the `\b` `model_is_a4xx_9pt` (which is the
+/// ExtraInfo3 0x0014 condition). A SUFFIXED A4xx body is not an exact match, so
+/// it must still parse the non-A4xx `FaceInfo` — matching ExifTool's `$`.
+#[test]
+fn faceinfo_dispatch_is_exact_match_not_word_boundary() {
+  let buf = more_info_with_face_block();
+
+  // Suffixed A4xx strings (`\b` would wrongly suppress these) still parse the
+  // non-A4xx FaceInfo: FacesDetected + the per-face row emit.
+  for model in ["DSLR-A500-x", "DSLR-A500 (extra)", "DSLR-A500X"] {
+    let out = parse_more_info(&buf, Some(model), true);
+    assert_eq!(
+      names(&out),
+      ["FacesDetected", "Face1Position"],
+      "suffixed {model} must parse the non-A4xx FaceInfo"
+    );
+    // [2,3,8,12] → top 45, left 30, height 180, width 120 (the ×15 ValueConv).
+    assert_eq!(out[1].value, TagValue::Str("45 30 180 120".into()));
+  }
+
+  // The A33 (SLT, exact-mismatch) keeps the activation-golden path: FaceInfo runs.
+  let a33 = parse_more_info(&buf, Some("SLT-A33"), true);
+  assert_eq!(names(&a33), ["FacesDetected", "Face1Position"]);
+  assert_eq!(a33[0].value, TagValue::I64(1));
+
+  // EXACTLY one of the three → the deferred `FaceInfoA`; the non-A4xx FaceInfo
+  // does NOT run, so the 0x0002 block emits nothing.
+  for model in ["DSLR-A450", "DSLR-A500", "DSLR-A550"] {
+    let out = parse_more_info(&buf, Some(model), true);
+    assert!(
+      out.is_empty(),
+      "exact {model} routes to the deferred FaceInfoA, not FaceInfo"
+    );
+  }
+}

--- a/src/exif/makernotes/vendors/sony/subtables.rs
+++ b/src/exif/makernotes/vendors/sony/subtables.rs
@@ -180,6 +180,18 @@ pub fn model_is_a4xx_9pt(model: Option<&str>) -> bool {
     || word_boundary_after(m, "DSLR-A550")
 }
 
+/// `$$self{Model} =~ /^DSLR-(A450|A500|A550)$/` — the `$`-anchored EXACT match.
+///
+/// This is the `MoreInfo` 0x0002 FaceInfo/FaceInfoA selector (`Sony.pm:3398`/
+/// `3402`): the A4xx-only `FaceInfoA` fires only for a model EQUAL to one of the
+/// three strings. Unlike [`model_is_a4xx_9pt`]'s `\b` boundary a suffixed body
+/// (`DSLR-A500-x`, `DSLR-A500 (...)`) is NOT a match and routes to the non-A4xx
+/// `FaceInfo`, matching ExifTool's `$` anchor.
+#[must_use]
+pub fn model_is_a4xx_exact(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m == "DSLR-A450" || m == "DSLR-A500" || m == "DSLR-A550")
+}
+
 /// `$$self{Model} =~ /^NEX-(3|5|5C)/` (a prefix match, not a `\b` boundary —
 /// the Perl alternation matches `NEX-3`, `NEX-5`, `NEX-5C`).
 #[must_use]

--- a/src/exif/makernotes/vendors/sony/subtables.rs
+++ b/src/exif/makernotes/vendors/sony/subtables.rs
@@ -192,6 +192,24 @@ pub fn model_is_a4xx_exact(model: Option<&str>) -> bool {
   model.is_some_and(|m| m == "DSLR-A450" || m == "DSLR-A500" || m == "DSLR-A550")
 }
 
+/// `$$self{Model} =~ /^DSLR-(A450|A500|A550)/` — the no-anchor PREFIX match (a
+/// `^` but NO `$` and NO `\b`): the model STARTS WITH one of the three strings.
+///
+/// This is the third A4xx anchor flavor, alongside [`model_is_a4xx_exact`]'s `$`
+/// and [`model_is_a4xx_9pt`]'s `\b`. It governs the overlapping-offset
+/// `MoreSettings` / `CameraSettings3` leaves whose ExifTool `Condition` is an
+/// un-anchored `/^DSLR-(A450|A500|A550)/` (e.g. `MoreSettings` 0x25 `ISO`,
+/// `CameraSettings3` 0x87/0x88 `FlashStatus*`). All three A4xx helpers AGREE for
+/// a real body (exactly `DSLR-A450/A500/A550`, or not an A4xx at all) and
+/// diverge only for a hypothetical suffixed string: `DSLR-A500X` is a PREFIX
+/// match but a `\b` NON-match; `DSLR-A500-x` is BOTH.
+#[must_use]
+pub fn model_is_a4xx_prefix(model: Option<&str>) -> bool {
+  model.is_some_and(|m| {
+    m.starts_with("DSLR-A450") || m.starts_with("DSLR-A500") || m.starts_with("DSLR-A550")
+  })
+}
+
 /// `$$self{Model} =~ /^NEX-(3|5|5C)/` (a prefix match, not a `\b` boundary —
 /// the Perl alternation matches `NEX-3`, `NEX-5`, `NEX-5C`).
 #[must_use]

--- a/src/exif/makernotes/vendors/sony/subtables.rs
+++ b/src/exif/makernotes/vendors/sony/subtables.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Shared helpers for the older Sony plain-`ProcessBinaryData` Main-IFD
+//! SubDirectories the A33-class (SLT / DSLR-A4xx-A5xx / NEX) bodies dispatch:
+//! [`super::camerainfo3`] (`CameraInfo3`), [`super::moreinfo`] (`MoreInfo` ->
+//! `MoreSettings`/`FaceInfo`/`MoreInfo0201`/`MoreInfo0401`),
+//! [`super::camerasettings3`] (`CameraSettings3`) and [`super::extrainfo3`]
+//! (`ExtraInfo3`).
+//!
+//! These tables are NOT enciphered (unlike the `Tag9xxx` series); the verbatim
+//! on-disk block bytes are read directly. Each per-field read follows the
+//! `ProcessBinaryData` per-field-availability contract
+//! ([[exifast-processbinarydata-per-field]]): a leaf is emitted IFF its byte
+//! range is in the block AND its model `Condition` holds.
+
+use crate::value::TagValue;
+use smol_str::SmolStr;
+
+/// One emitted leaf from an older Sony SubDirectory — the resolved `Name`,
+/// rendered value and ExifTool `Priority => N`. Shared by all four `subtables`
+/// modules so the [`crate::exif`] dispatch can iterate a single emission type.
+pub struct SubEmission {
+  /// `Name => '…'` from the bundled table.
+  pub name: &'static str,
+  /// The rendered value (`-j` PrintConv result, or `-n` raw `$val`).
+  pub value: TagValue,
+  /// The ExifTool `Priority => N` for this leaf (the table-level `PRIORITY`,
+  /// overridden by an explicit per-leaf `Priority`). `0` means this leaf NEVER
+  /// overrides an existing duplicate of the same `(doc, family1, name)`
+  /// (`ExifTool.pm:9544-9560`) — e.g. the `PRIORITY => 0` `CameraSettings3`
+  /// `Quality` must NOT override the higher-priority Main-IFD `0x0102` `Quality`
+  /// (`RAW + JPEG/HEIF`).
+  pub priority: u8,
+}
+
+impl SubEmission {
+  /// A `Priority => 1` (default) leaf. The dispatch / parse functions overwrite
+  /// `priority` for the `PRIORITY => 0` tables.
+  #[must_use]
+  pub fn new(name: &'static str, value: TagValue) -> Self {
+    Self {
+      name,
+      value,
+      priority: 1,
+    }
+  }
+}
+
+/// Read a little-endian `int16u` at byte `off` of the block (`None` if the
+/// 2-byte range is out of bounds).
+#[must_use]
+pub fn read_u16(buf: &[u8], off: usize) -> Option<u16> {
+  match buf.get(off..off + 2) {
+    Some(&[a, b]) => Some(u16::from_le_bytes([a, b])),
+    _ => None,
+  }
+}
+
+/// Read a little-endian `int16s` at byte `off` of the block.
+#[must_use]
+pub fn read_i16(buf: &[u8], off: usize) -> Option<i16> {
+  match buf.get(off..off + 2) {
+    Some(&[a, b]) => Some(i16::from_le_bytes([a, b])),
+    _ => None,
+  }
+}
+
+/// Read a little-endian `int32u` at byte `off` of the block.
+#[must_use]
+pub fn read_u32(buf: &[u8], off: usize) -> Option<u32> {
+  match buf.get(off..off + 4) {
+    Some(&[a, b, c, d]) => Some(u32::from_le_bytes([a, b, c, d])),
+    _ => None,
+  }
+}
+
+/// `%afStatusInfo` rendered value (`Minolta.pm:647-660`): `int16s` where
+/// `0 => 'In Focus'`, `-32768 => 'Out of Focus'`, else
+/// `Front Focus ($val)` (`$val < 0`) / `Back Focus (+$val)`. `-n` is the raw
+/// signed integer.
+#[must_use]
+pub fn af_status_value(v: i16, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(v));
+  }
+  let s = match v {
+    0 => "In Focus".to_string(),
+    -32768 => "Out of Focus".to_string(),
+    n if n < 0 => std::format!("Front Focus ({n})"),
+    n => std::format!("Back Focus (+{n})"),
+  };
+  TagValue::Str(SmolStr::new(s))
+}
+
+/// `int8s` `'$val > 0 ? "+$val" : $val'` PrintConv (the `ContrastSetting` /
+/// `SaturationSetting` / `SharpnessSetting` / `ColorCompensationFilterSet`
+/// signed-setting form). `-n` is the raw signed integer.
+#[must_use]
+pub fn signed_setting_value(v: i8, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(v));
+  }
+  let s = if v > 0 {
+    std::format!("+{v}")
+  } else {
+    std::format!("{v}")
+  };
+  TagValue::Str(SmolStr::new(s))
+}
+
+/// `'$val ? sprintf("%+.1f",$val) : 0'` — the `ExposureCompensationSet` /
+/// `FlashExposureCompSet` form (`ValueConv => '($val - 128) / 24'`). A zero
+/// value renders the integer `0`; a non-zero value renders `%+.1f`. `-n` keeps
+/// the float ValueConv result.
+#[must_use]
+pub fn exposure_comp_value(raw: u8, print_conv: bool) -> TagValue {
+  let val = (f64::from(raw) - 128.0) / 24.0;
+  if !print_conv {
+    return TagValue::F64(val);
+  }
+  if val == 0.0 {
+    TagValue::I64(0)
+  } else {
+    TagValue::Str(SmolStr::new(std::format!("{val:+.1}")))
+  }
+}
+
+/// `'$val / 8'` `int16s` exposure-comp form (`ExposureCompensation2` /
+/// `FlashExposureCompSet2`): `$val ? sprintf("%+.1f",$val) : 0`. `-n` keeps the
+/// float.
+#[must_use]
+pub fn exposure_comp2_value(raw: i16, print_conv: bool) -> TagValue {
+  let val = f64::from(raw) / 8.0;
+  if !print_conv {
+    return TagValue::F64(val);
+  }
+  if val == 0.0 {
+    TagValue::I64(0)
+  } else {
+    TagValue::Str(SmolStr::new(std::format!("{val:+.1}")))
+  }
+}
+
+/// Render a hash-PrintConv leaf with the bundled `PrintHex => 1` flag honoured.
+/// A hit renders the label; a miss renders `"Unknown (0x%x)"` (`-j`) or the raw
+/// integer (`-n`) per `ExifTool.pm:3603-3622`.
+#[must_use]
+pub fn hash_hex_value(raw: u32, hit: Option<&'static str>, print_conv: bool) -> TagValue {
+  match (print_conv, hit) {
+    (true, Some(s)) => TagValue::Str(SmolStr::new(s)),
+    (true, None) => TagValue::Str(SmolStr::new(std::format!("Unknown (0x{raw:x})"))),
+    (false, _) => TagValue::I64(i64::from(raw)),
+  }
+}
+
+/// `$$self{Model} =~ /^(SLT-|DSLR-A(560|580))\b/` — the 15-point-AF body class
+/// (`CameraInfo3` 15-point branch, `MoreSettings`/`CameraSettings3`/
+/// `ExtraInfo3` "other / SLT" branches).
+#[must_use]
+pub fn model_is_slt_15pt(model: Option<&str>) -> bool {
+  let Some(m) = model else { return false };
+  word_boundary_after(m, "SLT-")
+    || word_boundary_after(m, "DSLR-A560")
+    || word_boundary_after(m, "DSLR-A580")
+}
+
+/// `$$self{Model} =~ /^SLT-/`.
+#[must_use]
+pub fn model_is_slt(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("SLT-"))
+}
+
+/// `$$self{Model} =~ /^DSLR-A(450|500|550)\b/` — the 9-point-AF DSLR class.
+#[must_use]
+pub fn model_is_a4xx_9pt(model: Option<&str>) -> bool {
+  let Some(m) = model else { return false };
+  word_boundary_after(m, "DSLR-A450")
+    || word_boundary_after(m, "DSLR-A500")
+    || word_boundary_after(m, "DSLR-A550")
+}
+
+/// `$$self{Model} =~ /^NEX-(3|5|5C)/` (a prefix match, not a `\b` boundary —
+/// the Perl alternation matches `NEX-3`, `NEX-5`, `NEX-5C`).
+#[must_use]
+pub fn model_is_nex355c(model: Option<&str>) -> bool {
+  let Some(m) = model else { return false };
+  m.starts_with("NEX-3") || m.starts_with("NEX-5")
+}
+
+/// `$$self{Model} =~ /^NEX-/`.
+#[must_use]
+pub fn model_is_nex(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("NEX-"))
+}
+
+/// `$$self{Model} =~ /^DSLR-/`.
+#[must_use]
+pub fn model_is_dslr(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("DSLR-"))
+}
+
+/// `$$self{Model} =~ /^(NEX-(3|5|5C|C3|VG10|VG10E))\b/` — the ExtraInfo3 NEX
+/// exclusion class (`BatteryVoltage1`/`BatteryVoltage2`/`ImageStabilization`
+/// are NOT valid for these bodies).
+#[must_use]
+pub fn model_is_nex_battery_excl(model: Option<&str>) -> bool {
+  let Some(m) = model else { return false };
+  for tail in [
+    "NEX-3",
+    "NEX-5",
+    "NEX-5C",
+    "NEX-C3",
+    "NEX-VG10",
+    "NEX-VG10E",
+  ] {
+    if word_boundary_after(m, tail) {
+      return true;
+    }
+  }
+  false
+}
+
+/// True when `m` starts with `prefix` AND a Perl `\b` word-boundary holds at the
+/// position right after `prefix`, reproducing `/^prefix\b/`.
+///
+/// A `\b` boundary exists between two adjacent positions iff EXACTLY ONE is a
+/// word char (`[A-Za-z0-9_]`). The boundary here is between the LAST char of
+/// `prefix` and the NEXT char of `m` (or end-of-string). So a prefix ending in a
+/// word char (e.g. `DSLR-A560`) needs the next char to be a non-word char / end,
+/// whereas a prefix ending in a NON-word char (e.g. `SLT-`) needs the next char
+/// to be a word char (the `-`→`A` transition in `SLT-A33`).
+fn word_boundary_after(m: &str, prefix: &str) -> bool {
+  let Some(rest) = m.strip_prefix(prefix) else {
+    return false;
+  };
+  let is_word = |c: char| c.is_ascii_alphanumeric() || c == '_';
+  // The char immediately before the boundary = the last char of `prefix`.
+  let before_is_word = prefix.chars().next_back().is_some_and(is_word);
+  // The char immediately after the boundary = the first char of `rest` (a
+  // non-word "char" at end-of-string).
+  let after_is_word = rest.chars().next().is_some_and(is_word);
+  before_is_word != after_is_word
+}
+
+/// `%whiteBalanceSetting` PrintConv (`Sony.pm` — the `PrintHex => 1` WB table
+/// shared by `MoreSettings` 0x0d / `CameraSettings3` 0x16).
+#[must_use]
+pub fn white_balance_setting(v: u32) -> Option<&'static str> {
+  Some(match v {
+    0x10 => "Auto (-3)",
+    0x11 => "Auto (-2)",
+    0x12 => "Auto (-1)",
+    0x13 => "Auto (0)",
+    0x14 => "Auto (+1)",
+    0x15 => "Auto (+2)",
+    0x16 => "Auto (+3)",
+    0x20 => "Daylight (-3)",
+    0x21 => "Daylight (-2)",
+    0x22 => "Daylight (-1)",
+    0x23 => "Daylight (0)",
+    0x24 => "Daylight (+1)",
+    0x25 => "Daylight (+2)",
+    0x26 => "Daylight (+3)",
+    0x30 => "Shade (-3)",
+    0x31 => "Shade (-2)",
+    0x32 => "Shade (-1)",
+    0x33 => "Shade (0)",
+    0x34 => "Shade (+1)",
+    0x35 => "Shade (+2)",
+    0x36 => "Shade (+3)",
+    0x40 => "Cloudy (-3)",
+    0x41 => "Cloudy (-2)",
+    0x42 => "Cloudy (-1)",
+    0x43 => "Cloudy (0)",
+    0x44 => "Cloudy (+1)",
+    0x45 => "Cloudy (+2)",
+    0x46 => "Cloudy (+3)",
+    0x50 => "Tungsten (-3)",
+    0x51 => "Tungsten (-2)",
+    0x52 => "Tungsten (-1)",
+    0x53 => "Tungsten (0)",
+    0x54 => "Tungsten (+1)",
+    0x55 => "Tungsten (+2)",
+    0x56 => "Tungsten (+3)",
+    0x60 => "Fluorescent (-3)",
+    0x61 => "Fluorescent (-2)",
+    0x62 => "Fluorescent (-1)",
+    0x63 => "Fluorescent (0)",
+    0x64 => "Fluorescent (+1)",
+    0x65 => "Fluorescent (+2)",
+    0x66 => "Fluorescent (+3)",
+    0x70 => "Flash (-3)",
+    0x71 => "Flash (-2)",
+    0x72 => "Flash (-1)",
+    0x73 => "Flash (0)",
+    0x74 => "Flash (+1)",
+    0x75 => "Flash (+2)",
+    0x76 => "Flash (+3)",
+    0xa3 => "Custom",
+    0xf3 => "Color Temperature/Color Filter",
+    _ => return None,
+  })
+}
+
+/// `%sonyExposureProgram2` PrintConv (`Sony.pm`) — `MoreSettings` 0x02 /
+/// `CameraSettings3` 0x05 `ExposureProgram`.
+#[must_use]
+pub fn exposure_program2(v: u32) -> Option<&'static str> {
+  Some(match v {
+    1 => "Program AE",
+    2 => "Aperture-priority AE",
+    3 => "Shutter speed priority AE",
+    4 => "Manual",
+    5 => "Cont. Priority AE",
+    16 => "Auto",
+    17 => "Auto (no flash)",
+    18 => "Auto+",
+    49 => "Portrait",
+    50 => "Landscape",
+    51 => "Macro",
+    52 => "Sports",
+    53 => "Sunset",
+    54 => "Night view",
+    55 => "Night view/portrait",
+    56 => "Handheld Night Shot",
+    57 => "3D Sweep Panorama",
+    64 => "Auto 2",
+    65 => "Auto 2 (no flash)",
+    80 => "Sweep Panorama",
+    96 => "Anti Motion Blur",
+    128 => "Toy Camera",
+    129 => "Pop Color",
+    130 => "Posterization",
+    131 => "Posterization B/W",
+    132 => "Retro Photo",
+    133 => "High-key",
+    134 => "Partial Color Red",
+    135 => "Partial Color Green",
+    136 => "Partial Color Blue",
+    137 => "Partial Color Yellow",
+    138 => "High Contrast Monochrome",
+    _ => return None,
+  })
+}
+
+/// `%sonyDriveMode` shared `DriveMode2`/`DriveModeSetting`/`DriveMode` body
+/// PrintConv (`PrintHex => 1`; `MoreSettings` 0x01 / `CameraSettings3`
+/// 0x04). The extended `0xd1..0xd6` continuous variants only appear in the
+/// `CameraSettings3` 0x34 `DriveMode` table; pass `extended = true` there.
+#[must_use]
+pub fn drive_mode(v: u32, extended: bool) -> Option<&'static str> {
+  Some(match v {
+    0x10 => "Single Frame",
+    0x21 => "Continuous High",
+    0x22 => "Continuous Low",
+    0x30 => "Speed Priority Continuous",
+    0x51 => "Self-timer 10 sec",
+    0x52 => "Self-timer 2 sec, Mirror Lock-up",
+    0x71 => "Continuous Bracketing 0.3 EV",
+    0x75 => "Continuous Bracketing 0.7 EV",
+    0x91 => "White Balance Bracketing Low",
+    0x92 => "White Balance Bracketing High",
+    0xc0 => "Remote Commander",
+    0xd1 if extended => "Continuous - HDR",
+    0xd2 if extended => "Continuous - Multi Frame NR",
+    0xd3 if extended => "Continuous - Handheld Night Shot",
+    0xd4 if extended => "Continuous - Anti Motion Blur",
+    0xd5 if extended => "Continuous - Sweep Panorama",
+    0xd6 if extended => "Continuous - 3D Sweep Panorama",
+    _ => return None,
+  })
+}

--- a/src/exif/makernotes/vendors/sony/tag900b.rs
+++ b/src/exif/makernotes/vendors/sony/tag900b.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::Tag900b` (`Sony.pm:7549-7578`) — the `0x900b`
+//! Main-table SubDirectory dispatched when the (still-enciphered) first value
+//! byte is `0xae` (`Condition => '$$valPt =~ /^\xae/'`, `Sony.pm:1078-1082`).
+//!
+//! The block is enciphered (`PROCESS_PROC => \&ProcessEnciphered`); the
+//! dispatcher [`process_enciphered`](super::decipher::process_enciphered)s it
+//! (once, or twice for a double-enciphered body) and hands this table the
+//! DECIPHERED bytes. Per the `ProcessBinaryData` contract each tag is emitted
+//! IFF its byte range is in the deciphered block AND its model `Condition` holds
+//! ([[exifast-processbinarydata-per-field]]).
+//!
+//! Both leaves use indirect hash PrintConvs (the deciphered byte is an opaque
+//! code, NOT the face count): `FacesDetected` (0x0002) maps 98→'1', 57→'2', …
+//! and `FaceDetection` (0x00bd) maps 0→'Off', 98→'On'.
+
+use crate::value::TagValue;
+use smol_str::SmolStr;
+
+use super::subtables::{SubEmission, model_is_a4xx_9pt};
+
+/// `FacesDetected` (0x0002) PrintConv (`Sony.pm:7556-7567`) — the deciphered
+/// byte is an opaque code, decoded to the face-count string.
+fn faces_detected(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "0",
+    98 => "1",
+    57 => "2",
+    93 => "3",
+    77 => "4",
+    33 => "5",
+    168 => "6",
+    241 => "7",
+    115 => "8",
+    _ => return None,
+  })
+}
+
+/// `FaceDetection` (0x00bd) PrintConv (`Sony.pm:7572-7577`) — `0 => Off`,
+/// `98 => On`.
+fn face_detection(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    98 => "On",
+    _ => return None,
+  })
+}
+
+/// Render a hash leaf where the deciphered byte is opaque: a PrintConv hit gives
+/// the label; a miss gives `"Unknown ($val)"` (`-j`). `-n` keeps the raw byte.
+fn opaque_hash_value(raw: u8, hit: Option<&'static str>, print_conv: bool) -> TagValue {
+  match (print_conv, hit) {
+    (true, Some(s)) => TagValue::Str(SmolStr::new(s)),
+    (true, None) => TagValue::Str(SmolStr::new(std::format!("Unknown ({raw})"))),
+    (false, _) => TagValue::I64(i64::from(raw)),
+  }
+}
+
+/// Walk the DECIPHERED `Tag900b` block and emit the face leaves.
+///
+/// `buf` is the DECIPHERED `0x900b` block — the dispatcher confirmed the `0xae`
+/// gate on the raw bytes and ran
+/// [`process_enciphered`](super::decipher::process_enciphered). `model` gates
+/// the `0x00bd` `FaceDetection` row (`!~ /^DSLR-(A450|A500|A550)$/`).
+#[must_use]
+pub fn parse_tag900b(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+
+  // 0x0002 FacesDetected.
+  if let Some(&raw) = buf.get(0x0002) {
+    out.push(SubEmission {
+      priority: 1,
+      name: "FacesDetected",
+      value: opaque_hash_value(raw, faces_detected(raw), print_conv),
+    });
+  }
+
+  // 0x00bd FaceDetection — `Condition !~ /^DSLR-(A450|A500|A550)$/`.
+  if !model_is_a4xx_9pt(model)
+    && let Some(&raw) = buf.get(0x00bd)
+  {
+    out.push(SubEmission {
+      priority: 1,
+      name: "FaceDetection",
+      value: opaque_hash_value(raw, face_detection(raw), print_conv),
+    });
+  }
+
+  out
+}

--- a/src/exif/makernotes/vendors/sony/tag900b.rs
+++ b/src/exif/makernotes/vendors/sony/tag900b.rs
@@ -19,7 +19,7 @@
 use crate::value::TagValue;
 use smol_str::SmolStr;
 
-use super::subtables::{SubEmission, model_is_a4xx_9pt};
+use super::subtables::{SubEmission, model_is_a4xx_exact};
 
 /// `FacesDetected` (0x0002) PrintConv (`Sony.pm:7556-7567`) — the deciphered
 /// byte is an opaque code, decoded to the face-count string.
@@ -77,8 +77,10 @@ pub fn parse_tag900b(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<S
     });
   }
 
-  // 0x00bd FaceDetection — `Condition !~ /^DSLR-(A450|A500|A550)$/`.
-  if !model_is_a4xx_9pt(model)
+  // 0x00bd FaceDetection — `Condition !~ /^DSLR-(A450|A500|A550)$/` ($-anchored
+  // EXACT, Sony.pm:7571) — NOT the `\b` boundary, so a suffixed A4xx body still
+  // emits FaceDetection.
+  if !model_is_a4xx_exact(model)
     && let Some(&raw) = buf.get(0x00bd)
   {
     out.push(SubEmission {
@@ -90,3 +92,11 @@ pub fn parse_tag900b(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<S
 
   out
 }
+
+#[cfg(test)]
+// The module-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "tag900b_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/tag900b_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag900b_tests.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Sony::Tag900b` model-anchor regression: 0x00bd `FaceDetection` carries
+//! `Condition => '$$self{Model} !~ /^DSLR-(A450|A500|A550)$/'` (`$`-anchored
+//! EXACT, Sony.pm:7571), NOT the `\b` boundary. 0x0002 `FacesDetected` is
+//! unconditional.
+
+use super::*;
+
+fn has(model: &str, buf: &[u8], name: &str) -> bool {
+  parse_tag900b(buf, Some(model), true)
+    .iter()
+    .any(|e| e.name == name)
+}
+
+#[test]
+fn facedetection_is_exact_not_word_boundary() {
+  let mut buf = vec![0u8; 0xc0];
+  buf[0x0002] = 98; // FacesDetected -> "1"
+  buf[0x00bd] = 98; // FaceDetection -> "On"
+
+  // SLT-A33 + suffixed A4xx strings: NOT a `$`-exact match, so FaceDetection
+  // still emits (the `\b` port wrongly dropped `DSLR-A500-x`).
+  for m in ["SLT-A33", "DSLR-A500-x", "DSLR-A500X"] {
+    assert!(has(m, &buf, "FacesDetected"), "{m} FacesDetected");
+    assert!(
+      has(m, &buf, "FaceDetection"),
+      "{m} FaceDetection must emit ($-exact)"
+    );
+  }
+
+  // Real exact A4xx bodies: FaceDetection suppressed (always 98 there), but
+  // FacesDetected still emits.
+  for m in ["DSLR-A450", "DSLR-A500", "DSLR-A550"] {
+    assert!(has(m, &buf, "FacesDetected"), "{m} FacesDetected");
+    assert!(
+      !has(m, &buf, "FaceDetection"),
+      "{m} FaceDetection suppressed (exact)"
+    );
+  }
+}

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12158,9 +12158,82 @@ pub(in crate::exif) fn sony_makernote_isolated(
         print_conv,
         &mut sink,
       );
+      // The older-body plain (un-enciphered) `ProcessBinaryData` SubDirectories
+      // (`CameraInfo3` 0x0010 / `MoreInfo` 0x0020 / `CameraSettings3` 0x0114 /
+      // `ExtraInfo3` 0x0116) the A33-class bodies write — decoded HERE in the
+      // same walk-order pass, so an overlapping leaf shared with a later block
+      // (e.g. `MeteringMode` in both `MoreSettings` 0x0020 and `CameraSettings3`
+      // 0x0114) is last-wins-overridden byte-identically to ExifTool's IFD-order
+      // emission. (`Tag900b` 0x900b is enciphered → handled above.)
+      sony_emit_binary_subdir(data, g1, entry, model, print_conv, &mut sink);
     }
   }
   Some((emissions, typed))
+}
+
+/// Decode an older Sony Main-IFD plain (un-enciphered) `ProcessBinaryData`
+/// SubDirectory the A33-class (SLT / DSLR-A4xx-A5xx / NEX) bodies write —
+/// `CameraInfo3` (0x0010), `MoreInfo` (0x0020), `CameraSettings3` (0x0114) or
+/// `ExtraInfo3` (0x0116) — and emit its ported leaves into `sink`.
+///
+/// `entry` is the Sony Main-IFD SubDirectory row; its verbatim on-disk value
+/// bytes are `data[value_offset .. value_offset + value_size]`. These tables are
+/// NOT enciphered (unlike the `Tag9xxx` series), so the raw block is read
+/// directly. The per-table parsers honour the `ProcessBinaryData` per-field
+/// availability contract + the model `Condition`s; a hostile / out-of-range span
+/// is bounds-checked by `get` (decodes nothing rather than panicking). The
+/// leaves ride the Sony vendor family-1 group; none are `Unknown => 1`.
+#[cfg(feature = "alloc")]
+fn sony_emit_binary_subdir<S: ExifSink>(
+  data: &[u8],
+  group1: &str,
+  entry: &ExifEntry,
+  model: Option<&str>,
+  print_conv: bool,
+  out: &mut S,
+) {
+  use makernotes::vendors::sony::{camerainfo3, camerasettings3, extrainfo3, moreinfo};
+  let off = entry.value_offset();
+  let Some(end) = off.checked_add(entry.value_size()) else {
+    return;
+  };
+  let Some(raw) = data.get(off..end) else {
+    return;
+  };
+  let emissions = match entry.tag_id() {
+    // `CameraInfo3` — `$count == 15360` (Sony.pm:2280-2300). The `$count` gate
+    // is the entry's value byte-count.
+    0x0010 if entry.value_size() == 15360 => {
+      camerainfo3::parse_camera_info3(raw, model, print_conv)
+    }
+    // `MoreInfo` — dispatched (over `FocusInfo`) when `$count` is NOT
+    // 19154/19148 (Sony.pm:44-63).
+    0x0020 if entry.value_size() != 19154 && entry.value_size() != 19148 => {
+      moreinfo::parse_more_info(raw, model, print_conv)
+    }
+    // `CameraSettings3` — `$count == 1536 || $count == 2048` (Sony.pm:97-127).
+    0x0114 if entry.value_size() == 1536 || entry.value_size() == 2048 => {
+      camerasettings3::parse_camera_settings3(raw, model, print_conv)
+    }
+    // `ExtraInfo3` — the final (non-conditional) `ExtraInfo` ARRAY branch
+    // (Sony.pm:150-167); the A33 writes this variant.
+    0x0116 => extrainfo3::parse_extra_info3(raw, model, print_conv),
+    _ => return,
+  };
+  // Each leaf carries its ExifTool `Priority => N` (the table-level `PRIORITY`,
+  // or the explicit per-leaf `Priority` for `CameraInfo3` `FocalLength`), so the
+  // sink's priority-aware dedup keeps a higher-priority Main-IFD leaf of the
+  // same `(doc, family1, name)` (e.g. `0x0102` `Quality`).
+  for emi in emissions {
+    let Ok(()) = out.write_vendor_value_with_priority(
+      "MakerNotes",
+      group1,
+      emi.name,
+      emi.value,
+      false,
+      emi.priority,
+    );
+  }
 }
 
 /// Decode a Sony Main-IFD `ProcessBinaryData` SubDirectory sub-block
@@ -12205,7 +12278,7 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
 ) {
   use makernotes::vendors::sony::decipher::process_enciphered;
   use makernotes::vendors::sony::{
-    tag202a, tag940c, tag9050, tag9400, tag9401, tag9402, tag9406, tag9416,
+    tag202a, tag900b, tag940c, tag9050, tag9400, tag9401, tag9402, tag9406, tag9416,
   };
   // The verbatim on-disk value span (the enciphered cipher block, or the plain
   // `Tag202a` bytes) — the same buffer the walk read, sliced at the entry's
@@ -12277,6 +12350,15 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
     0x9416 => {
       let buf = process_enciphered(raw, double_cipher);
       for emi in tag9416::parse_tag9416(&buf, model, print_conv) {
+        let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
+      }
+    }
+    // `Tag900b` — the enciphered face-info block the older A33-class bodies
+    // write, selected by the (still-enciphered) first value byte = `0xae`
+    // (`Condition => '$$valPt =~ /^\xae/'`, `Sony.pm:1080`).
+    0x900b if raw.first() == Some(&0xae) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag900b::parse_tag900b(&buf, model, print_conv) {
         let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
       }
     }

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -10165,13 +10165,16 @@ fn arw_preview_image_conformance() {
 /// `SubIFD:*` raw tags + the standalone conversions (Compression 32767, the IFD2
 /// `JpgFromRaw*`/`YCbCrSubSampling`, the `IsImageData` placeholders) are
 /// byte-exact in BOTH `-j` and `-n`. The `%Sony::Main` ENCRYPTED sub-table tower
-/// (the `Decipher` cipher + the model-version ProcessBinaryData tables) is a
-/// separate deferred port, so its `Sony:*` exposure/AF/lens leaves and the
-/// dependent `Composite:*` are dropped from BOTH sides here (the SAME keys the
-/// `NOT_ACTIVE` deferral in `tests/typed_serde_parity.rs` documents). This test
-/// LOCKS the SR2/SubIFD/conversion foundation byte-exact as a regression guard;
-/// when the sub-table tower lands, the exclusions shrink and the fixtures move
-/// into the active byte-exact set.
+/// (the `Decipher` cipher + the model-version ProcessBinaryData tables) is now
+/// FULLY PORTED for BOTH bodies: the FX3's modern `Tag9xxx` series AND the A33's
+/// older plain-`ProcessBinaryData` SubDirectories (`CameraInfo3` with the
+/// `AFStatus15` grid, `MoreInfo`→`MoreSettings`/`FaceInfo`/`MoreInfo0201`/
+/// `MoreInfo0401`, `CameraSettings3`, `ExtraInfo3`, the enciphered `Tag900b`).
+/// Each fixture's `Sony:*` exposure/AF/lens/battery/settings leaves and the
+/// dependent `Composite:*` are now byte-exact; the SOLE per-fixture exclusion is
+/// one niche composite each (FX3 `XMP-xmp:Rating`, A33 `Composite:LensID`), kept
+/// in sync with the `FIXTURE_EXCLUDED_KEYS` deferrals in
+/// `tests/typed_serde_parity.rs`.
 #[test]
 fn sony_arw_real_sr2_and_subifd_conformance() {
   // The deferred `%Sony::Main` sub-table leaves (+ extra/divergent Sony Main
@@ -10197,117 +10200,27 @@ fn sony_arw_real_sr2_and_subifd_conformance() {
     // emitted byte-exact.
     "XMP-xmp:Rating",
   ];
-  // A33 (older SLT body: `CameraInfo3`/`AFInfo`(AFStatus grid)/`CameraSettings3`/
-  // `ExtraInfo3`/`MoreInfo`/`Tag900b`).
+  // A33 (older SLT body): the `CameraInfo3` (incl. the `AFStatus15` AF grid),
+  // `MoreInfo` (→ `MoreSettings`/`FaceInfo`/`MoreInfo0201`/`MoreInfo0401` +
+  // `TiffMeteringImage`), `CameraSettings3`, `ExtraInfo3` and `Tag900b`
+  // SubDirectories are now FULLY PORTED — every `Sony:*` exposure/AF/battery/
+  // settings leaf emits byte-exact, and the dependent `Composite:*`
+  // (BlueBalance/RedBalance/CFAPattern/FocalLength35efl/FocusDistance2) now
+  // compute. The SOLE residual is one composite:
   const A33_DEFERRED: &[&str] = &[
-    "Composite:BlueBalance",
-    "Composite:CFAPattern",
-    "Composite:FocalLength35efl",
-    "Composite:FocusDistance2",
+    // `Composite:LensID` (= `Sony DT 18-55mm F3.5-5.6 SAM (SAL1855)`). The A33's
+    // `Sony:LensType` (= 55) is AMBIGUOUS — its PrintConv is the multi-candidate
+    // `Sony DT 18-55mm F3.5-5.6 SAM (SAL1855) or SAM II`. ExifTool's
+    // `Composite:LensID` disambiguates to the single SAL1855 via the full
+    // `Exif::PrintLensID` lens-DB matcher (`Exif.pm:5881` — uses `LensSpec` +
+    // `FocalLength` + `MaxAperture` to pick among the `" or "` candidates).
+    // exifast's composite post-pass ports only the UNAMBIGUOUS-LensType case
+    // (`composite/table.rs` `lens_id`, which defers any `" or "` placeholder);
+    // the focal/aperture/LensSpec disambiguation is a separate cross-cutting
+    // subsystem (it would re-key every vendor's ambiguous LensType) NOT part of
+    // this Sony deep-table port. This is the lone niche exclusion; the
+    // `Sony:LensType` (the ambiguous MakerNote leaf) IS emitted byte-exact.
     "Composite:LensID",
-    "Composite:RedBalance",
-    "Sony:AELock",
-    "Sony:AFAreaMode",
-    "Sony:AFButtonPressed",
-    "Sony:AFPoint",
-    "Sony:AFPointSelected",
-    "Sony:AFStatusActiveSensor",
-    "Sony:AFStatusBottomHorizontal",
-    "Sony:AFStatusBottomVertical",
-    "Sony:AFStatusCenterHorizontal",
-    "Sony:AFStatusCenterVertical",
-    "Sony:AFStatusFarLeft",
-    "Sony:AFStatusFarRight",
-    "Sony:AFStatusLeft",
-    "Sony:AFStatusLower-left",
-    "Sony:AFStatusLower-middle",
-    "Sony:AFStatusLower-right",
-    "Sony:AFStatusNearLeft",
-    "Sony:AFStatusNearRight",
-    "Sony:AFStatusRight",
-    "Sony:AFStatusTopHorizontal",
-    "Sony:AFStatusTopVertical",
-    "Sony:AFStatusUpper-left",
-    "Sony:AFStatusUpper-middle",
-    "Sony:AFStatusUpper-right",
-    "Sony:ApertureSetting",
-    "Sony:AspectRatio",
-    "Sony:BatteryLevel",
-    "Sony:BatteryState",
-    "Sony:BatteryTemperature",
-    "Sony:BatteryVoltage1",
-    "Sony:BatteryVoltage2",
-    "Sony:CameraOrientation",
-    "Sony:ColorCompensationFilterSet",
-    "Sony:ColorSpace",
-    "Sony:ColorTemperatureSetting",
-    "Sony:ContrastSetting",
-    "Sony:CreativeStyleSetting",
-    "Sony:CustomWB_RBLevels",
-    "Sony:CustomWB_RGBLevels",
-    "Sony:DriveMode",
-    "Sony:DriveMode2",
-    "Sony:DriveModeSetting",
-    "Sony:DynamicRangeOptimizerLevel",
-    "Sony:DynamicRangeOptimizerSetting",
-    "Sony:ExposureCompensation2",
-    "Sony:ExposureCompensationSet",
-    "Sony:ExposureProgram",
-    "Sony:ExposureTime",
-    "Sony:FNumber",
-    "Sony:FaceDetection",
-    "Sony:FacesDetected",
-    "Sony:FlashAction",
-    "Sony:FlashActionExternal",
-    "Sony:FlashControl",
-    "Sony:FlashExposureComp",
-    "Sony:FlashExposureCompSet",
-    "Sony:FlashExposureCompSet2",
-    "Sony:FlashMode",
-    "Sony:FlashStatus",
-    "Sony:FlashStatusBuilt-in",
-    "Sony:FlashStatusExternal",
-    "Sony:FocalLength",
-    "Sony:FocalLength2",
-    "Sony:FocalLengthTeleZoom",
-    "Sony:FocusMode",
-    "Sony:FocusMode2",
-    "Sony:FocusModeSetting",
-    "Sony:FocusPosition2",
-    "Sony:FocusStatus",
-    "Sony:FolderNumber",
-    "Sony:HDRLevel",
-    "Sony:HDRSetting",
-    "Sony:ISO",
-    "Sony:ISOSetting",
-    "Sony:ImageCount",
-    "Sony:ImageNumber",
-    "Sony:LensMount",
-    "Sony:LiveViewAFMethod",
-    "Sony:LiveViewAFSetting",
-    "Sony:LiveViewFocusMode",
-    "Sony:LiveViewMetering",
-    "Sony:MeteringMode",
-    "Sony:MultiFrameNoiseReduction",
-    "Sony:Orientation2",
-    "Sony:PanoramaSize3D",
-    "Sony:RedEyeReduction",
-    "Sony:SaturationSetting",
-    "Sony:SequenceNumber",
-    "Sony:SharpnessSetting",
-    "Sony:ShotNumberSincePowerUp",
-    "Sony:ShotNumberSincePowerUp2",
-    "Sony:ShutterCount",
-    "Sony:ShutterSpeedSetting",
-    "Sony:SmileShutter",
-    "Sony:SmileShutterMode",
-    "Sony:SonyImageSize",
-    "Sony:SweepPanoramaDirection",
-    "Sony:SweepPanoramaSize",
-    "Sony:TiffMeteringImage",
-    "Sony:ViewingMode",
-    "Sony:ViewingMode2",
-    "Sony:WhiteBalanceSetting",
   ];
   check_excluding(
     "Sony_ILME-FX3_real.ARW",
@@ -10371,6 +10284,54 @@ fn sony_arw_real_sr2_and_subifd_conformance() {
     assert!(
       got.contains(needle),
       "SR2/SubIFD + Tag9050c/Tag9400c foundation must emit {needle}: {got}",
+    );
+  }
+
+  // Positively assert the A33's OLDER plain-`ProcessBinaryData` SubDirectories
+  // actually fired — not just that the lone composite residual was excluded.
+  let a33 = std::fs::read(format!("{root}/tests/fixtures/Sony_SLT-A33_real.ARW"))
+    .expect("read Sony_SLT-A33_real.ARW");
+  let got = extract_info("Sony_SLT-A33_real.ARW", &a33, true);
+  for needle in [
+    // CameraInfo3 (0x0010, 15-point SLT branch): FocalLength / FocusStatus /
+    // AFPoint (afPoint15) / AFStatusActiveSensor + the AFStatus15 grid.
+    "\"Sony:FocalLength\":\"24.0 mm\"",
+    "\"Sony:FocusStatus\":\"AF-C - Confirmed\"",
+    "\"Sony:AFPoint\":\"Near Right\"",
+    "\"Sony:AFStatusActiveSensor\":\"Back Focus (+35)\"",
+    "\"Sony:AFStatusUpper-left\":\"Front Focus (-93)\"",
+    "\"Sony:AFStatusCenterHorizontal\":\"Out of Focus\"",
+    // MoreInfo (0x0020): MoreSettings exposure (FNumber/ExposureTime/ISO/
+    // FocalLength2), MoreInfo0201 ImageCount/ShutterCount, MoreInfo0401
+    // ShotNumberSincePowerUp, the TiffMeteringImage placeholder.
+    "\"Sony:FNumber\":18.2",
+    "\"Sony:ExposureTime\":\"1/29\"",
+    "\"Sony:ImageCount\":1875",
+    "\"Sony:ShutterCount\":2639",
+    "\"Sony:ShotNumberSincePowerUp\":22",
+    "\"Sony:TiffMeteringImage\":\"(Binary data 7404 bytes, use -b option to extract)\"",
+    // CameraSettings3 (0x0114): ApertureSetting / DriveModeSetting / LensMount +
+    // the masked FolderNumber/ImageNumber. The `PRIORITY => 0` `Quality` here
+    // must NOT override the Main-IFD `0x0102` `Quality` = `RAW + JPEG/HEIF`.
+    "\"Sony:ApertureSetting\":18.2",
+    "\"Sony:DriveModeSetting\":\"Continuous Bracketing 0.7 EV\"",
+    "\"Sony:LensMount\":\"A-mount\"",
+    "\"Sony:FolderNumber\":100",
+    "\"Sony:ImageNumber\":1867",
+    "\"Sony:Quality\":\"RAW + JPEG/HEIF\"",
+    // ExtraInfo3 (0x0116): battery temp/level/voltage + BatteryState (SLT) +
+    // masked CameraOrientation.
+    "\"Sony:BatteryTemperature\":\"33.9 C\"",
+    "\"Sony:BatteryVoltage1\":\"6.66 V\"",
+    "\"Sony:BatteryState\":\"Low\"",
+    "\"Sony:CameraOrientation\":\"Horizontal (normal)\"",
+    // Tag900b (0x900b, enciphered): FacesDetected / FaceDetection.
+    "\"Sony:FacesDetected\":0",
+    "\"Sony:FaceDetection\":\"On\"",
+  ] {
+    assert!(
+      got.contains(needle),
+      "A33 older-SubDirectory port must emit {needle}: {got}",
     );
   }
 }

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -243,21 +243,31 @@ const NOT_ACTIVE: &[&str] = &[
   // residual (the IFD0 `0x02bc` ApplicationNotes XMP routing is a separate
   // cross-cutting subsystem — see `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`).
   //
-  // The two OLDER Sony ARW raws (`SLT-A33` / `DSLR-A200`) stay accept-deferred:
-  // their core EXIF/SubIFD + the ENTIRE SR2 subsystem (the `DNGPrivateData`
-  // 0xc634 → `%Sony::SR2Private` descent, the `Decrypt` LFSR, and the decrypted
+  // The `Sony_SLT-A33_real.ARW` raw is now ACTIVE: the OLDER-body `%Sony::Main`
+  // plain-`ProcessBinaryData` sub-table tower is FULLY PORTED — `CameraInfo3`
+  // (incl. the 15-point `AFStatus15` AF grid), `MoreInfo` (→ `MoreSettings`/
+  // `FaceInfo`/`MoreInfo0201`/`MoreInfo0401` + `TiffMeteringImage`),
+  // `CameraSettings3`, `ExtraInfo3` and the enciphered `Tag900b` emit every
+  // remaining `Sony:*` exposure/AF/battery/settings leaf, and the dependent
+  // `Composite:*` (BlueBalance/RedBalance/CFAPattern/FocalLength35efl/
+  // FocusDistance2) now compute byte-exact. A33 carries a per-fixture
+  // `FIXTURE_EXCLUDED_KEYS` entry for the lone `Composite:LensID` (the ambiguous
+  // `Sony:LensType` 55 needs the unported `Exif::PrintLensID` disambiguator —
+  // see `FIXTURE_EXCLUDED_KEYS`).
+  //
+  // The remaining OLDER Sony ARW raw (`DSLR-A200`) stays accept-deferred: its
+  // core EXIF/SubIFD + the ENTIRE SR2 subsystem (the `DNGPrivateData` 0xc634 →
+  // `%Sony::SR2Private` descent, the `Decrypt` LFSR, and the decrypted
   // `%Sony::SR2SubIFD` + `%Sony::SR2DataIFD` walks — `SR2:*`/`SR2SubIFD:*`/
-  // `SR2DataIFD*:ColorMode`) ARE byte-exact in BOTH `-j` and `-n`, as are their
+  // `SR2DataIFD*:ColorMode`) ARE byte-exact in BOTH `-j` and `-n`, as are its
   // Sony ARW `SubIFD:*` raw tags, the `Compression => 'Sony ARW Compressed'`
-  // (32767), the IFD2 `JpgFromRaw*`, and the `IsImageData` placeholders. Their
-  // RESIDUAL is the OLDER-body `%Sony::Main` sub-table tower (A33: `CameraInfo3`/
-  // `AFInfo`(AFStatus grid)/`CameraSettings3`/`ExtraInfo3`/`MoreInfo`/`Tag900b`
-  // — ~101 leaves; A200: `CameraSettings`/`CameraInfoA200` — ~72 leaves) which
-  // emit the remaining `Sony:*` exposure/AF/lens leaves + the dependent
-  // `Composite:*`; A200 ADDITIONALLY needs the `%MinoltaRaw::Main` MRW port (22
-  // `MinoltaRaw:*`, which also overrides its `Composite:ImageSize`/`Megapixels`).
-  // Those OLDER sub-table towers are a separate faithful campaign.
-  "Sony_SLT-A33_real.ARW",
+  // (32767), the IFD2 `JpgFromRaw*`, and the `IsImageData` placeholders. Its
+  // RESIDUAL is the A200-specific sub-table tower (`CameraSettings`/
+  // `CameraInfoA200` — ~72 leaves) which emits the remaining `Sony:*`
+  // exposure/AF/lens leaves + the dependent `Composite:*`; A200 ADDITIONALLY
+  // needs the `%MinoltaRaw::Main` MRW port (22 `MinoltaRaw:*`, which also
+  // overrides its `Composite:ImageSize`/`Megapixels`). That OLDER sub-table
+  // tower is a separate faithful campaign.
   "Sony_DSLR-A200_real.ARW",
 ];
 
@@ -491,6 +501,19 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   // IS emitted. Mirrors `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`'s
   // `FX3_DEFERRED`.
   ("Sony_ILME-FX3_real.ARW", &["XMP-xmp:Rating"]),
+  // The `Sony_SLT-A33_real.ARW` raw is now active (its OLDER plain-
+  // `ProcessBinaryData` sub-table tower — `CameraInfo3`/`MoreInfo`/
+  // `CameraSettings3`/`ExtraInfo3`/`Tag900b` — is fully ported, see the
+  // `NOT_ACTIVE` note). The lone residual is `Composite:LensID`: the A33's
+  // `Sony:LensType` (= 55) PrintConv is the multi-candidate `Sony DT 18-55mm
+  // F3.5-5.6 SAM (SAL1855) or SAM II`, and ExifTool's `Composite:LensID`
+  // disambiguates it to the single `SAL1855` via the full `Exif::PrintLensID`
+  // lens-DB matcher (LensSpec + FocalLength + MaxAperture). exifast's composite
+  // post-pass ports only the unambiguous-LensType case (it defers any `" or "`
+  // placeholder), so this composite is dropped from BOTH sides; the ambiguous
+  // `Sony:LensType` MakerNote leaf IS emitted. Mirrors
+  // `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`'s `A33_DEFERRED`.
+  ("Sony_SLT-A33_real.ARW", &["Composite:LensID"]),
 ];
 
 /// The fully-qualified `Family1:Name` keys to drop for `fixture` (empty when
@@ -1609,7 +1632,15 @@ fn drop_keys(doc: &str, exact_keys: &[&str]) -> String {
 /// `Tag9402`/`Tag9406`/`Tag940c`/`Tag9416`/`Tag202a` ProcessBinaryData tables +
 /// the five dependent `Composite:*`), with a single `FIXTURE_EXCLUDED_KEYS`
 /// entry for the `XMP-xmp:Rating` IFD0-`0x02bc`-XMP residual.
-const EXPECTED_ACTIVE_FIXTURES: usize = 637;
+///
+/// 637 → 638: the `Sony_SLT-A33_real.ARW` raw GRADUATES out of `NOT_ACTIVE` —
+/// its OLDER-body plain-`ProcessBinaryData` sub-table tower is fully ported
+/// (`CameraInfo3` with the 15-point `AFStatus15` AF grid, `MoreInfo` →
+/// `MoreSettings`/`FaceInfo`/`MoreInfo0201`/`MoreInfo0401` + `TiffMeteringImage`,
+/// `CameraSettings3`, `ExtraInfo3`, the enciphered `Tag900b` + the five
+/// dependent `Composite:*`), with a single `FIXTURE_EXCLUDED_KEYS` entry for the
+/// `Composite:LensID` ambiguous-LensType-disambiguation residual.
+const EXPECTED_ACTIVE_FIXTURES: usize = 638;
 
 /// Every `tests/fixtures/<f>` that has both `tests/golden/<f>.json` and
 /// `tests/golden/<f>.n.json`, MINUS the [`NOT_ACTIVE`] formally-accept-


### PR DESCRIPTION
Activates the **2nd real-device Sony fixture** (`Sony_SLT-A33_real.ARW`) byte-exact vs ExifTool 13.59 — ~103 deep-MakerNote tags. The SLT-A33 (2010 SLT body) uses the **older plain-ProcessBinaryData SubDirectories** (not the 0x94xx cipher series the FX3 uses), ground-truthed via `-v4`.

- **CameraInfo3** (0x0010) with the 15-point SLT **AFStatus grid** · **MoreInfo** (0x0020 → MoreSettings/FaceInfo/MoreInfo0201/0401 + TiffMeteringImage, via the bespoke ProcessMoreInfo index walker) · **CameraSettings3** (0x0114) · **ExtraInfo3** (0x0116) · enciphered **Tag900b** (0x900b).
- **FaceInfo** per-face position rectangles (FacesDetected-gated, the `FORMAT=int16u` increment-2 key→byte mapping, ×15+reorder ValueConv).
- **ExtraInfo3 0x0014** model-conditional (SLT→BatteryState / A4xx→ExposureProgram / DSLR→ModeDialPosition).
- **Model-condition anchor faithfulness** swept across all sub-tables: `$`-exact vs `\b` vs no-anchor-prefix helpers, ground-truthed per condition against Sony.pm (the `\b`-bool reuse bug was fixed in CameraInfo3/MoreSettings/MoreInfo0201/CameraSettings3/Tag900b/FaceInfo).
- 3 subtle fixes: the `/^SLT-\b/` boundary, CameraSettings3 `PRIORITY=>0` (Quality doesn't override Main 0x0102), the TiffMeteringImage placeholder. Hash-PrintConv misses → `Unknown (N)`. Per-field ProcessBinaryData availability throughout.

A33 byte-exact (1 niche: `Composite:LensID` — the ambiguous SAL1855 needs the full `Exif::PrintLensID` lens-DB matcher, a cross-cutting subsystem deferred; the ambiguous `Sony:LensType` leaf itself is byte-exact). FX3 + all existing goldens byte-identical. `build(-Dwarnings)=0 conformance=495/0 typed_serde=638 lib=3981/0 timed=161/0 xtask=26`. **Codex: APPROVE** (4 rounds: port → FaceInfo/ExtraInfo3 → FaceInfo $-anchor → the full anchor class sweep).

**Deferred:** the crafted-input memory-amplification → **#443** (shared with the FX3 port; needs a crate-wide lazy/borrowed value). EXPECTED_ACTIVE 637→638. Advances #442 §A; A200 (MinoltaRaw) + Canon next. Closes part of #101/#99/#98.