### PR TITLE
feat(canon): activate Canon_EOS-7D_sRAW_real.CR2 — CameraInfo7D (firmware Hook) + CustomFunctions2 + 6 sub-tables

### DIFF
--- a/src/exif/makernotes/vendors/canon/camera_info.rs
+++ b/src/exif/makernotes/vendors/canon/camera_info.rs
@@ -6,8 +6,17 @@
 //! The `%Canon::Main` tag `0x0d` (`Canon.pm:1308-1494`) is a model-conditional
 //! list of `Canon::CameraInfo<Model>` SubDirectories. This module ports the
 //! EOS 5D table (`%Canon::CameraInfo5D`, `Canon.pm:3777-3964`, selected by
-//! `$$self{Model} =~ /EOS 5D$/`). The newer bodies (`CameraInfo7D`, …) have a
-//! firmware-dependent `Hook`/`varSize` offset shift and are deferred.
+//! `$$self{Model} =~ /EOS 5D$/`) and the EOS 7D table (`%Canon::CameraInfo7D`,
+//! `Canon.pm:4342-4489`, selected by `$$self{Model} =~ /EOS 7D$/`).
+//!
+//! `CameraInfo7D` is `FORMAT => 'int8u'`, `PRIORITY => 0`, with a
+//! firmware-dependent `Hook`/`varSize` offset shift (`Canon.pm:4347-4402`): the
+//! `0x00 FirmwareVersionLookAhead` RawConv probes the version string at 0x1a8
+//! (`CanonFirm = 1`) then 0x1ac (`CanonFirm = 2`); the `0x1e` `Hook`
+//! (`$varSize += ($$self{CanonFirm} ? -4 : 0x10000) if $$self{CanonFirm} < 2`)
+//! shifts every leaf at/after 0x1e accordingly. Its `0x327 PictureStyleInfo`
+//! `IS_SUBDIR` points at the nested `%Canon::PSInfo` table (`Canon.pm:6018`,
+//! `PRIORITY => 0`), emitted in the same `Canon` group.
 //!
 //! `CameraInfo5D` is `FORMAT => 'int8s'`, `FIRST_ENTRY => 0`, `PRIORITY => 0`,
 //! so a tag at position `p` is at byte offset `p` (one `int8s` per unit) and
@@ -52,9 +61,19 @@ pub fn parse(
 ) -> Vec<(SmolStr, TagValue)> {
   if model_is_camera_info_5d(model) {
     camera_info_5d(data, order, print_conv)
+  } else if model_is_camera_info_7d(model) {
+    camera_info_7d(data, order, print_conv)
   } else {
     Vec::new()
   }
+}
+
+/// `true` when `model` selects `%Canon::CameraInfo7D` via the `0x0d`
+/// conditional list (`Canon.pm:4338`, `$$self{Model} =~ /EOS 7D$/` — anchored,
+/// so the original 7D only, NOT "7D Mark II").
+#[must_use]
+pub fn model_is_camera_info_7d(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.trim_end().ends_with("EOS 7D"))
 }
 
 /// `%Canon::CameraInfo5D` (`Canon.pm:3777-3964`).
@@ -213,6 +232,524 @@ fn camera_info_5d(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolS
     );
   }
   out
