### PR TITLE
fix(value): zero-heap whole_f64_to_tag_value + re-baseline a stale MOV alloc budget

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -176,7 +176,22 @@ pub fn format_g(val: f64, precision: usize) -> String {
 /// aperture / focal-length / temperature ValueConvs).
 #[must_use]
 pub fn whole_f64_to_tag_value(val: f64) -> TagValue {
-  let token = format_g(val, 15);
+  // Render the `%.15g` token onto the STACK (no heap `String`): a `StackBuf`'s
+  // 128-byte capacity covers every `%.15g` token (≤ ~24 bytes) with wide
+  // margin, so `format_g_into` never overflows here — the cold overflow branch
+  // is unreached for precision 15 (and falling back to `F64` there is the
+  // conservative choice the integer-detection below would anyway take on a
+  // half-rendered token). These are exactly the bytes `format_g` would
+  // heap-allocate — only the backing store changes — so the I64/F64 decision
+  // stays byte-identical. The helper runs on the composite
+  // `FocalLength35efl`/`FocusDistance` ValueConv paths (and every Sony `-n`
+  // ValueConv), so dropping its per-call `String` keeps those paths
+  // allocation-free.
+  let mut buf = StackBuf::new();
+  if format_g_into(&mut buf, val, 15).is_err() {
+    return TagValue::F64(val);
+  }
+  let token = buf.as_str();
   // A pure-integer `%.15g` token (no `.` / `e` / `E`) → an exact `i64` so the
   // JSON token is bundled-identical (`800`, not `800.0`). `%.15g` caps the
   // integer part at 15 digits, so it always fits `i64`; a non-integer or

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -418,7 +418,20 @@ fn extract_info_budget(name: &str) -> (usize, usize) {
     // `-n` 137 → 213. The intended cost of the newly-built video composites (the
     // `Composite:GPSPosition` is the unported timed-GPS deferral), NOT a redundant
     // clone. Ceilings raised to (210, 230).
-    "QuickTime_frea_rexing17b.mov" => (210, 230), // measured (195, 213) — #133 PR 5 video composites
+    //
+    // RE-BASELINED (composite-def scratch drift): the `BuildCompositeTags`
+    // fixpoint evaluates more `Composite` defs per pass than at the (195, 213)
+    // baseline (the post-`#133` def additions — e.g. the `Flash`/`LensID`/
+    // `DateTimeCreated` set that also re-baselined `MakerNotes_Apple` above),
+    // over BOTH views. None of the added defs builds for this dashcam — the
+    // golden still emits only `Composite:AvgBitrate`, and `FocalLength35efl`/
+    // `FocusDistance` never fire (no `FocalLength`, no Sony `FocusInfo`), so the
+    // now-zero-heap `whole_f64_to_tag_value` is not on this path — but each
+    // evaluated def still allocates its per-def `$val[]`/`$prt[]` scratch pair,
+    // so `-j` 195 → 217 and `-n` 213 → 234. Documented engine-overhead scratch
+    // (a future perf PR could reuse the scratch Vecs), NOT a redundant clone /
+    // double decode. Ceilings raised to (232, 250).
+    "QuickTime_frea_rexing17b.mov" => (232, 250), // measured (217, 234) — +composite-def scratch
     "Real.ra" => (100, 100),                      // measured (88, 87)
     _ => (usize::MAX, usize::MAX),
   }


### PR DESCRIPTION
Fixes the red `alloc_budget` test on main (CI runs `cargo test --all-targets`, which includes it). `QuickTime_frea_rexing17b.mov` had drifted to `(217,234)` allocations over its `(210,230)` budget.

- **Root cause (not a recent regression):** the drift is the composite-engine per-def scratch cost (`val[]`/`prt[]` per pass over both views) of Composite defs added since the `(195,213)` baseline — the same mechanism the `MakerNotes_Apple.jpg` budget comment already documents. Confirmed via fixture evidence: this MOV emits only `Composite:AvgBitrate` (no FocalLength35efl/FocusDistance, the only `whole_f64_to_tag_value` callers), and the count was identical before/after the helper rewrite.
- **Re-baseline:** the MOV ceiling `(210,230)→(232,250)`, comment updated to `measured (217,234)` with the Apple precedent.
- **Bonus (kept):** `whole_f64_to_tag_value` is now zero-heap — it renders the `format_g(_,15)` token into a `StackBuf` via `format_g_into` instead of a heap String, taking the identical I64/F64 token decision. Output byte-identical; helps real Apple/Canon/Sony extractions that *do* build those composites.

`alloc_budget=PASS build(-Dwarnings)=0 conformance=496/0 typed_serde=1/0 timed=161/0 lib=4016/0 xtask=26`. All goldens byte-identical. **Codex: APPROVE.**