+}
+
+/// `%Canon::CameraInfo7D` (`Canon.pm:4342-4489`). `FORMAT => 'int8u'`,
+/// `PRIORITY => 0`. The `0x1e` `Hook` shifts every leaf at/after 0x1e by
+/// `varSize` (firmware-version dependent); the `0x327 PictureStyleInfo`
+/// `IS_SUBDIR` walks the nested `%Canon::PSInfo` table.
+fn camera_info_7d(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let mut push = |name: &'static str, v: TagValue| out.push((SmolStr::new_static(name), v));
+
+  // 0x00 FirmwareVersionLookAhead (`Canon.pm:4354-4368`): probe the firmware
+  // string position to set CanonFirm, which drives the 0x1e `Hook` shift.
+  let canon_firm = canon_firm_7d(data);
+  // 0x1e `Hook`: `$varSize += ($$self{CanonFirm} ? -4 : 0x10000) if
+  // $$self{CanonFirm} < 2` — applied to EVERY leaf at byte offset >= 0x1e.
+  let var_size: i64 = if canon_firm < 2 {
+    if canon_firm != 0 { -4 } else { 0x1_0000 }
+  } else {
+    0
+  };
+  // Map a table offset to its actual byte offset (the `Hook` shift fires at
+  // 0x1e). `None` when the shifted offset is not representable (CanonFirm == 0
+  // pushes every later leaf out of range — ExifTool emits nothing for them).
+  let at = |off: usize| -> Option<usize> {
+    let a: i64 = if off >= 0x1e {
+      off as i64 + var_size
+    } else {
+      off as i64
+    };
+    usize::try_from(a).ok()
+  };
+
+  // 0x03 FNumber / 0x04 ExposureTime / 0x06 ISO (`%ciFNumber`/`%ciExposureTime`/
+  // `%ciISO`, int8u). FNumber/ExposureTime collide with the walked-first
+  // `ShotInfo` (`Priority => 0` ⇒ suppressed); ISO is the lone non-colliding leaf.
+  if let Some(off) = at(0x03)
+    && let Some(raw) = i8u(data, off)
+    && raw != 0
+  {
+    let vc = ((raw as f64 - 8.0) / 16.0 * std::f64::consts::LN_2).exp();
+    push("FNumber", value_or_print(print_conv, vc, format_g2(vc)));
+  }
+  if let Some(off) = at(0x04)
+    && let Some(raw) = i8u(data, off)
+    && raw != 0
+  {
+    let vc = (4.0 * std::f64::consts::LN_2 * (1.0 - canon_ev(raw - 24))).exp();
+    push(
+      "ExposureTime",
+      value_or_print(print_conv, vc, print_exposure_time(vc)),
+    );
+  }
+  if let Some(off) = at(0x06)
+    && let Some(raw) = i8u(data, off)
+  {
+    let vc = 100.0 * ((raw as f64 / 8.0 - 9.0) * std::f64::consts::LN_2).exp();
+    push(
+      "ISO",
+      value_or_print(print_conv, vc, std::format!("{vc:.0}")),
+    );
+  }
+  // 0x07 HighlightTonePriority (int8u, %offOn).
+  if let Some(off) = at(0x07)
+    && let Some(v) = i8u(data, off)
+  {
+    push("HighlightTonePriority", enum8(v, print_conv, off_on_label));
+  }
+  // 0x08 MeasuredEV2 / 0x09 MeasuredEV (int8u, RawConv drop-0, `$val/8-6`,
+  // NO PrintConv ⇒ a bare JSON number in both views).
+  if let Some(off) = at(0x08)
+    && let Some(raw) = i8u(data, off)
+    && raw != 0
+  {
+    push("MeasuredEV2", ev_value(raw as f64 / 8.0 - 6.0));
+  }
+  if let Some(off) = at(0x09)
+    && let Some(raw) = i8u(data, off)
+    && raw != 0
+  {
+    push("MeasuredEV", ev_value(raw as f64 / 8.0 - 6.0));
+  }
+  // 0x15 FlashMeteringMode (int8u, PrintConv hash).
+  if let Some(off) = at(0x15)
+    && let Some(v) = i8u(data, off)
+  {
+    push(
+      "FlashMeteringMode",
+      enum8(v, print_conv, flash_metering_mode_label),
+    );
+  }
+  // 0x19 CameraTemperature (`%ciCameraTemperature`, int8u, `$val-128`, "$val C").
+  if let Some(off) = at(0x19)
+    && let Some(raw) = i8u(data, off)
+  {
+    let c = raw - 128;
+    push(
+      "CameraTemperature",
+      if print_conv {
+        TagValue::Str(SmolStr::from(std::format!("{c} C")))
+      } else {
+        TagValue::I64(c)
+      },
+    );
+  }
+  // 0x1e FocalLength (`%ciFocalLength`, int16uRev, RawConv drop-0, "$val mm")
+  // — the `Hook` leaf itself (read at the shifted offset).
+  if let Some(off) = at(0x1e)
+    && let Some(v) = u16_rev(data, off, order)
+    && v != 0
+  {
+    push("FocalLength", mm_value(v, print_conv));
+  }
+  // 0x35 CameraOrientation (int8u, PrintConv).
+  if let Some(off) = at(0x35)
+    && let Some(v) = i8u(data, off)
+  {
+    push(
+      "CameraOrientation",
+      enum8(v, print_conv, camera_orientation_label),
+    );
+  }
+  // 0x54 FocusDistanceUpper / 0x56 FocusDistanceLower (`%focusDistanceByteSwap`,
+  // int16uRev, `$val/100`, ">655.345 ? inf : '$val m'"). Collide with the
+  // higher-priority `FileInfo` leaves (walked later ⇒ they win).
+  if let Some(off) = at(0x54)
+    && let Some(raw) = u16_rev(data, off, order)
+  {
+    push("FocusDistanceUpper", focus_distance_value(raw, print_conv));
+  }
+  if let Some(off) = at(0x56)
+    && let Some(raw) = u16_rev(data, off, order)
+  {
+    push("FocusDistanceLower", focus_distance_value(raw, print_conv));
+  }
+  // 0x77 WhiteBalance (int16u, %canonWhiteBalance).
+  if let Some(off) = at(0x77)
+    && let Some(v) = u16(data, off, order)
+  {
+    push(
+      "WhiteBalance",
+      if print_conv {
+        hash16(v, white_balance_label(v))
+      } else {
+        TagValue::I64(v)
+      },
+    );
+  }
+  // 0x7b ColorTemperature (int16u, plain).
+  if let Some(off) = at(0x7b)
+    && let Some(v) = u16(data, off, order)
+  {
+    push("ColorTemperature", TagValue::I64(v));
+  }
+  // 0xaf CameraPictureStyle (int8u, PrintHex, model-specific hash).
+  if let Some(off) = at(0xaf)
+    && let Some(v) = i8u(data, off)
+  {
+    push(
+      "CameraPictureStyle",
+      camera_picture_style_value(v, print_conv),
+    );
+  }
+  // 0xc9 HighISONoiseReduction (int8u, PrintConv hash).
+  if let Some(off) = at(0xc9)
+    && let Some(v) = i8u(data, off)
+  {
+    push(
+      "HighISONoiseReduction",
+      enum8(v, print_conv, high_iso_nr_label),
+    );
+  }
+  // 0x112 LensType (int16uRev, %canonLensTypes).
+  if let Some(off) = at(0x112)
+    && let Some(v) = u16_rev(data, off, order)
+  {
+    push("LensType", lens_type_value(v, print_conv));
+  }
+  // 0x114 MinFocalLength / 0x116 MaxFocalLength (int16uRev, "$val mm").
+  if let Some(off) = at(0x114)
+    && let Some(v) = u16_rev(data, off, order)
+  {
+    push("MinFocalLength", mm_value(v, print_conv));
+  }
+  if let Some(off) = at(0x116)
+    && let Some(v) = u16_rev(data, off, order)
+  {
+    push("MaxFocalLength", mm_value(v, print_conv));
+  }
+  // 0x1ac FirmwareVersion (string[6], RawConv `/^\d+\.\d+\.\d+\s*$/`).
+  if let Some(off) = at(0x1ac)
+    && let Some(s) = read_string(data, off, 6)
+    && is_firmware_version(&s)
+  {
+    push("FirmwareVersion", TagValue::Str(SmolStr::from(s)));
+  }
+  // 0x1eb FileIndex (int32u, ValueConv `$val + 1`).
+  if let Some(off) = at(0x1eb)
+    && let Some(v) = u32(data, off, order)
+  {
+    push("FileIndex", TagValue::I64(v + 1));
+  }
+  // 0x1f7 DirectoryIndex (int32u, ValueConv `$val - 1`).
+  if let Some(off) = at(0x1f7)
+    && let Some(v) = u32(data, off, order)
+  {
+    push("DirectoryIndex", TagValue::I64(v - 1));
+  }
+  // 0x327 PictureStyleInfo (`IS_SUBDIR` ⇒ `%Canon::PSInfo`, FIRST_ENTRY 0,
+  // PRIORITY 0). The SubDirectory starts at the shifted 0x327.
+  if let Some(ps_start) = at(0x327) {
+    ps_info(data, ps_start, order, print_conv, &mut push);
+  }
+  out
+}
+
+/// `%Canon::CameraInfo7D` `0x00 FirmwareVersionLookAhead` RawConv
+/// (`Canon.pm:4359-4366`): `CanonFirm = 1` if a `D.D.D` version prefix sits at
+/// 0x1a8, else `2` if at 0x1ac, else `0` (ExifTool warns then the `Hook` shifts
+/// every later leaf out of range).
+fn canon_firm_7d(data: &[u8]) -> u8 {
+  if firmware_prefix_at(data, 0x1a8) {
+    1
+  } else if firmware_prefix_at(data, 0x1ac) {
+    2
+  } else {
+    0
+  }
+}
+
+/// `substr($val, $off, 6) =~ /^\d+\.\d+\.\d+/` — a `D.D.D` version prefix in the
+/// 6-byte window at `off`.
+fn firmware_prefix_at(data: &[u8], off: usize) -> bool {
+  data
+    .get(off..off + 6)
+    .is_some_and(|b| version_prefix_len(b).is_some())
+}
+
+/// `/^\d+\.\d+\.\d+\s*$/` — the `0x1ac FirmwareVersion` RawConv (`Canon.pm:4469`):
+/// a full `D.D.D` version, optionally trailing whitespace, NOTHING else.
+fn is_firmware_version(s: &str) -> bool {
+  match version_prefix_len(s.as_bytes()) {
+    Some(n) => s.as_bytes().get(n..).is_some_and(|t| {
+      t.iter()
+        .all(|&c| c == b' ' || c == b'\t' || c == b'\r' || c == b'\n')
+    }),
+    None => false,
+  }
+}
+
+/// Length of a leading `\d+\.\d+\.\d+` (digits, dot, digits, dot, digits), or
+/// `None` if the bytes do not start with one.
+fn version_prefix_len(b: &[u8]) -> Option<usize> {
+  let mut i = 0usize;
+  let digits = |i: &mut usize| -> bool {
+    let start = *i;
+    while b.get(*i).is_some_and(u8::is_ascii_digit) {
+      *i += 1;
+    }
+    *i > start
+  };
+  if !digits(&mut i) {
+    return None;
+  }
+  if b.get(i) != Some(&b'.') {
+    return None;
+  }
+  i += 1;
+  if !digits(&mut i) {
+    return None;
+  }
+  if b.get(i) != Some(&b'.') {
+    return None;
+  }
+  i += 1;
+  if !digits(&mut i) {
+    return None;
+  }
+  Some(i)
+}
+
+/// `%Canon::PSInfo` (`Canon.pm:6018-6175`). FORMAT int32s, FIRST_ENTRY 0,
+/// PRIORITY 0. The `Unknown => 1` rows (the per-style FilterEffect/ToningEffect
+/// for Standard..Faithful, and Saturation/ColorTone Monochrome) are suppressed.
+fn ps_info<F: FnMut(&'static str, TagValue)>(
+  data: &[u8],
+  start: usize,
+  order: ByteOrder,
+  print_conv: bool,
+  push: &mut F,
+) {
+  // The plain int32s scalars (`%psConv`: 0xdeadbeef ⇒ "n/a", else passthrough).
+  for &(off, name) in PS_SCALARS {
+    if let Some(v) = i32s(data, start + off, order) {
+      push(name, ps_scalar_value(v, print_conv));
+    }
+  }
+  // FilterEffect/ToningEffect (Monochrome + the three UserDefs) — explicit
+  // PrintConv hashes (with 0xdeadbeef ⇒ "n/a").
+  for &(off, name, toning) in PS_EFFECTS {
+    if let Some(v) = i32s(data, start + off, order) {
+      let label = if toning {
+        ps_toning_effect_label(v)
+      } else {
+        ps_filter_effect_label(v)
+      };
+      push(name, ps_effect_value(v, print_conv, label));
+    }
+  }
+  // UserDef{1,2,3}PictureStyle (int16u, %userDefStyles). PSInfo's entries carry
+  // NO `PrintHex` (`Canon.pm:6152-6169`), so an unresolved value renders the
+  // DECIMAL `Unknown (N)` fallback (unlike the `CameraInfo5D` UserDef1 leaf).
+  for &(off, name) in &[
+    (0xd8usize, "UserDef1PictureStyle"),
+    (0xda, "UserDef2PictureStyle"),
+    (0xdc, "UserDef3PictureStyle"),
+  ] {
+    if let Some(v) = u16(data, start + off, order) {
+      let value = if print_conv {
+        match user_def_style_label(v) {
+          Some(l) => TagValue::Str(SmolStr::new_static(l)),
+          None => TagValue::Str(SmolStr::from(std::format!("Unknown ({v})"))),
+        }
+      } else {
+        TagValue::I64(v)
+      };
+      push(name, value);
+    }
+  }
+}
+
+/// The plain `%psInfo` scalars emitted for the 7D (`Canon.pm:6025-6130`, minus
+/// the `Unknown => 1` FilterEffect/ToningEffect Standard..Faithful + Saturation/
+/// ColorTone Monochrome rows).
+const PS_SCALARS: &[(usize, &str)] = &[
+  (0x00, "ContrastStandard"),
+  (0x04, "SharpnessStandard"),
+  (0x08, "SaturationStandard"),
+  (0x0c, "ColorToneStandard"),
+  (0x18, "ContrastPortrait"),
+  (0x1c, "SharpnessPortrait"),
+  (0x20, "SaturationPortrait"),
+  (0x24, "ColorTonePortrait"),
+  (0x30, "ContrastLandscape"),
+  (0x34, "SharpnessLandscape"),
+  (0x38, "SaturationLandscape"),
+  (0x3c, "ColorToneLandscape"),
+  (0x48, "ContrastNeutral"),
+  (0x4c, "SharpnessNeutral"),
+  (0x50, "SaturationNeutral"),
+  (0x54, "ColorToneNeutral"),
+  (0x60, "ContrastFaithful"),
+  (0x64, "SharpnessFaithful"),
+  (0x68, "SaturationFaithful"),
+  (0x6c, "ColorToneFaithful"),
+  (0x78, "ContrastMonochrome"),
+  (0x7c, "SharpnessMonochrome"),
+  (0x90, "ContrastUserDef1"),
+  (0x94, "SharpnessUserDef1"),
+  (0x98, "SaturationUserDef1"),
+  (0x9c, "ColorToneUserDef1"),
+  (0xa8, "ContrastUserDef2"),
+  (0xac, "SharpnessUserDef2"),
+  (0xb0, "SaturationUserDef2"),
+  (0xb4, "ColorToneUserDef2"),
+  (0xc0, "ContrastUserDef3"),
+  (0xc4, "SharpnessUserDef3"),
+  (0xc8, "SaturationUserDef3"),
+  (0xcc, "ColorToneUserDef3"),
+];
+
+/// The FilterEffect/ToningEffect PSInfo entries that carry an explicit PrintConv
+/// (`Canon.pm:6059-6149`): `(offset, name, is_toning)`.
+const PS_EFFECTS: &[(usize, &str, bool)] = &[
+  (0x88, "FilterEffectMonochrome", false),
+  (0x8c, "ToningEffectMonochrome", true),
+  (0xa0, "FilterEffectUserDef1", false),
+  (0xa4, "ToningEffectUserDef1", true),
+  (0xb8, "FilterEffectUserDef2", false),
+  (0xbc, "ToningEffectUserDef2", true),
+  (0xd0, "FilterEffectUserDef3", false),
+  (0xd4, "ToningEffectUserDef3", true),
+];
+
+/// `%offOn` (`Canon.pm:1218`).
+fn off_on_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "On",
+    _ => return None,
+  })
+}
+
+/// `FlashMeteringMode` PrintConv (`Canon.pm:4392-4398`).
+fn flash_metering_mode_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "E-TTL",
+    3 => "TTL",
+    4 => "External Auto",
+    5 => "External Manual",
+    6 => "Off",
+    _ => return None,
+  })
+}
+
+/// `HighISONoiseReduction` PrintConv (`Canon.pm:4447-4452`).
+fn high_iso_nr_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Standard",
+    1 => "Low",
+    2 => "Strong",
+    3 => "Off",
+    _ => return None,
+  })
+}
+
+/// `CameraPictureStyle` (`Canon.pm:4431-4443`, `PrintHex`): the label, or
+/// `Unknown (0xNN)`.
+fn camera_picture_style_value(v: i64, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(v);
+  }
+  let label = match v {
+    0x21 => "User Defined 1",
+    0x22 => "User Defined 2",
+    0x23 => "User Defined 3",
+    0x81 => "Standard",
+    0x82 => "Portrait",
+    0x83 => "Landscape",
+    0x84 => "Neutral",
+    0x85 => "Faithful",
+    0x86 => "Monochrome",
+    _ => return TagValue::Str(SmolStr::from(std::format!("Unknown (0x{v:x})"))),
+  };
+  TagValue::Str(SmolStr::new_static(label))
+}
+
+/// `%focusDistanceByteSwap` (`Canon.pm:1200-1208`): `$val/100`, then
+/// `$val > 655.345 ? "inf" : "$val m"`.
+fn focus_distance_value(raw: i64, print_conv: bool) -> TagValue {
+  let v = raw as f64 / 100.0;
+  if print_conv {
+    if v > 655.345 {
+      TagValue::Str(SmolStr::new_static("inf"))
+    } else {
+      TagValue::Str(SmolStr::from(std::format!("{v} m")))
+    }
+  } else if v.fract() == 0.0 {
+    TagValue::I64(v as i64)
+  } else {
+    TagValue::F64(v)
+  }
+}
+
+/// `%psConv` (`Canon.pm:1168-1171`): `-559038737` (0xdeadbeef) ⇒ "n/a", else
+/// the raw int passes through (`OTHER => sub { shift }`). `PrintHex` never fires
+/// (the `OTHER` catch-all returns the value unchanged).
+fn ps_scalar_value(v: i64, print_conv: bool) -> TagValue {
+  if print_conv && v == -559_038_737 {
+    TagValue::Str(SmolStr::new_static("n/a"))
+  } else {
+    TagValue::I64(v)
+  }
+}
+
+/// `FilterEffect`/`ToningEffect` PSInfo PrintConv: the label (with `0xdeadbeef
+/// ⇒ "n/a"`), or the `PrintHex` `Unknown (0xNN)` fallback; raw int under `-n`.
+fn ps_effect_value(v: i64, print_conv: bool, label: Option<&'static str>) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(v);
+  }
+  match label {
+    Some(l) => TagValue::Str(SmolStr::new_static(l)),
+    None if v == -559_038_737 => TagValue::Str(SmolStr::new_static("n/a")),
+    None => TagValue::Str(SmolStr::from(std::format!("Unknown (0x{v:x})"))),
+  }
+}
+
+/// PSInfo `FilterEffect*` PrintConv (`Canon.pm:6083-6091`).
+fn ps_filter_effect_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "None",
+    1 => "Yellow",
+    2 => "Orange",
+    3 => "Red",
+    4 => "Green",
+    _ => return None,
+  })
+}
+
+/// PSInfo `ToningEffect*` PrintConv (`Canon.pm:6093-6101`).
+fn ps_toning_effect_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "None",
+    1 => "Sepia",
+    2 => "Blue",
+    3 => "Purple",
+    4 => "Green",
+    _ => return None,
+  })
+}
+
+/// `MeasuredEV`/`MeasuredEV2` (`$val/8-6`, no PrintConv): a bare number —
+/// integral values collapse to `I64` (so `-j`/`-n` agree, e.g. `4` not `4.0`).
+fn ev_value(v: f64) -> TagValue {
+  if v.fract() == 0.0 {
+    TagValue::I64(v as i64)
+  } else {
+    TagValue::F64(v)
+  }
+}
+
+/// Read one signed 32-bit word at byte `off` in the file's byte order.
+fn i32s(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 4] = data.get(off..off + 4)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => i32::from_le_bytes(arr),
+    ByteOrder::Big => i32::from_be_bytes(arr),
+  } as i64)
 }
 
 /// The plain `int8s` per-style scalars (`Contrast`/`Sharpness`/`Saturation`/
@@ -557,7 +1094,18 @@ mod tests {
     assert!(model_is_camera_info_5d(Some("Canon EOS 5D")));
     assert!(!model_is_camera_info_5d(Some("Canon EOS 5D Mark II")));
     assert!(!model_is_camera_info_5d(Some("Canon EOS 7D")));
-    // A non-5D model yields nothing.
-    assert!(parse(&[0u8; 0x120], ByteOrder::Little, true, Some("Canon EOS 7D")).is_empty());
+    assert!(model_is_camera_info_7d(Some("Canon EOS 7D")));
+    assert!(!model_is_camera_info_7d(Some("Canon EOS 7D Mark II")));
+    assert!(!model_is_camera_info_7d(Some("Canon EOS 5D")));
+    // A model handled by neither table yields nothing.
+    assert!(
+      parse(
+        &[0u8; 0x120],
+        ByteOrder::Little,
+        true,
+        Some("Canon EOS 60D")
+      )
+      .is_empty()
+    );
   }
 }

--- a/src/exif/makernotes/vendors/canon/canon_custom.rs
+++ b/src/exif/makernotes/vendors/canon/canon_custom.rs
@@ -11,9 +11,15 @@
 //! table's PrintConv.
 //!
 //! This module ports the EOS 5D table (`%CanonCustom::Functions5D`,
-//! `CanonCustom.pm:228-383`, selected by `$$self{Model} =~ /EOS 5D/`). The
-//! emitted leaves land in the `CanonCustom` family-1 group (the
-//! `Image::ExifTool::CanonCustom::*` package group), NOT `Canon`.
+//! `CanonCustom.pm:228-383`, selected by `$$self{Model} =~ /EOS 5D/`) and the
+//! consistent `%CanonCustom::Functions2` (`CanonCustom.pm:1198-2640`) used from
+//! the EOS 1D Mark III onward — the `Canon::Main` tag `0x99` `CustomFunctions2`,
+//! processed by a DIFFERENT walker, `ProcessCanonCustom2`
+//! (`CanonCustom.pm:2642-2745`): a `int16u` size word, a `int32u` group count,
+//! then per-group `(recNum, recLen, recCount)` headers each followed by
+//! `(tag, num, int32s × num)` records. The emitted leaves land in the
+//! `CanonCustom` family-1 group (the `Image::ExifTool::CanonCustom::*` package
+//! group), NOT `Canon`.
 //!
 //! D8: pure decoder (no public struct fields); returns the `(Name, TagValue)`
 //! emission pairs the dispatch site wraps in the `CanonCustom` family-1 group.
@@ -23,6 +29,8 @@
 use crate::exif::ifd::ByteOrder;
 use crate::value::TagValue;
 use smol_str::SmolStr;
+use std::string::String;
+use std::string::ToString;
 use std::vec::Vec;
 
 /// `true` when `model` selects `%CanonCustom::Functions5D` via the `0x0f`
@@ -252,6 +260,499 @@ fn disable_enable(v: i64) -> Option<&'static str> {
   })
 }
 
+/// `%enableDisable` (`CanonCustom.pm:35`).
+fn enable_disable(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Enable",
+    1 => "Disable",
+    _ => return None,
+  })
+}
+
+// ─── ProcessCanonCustom2 (`Canon::Main` 0x99) ────────────────────────────────
+
+/// Decode a `ProcessCanonCustom2` block (`CanonCustom.pm:2642-2745`) against
+/// `%CanonCustom::Functions2`. Structure: an `int16u` size word equal to the
+/// block length (and at least 8 bytes), an `int32u` group count, then per-group
+/// `(recNum, recLen, recCount)` `int32u` headers each followed by `recCount`
+/// records of `(tag:int32u, num:int32u, int32s × num)`. Each record routes
+/// through the model-keyed `Functions2` PrintConv; an unknown `tag` is dropped.
+/// A malformed block stops the walk and keeps the records found so far
+/// (ExifTool's `HandleTag` stores them before the `return 0`).
+#[must_use]
+pub fn parse_functions2(
+  data: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+  model: Option<&str>,
+) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let size = data.len();
+  if size < 2 {
+    return out;
+  }
+  // First 16-bit value is the block length; must equal the size and be >= 8.
+  let Some(len) = u16_at(data, 0, order) else {
+    return out;
+  };
+  if len != size || len < 8 {
+    return out;
+  }
+  // (group count at offset 4 is verbose-only; the walk is bounded by `size`.)
+  let mut pos = 8usize;
+  while pos < size {
+    let Some(next) = pos.checked_add(12) else {
+      break;
+    };
+    if next > size {
+      break;
+    }
+    // (recNum at `pos` is verbose-only.)
+    let Some(rec_len) = u32_at(data, pos + 4, order) else {
+      break;
+    };
+    if rec_len < 8 {
+      break;
+    }
+    pos += 12;
+    let mut rec_pos = pos;
+    // recEnd = pos + recLen - 8; a recEnd past the block end is corruption →
+    // stop (ExifTool `return 0`, keeping records already extracted).
+    let Some(rec_end) = pos.checked_add(rec_len - 8) else {
+      break;
+    };
+    if rec_end > size {
+      break;
+    }
+    while rec_pos + 8 < rec_end {
+      let (Some(tag), Some(num)) = (
+        u32_at(data, rec_pos, order),
+        u32_at(data, rec_pos + 4, order),
+      ) else {
+        break;
+      };
+      let Some(next_rec) = rec_pos
+        .checked_add(8)
+        .and_then(|p| num.checked_mul(4).and_then(|n| p.checked_add(n)))
+      else {
+        break;
+      };
+      if next_rec > rec_end {
+        break;
+      }
+      rec_pos += 8;
+      let mut vals: Vec<i64> = Vec::with_capacity(num);
+      let mut ok = true;
+      for i in 0..num {
+        match i32s_at(data, rec_pos + i * 4, order) {
+          Some(v) => vals.push(v),
+          None => {
+            ok = false;
+            break;
+          }
+        }
+      }
+      if !ok {
+        break;
+      }
+      if let Some((name, value)) = functions2_render(tag, num, &vals, print_conv, model) {
+        out.push((SmolStr::new_static(name), value));
+      }
+      rec_pos = next_rec;
+    }
+    pos = rec_end;
+  }
+  out
+}
+
+/// Render one `%CanonCustom::Functions2` record. `None` ⇒ an unknown `tag`
+/// (dropped, gated behind `-u` in bundled). `num`/`vals` are the `int32s` array.
+fn functions2_render(
+  tag: usize,
+  num: usize,
+  vals: &[i64],
+  print_conv: bool,
+  model: Option<&str>,
+) -> Option<(&'static str, TagValue)> {
+  let v0 = vals.first().copied().unwrap_or(0);
+  // The three multi-value specials.
+  match tag {
+    // 0x507 AFMicroadjustment (Count 5, list PrintConv `[hash]`).
+    0x507 => {
+      let value = if print_conv {
+        TagValue::Str(SmolStr::from(list_print(vals, af_microadjustment_label)))
+      } else {
+        joined(num, vals)
+      };
+      return Some(("AFMicroadjustment", value));
+    }
+    // 0x512 SelectAFAreaSelectMode (list PrintConv `[hash, 'Flags 0x%x']`).
+    0x512 => {
+      let value = if print_conv {
+        TagValue::Str(SmolStr::from(list_print_flags(vals, select_af_area_label)))
+      } else {
+        joined(num, vals)
+      };
+      return Some(("SelectAFAreaSelectMode", value));
+    }
+    // 0x70c CustomControls (no PrintConv — passthrough).
+    0x70c => return Some(("CustomControls", joined(num, vals))),
+    _ => {}
+  }
+  // Single-value hash tags.
+  let (name, label): (&'static str, fn(i64) -> Option<&'static str>) = match tag {
+    0x101 if model_has(model, "1D") => ("ExposureLevelIncrements", exposure_level_1d_label),
+    0x101 => ("ExposureLevelIncrements", exposure_level_label),
+    0x102 => ("ISOSpeedIncrements", iso_speed_increments_label),
+    0x103 => ("ISOExpansion", off_on),
+    0x104 => ("AEBAutoCancel", on_off),
+    0x105 => ("AEBSequence", aeb_sequence_label),
+    0x108 => ("SafetyShift", safety_shift_label),
+    0x10f => ("FlashSyncSpeedAv", flash_sync_speed_av_label),
+    0x201 => ("LongExposureNoiseReduction", long_exposure_nr_label),
+    0x202 => ("HighISONoiseReduction", high_iso_nr_label),
+    0x203 => ("HighlightTonePriority", disable_enable),
+    0x502 => (
+      "AIServoTrackingSensitivity",
+      ai_servo_tracking_sensitivity_label,
+    ),
+    0x503 => ("AIServoImagePriority", ai_servo_image_priority_label),
+    0x504 => ("AIServoTrackingMethod", ai_servo_tracking_method_label),
+    0x505 => ("LensDriveNoAF", lens_drive_no_af_label),
+    0x50e => ("AFAssistBeam", af_assist_beam_label),
+    0x510 if model_has(model, "7D") => ("VFDisplayIllumination", vf_display_illumination_label),
+    0x510 => ("SuperimposedDisplay", on_off),
+    0x513 => (
+      "ManualAFPointSelectPattern",
+      manual_af_point_select_pattern_label,
+    ),
+    0x514 => ("DisplayAllAFPoints", enable_disable),
+    0x515 => ("FocusDisplayAIServoAndMF", enable_disable),
+    0x516 => (
+      "OrientationLinkedAFPoint",
+      orientation_linked_af_point_label,
+    ),
+    0x60f => ("MirrorLockup", mirror_lockup_label),
+    0x706 => ("DialDirectionTvAv", dial_direction_tv_av_label),
+    0x80e => ("AddAspectRatioInfo", add_aspect_ratio_info_label),
+    0x80f => ("AddOriginalDecisionData", off_on),
+    _ => return None,
+  };
+  let value = if num != 1 {
+    joined(num, vals)
+  } else if print_conv {
+    match label(v0) {
+      Some(l) => TagValue::Str(SmolStr::new_static(l)),
+      None => TagValue::Str(SmolStr::from(std::format!("Unknown ({v0})"))),
+    }
+  } else {
+    TagValue::I64(v0)
+  };
+  Some((name, value))
+}
+
+/// `joined(num, vals)`: a single value as `I64`; a multi-value as the
+/// space-joined raw int32s string (matching ExifTool `ReadValue` for `num > 1`).
+fn joined(num: usize, vals: &[i64]) -> TagValue {
+  if num == 1 {
+    TagValue::I64(vals.first().copied().unwrap_or(0))
+  } else {
+    TagValue::Str(SmolStr::from(space_joined(vals)))
+  }
+}
+
+/// `vals` joined with a single space.
+fn space_joined(vals: &[i64]) -> String {
+  vals
+    .iter()
+    .map(ToString::to_string)
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
+/// A list PrintConv `[hash]`: element 0 via `label` (Unknown ⇒ `Unknown (N)`),
+/// the rest passthrough; joined with "; ".
+fn list_print(vals: &[i64], label: fn(i64) -> Option<&'static str>) -> String {
+  vals
+    .iter()
+    .enumerate()
+    .map(|(i, &v)| {
+      if i == 0 {
+        match label(v) {
+          Some(l) => l.to_string(),
+          None => std::format!("Unknown ({v})"),
+        }
+      } else {
+        v.to_string()
+      }
+    })
+    .collect::<Vec<_>>()
+    .join("; ")
+}
+
+/// A list PrintConv `[hash, 'Flags 0x%x']`: element 0 via `label`, element 1 as
+/// `Flags 0x%x`, the rest passthrough; joined with "; ".
+fn list_print_flags(vals: &[i64], label: fn(i64) -> Option<&'static str>) -> String {
+  vals
+    .iter()
+    .enumerate()
+    .map(|(i, &v)| match i {
+      0 => match label(v) {
+        Some(l) => l.to_string(),
+        None => std::format!("Unknown ({v})"),
+      },
+      1 => std::format!("Flags 0x{v:x}"),
+      _ => v.to_string(),
+    })
+    .collect::<Vec<_>>()
+    .join("; ")
+}
+
+/// `$$self{Model} =~ /…/` — a substring model match (the Canon model strings use
+/// space/`-` word boundaries, so a plain `contains` is faithful here).
+fn model_has(model: Option<&str>, needle: &str) -> bool {
+  model.is_some_and(|m| m.contains(needle))
+}
+
+/// 0x101 `ExposureLevelIncrements`, non-1D arm (`CanonCustom.pm:1230-1233`).
+fn exposure_level_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "1/3 Stop",
+    1 => "1/2 Stop",
+    _ => return None,
+  })
+}
+
+/// 0x101 `ExposureLevelIncrements`, 1D arm (`CanonCustom.pm:1221-1225`).
+fn exposure_level_1d_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "1/3-stop set, 1/3-stop comp.",
+    1 => "1-stop set, 1/3-stop comp.",
+    2 => "1/2-stop set, 1/2-stop comp.",
+    _ => return None,
+  })
+}
+
+/// 0x102 `ISOSpeedIncrements` (`CanonCustom.pm:1238-1241`).
+fn iso_speed_increments_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "1/3 Stop",
+    1 => "1 Stop",
+    _ => return None,
+  })
+}
+
+/// 0x105 `AEBSequence` (`CanonCustom.pm:1286-1290`).
+fn aeb_sequence_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "0,-,+",
+    1 => "-,0,+",
+    2 => "+,0,-",
+    _ => return None,
+  })
+}
+
+/// 0x108 `SafetyShift` (`CanonCustom.pm:1333-1337`).
+fn safety_shift_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Disable",
+    1 => "Enable (Tv/Av)",
+    2 => "Enable (ISO speed)",
+    _ => return None,
+  })
+}
+
+/// 0x10f `FlashSyncSpeedAv`, 50D/60D/7D arm (`CanonCustom.pm:1510-1514`).
+fn flash_sync_speed_av_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Auto",
+    1 => "1/250-1/60 Auto",
+    2 => "1/250 Fixed",
+    _ => return None,
+  })
+}
+
+/// 0x201 `LongExposureNoiseReduction` (`CanonCustom.pm:1598-1602`).
+fn long_exposure_nr_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "Auto",
+    2 => "On",
+    _ => return None,
+  })
+}
+
+/// 0x202 `HighISONoiseReduction`, 50D/.../7D arm (`CanonCustom.pm:1612-1617`).
+fn high_iso_nr_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Standard",
+    1 => "Low",
+    2 => "Strong",
+    3 => "Off",
+    _ => return None,
+  })
+}
+
+/// 0x502 `AIServoTrackingSensitivity` (`CanonCustom.pm:1739-1743`).
+fn ai_servo_tracking_sensitivity_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Standard",
+    1 => "Medium Fast",
+    2 => "Fast",
+    _ => return None,
+  })
+}
+
+/// 0x503 `AIServoImagePriority` (`CanonCustom.pm:1747-1752`).
+fn ai_servo_image_priority_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "1: AF, 2: Tracking",
+    1 => "1: AF, 2: Drive speed",
+    2 => "1: Release, 2: Drive speed",
+    3 => "1: Release, 2: Tracking",
+    _ => return None,
+  })
+}
+
+/// 0x504 `AIServoTrackingMethod` (`CanonCustom.pm:1756-1759`).
+fn ai_servo_tracking_method_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Main focus point priority",
+    1 => "Continuous AF track priority",
+    _ => return None,
+  })
+}
+
+/// 0x505 `LensDriveNoAF` (`CanonCustom.pm:1763-1766`).
+fn lens_drive_no_af_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Focus search on",
+    1 => "Focus search off",
+    _ => return None,
+  })
+}
+
+/// 0x507 `AFMicroadjustment` element-0 hash (`CanonCustom.pm:1786-1790`).
+fn af_microadjustment_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Disable",
+    1 => "Adjust all by same amount",
+    2 => "Adjust by lens",
+    _ => return None,
+  })
+}
+
+/// 0x50e `AFAssistBeam`, non-(1DmkIV/6D) arm (`CanonCustom.pm:1920-1925`).
+fn af_assist_beam_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Emits",
+    1 => "Does not emit",
+    2 => "Only ext. flash emits",
+    3 => "IR AF assist beam only",
+    _ => return None,
+  })
+}
+
+/// 0x510 `VFDisplayIllumination`, 7D arm (`CanonCustom.pm:1954-1958`).
+fn vf_display_illumination_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Auto",
+    1 => "Enable",
+    2 => "Disable",
+    _ => return None,
+  })
+}
+
+/// 0x512 `SelectAFAreaSelectMode` element-0 hash (`CanonCustom.pm:1986-1992`).
+fn select_af_area_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Disable",
+    1 => "Enable",
+    2 => "Register",
+    3 => "Select AF-modes",
+    _ => return None,
+  })
+}
+
+/// 0x513 `ManualAFPointSelectPattern` (`CanonCustom.pm:2002-2005`).
+fn manual_af_point_select_pattern_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Stops at AF area edges",
+    1 => "Continuous",
+    _ => return None,
+  })
+}
+
+/// 0x516 `OrientationLinkedAFPoint` (`CanonCustom.pm:2017-2020`).
+fn orientation_linked_af_point_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Same for vertical and horizontal",
+    1 => "Select different AF points",
+    _ => return None,
+  })
+}
+
+/// 0x60f `MirrorLockup` (`CanonCustom.pm:2085-2089`).
+fn mirror_lockup_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Disable",
+    1 => "Enable",
+    2 => "Enable: Down with Set",
+    _ => return None,
+  })
+}
+
+/// 0x706 `DialDirectionTvAv` (`CanonCustom.pm:2349-2352`).
+fn dial_direction_tv_av_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Normal",
+    1 => "Reversed",
+    _ => return None,
+  })
+}
+
+/// 0x80e `AddAspectRatioInfo` (`CanonCustom.pm:2563-2570`).
+fn add_aspect_ratio_info_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "6:6",
+    2 => "3:4",
+    3 => "4:5",
+    4 => "6:7",
+    5 => "10:12",
+    6 => "5:7",
+    _ => return None,
+  })
+}
+
+/// Read an unsigned 16-bit word at byte `off`.
+fn u16_at(data: &[u8], off: usize, order: ByteOrder) -> Option<usize> {
+  let arr: [u8; 2] = data.get(off..off + 2)?.try_into().ok()?;
+  Some(usize::from(match order {
+    ByteOrder::Little => u16::from_le_bytes(arr),
+    ByteOrder::Big => u16::from_be_bytes(arr),
+  }))
+}
+
+/// Read an unsigned 32-bit word at byte `off` as a `usize` (offsets/counts).
+fn u32_at(data: &[u8], off: usize, order: ByteOrder) -> Option<usize> {
+  let arr: [u8; 4] = data.get(off..off + 4)?.try_into().ok()?;
+  let v = match order {
+    ByteOrder::Little => u32::from_le_bytes(arr),
+    ByteOrder::Big => u32::from_be_bytes(arr),
+  };
+  usize::try_from(v).ok()
+}
+
+/// Read a signed 32-bit word at byte `off`.
+fn i32s_at(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 4] = data.get(off..off + 4)?.try_into().ok()?;
+  Some(i64::from(match order {
+    ByteOrder::Little => i32::from_le_bytes(arr),
+    ByteOrder::Big => i32::from_be_bytes(arr),
+  }))
+}
+
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
 mod tests {
@@ -328,5 +829,74 @@ mod tests {
     assert!(!model_is_functions_5d(Some("Canon EOS 7D")));
     assert!(!model_is_functions_5d(Some("Canon EOS-1D Mark III")));
     assert!(!model_is_functions_5d(None));
+  }
+
+  /// A single-group `ProcessCanonCustom2` block (`int32u` words): size, group
+  /// count 1, one group (recNum 1, recLen 96, recCount 5), then five records
+  /// exercising a scalar hash (0x101), `%offOn` (0x103), the multi-value
+  /// `AFMicroadjustment` (0x507) and `SelectAFAreaSelectMode` (0x512) list
+  /// PrintConvs, and the no-PrintConv `CustomControls` (0x70c).
+  fn build_custom2() -> Vec<u8> {
+    let words: &[u32] = &[
+      108, 1, // size, group count
+      1, 96, 5, // recNum, recLen, recCount
+      0x101, 1, 0, // ExposureLevelIncrements = 0
+      0x103, 1, 1, // ISOExpansion = 1
+      0x507, 5, 0, 0, 0, 0, 0, // AFMicroadjustment = 0 0 0 0 0
+      0x512, 2, 1, 31, // SelectAFAreaSelectMode = 1 31
+      0x70c, 3, 0, 3, 5, // CustomControls = 0 3 5
+    ];
+    let mut v = Vec::new();
+    for w in words {
+      v.extend_from_slice(&w.to_le_bytes());
+    }
+    v
+  }
+
+  #[test]
+  fn custom2_print_values() {
+    let data = build_custom2();
+    let em = parse_functions2(&data, ByteOrder::Little, true, Some("Canon EOS 7D"));
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(
+      find("ExposureLevelIncrements"),
+      Some(TagValue::Str("1/3 Stop".into()))
+    );
+    assert_eq!(find("ISOExpansion"), Some(TagValue::Str("On".into())));
+    assert_eq!(
+      find("AFMicroadjustment"),
+      Some(TagValue::Str("Disable; 0; 0; 0; 0".into()))
+    );
+    assert_eq!(
+      find("SelectAFAreaSelectMode"),
+      Some(TagValue::Str("Enable; Flags 0x1f".into()))
+    );
+    assert_eq!(find("CustomControls"), Some(TagValue::Str("0 3 5".into())));
+    assert_eq!(em.len(), 5);
+  }
+
+  #[test]
+  fn custom2_numeric_values() {
+    let data = build_custom2();
+    let em = parse_functions2(&data, ByteOrder::Little, false, Some("Canon EOS 7D"));
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(find("ExposureLevelIncrements"), Some(TagValue::I64(0)));
+    assert_eq!(find("ISOExpansion"), Some(TagValue::I64(1)));
+    assert_eq!(
+      find("AFMicroadjustment"),
+      Some(TagValue::Str("0 0 0 0 0".into()))
+    );
+    assert_eq!(
+      find("SelectAFAreaSelectMode"),
+      Some(TagValue::Str("1 31".into()))
+    );
+  }
+
+  #[test]
+  fn custom2_bad_size_rejected() {
+    let mut data = build_custom2();
+    // Corrupt the size word ⇒ `len != size` ⇒ nothing emitted.
+    data[0] = 0xff;
+    assert!(parse_functions2(&data, ByteOrder::Little, true, Some("Canon EOS 7D")).is_empty());
   }
 }

--- a/src/exif/makernotes/vendors/canon/crop_info.rs
+++ b/src/exif/makernotes/vendors/canon/crop_info.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Canon::CropInfo` (`Canon.pm:7165-7174`, `Canon::Main` tag `0x98`) and
+//! `%Canon::AspectInfo` (`Canon.pm:7177-7200`, tag `0x9a`).
+//!
+//! CropInfo is `FORMAT => 'int16u'`, FIRST_ENTRY 0 (CropLeftMargin/RightMargin/
+//! TopMargin/BottomMargin at bytes 0/2/4/6). AspectInfo is `FORMAT => 'int32u'`,
+//! FIRST_ENTRY 0 (AspectRatio @ 0, then CroppedImageWidth/Height/Left/Top at
+//! bytes 4/8/12/16). Each emits only the in-range leaves (per-field
+//! availability).
+//!
+//! D8: pure decoders — return the `(Name, TagValue)` emission pairs the dispatch
+//! site wraps in the `Canon` family-1 group.
+
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::ByteOrder;
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Decode `%Canon::CropInfo` from the int16u `0x98` blob.
+#[must_use]
+pub fn parse_crop(data: &[u8], order: ByteOrder, _print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  for &(off, name) in &[
+    (0usize, "CropLeftMargin"),
+    (2, "CropRightMargin"),
+    (4, "CropTopMargin"),
+    (6, "CropBottomMargin"),
+  ] {
+    if let Some(v) = u16(data, off, order) {
+      out.push((SmolStr::new_static(name), TagValue::I64(v)));
+    }
+  }
+  out
+}
+
+/// Decode `%Canon::AspectInfo` from the int32u `0x9a` blob.
+#[must_use]
+pub fn parse_aspect(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // 0) AspectRatio @ 0 (int32u, PrintConv hash).
+  if let Some(v) = u32(data, 0, order) {
+    out.push((
+      SmolStr::new_static("AspectRatio"),
+      if print_conv {
+        match aspect_ratio_label(v) {
+          Some(l) => TagValue::Str(SmolStr::new_static(l)),
+          None => TagValue::Str(SmolStr::from(std::format!("Unknown ({v})"))),
+        }
+      } else {
+        TagValue::I64(v)
+      },
+    ));
+  }
+  // 1..4) CroppedImageWidth/Height/Left/Top (int32u, plain).
+  for &(off, name) in &[
+    (4usize, "CroppedImageWidth"),
+    (8, "CroppedImageHeight"),
+    (12, "CroppedImageLeft"),
+    (16, "CroppedImageTop"),
+  ] {
+    if let Some(v) = u32(data, off, order) {
+      out.push((SmolStr::new_static(name), TagValue::I64(v)));
+    }
+  }
+  out
+}
+
+/// `AspectRatio` PrintConv (`Canon.pm:7184-7193`).
+fn aspect_ratio_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "3:2",
+    1 => "1:1",
+    2 => "4:3",
+    7 => "16:9",
+    8 => "4:5",
+    12 => "3:2 (APS-H crop)",
+    13 => "3:2 (APS-C crop)",
+    258 => "4:3 crop",
+    _ => return None,
+  })
+}
+
+/// Read an unsigned 16-bit word at byte `off`.
+fn u16(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 2] = data.get(off..off + 2)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => u16::from_le_bytes(arr),
+    ByteOrder::Big => u16::from_be_bytes(arr),
+  } as i64)
+}
+
+/// Read an unsigned 32-bit word at byte `off`.
+fn u32(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 4] = data.get(off..off + 4)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => u32::from_le_bytes(arr),
+    ByteOrder::Big => u32::from_be_bytes(arr),
+  } as i64)
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn crop_info_zeros() {
+    let b = [0u8; 8];
+    let em = parse_crop(&b, ByteOrder::Little, true);
+    assert_eq!(em.len(), 4);
+    assert_eq!(
+      em[0],
+      (SmolStr::new_static("CropLeftMargin"), TagValue::I64(0))
+    );
+  }
+
+  #[test]
+  fn aspect_info_unknown_ratio() {
+    // AspectRatio=256, CroppedImageWidth=2592, CroppedImageHeight=1728.
+    let mut b = vec![0u8; 20];
+    b[0..4].copy_from_slice(&256u32.to_le_bytes());
+    b[4..8].copy_from_slice(&2592u32.to_le_bytes());
+    b[8..12].copy_from_slice(&1728u32.to_le_bytes());
+    let em = parse_aspect(&b, ByteOrder::Little, true);
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(
+      find("AspectRatio"),
+      Some(TagValue::Str("Unknown (256)".into()))
+    );
+    assert_eq!(find("CroppedImageWidth"), Some(TagValue::I64(2592)));
+    assert_eq!(find("CroppedImageHeight"), Some(TagValue::I64(1728)));
+  }
+}

--- a/src/exif/makernotes/vendors/canon/lens_correction.rs
+++ b/src/exif/makernotes/vendors/canon/lens_correction.rs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! The Canon image-correction sub-tables (`Canon::Main` tags `0x4015`-`0x4019`):
+//! `%Canon::VignettingCorr` (`Canon.pm:8999-9034`), `%Canon::VignettingCorr2`
+//! (`:9050-9071`), `%Canon::LightingOpt` (`:9074-9129`) and `%Canon::LensInfo`
+//! (`:9132-9148`).
+//!
+//! All emit only the in-range leaves (per-field availability). `VignettingCorr`
+//! (0x4015) is a conditional SubDirectory list — only the first arm
+//! (`$$valPt =~ /^\0/` and not all-zero / not the `\x00\x40\xdc\x05` Powershot
+//! prefix) is the real table; both it and `VignettingCorr2` (0x4016) carry a
+//! `Canon::Validate` size-word gate.
+//!
+//! D8: pure decoders — return the `(Name, TagValue)` emission pairs the dispatch
+//! site wraps in the `Canon` family-1 group.
+
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::ByteOrder;
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::string::String;
+use std::vec::Vec;
+
+/// Decode `%Canon::VignettingCorr` (0x4015, arm 1) from the `undef[N]` blob
+/// (`FORMAT => 'int16s'`). Gated by the conditional-list arm-1 condition and the
+/// `Validate($dirData, $start+2, $size)` size-word check; a miss emits nothing.
+#[must_use]
+pub fn parse_vignetting(
+  data: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+) -> Vec<(SmolStr, TagValue)> {
+  if !vignetting_corr_condition(data) || !validate(data, 2, order) {
+    return Vec::new();
+  }
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // 0 VignettingCorrVersion (Format int8u override) @ byte 0.
+  if let Some(&b) = data.first() {
+    out.push((
+      SmolStr::new_static("VignettingCorrVersion"),
+      TagValue::I64(i64::from(b)),
+    ));
+  }
+  // int16s leaves at byte offset = index * 2.
+  for &(idx, name, off_on) in &[
+    (2usize, "PeripheralLighting", true),
+    (3, "DistortionCorrection", true),
+    (4, "ChromaticAberrationCorr", true),
+    (5, "ChromaticAberrationCorr", true),
+    (6, "PeripheralLightingValue", false),
+    (9, "DistortionCorrectionValue", false),
+    (11, "OriginalImageWidth", false),
+    (12, "OriginalImageHeight", false),
+  ] {
+    if let Some(v) = i16s(data, idx * 2, order) {
+      out.push((
+        SmolStr::new_static(name),
+        scalar_or_off_on(v, print_conv, off_on),
+      ));
+    }
+  }
+  out
+}
+
+/// Decode `%Canon::VignettingCorr2` (0x4016) from the int32s blob. Gated by
+/// `Validate($dirData, $start, $size)`.
+#[must_use]
+pub fn parse_vignetting2(
+  data: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+) -> Vec<(SmolStr, TagValue)> {
+  if !validate(data, 0, order) {
+    return Vec::new();
+  }
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // int32s leaves at byte offset = index * 4.
+  for &(idx, name) in &[
+    (5usize, "PeripheralLightingSetting"),
+    (6, "ChromaticAberrationSetting"),
+    (7, "DistortionCorrectionSetting"),
+    (9, "DigitalLensOptimizerSetting"),
+  ] {
+    if let Some(v) = i32s(data, idx * 4, order) {
+      out.push((SmolStr::new_static(name), off_on_value(v, print_conv)));
+    }
+  }
+  out
+}
+
+/// Decode `%Canon::LightingOpt` (0x4018) from the int32s blob.
+#[must_use]
+pub fn parse_lighting_opt(
+  data: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // 1 PeripheralIlluminationCorr @ 4 (%offOn).
+  if let Some(v) = i32s(data, 4, order) {
+    out.push((
+      SmolStr::new_static("PeripheralIlluminationCorr"),
+      off_on_value(v, print_conv),
+    ));
+  }
+  // 2 AutoLightingOptimizer @ 8.
+  if let Some(v) = i32s(data, 8, order) {
+    out.push((
+      SmolStr::new_static("AutoLightingOptimizer"),
+      hash(v, print_conv, auto_lighting_optimizer_label),
+    ));
+  }
+  // 3 HighlightTonePriority @ 12 ({%offOn, 2 => 'Enhanced'}).
+  if let Some(v) = i32s(data, 12, order) {
+    out.push((
+      SmolStr::new_static("HighlightTonePriority"),
+      hash(v, print_conv, highlight_tone_priority_label),
+    ));
+  }
+  // 4 LongExposureNoiseReduction @ 16.
+  if let Some(v) = i32s(data, 16, order) {
+    out.push((
+      SmolStr::new_static("LongExposureNoiseReduction"),
+      hash(v, print_conv, long_exposure_nr_label),
+    ));
+  }
+  // 5 HighISONoiseReduction @ 20.
+  if let Some(v) = i32s(data, 20, order) {
+    out.push((
+      SmolStr::new_static("HighISONoiseReduction"),
+      hash(v, print_conv, high_iso_nr_label),
+    ));
+  }
+  out
+}
+
+/// Decode `%Canon::LensInfo` (0x4019) from the `undef[N]` blob.
+#[must_use]
+pub fn parse_lens_info(
+  data: &[u8],
+  _order: ByteOrder,
+  _print_conv: bool,
+) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // 0 LensSerialNumber (Format undef[5], Priority 0): RawConv drops a value
+  // starting with four NUL bytes; ValueConv `unpack("H*", $val)` ⇒ lowercase hex.
+  if let Some(bytes) = data.get(0..5)
+    && bytes.get(0..4) != Some(&[0, 0, 0, 0])
+  {
+    let hex: String = bytes.iter().map(|b| std::format!("{b:02x}")).collect();
+    out.push((
+      SmolStr::new_static("LensSerialNumber"),
+      TagValue::Str(SmolStr::from(hex)),
+    ));
+  }
+  out
+}
+
+/// `%Canon::VignettingCorr` 0x4015 conditional-list arm-1 condition
+/// (`Canon.pm:9001`): first byte `\0`, and not all-zero / not the
+/// `\x00\x40\xdc\x05` (60D-style) prefix.
+fn vignetting_corr_condition(b: &[u8]) -> bool {
+  b.first() == Some(&0)
+    && b.get(0..4) != Some(&[0, 0, 0, 0])
+    && b.get(0..4) != Some(&[0x00, 0x40, 0xdc, 0x05])
+}
+
+/// `Image::ExifTool::Canon::Validate($dataPt, $offset, $size)`
+/// (`Canon.pm:Validate`): the 16-bit word at `off` must equal the blob length.
+fn validate(data: &[u8], off: usize, order: ByteOrder) -> bool {
+  matches!(u16(data, off, order), Some(v) if v == data.len() as i64)
+}
+
+/// `%offOn` (`Canon.pm:1218`).
+fn off_on_value(v: i64, print_conv: bool) -> TagValue {
+  hash(v, print_conv, off_on_label)
+}
+
+/// A plain int16s leaf, OR a `%offOn` leaf when `off_on`.
+fn scalar_or_off_on(v: i64, print_conv: bool, off_on: bool) -> TagValue {
+  if off_on {
+    off_on_value(v, print_conv)
+  } else {
+    TagValue::I64(v)
+  }
+}
+
+fn off_on_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "On",
+    _ => return None,
+  })
+}
+
+/// `AutoLightingOptimizer` PrintConv (`Canon.pm:9086-9091`).
+fn auto_lighting_optimizer_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Standard",
+    1 => "Low",
+    2 => "Strong",
+    3 => "Off",
+    _ => return None,
+  })
+}
+
+/// `HighlightTonePriority` PrintConv (`Canon.pm:9095`, `{%offOn, 2 => 'Enhanced'}`).
+fn highlight_tone_priority_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "On",
+    2 => "Enhanced",
+    _ => return None,
+  })
+}
+
+/// `LongExposureNoiseReduction` PrintConv (`Canon.pm:9099-9103`).
+fn long_exposure_nr_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "Auto",
+    2 => "On",
+    _ => return None,
+  })
+}
+
+/// `HighISONoiseReduction` PrintConv (`Canon.pm:9107-9112`).
+fn high_iso_nr_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Standard",
+    1 => "Low",
+    2 => "Strong",
+    3 => "Off",
+    _ => return None,
+  })
+}
+
+/// Render a hash PrintConv: the label, or `Unknown (N)`; raw int under `-n`.
+fn hash(v: i64, print_conv: bool, label: fn(i64) -> Option<&'static str>) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(v);
+  }
+  match label(v) {
+    Some(l) => TagValue::Str(SmolStr::new_static(l)),
+    None => TagValue::Str(SmolStr::from(std::format!("Unknown ({v})"))),
+  }
+}
+
+/// Read one signed 16-bit word at byte `off`.
+fn i16s(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 2] = data.get(off..off + 2)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => i16::from_le_bytes(arr),
+    ByteOrder::Big => i16::from_be_bytes(arr),
+  } as i64)
+}
+
+/// Read one unsigned 16-bit word at byte `off`.
+fn u16(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 2] = data.get(off..off + 2)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => u16::from_le_bytes(arr),
+    ByteOrder::Big => u16::from_be_bytes(arr),
+  } as i64)
+}
+
+/// Read one signed 32-bit word at byte `off`.
+fn i32s(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 4] = data.get(off..off + 4)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => i32::from_le_bytes(arr),
+    ByteOrder::Big => i32::from_be_bytes(arr),
+  } as i64)
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn vignetting_corr_7d() {
+    let mut b = vec![0u8; 116];
+    b[2] = 116; // size word (LE) == len ⇒ Validate passes
+    b[22] = 0x40; // OriginalImageWidth int16s LE 0x1440 = 5184
+    b[23] = 0x14;
+    b[24] = 0x80; // OriginalImageHeight 0x0d80 = 3456
+    b[25] = 0x0d;
+    let em = parse_vignetting(&b, ByteOrder::Little, true);
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(find("VignettingCorrVersion"), Some(TagValue::I64(0)));
+    assert_eq!(
+      find("PeripheralLighting"),
+      Some(TagValue::Str("Off".into()))
+    );
+    assert_eq!(find("OriginalImageWidth"), Some(TagValue::I64(5184)));
+    assert_eq!(find("OriginalImageHeight"), Some(TagValue::I64(3456)));
+  }
+
+  #[test]
+  fn vignetting_corr_validate_fails() {
+    let b = vec![0u8; 116]; // size word == 0 != 116 ⇒ Validate fails (also first4 all-zero)
+    assert!(parse_vignetting(&b, ByteOrder::Little, true).is_empty());
+  }
+
+  #[test]
+  fn vignetting2_per_field() {
+    let mut b = vec![0u8; 28];
+    b[0] = 28; // size word == len
+    let em = parse_vignetting2(&b, ByteOrder::Little, true);
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    // entries 5/6 in range; 7 (@28) and 9 (@36) out of the 28-byte block.
+    assert_eq!(
+      find("PeripheralLightingSetting"),
+      Some(TagValue::Str("Off".into()))
+    );
+    assert_eq!(
+      find("ChromaticAberrationSetting"),
+      Some(TagValue::Str("Off".into()))
+    );
+    assert!(find("DistortionCorrectionSetting").is_none());
+    assert!(find("DigitalLensOptimizerSetting").is_none());
+  }
+
+  #[test]
+  fn lighting_opt_7d() {
+    let mut b = vec![0u8; 28];
+    b[4] = 1; // PeripheralIlluminationCorr = On
+    b[8] = 3; // AutoLightingOptimizer = Off
+    let em = parse_lighting_opt(&b, ByteOrder::Little, true);
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(
+      find("PeripheralIlluminationCorr"),
+      Some(TagValue::Str("On".into()))
+    );
+    assert_eq!(
+      find("AutoLightingOptimizer"),
+      Some(TagValue::Str("Off".into()))
+    );
+    assert_eq!(
+      find("HighISONoiseReduction"),
+      Some(TagValue::Str("Standard".into()))
+    );
+  }
+
+  #[test]
+  fn lens_info_hex_serial() {
+    let b = [0x00, 0x00, 0x14, 0x69, 0xa3, 0, 0, 0];
+    let em = parse_lens_info(&b, ByteOrder::Little, true);
+    assert_eq!(
+      em.first().map(|(_, v)| v.clone()),
+      Some(TagValue::Str("00001469a3".into()))
+    );
+  }
+
+  #[test]
+  fn lens_info_all_zero_dropped() {
+    let b = [0u8; 8];
+    assert!(parse_lens_info(&b, ByteOrder::Little, true).is_empty());
+  }
+}

--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -76,8 +76,10 @@ pub mod camera_settings;
 pub mod canon_custom;
 pub mod color_balance;
 pub mod colordata;
+pub mod crop_info;
 pub mod file_info;
 pub mod focal_length;
+pub mod lens_correction;
 pub mod lens_types;
 pub mod measured_color;
 pub mod model_ids;
@@ -87,6 +89,7 @@ pub mod sensor_info;
 pub mod serial_info;
 pub mod shot_info;
 pub mod tags;
+pub mod time_info;
 
 use crate::exif::makernotes::VendorEmission;
 use crate::value::TagValue;

--- a/src/exif/makernotes/vendors/canon/tags.rs
+++ b/src/exif/makernotes/vendors/canon/tags.rs
@@ -276,6 +276,18 @@ impl SubTable {
         | SubTable::ColorData
         | SubTable::AfMicroAdj
         | SubTable::CustomFunctions
+        // The EOS 7D image-info sub-tables (#445): TimeInfo (0x35) / CropInfo
+        // (0x98) / CustomFunctions2 (0x99) / AspectInfo (0x9a) / VignettingCorr
+        // (0x4015) / VignettingCorr2 (0x4016) / LightingOpt (0x4018) / LensInfo
+        // (0x4019).
+        | SubTable::TimeInfo
+        | SubTable::CropInfo
+        | SubTable::CustomFunctions2
+        | SubTable::AspectInfo
+        | SubTable::VignettingCorr
+        | SubTable::VignettingCorr2
+        | SubTable::LightingOpt
+        | SubTable::LensInfo
     )
   }
 
@@ -341,6 +353,9 @@ impl SubTable {
         | (SubTable::CameraInfo, _)
         // `%Canon::Processing` tag 2 `Sharpness` is `Priority => 0` (`Canon.pm:7220`).
         | (SubTable::Processing, "Sharpness")
+        // `%Canon::LensInfo` (0x4019) `LensSerialNumber` is `Priority => 0`
+        // (`Canon.pm:9143`).
+        | (SubTable::LensInfo, "LensSerialNumber")
     );
     u8::from(!priority_zero)
   }
@@ -1229,7 +1244,9 @@ mod tests {
       (0x0au16, "UnknownD30", SubTable::UnknownD30),
       // (0x0f CustomFunctions is now WALKED — see `custom_functions_5d_is_walked`.)
       (0x2f, "FaceDetect3", SubTable::FaceDetect3),
-      (0x35, "TimeInfo", SubTable::TimeInfo),
+      // (0x35 TimeInfo / 0x98 CropInfo / 0x99 CustomFunctions2 / 0x9a AspectInfo
+      // / 0x4015 VignettingCorr / 0x4016 VignettingCorr2 / 0x4018 LightingOpt /
+      // 0x4019 LensInfo are now WALKED — the #445 EOS 7D sub-tables.)
       (0x90, "CustomFunctions1D", SubTable::CustomFunctions1D),
       (0x91, "PersonalFunctions", SubTable::PersonalFunctions),
       (
@@ -1241,9 +1258,6 @@ mod tests {
       (0xb1, "ModifiedInfo", SubTable::ModifiedInfo),
       (0xb6, "PreviewImageInfo", SubTable::PreviewImageInfo),
       (0x4003, "ColorInfo", SubTable::ColorInfo),
-      (0x4015, "VignettingCorr", SubTable::VignettingCorr),
-      (0x4016, "VignettingCorr2", SubTable::VignettingCorr2),
-      (0x4018, "LightingOpt", SubTable::LightingOpt),
       (0x4020, "AmbienceInfo", SubTable::AmbienceInfo),
       (0x4021, "MultiExp", SubTable::MultiExp),
       (0x4024, "FilterInfo", SubTable::FilterInfo),
@@ -1286,9 +1300,18 @@ mod tests {
     assert!(SubTable::ColorData.is_walked());
     assert!(SubTable::AfMicroAdj.is_walked());
     assert!(SubTable::CustomFunctions.is_walked());
+    // The EOS 7D image-info sub-tables (#445) are now walked too.
+    assert!(SubTable::TimeInfo.is_walked());
+    assert!(SubTable::CropInfo.is_walked());
+    assert!(SubTable::CustomFunctions2.is_walked());
+    assert!(SubTable::AspectInfo.is_walked());
+    assert!(SubTable::VignettingCorr.is_walked());
+    assert!(SubTable::VignettingCorr2.is_walked());
+    assert!(SubTable::LightingOpt.is_walked());
+    assert!(SubTable::LensInfo.is_walked());
     // Still-deferred sub-tables remain raw.
     assert!(!SubTable::Panorama.is_walked());
     assert!(!SubTable::MyColors.is_walked());
-    assert!(!SubTable::CustomFunctions2.is_walked());
+    assert!(!SubTable::AmbienceInfo.is_walked());
   }
 }

--- a/src/exif/makernotes/vendors/canon/time_info.rs
+++ b/src/exif/makernotes/vendors/canon/time_info.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Canon::TimeInfo` (`Canon.pm:6635-6702`) — `Canon::Main` tag `0x35`.
+//!
+//! `FORMAT => 'int32s'`, `FIRST_ENTRY => 1` (index 0 is the 16-byte size), so a
+//! tag at index `i` lives at byte offset `i * 4`: TimeZone (1) @ 4,
+//! TimeZoneCity (2) @ 8, DaylightSavings (3) @ 12.
+//!
+//! D8: pure decoder — returns the `(Name, TagValue)` emission pairs the
+//! dispatch site wraps in the `Canon` family-1 group.
+
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::ByteOrder;
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::string::String;
+use std::vec::Vec;
+
+/// Decode `%Canon::TimeInfo` from the 16-byte `0x35` blob.
+#[must_use]
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // 1) TimeZone @ byte 4 (int32s, `TimeZoneString($val)`).
+  if let Some(v) = i32s(data, 4, order) {
+    out.push((
+      SmolStr::new_static("TimeZone"),
+      if print_conv {
+        TagValue::Str(SmolStr::from(time_zone_string(v)))
+      } else {
+        TagValue::I64(v)
+      },
+    ));
+  }
+  // 2) TimeZoneCity @ byte 8 (int32s, PrintConv hash).
+  if let Some(v) = i32s(data, 8, order) {
+    out.push((
+      SmolStr::new_static("TimeZoneCity"),
+      hash(v, print_conv, time_zone_city_label),
+    ));
+  }
+  // 3) DaylightSavings @ byte 12 (int32s, `{0 => 'Off', 60 => 'On'}`).
+  if let Some(v) = i32s(data, 12, order) {
+    out.push((
+      SmolStr::new_static("DaylightSavings"),
+      hash(v, print_conv, daylight_savings_label),
+    ));
+  }
+  out
+}
+
+/// `Image::ExifTool::TimeZoneString($min)` (`ExifTool.pm:6750-6762`) for a
+/// minute offset: `±HH:MM`.
+fn time_zone_string(min: i64) -> String {
+  let sign = if min < 0 { '-' } else { '+' };
+  let min = min.abs();
+  let h = min / 60;
+  let m = min - h * 60;
+  std::format!("{sign}{h:02}:{m:02}")
+}
+
+/// `TimeZoneCity` PrintConv (`Canon.pm:6654-6693`).
+fn time_zone_city_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "n/a",
+    1 => "Chatham Islands",
+    2 => "Wellington",
+    3 => "Solomon Islands",
+    4 => "Sydney",
+    5 => "Adelaide",
+    6 => "Tokyo",
+    7 => "Hong Kong",
+    8 => "Bangkok",
+    9 => "Yangon",
+    10 => "Dhaka",
+    11 => "Kathmandu",
+    12 => "Delhi",
+    13 => "Karachi",
+    14 => "Kabul",
+    15 => "Dubai",
+    16 => "Tehran",
+    17 => "Moscow",
+    18 => "Cairo",
+    19 => "Paris",
+    20 => "London",
+    21 => "Azores",
+    22 => "Fernando de Noronha",
+    23 => "Sao Paulo",
+    24 => "Newfoundland",
+    25 => "Santiago",
+    26 => "Caracas",
+    27 => "New York",
+    28 => "Chicago",
+    29 => "Denver",
+    30 => "Los Angeles",
+    31 => "Anchorage",
+    32 => "Honolulu",
+    33 => "Samoa",
+    32766 => "(not set)",
+    _ => return None,
+  })
+}
+
+/// `DaylightSavings` PrintConv (`Canon.pm:6697-6700`).
+fn daylight_savings_label(v: i64) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    60 => "On",
+    _ => return None,
+  })
+}
+
+/// Render a hash PrintConv: the label, or `Unknown (N)`; raw int under `-n`.
+fn hash(v: i64, print_conv: bool, label: fn(i64) -> Option<&'static str>) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(v);
+  }
+  match label(v) {
+    Some(l) => TagValue::Str(SmolStr::new_static(l)),
+    None => TagValue::Str(SmolStr::from(std::format!("Unknown ({v})"))),
+  }
+}
+
+/// Read one signed 32-bit word at byte `off`.
+fn i32s(data: &[u8], off: usize, order: ByteOrder) -> Option<i64> {
+  let arr: [u8; 4] = data.get(off..off + 4)?.try_into().ok()?;
+  Some(match order {
+    ByteOrder::Little => i32::from_le_bytes(arr),
+    ByteOrder::Big => i32::from_be_bytes(arr),
+  } as i64)
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn time_info_7d() {
+    // [size=16][TimeZone=60][TimeZoneCity=19][DaylightSavings=0]
+    let mut b = vec![0u8; 16];
+    b[0] = 16;
+    b[4] = 60;
+    b[8] = 19;
+    let em = parse(&b, ByteOrder::Little, true);
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(find("TimeZone"), Some(TagValue::Str("+01:00".into())));
+    assert_eq!(find("TimeZoneCity"), Some(TagValue::Str("Paris".into())));
+    assert_eq!(find("DaylightSavings"), Some(TagValue::Str("Off".into())));
+
+    let em = parse(&b, ByteOrder::Little, false);
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(find("TimeZone"), Some(TagValue::I64(60)));
+    assert_eq!(find("TimeZoneCity"), Some(TagValue::I64(19)));
+  }
+
+  #[test]
+  fn time_zone_string_negative() {
+    assert_eq!(time_zone_string(-300), "-05:00");
+    assert_eq!(time_zone_string(0), "+00:00");
+    assert_eq!(time_zone_string(330), "+05:30");
+  }
+}

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -11651,8 +11651,8 @@ fn emit_canon_subtable<S: ExifSink>(
   use makernotes::vendors::canon::tags::SubTable;
   use makernotes::vendors::canon::{
     af_info, af_micro_adj, camera_info, camera_settings, canon_custom, color_balance, colordata,
-    file_info, first4_all_zero, focal_length, measured_color, processing, reserialize_int_array,
-    sensor_info, shot_info,
+    crop_info, file_info, first4_all_zero, focal_length, lens_correction, measured_color,
+    processing, reserialize_int_array, reserialize_int32_array, sensor_info, shot_info, time_info,
   };
 
   let blob = reserialize_int_array(raw, order);
@@ -11730,6 +11730,40 @@ fn emit_canon_subtable<S: ExifSink>(
         Vec::new()
       }
     }
+    // The EOS 7D image-info sub-tables (#445). TimeInfo (0x35) / AspectInfo
+    // (0x9a) / VignettingCorr2 (0x4016) / LightingOpt (0x4018) are `int32`-format
+    // tables read as `int32u[N]` IFD entries, so each word must be widened back
+    // to 4 bytes (`reserialize_int32_array`), like AFMicroAdj. CustomFunctions2
+    // (0x99) is likewise `int32u`-read.
+    SubTable::TimeInfo => {
+      let blob32 = reserialize_int32_array(raw, order);
+      time_info::parse(&blob32, order, print_conv)
+    }
+    // CropInfo (0x98) is `int16u` — the shared `int16` blob is correct.
+    SubTable::CropInfo => crop_info::parse_crop(&blob, order, print_conv),
+    SubTable::AspectInfo => {
+      let blob32 = reserialize_int32_array(raw, order);
+      crop_info::parse_aspect(&blob32, order, print_conv)
+    }
+    // VignettingCorr (0x4015) is read as `undef[N]` ⇒ the shared blob is the raw
+    // bytes (its int16s leaves read at byte offsets within it).
+    SubTable::VignettingCorr => lens_correction::parse_vignetting(&blob, order, print_conv),
+    SubTable::VignettingCorr2 => {
+      let blob32 = reserialize_int32_array(raw, order);
+      lens_correction::parse_vignetting2(&blob32, order, print_conv)
+    }
+    SubTable::LightingOpt => {
+      let blob32 = reserialize_int32_array(raw, order);
+      lens_correction::parse_lighting_opt(&blob32, order, print_conv)
+    }
+    // LensInfo (0x4019) is read as `undef[N]` ⇒ the shared raw-bytes blob.
+    SubTable::LensInfo => lens_correction::parse_lens_info(&blob, order, print_conv),
+    // CustomFunctions2 (0x99) — `ProcessCanonCustom2` against `CanonCustom::
+    // Functions2`; emitted into the `CanonCustom` family-1 group (handled below).
+    SubTable::CustomFunctions2 => {
+      let blob32 = reserialize_int32_array(raw, order);
+      canon_custom::parse_functions2(&blob32, order, print_conv, model)
+    }
     // `emit_entry` only routes the `is_walked()` set here; any other variant is
     // a caller bug, not a malformed-input case — emit nothing.
     _ => Vec::new(),
@@ -11738,7 +11772,7 @@ fn emit_canon_subtable<S: ExifSink>(
   // The `CanonCustom::*` tables emit into the `CanonCustom` family-1 group (the
   // `Image::ExifTool::CanonCustom` package group, `CanonCustom.pm:229`), NOT the
   // parent `Canon` group; every other walked sub-table stays in `group1`.
-  let emit_group1 = if matches!(sub, SubTable::CustomFunctions) {
+  let emit_group1 = if matches!(sub, SubTable::CustomFunctions | SubTable::CustomFunctions2) {
     "CanonCustom"
   } else {
     group1

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -10551,6 +10551,72 @@ fn canon_cr2_real_conformance() {
     "EOS 5D must NOT emit the Unknown CRWParam/Flavor leaves: {got}",
   );
 }
+
+/// Real-device Canon CR2 #2 — the EOS 7D deep Canon MakerNote sub-table
+/// activation (#445). `Canon_EOS-7D_sRAW_real.CR2` exercises the firmware-Hook
+/// `CameraInfo7D` (0x0d, `PRIORITY => 0`, with its nested `PSInfo` picture-style
+/// SubDirectory), `CustomFunctions2` (0x99 → `ProcessCanonCustom2`, the grouped
+/// record walker, into the `CanonCustom` family-1 group), `TimeInfo` (0x35),
+/// `CropInfo` (0x98), `AspectInfo` (0x9a), `VignettingCorr` (0x4015) +
+/// `VignettingCorr2` (0x4016), `LightingOpt` (0x4018) and `LensInfo` (0x4019).
+/// Byte-exact vs ExifTool 13.59 except for the documented niche residuals
+/// (separate cross-cutting subsystems, kept in sync with `FIXTURE_EXCLUDED_KEYS`
+/// in `tests/typed_serde_parity.rs`).
+#[test]
+fn canon_eos_7d_conformance() {
+  const EOS_7D_DEFERRED: &[&str] = &[
+    // `XMP-xmp:Rating` — the TIFF tag-0x02bc (`ApplicationNotes`) XMP packet
+    // routing (a cross-cutting XMP subsystem), niche-deferred like the Sony
+    // fixtures. NOT part of the Canon MakerNote sub-table port.
+    "XMP-xmp:Rating",
+    // The CR2-private SRaw / CFA-pattern IFD2/IFD3 leaves (0xc6c5 SRawType,
+    // 0xc5e1 CR2CFAPattern, 0xc640 RawImageSegmentation) — deferred EXIF
+    // leaf-table items (the same EXIF leaf-coverage class the EOS 5D defers),
+    // NOT the Canon MakerNote port.
+    "IFD2:SRawType",
+    "IFD3:SRawType",
+    "IFD3:CR2CFAPattern",
+    "IFD3:RawImageSegmentation",
+  ];
+  check_excluding(
+    "Canon_EOS-7D_sRAW_real.CR2",
+    "Canon_EOS-7D_sRAW_real.CR2.json",
+    true,
+    EOS_7D_DEFERRED,
+  );
+  check_excluding(
+    "Canon_EOS-7D_sRAW_real.CR2",
+    "Canon_EOS-7D_sRAW_real.CR2.n.json",
+    false,
+    EOS_7D_DEFERRED,
+  );
+
+  // Positively assert the firmware-Hook CameraInfo7D leaf (the lone
+  // non-colliding `Canon:ISO`), a nested PSInfo picture-style leaf, the six
+  // smaller sub-tables and a CustomFunctions2 leaf in its own family-1 group.
+  let root = env!("CARGO_MANIFEST_DIR");
+  let data = std::fs::read(format!("{root}/tests/fixtures/Canon_EOS-7D_sRAW_real.CR2"))
+    .expect("read Canon_EOS-7D_sRAW_real.CR2");
+  let got = extract_info("Canon_EOS-7D_sRAW_real.CR2", &data, true);
+  for needle in [
+    "\"Canon:ISO\":1234",                                        // CameraInfo7D 0x06
+    "\"Canon:FirmwareVersion\":\"2.0.3\"",                       // CameraInfo7D 0x1ac
+    "\"Canon:FileIndex\":5334",                                  // CameraInfo7D 0x1eb (+1)
+    "\"Canon:CameraPictureStyle\":\"User Defined 3\"",           // CameraInfo7D 0xaf
+    "\"Canon:SaturationLandscape\":4",                           // nested PSInfo
+    "\"Canon:UserDef3PictureStyle\":\"Standard\"",               // nested PSInfo (0x81)
+    "\"Canon:TimeZoneCity\":\"Paris\"",                          // TimeInfo 0x35
+    "\"Canon:AspectRatio\":\"Unknown (256)\"",                   // AspectInfo 0x9a
+    "\"Canon:OriginalImageWidth\":5184",                         // VignettingCorr 0x4015
+    "\"Canon:PeripheralLightingSetting\":\"Off\"",               // VignettingCorr2 0x4016
+    "\"Canon:AutoLightingOptimizer\":\"Off\"",                   // LightingOpt 0x4018
+    "\"Canon:LensSerialNumber\":\"00001469a3\"",                 // LensInfo 0x4019
+    "\"CanonCustom:AFMicroadjustment\":\"Disable; 0; 0; 0; 0\"", // CustomFunctions2
+    "\"CanonCustom:SelectAFAreaSelectMode\":\"Enable; Flags 0x1f\"",
+  ] {
+    assert!(got.contains(needle), "EOS 7D must emit {needle}: {got}",);
+  }
+}
 #[test]
 #[ignore = "DNG_preview_image.dng's full -G1 golden is not byte-exact because \
             `IFD0:DNGVersion` (0xc612) is not yet an emitted leaf (a deferred \

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -273,16 +273,11 @@ const NOT_ACTIVE: &[&str] = &[
   // / Processing / MeasuredColor / CustomFunctions5D are ported byte-exact, see
   // `conformance.rs::canon_cr2_real_conformance` + its `FIXTURE_EXCLUDED_KEYS`.)
   //
-  // `Canon_EOS-7D_sRAW_real.CR2` — the SECOND real-device CR2. This chunk ported
-  // the SHARED infra it needs (the count-797→`ColorData4`/`ColorCoefs` variant +
-  // `AFMicroAdj` 0x4013), but the 7D needs several MORE Canon sub-tables not yet
-  // ported: `CameraInfo7D` (0x0d — a firmware-dependent `Hook`/`varSize` offset
-  // shift, `Canon.pm:4347-4402`), `CustomFunctions2` (0x99 → `ProcessCanonCustom2`,
-  // the grouped/27-tag variant), `TimeInfo` (0x35), `CropInfo` (0x98),
-  // `AspectInfo` (0x9a), `VignettingCorr` (0x4015), `LightingOpt` (0x4018) and
-  // `LensInfo` (0x4019). Accept-deferred until those are ported (its goldens are
-  // committed so the next chunk can diff against them).
-  "Canon_EOS-7D_sRAW_real.CR2",
+  // (`Canon_EOS-7D_sRAW_real.CR2` is now ACTIVE — #445 ported the firmware-Hook
+  // `CameraInfo7D` + nested `PSInfo`, `CustomFunctions2` (`ProcessCanonCustom2`),
+  // `TimeInfo`/`CropInfo`/`AspectInfo`/`VignettingCorr`{,2}/`LightingOpt`/
+  // `LensInfo` byte-exact, see `conformance.rs::canon_eos_7d_conformance` + its
+  // `FIXTURE_EXCLUDED_KEYS`.)
 ];
 
 /// ACTIVE fixtures that emit a tag whose VALUE diverges from bundled because a
@@ -566,6 +561,26 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
     "Canon_EOS-5D_real.CR2",
     &[
       "ExifTool:Warning",
+      "IFD3:CR2CFAPattern",
+      "IFD3:RawImageSegmentation",
+    ],
+  ),
+  // `Canon_EOS-7D_sRAW_real.CR2` — the EOS 7D deep Canon MakerNote sub-table
+  // activation (#445). The firmware-Hook `CameraInfo7D` (0x0d) + nested `PSInfo`,
+  // `CustomFunctions2` (0x99 → `ProcessCanonCustom2`), `TimeInfo`/`CropInfo`/
+  // `AspectInfo`/`VignettingCorr`{,2}/`LightingOpt`/`LensInfo` all emit
+  // byte-exact. The niche residuals dropped from BOTH sides: `XMP-xmp:Rating`
+  // (the TIFF-0x02bc XMP-packet routing, a cross-cutting XMP subsystem) and the
+  // four CR2-private SRaw/CFA IFD2/IFD3 leaves (`IFD2:SRawType`/`IFD3:SRawType`/
+  // `IFD3:CR2CFAPattern`/`IFD3:RawImageSegmentation`) the EXIF leaf-table port
+  // does not yet display. Mirrors `conformance.rs::canon_eos_7d_conformance`'s
+  // `EOS_7D_DEFERRED`.
+  (
+    "Canon_EOS-7D_sRAW_real.CR2",
+    &[
+      "XMP-xmp:Rating",
+      "IFD2:SRawType",
+      "IFD3:SRawType",
       "IFD3:CR2CFAPattern",
       "IFD3:RawImageSegmentation",
     ],
@@ -1711,10 +1726,20 @@ fn drop_keys(doc: &str, exact_keys: &[&str]) -> String {
 /// `ProcessCanonCustom`, grouped under `CanonCustom`), plus the `CRWParam`/`Flavor`
 /// (0x4002/0x4005 `Unknown`) suppression, with a `FIXTURE_EXCLUDED_KEYS` entry for
 /// the `ExifTool:Warning` (`OriginalDecisionData`/`ReadODD` subsystem) + the two
-/// CR2-private IFD3 leaves. (The sibling `Canon_EOS-7D_sRAW_real.CR2` was added to
-/// the both-goldens set but stays in `NOT_ACTIVE` — it needs `CameraInfo7D` +
-/// `CustomFunctions2` + several smaller sub-tables, deferred to the next chunk.)
-const EXPECTED_ACTIVE_FIXTURES: usize = 640;
+/// CR2-private IFD3 leaves.
+///
+/// 640 → 641: the `Canon_EOS-7D_sRAW_real.CR2` raw GRADUATES out of `NOT_ACTIVE`
+/// (#445) — the EOS 7D deep sub-table tower is ported byte-exact: the
+/// firmware-Hook `CameraInfo7D` (0x0d, `PRIORITY => 0`, with the `varSize` shift
+/// keyed off the 0x1a8/0x1ac `FirmwareVersionLookAhead`) + its nested `PSInfo`
+/// picture-style SubDirectory, `CustomFunctions2` (0x99 → `ProcessCanonCustom2`,
+/// the grouped-record walker, under `CanonCustom`), `TimeInfo` (0x35), `CropInfo`
+/// (0x98), `AspectInfo` (0x9a), `VignettingCorr` (0x4015) + `VignettingCorr2`
+/// (0x4016), `LightingOpt` (0x4018) and `LensInfo` (0x4019) — reusing the
+/// chunk-1 `ColorData4`/`AFMicroAdj` infra. A `FIXTURE_EXCLUDED_KEYS` entry
+/// drops the `XMP-xmp:Rating` (TIFF-0x02bc XMP routing) + the four CR2-private
+/// SRaw/CFA IFD2/IFD3 leaves.
+const EXPECTED_ACTIVE_FIXTURES: usize = 641;
 
 /// Every `tests/fixtures/<f>` that has both `tests/golden/<f>.json` and
 /// `tests/golden/<f>.n.json`, MINUS the [`NOT_ACTIVE`] formally-accept-


### PR DESCRIPTION
Activates the **2nd Canon real-device fixture** (`Canon_EOS-7D_sRAW_real.CR2`) byte-exact vs ExifTool 13.59 — completing the Canon CR2 cluster (5D #447 + 7D). Builds on the merged 5D Canon infra (ColorData4 + AFMicroAdj). Ground-truthed via `-v4`.

- **CameraInfo7D** (0x0d, the firmware-dependent Hook: FirmwareVersionLookAhead probes '2.0.3' → CanonFirm=2 → varSize shift) + the nested **PSInfo** SubDirectory (45 leaves; the `Unknown=>1` FilterEffect/ToningEffect rows suppressed, `%userDefStyles` decimal Unknown fallback). (#85)
- **CustomFunctions2** (0x99 → `ProcessCanonCustom2`) — the grouped-record walker (Get16u size + Get32u group-count + per-group (recNum,recLen,recCount) headers + (tag,num,int32s×num) records), 27 CanonCustom tags into the CanonCustom group. (#87) [Note: the group-count/recCount are verbose-only in ExifTool's ProcessCanonCustom2; the walk is block-end + recLen bounded — exifast matches exactly, with bounds-checked arithmetic.]
- 6 smaller tables: TimeInfo (0x35) / CropInfo (0x98) / AspectInfo (0x9a) / VignettingCorr+VignettingCorr2 (0x4015/0x4016) / LightingOpt (0x4018) / LensInfo (0x4019).

7D byte-exact (5 niches: `XMP-xmp:Rating` = the TIFF-0x02bc XMP routing; `IFD2/IFD3:SRawType`, `IFD3:CR2CFAPattern`/`RawImageSegmentation` = deferred EXIF leaf-tables). 5D + Sony + all existing goldens byte-identical. `build(-Dwarnings)=0 alloc_budget=PASS conformance=497/0 typed_serde=641 lib=4029/0 timed=161/0 xtask=26`. **Codex: APPROVE** (the count-bound finding was ground-truthed as a misread — exifast matches ExifTool's verbose-only-count walk).

**Deferred:** memory-amplification → **#443**. EXPECTED_ACTIVE 640→641. Completes the **Canon CR2 cluster** (#442 §A); CR3 (EOS R) next. Closes part of #84/#85/#87.