### PR TITLE
feat(sony): port Tag9403/Tag9404a-c/Tag940a/Tag940e enciphered 0x94xx subtables (#101)

### DIFF
--- a/src/exif/makernotes/vendors/sony/mod.rs
+++ b/src/exif/makernotes/vendors/sony/mod.rs
@@ -91,8 +91,12 @@ pub mod tag9050;
 pub mod tag9400;
 pub mod tag9401;
 pub mod tag9402;
+pub mod tag9403;
+pub mod tag9404;
 pub mod tag9406;
+pub mod tag940a;
 pub mod tag940c;
+pub mod tag940e;
 pub mod tag9416;
 pub mod tags;
 
@@ -105,6 +109,10 @@ pub use printconv::{
   CONDITION_GATED_IDS, RAWCONV_DROP_IDS, SonyPrintConv, rawconv_drops, single_hash_condition_holds,
 };
 pub use tags::{SONY_TAGS, SonyTag, SubTable, format_override, lookup};
+// `%sonyExposureProgram3` (= the `%exposureProgram2010` PrintConv) is shared by
+// the `Tag9416` `0x0035` row and the `Tag9404a/b/c` `ExposureProgram` rows, so
+// the `Tag9404` parser reaches it as `super::print_exposure_program3`.
+pub(crate) use tag9416::print_exposure_program3;
 
 use super::super::super::ifd::RawValue;
 

--- a/src/exif/makernotes/vendors/sony/tag9403.rs
+++ b/src/exif/makernotes/vendors/sony/tag9403.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::Tag9403` (`Sony.pm:8792-8818`) — the enciphered
+//! `Tag9403` `ProcessBinaryData` block (camera/sensor temperature).
+//!
+//! The `0x9403` Main-table row is an UNCONDITIONAL SubDirectory
+//! (`Sony.pm:1975-1978`): every body that writes `0x9403` routes here. The
+//! block is enciphered (`PROCESS_PROC => \&ProcessEnciphered`, `Sony.pm:8793`)
+//! so the dispatcher
+//! [`process_enciphered`](super::decipher::process_enciphered)s it (once, or
+//! twice for a double-enciphered body) and hands this table the DECIPHERED
+//! bytes; `FORMAT => 'int8u'` + `FIRST_ENTRY => 0` (`Sony.pm:8796,8798`).
+//!
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range
+//! is in the deciphered block ([[exifast-processbinarydata-per-field]]). The
+//! `0x04` `TempTest2` DataMember is `Hidden => 1` with a `RawConv` that returns
+//! `undef` unless `Unknown >= 2` (`Sony.pm:8804-8807`), so it is NEVER emitted;
+//! it only gates `0x05` `CameraTemperature`. The real ILME-FX3 writes a 4-byte
+//! `0x9403` block (offsets `0..3`), so NEITHER field is in range and the table
+//! emits nothing — matching ExifTool's empty `Tag9403` directory for the FX3.
+
+use crate::value::TagValue;
+
+/// One emitted `Tag9403` leaf — the resolved tag name and rendered value.
+pub struct Tag9403Emission {
+  /// `Name => '…'` from the bundled table.
+  pub name: &'static str,
+  /// The rendered value (`-j` PrintConv result, or `-n` raw `$val`).
+  pub value: TagValue,
+}
+
+/// Walk the DECIPHERED `Tag9403` block and emit `CameraTemperature`.
+///
+/// `buf` is the DECIPHERED `0x9403` block — the dispatcher already ran
+/// [`process_enciphered`](super::decipher::process_enciphered) (twice for a
+/// double-enciphered body). `print_conv` selects `-j` (PrintConv) vs `-n` (raw
+/// `$val`).
+#[must_use]
+pub fn parse_tag9403(buf: &[u8], print_conv: bool) -> Vec<Tag9403Emission> {
+  let mut out = std::vec::Vec::new();
+
+  // 0x04 TempTest2 — int8u DataMember, `Hidden => 1` + `RawConv` keeps it
+  // `undef` unless `Unknown >= 2` (Sony.pm:8801-8808), so it is never emitted;
+  // its int8u value only gates 0x05.
+  let temp_test2 = buf.get(0x04).copied();
+
+  // 0x05 CameraTemperature — int8s, `Condition => '$$self{TempTest2} and
+  // $$self{TempTest2} < 100'` (Sony.pm:8809-8815): emitted only when TempTest2
+  // is non-zero AND < 100. `PrintConv => '"$val C"'`; `$val` is the SIGNED byte.
+  if let Some(tt2) = temp_test2
+    && tt2 != 0
+    && tt2 < 100
+    && let Some(&raw) = buf.get(0x05)
+  {
+    let signed = i64::from(raw as i8);
+    let value = if print_conv {
+      TagValue::Str(std::format!("{signed} C").into())
+    } else {
+      TagValue::I64(signed)
+    };
+    out.push(Tag9403Emission {
+      name: "CameraTemperature",
+      value,
+    });
+  }
+
+  out
+}
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "tag9403_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/tag9403_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag9403_tests.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+use super::*;
+
+/// Forward Sony cipher `c = (b·b·b) mod 249` (`Sony.pm:11521`).
+fn encipher_byte(b: u8) -> u8 {
+  if b <= 248 {
+    (((u32::from(b) * u32::from(b)) % 249 * u32::from(b)) % 249) as u8
+  } else {
+    b
+  }
+}
+
+fn encipher(plain: &[u8]) -> Vec<u8> {
+  plain.iter().map(|&b| encipher_byte(b)).collect()
+}
+
+/// The dispatcher's central decipher (`process_enciphered`) — single pass —
+/// reproducing the production path that hands `parse_tag9403` ALREADY-DECIPHERED
+/// bytes.
+fn process_enciphered(enc: &[u8], double_cipher: bool) -> Vec<u8> {
+  super::super::decipher::process_enciphered(enc, double_cipher)
+}
+
+fn find<'a>(em: &'a [Tag9403Emission], name: &str) -> Option<&'a TagValue> {
+  em.iter().rev().find(|e| e.name == name).map(|e| &e.value)
+}
+
+/// The real ILME-FX3 writes a 4-byte `0x9403` block (offsets `0..3`): neither
+/// `0x04` (`TempTest2`) nor `0x05` (`CameraTemperature`) is in range, so the
+/// table emits nothing — matching ExifTool's empty `Tag9403` directory.
+#[test]
+fn fx3_four_byte_block_emits_nothing() {
+  let plain = vec![0u8; 4];
+  let em = parse_tag9403(&process_enciphered(&encipher(&plain), false), true);
+  assert!(em.is_empty());
+}
+
+#[test]
+fn camera_temperature_emitted_in_range() {
+  let mut plain = vec![0u8; 8];
+  plain[0x04] = 20; // TempTest2 non-zero AND < 100 ⇒ Condition holds
+  plain[0x05] = 25; // CameraTemperature int8s
+  let em = parse_tag9403(&process_enciphered(&encipher(&plain), false), true);
+  assert_eq!(
+    find(&em, "CameraTemperature"),
+    Some(&TagValue::Str("25 C".into()))
+  );
+  // -n keeps the raw signed integer.
+  let em_n = parse_tag9403(&process_enciphered(&encipher(&plain), false), false);
+  assert_eq!(find(&em_n, "CameraTemperature"), Some(&TagValue::I64(25)));
+}
+
+/// `CameraTemperature` is `int8s` (`Sony.pm:8812`): a high byte reads negative.
+#[test]
+fn camera_temperature_int8s_negative() {
+  let mut plain = vec![0u8; 8];
+  plain[0x04] = 20;
+  plain[0x05] = 0xff; // -1 as int8s
+  let em = parse_tag9403(&process_enciphered(&encipher(&plain), false), true);
+  assert_eq!(
+    find(&em, "CameraTemperature"),
+    Some(&TagValue::Str("-1 C".into()))
+  );
+}
+
+/// `Condition => '$$self{TempTest2} and …'`: a zero `TempTest2` is falsey ⇒
+/// `CameraTemperature` is suppressed.
+#[test]
+fn temp_test2_zero_suppresses() {
+  let mut plain = vec![0u8; 8];
+  plain[0x04] = 0;
+  plain[0x05] = 25;
+  let em = parse_tag9403(&process_enciphered(&encipher(&plain), false), true);
+  assert!(find(&em, "CameraTemperature").is_none());
+}
+
+/// `Condition => '… and $$self{TempTest2} < 100'`: a `TempTest2 >= 100` ⇒
+/// `CameraTemperature` is suppressed.
+#[test]
+fn temp_test2_ge_100_suppresses() {
+  let mut plain = vec![0u8; 8];
+  plain[0x04] = 130;
+  plain[0x05] = 25;
+  let em = parse_tag9403(&process_enciphered(&encipher(&plain), false), true);
+  assert!(find(&em, "CameraTemperature").is_none());
+}
+
+/// `TempTest2` is `Hidden => 1` with an `Unknown < 2` RawConv ⇒ never emitted.
+#[test]
+fn temp_test2_is_never_emitted() {
+  let mut plain = vec![0u8; 8];
+  plain[0x04] = 20;
+  plain[0x05] = 25;
+  let em = parse_tag9403(&process_enciphered(&encipher(&plain), false), true);
+  assert!(find(&em, "TempTest2").is_none());
+}
+
+/// Per-field availability: a 5-byte block has `0x04` (gates) but not `0x05`.
+#[test]
+fn per_field_truncation() {
+  let mut plain = vec![0u8; 5];
+  plain[0x04] = 20;
+  let em = parse_tag9403(&process_enciphered(&encipher(&plain), false), true);
+  assert!(em.is_empty());
+  assert!(parse_tag9403(&[], true).is_empty());
+}

--- a/src/exif/makernotes/vendors/sony/tag9404.rs
+++ b/src/exif/makernotes/vendors/sony/tag9404.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::Tag9404a`/`Tag9404b`/`Tag9404c`
+//! (`Sony.pm:8821-8876`) — the enciphered `Tag9404` `ProcessBinaryData` blocks
+//! (ExposureProgram / IntelligentAuto / LensZoomPosition / FocusPosition2).
+//!
+//! The `0x9404` Main-table row is a conditional-ARRAY SubDirectory dispatcher
+//! (`Sony.pm:1990-2008`) selected by the (still-enciphered) first and fourth
+//! value bytes:
+//!
+//! - `Tag9404a` — `$$valPt =~ /^[\x40\x7d]..\x01/` (first byte `0x40`/`0x7d`
+//!   = deciphered 4/5, fourth byte `0x01`).
+//! - `Tag9404b` — `$$valPt =~ /^[\xe7\xea\xcd\x8a\x70]..\x08/` (first byte
+//!   = deciphered 9/12/13/15/16, fourth byte `0x08` = deciphered 2).
+//! - `Tag9404c` — `$$valPt =~ /^\xb6..\x01/` (first byte = deciphered 17,
+//!   fourth byte `0x01`).
+//! - else `Sony_0x9404` (`%unknownCipherData`) — emits nothing.
+//!
+//! Each regex has two `.` wildcards at value bytes 1 and 2; with NO `/s` flag a
+//! `.` matches any byte EXCEPT newline (`0x0a`), so a block with `0x0a` at byte
+//! 1 or 2 fails the gate and falls through to `Sony_0x9404` (emits nothing).
+//!
+//! The variant gate is tested on the RAW on-disk (pre-decipher) bytes (the
+//! Perl `$$valPt` is pre-decipher); the dispatcher then
+//! [`process_enciphered`](super::decipher::process_enciphered)s the block (once,
+//! or twice for a double-enciphered body) and hands the per-variant parser the
+//! DECIPHERED bytes. `FORMAT => 'int8u'` + `FIRST_ENTRY => 0`.
+//!
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range
+//! is in the deciphered block ([[exifast-processbinarydata-per-field]]) AND its
+//! per-leaf model `Condition` holds. The real ILME-FX3's `0x9404` matches none
+//! of the three variant gates (ExifTool dispatches it as `Sony_0x9404`), so this
+//! module emits nothing for the FX3.
+
+use crate::value::TagValue;
+
+/// One emitted `Tag9404` leaf — the resolved tag name and rendered value.
+pub struct Tag9404Emission {
+  /// `Name => '…'` from the bundled table.
+  pub name: &'static str,
+  /// The rendered value (`-j` PrintConv result, or `-n` raw `$val`).
+  pub value: TagValue,
+}
+
+/// Read a little-endian `int16u` at byte `off` of the deciphered block.
+fn read_u16(buf: &[u8], off: usize) -> Option<u16> {
+  match buf.get(off..off.checked_add(2)?) {
+    Some(&[a, b]) => Some(u16::from_le_bytes([a, b])),
+    _ => None,
+  }
+}
+
+/// `IntelligentAuto` PrintConv hash (`Sony.pm:8830`/`8850`/`8875`):
+/// `{ 0 => 'Off', 1 => 'On' }`. `None` for an unmapped value (the hash-PrintConv
+/// miss renders `"Unknown ($val)"` in `-j` via [`super::hash_print_value`]).
+fn print_intelligent_auto(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "On",
+    _ => return None,
+  })
+}
+
+/// `LensZoomPosition` rendered value — `int16u`, `PrintConv =>
+/// 'sprintf("%.0f%%",$val/10.24)'` (`Sony.pm:8835`/`8855`). `-n` keeps the raw
+/// `int16u` (no ValueConv on this row).
+fn lens_zoom_position_value(raw: u16, print_conv: bool) -> TagValue {
+  if print_conv {
+    TagValue::Str(std::format!("{:.0}%", f64::from(raw) / 10.24).into())
+  } else {
+    TagValue::I64(i64::from(raw))
+  }
+}
+
+/// `$$self{Model} =~ /^SLT-/` — the `Tag9404a` `LensZoomPosition` exclusion
+/// (`Sony.pm:8834`: the leaf is valid only when the model is NOT an SLT body).
+/// A `None` model does NOT match (`undef !~ /…/` is true), so the leaf is valid.
+fn model_is_slt(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("SLT-"))
+}
+
+/// `$$self{Model} =~ /^(SLT-|HV|ILCA-)/` — the `Tag9404b` phase-detect body
+/// class (`Sony.pm:8854`/`8861`): `LensZoomPosition` is excluded for these
+/// bodies, `FocusPosition2` is valid only for them.
+fn model_is_slt_hv_ilca(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("SLT-") || m.starts_with("HV") || m.starts_with("ILCA-"))
+}
+
+/// Perl `.` WITHOUT the `/s` flag (`Sony.pm:1993`/`1998`/`2003` carry no `/s`):
+/// the byte at `off` must EXIST and must not be the newline `0x0a` — a `.`
+/// matches any single character except `\n`.
+fn dot_no_newline(raw: &[u8], off: usize) -> bool {
+  matches!(raw.get(off), Some(&b) if b != b'\n')
+}
+
+/// `true` when the on-disk (enciphered) `0x9404` value selects `Tag9404a`
+/// (`Sony.pm:1993`, `/^[\x40\x7d]..\x01/`): first byte `0x40`/`0x7d`, bytes 1+2
+/// non-newline (`.` without `/s`), fourth byte `0x01`. Tested against the RAW
+/// on-disk bytes (the Perl `$$valPt` is pre-decipher).
+#[must_use]
+pub fn selects_tag9404a(raw: &[u8]) -> bool {
+  matches!(raw.first(), Some(0x40 | 0x7d))
+    && dot_no_newline(raw, 1)
+    && dot_no_newline(raw, 2)
+    && raw.get(3) == Some(&0x01)
+}
+
+/// `true` when the on-disk (enciphered) `0x9404` value selects `Tag9404b`
+/// (`Sony.pm:1998`, `/^[\xe7\xea\xcd\x8a\x70]..\x08/`): first byte
+/// `0xe7`/`0xea`/`0xcd`/`0x8a`/`0x70`, bytes 1+2 non-newline (`.` without `/s`),
+/// fourth byte `0x08`. Tested against the RAW on-disk bytes.
+#[must_use]
+pub fn selects_tag9404b(raw: &[u8]) -> bool {
+  matches!(raw.first(), Some(0xe7 | 0xea | 0xcd | 0x8a | 0x70))
+    && dot_no_newline(raw, 1)
+    && dot_no_newline(raw, 2)
+    && raw.get(3) == Some(&0x08)
+}
+
+/// `true` when the on-disk (enciphered) `0x9404` value selects `Tag9404c`
+/// (`Sony.pm:2003`, `/^\xb6..\x01/`): first byte `0xb6`, bytes 1+2 non-newline
+/// (`.` without `/s`), fourth byte `0x01`. Tested against the RAW on-disk bytes.
+#[must_use]
+pub fn selects_tag9404c(raw: &[u8]) -> bool {
+  raw.first() == Some(&0xb6)
+    && dot_no_newline(raw, 1)
+    && dot_no_newline(raw, 2)
+    && raw.get(3) == Some(&0x01)
+}
+
+/// Walk the DECIPHERED `Tag9404a` block (`Sony.pm:8821-8838`).
+#[must_use]
+pub fn parse_tag9404a(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<Tag9404Emission> {
+  let mut out = std::vec::Vec::new();
+
+  // 0x000b ExposureProgram — int8u, %sonyExposureProgram3 (Sony.pm:8829).
+  if let Some(&raw) = buf.get(0x0b) {
+    out.push(Tag9404Emission {
+      name: "ExposureProgram",
+      value: super::hash_print_value(raw, super::print_exposure_program3(raw), print_conv),
+    });
+  }
+
+  // 0x000d IntelligentAuto — int8u hash (Sony.pm:8830).
+  if let Some(&raw) = buf.get(0x0d) {
+    out.push(Tag9404Emission {
+      name: "IntelligentAuto",
+      value: super::hash_print_value(raw, print_intelligent_auto(raw), print_conv),
+    });
+  }
+
+  // 0x0019 LensZoomPosition — int16u, `Condition => '$$self{Model} !~ /^SLT-/'`
+  // (Sony.pm:8831-8837).
+  if !model_is_slt(model)
+    && let Some(raw) = read_u16(buf, 0x19)
+  {
+    out.push(Tag9404Emission {
+      name: "LensZoomPosition",
+      value: lens_zoom_position_value(raw, print_conv),
+    });
+  }
+
+  out
+}
+
+/// Walk the DECIPHERED `Tag9404b` block (`Sony.pm:8841-8863`).
+#[must_use]
+pub fn parse_tag9404b(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<Tag9404Emission> {
+  let mut out = std::vec::Vec::new();
+
+  // 0x000c ExposureProgram — int8u, %sonyExposureProgram3 (Sony.pm:8849).
+  if let Some(&raw) = buf.get(0x0c) {
+    out.push(Tag9404Emission {
+      name: "ExposureProgram",
+      value: super::hash_print_value(raw, super::print_exposure_program3(raw), print_conv),
+    });
+  }
+
+  // 0x000e IntelligentAuto — int8u hash (Sony.pm:8850).
+  if let Some(&raw) = buf.get(0x0e) {
+    out.push(Tag9404Emission {
+      name: "IntelligentAuto",
+      value: super::hash_print_value(raw, print_intelligent_auto(raw), print_conv),
+    });
+  }
+
+  // 0x001e LensZoomPosition — int16u, `Condition => '$$self{Model} !~
+  // /^(SLT-|HV|ILCA-)/'` (Sony.pm:8851-8857).
+  if !model_is_slt_hv_ilca(model)
+    && let Some(raw) = read_u16(buf, 0x1e)
+  {
+    out.push(Tag9404Emission {
+      name: "LensZoomPosition",
+      value: lens_zoom_position_value(raw, print_conv),
+    });
+  }
+
+  // 0x0020 FocusPosition2 — int8u, `Condition => '$$self{Model} =~
+  // /^(SLT-|HV|ILCA-)/'` (Sony.pm:8858-8862). No PrintConv ⇒ raw in both modes.
+  if model_is_slt_hv_ilca(model)
+    && let Some(&raw) = buf.get(0x20)
+  {
+    out.push(Tag9404Emission {
+      name: "FocusPosition2",
+      value: TagValue::I64(i64::from(raw)),
+    });
+  }
+
+  out
+}
+
+/// Walk the DECIPHERED `Tag9404c` block (`Sony.pm:8866-8876`).
+#[must_use]
+pub fn parse_tag9404c(buf: &[u8], print_conv: bool) -> Vec<Tag9404Emission> {
+  let mut out = std::vec::Vec::new();
+
+  // 0x000b ExposureProgram — int8u, %sonyExposureProgram3 (Sony.pm:8874).
+  if let Some(&raw) = buf.get(0x0b) {
+    out.push(Tag9404Emission {
+      name: "ExposureProgram",
+      value: super::hash_print_value(raw, super::print_exposure_program3(raw), print_conv),
+    });
+  }
+
+  // 0x000d IntelligentAuto — int8u hash (Sony.pm:8875).
+  if let Some(&raw) = buf.get(0x0d) {
+    out.push(Tag9404Emission {
+      name: "IntelligentAuto",
+      value: super::hash_print_value(raw, print_intelligent_auto(raw), print_conv),
+    });
+  }
+
+  out
+}
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "tag9404_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/tag9404_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag9404_tests.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+use super::*;
+
+/// Forward Sony cipher `c = (b·b·b) mod 249` (`Sony.pm:11521`).
+fn encipher_byte(b: u8) -> u8 {
+  if b <= 248 {
+    (((u32::from(b) * u32::from(b)) % 249 * u32::from(b)) % 249) as u8
+  } else {
+    b
+  }
+}
+
+fn encipher(plain: &[u8]) -> Vec<u8> {
+  plain.iter().map(|&b| encipher_byte(b)).collect()
+}
+
+fn process_enciphered(enc: &[u8], double_cipher: bool) -> Vec<u8> {
+  super::super::decipher::process_enciphered(enc, double_cipher)
+}
+
+fn find<'a>(em: &'a [Tag9404Emission], name: &str) -> Option<&'a TagValue> {
+  em.iter().rev().find(|e| e.name == name).map(|e| &e.value)
+}
+
+/// The variant gates test the RAW (enciphered) first + fourth bytes
+/// (`Sony.pm:1993`/`1998`/`2003`).
+#[test]
+fn variant_gates() {
+  // Tag9404a: first byte 0x40/0x7d, fourth byte 0x01.
+  assert!(selects_tag9404a(&[0x40, 0, 0, 0x01]));
+  assert!(selects_tag9404a(&[0x7d, 0xaa, 0xbb, 0x01]));
+  assert!(!selects_tag9404a(&[0x40, 0, 0, 0x02])); // wrong fourth byte
+  assert!(!selects_tag9404a(&[0x41, 0, 0, 0x01])); // wrong first byte
+  // Tag9404b: first byte in {0xe7,0xea,0xcd,0x8a,0x70}, fourth byte 0x08.
+  assert!(selects_tag9404b(&[0xe7, 0, 0, 0x08]));
+  assert!(selects_tag9404b(&[0x70, 0, 0, 0x08]));
+  assert!(!selects_tag9404b(&[0xe7, 0, 0, 0x01]));
+  // Tag9404c: first byte 0xb6, fourth byte 0x01.
+  assert!(selects_tag9404c(&[0xb6, 0, 0, 0x01]));
+  assert!(!selects_tag9404c(&[0xb6, 0, 0, 0x08]));
+  // Mutual exclusivity (a's 0x40 is not c's 0xb6) + short buffers.
+  assert!(!selects_tag9404c(&[0x40, 0, 0, 0x01]));
+  assert!(!selects_tag9404a(&[0x40]));
+  assert!(!selects_tag9404a(&[]));
+}
+
+/// The two `.` wildcards at value bytes 1 and 2 are Perl `.` WITHOUT `/s`
+/// (`Sony.pm:1993`/`1998`/`2003` have no `/s`), so a `0x0a` newline there fails
+/// the regex and the variant is NOT selected — ExifTool falls through to the
+/// unknown `Sony_0x9404` (emits nothing).
+#[test]
+fn variant_gates_reject_newline_in_wildcard() {
+  // Tag9404a — byte 0 ∈ {0x40,0x7d}, byte 3 == 0x01; bytes 1,2 must be non-0x0a.
+  assert!(selects_tag9404a(&[0x40, 0x55, 0x55, 0x01]));
+  assert!(!selects_tag9404a(&[0x40, 0x0a, 0x55, 0x01])); // \n at byte 1
+  assert!(!selects_tag9404a(&[0x40, 0x55, 0x0a, 0x01])); // \n at byte 2
+  // Tag9404b — byte 0 ∈ {0xe7,0xea,0xcd,0x8a,0x70}, byte 3 == 0x08.
+  assert!(selects_tag9404b(&[0xe7, 0x55, 0x55, 0x08]));
+  assert!(!selects_tag9404b(&[0xe7, 0x0a, 0x55, 0x08])); // \n at byte 1
+  assert!(!selects_tag9404b(&[0xe7, 0x55, 0x0a, 0x08])); // \n at byte 2
+  // Tag9404c — byte 0 == 0xb6, byte 3 == 0x01.
+  assert!(selects_tag9404c(&[0xb6, 0x55, 0x55, 0x01]));
+  assert!(!selects_tag9404c(&[0xb6, 0x0a, 0x55, 0x01])); // \n at byte 1
+  assert!(!selects_tag9404c(&[0xb6, 0x55, 0x0a, 0x01])); // \n at byte 2
+}
+
+#[test]
+fn tag9404a_print_conv() {
+  let mut plain = vec![0u8; 0x20];
+  plain[0x0b] = 3; // ExposureProgram = Manual
+  plain[0x0d] = 1; // IntelligentAuto = On
+  plain[0x19] = 0x00; // LensZoomPosition int16u LE = 1024 ⇒ 100%
+  plain[0x1a] = 0x04;
+  let em = parse_tag9404a(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-7M2"),
+    true,
+  );
+  assert_eq!(
+    find(&em, "ExposureProgram"),
+    Some(&TagValue::Str("Manual".into()))
+  );
+  assert_eq!(
+    find(&em, "IntelligentAuto"),
+    Some(&TagValue::Str("On".into()))
+  );
+  assert_eq!(
+    find(&em, "LensZoomPosition"),
+    Some(&TagValue::Str("100%".into()))
+  );
+}
+
+#[test]
+fn tag9404a_raw() {
+  let mut plain = vec![0u8; 0x20];
+  plain[0x0b] = 3;
+  plain[0x0d] = 1;
+  plain[0x19] = 0x00;
+  plain[0x1a] = 0x04; // 1024
+  let em = parse_tag9404a(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-7M2"),
+    false,
+  );
+  assert_eq!(find(&em, "ExposureProgram"), Some(&TagValue::I64(3)));
+  assert_eq!(find(&em, "IntelligentAuto"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "LensZoomPosition"), Some(&TagValue::I64(1024)));
+}
+
+/// `Tag9404a` 0x19 `LensZoomPosition` `Condition => '$$self{Model} !~ /^SLT-/'`.
+#[test]
+fn tag9404a_lens_zoom_excluded_for_slt() {
+  let mut plain = vec![0u8; 0x20];
+  plain[0x19] = 0x00;
+  plain[0x1a] = 0x04;
+  let em = parse_tag9404a(
+    &process_enciphered(&encipher(&plain), false),
+    Some("SLT-A99V"),
+    true,
+  );
+  assert!(find(&em, "LensZoomPosition").is_none());
+}
+
+/// `%sonyExposureProgram3` miss ⇒ `"Unknown ($val)"` (decimal; no `PrintHex`).
+#[test]
+fn tag9404a_exposure_program_unknown() {
+  let mut plain = vec![0u8; 0x10];
+  plain[0x0b] = 99;
+  let em = parse_tag9404a(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-7M2"),
+    true,
+  );
+  assert_eq!(
+    find(&em, "ExposureProgram"),
+    Some(&TagValue::Str("Unknown (99)".into()))
+  );
+}
+
+/// `Tag9404b` 0x1e `LensZoomPosition` (non-SLT/HV/ILCA) vs 0x20 `FocusPosition2`
+/// (SLT/HV/ILCA) are mutually-exclusive by model.
+#[test]
+fn tag9404b_lens_zoom_vs_focus_position() {
+  let mut plain = vec![0u8; 0x24];
+  plain[0x0c] = 1; // ExposureProgram = Aperture-priority AE
+  plain[0x0e] = 0; // IntelligentAuto = Off
+  plain[0x1e] = 0x00; // LensZoomPosition int16u LE = 512 ⇒ 50%
+  plain[0x1f] = 0x02;
+  plain[0x20] = 182; // FocusPosition2 (only valid for SLT/HV/ILCA)
+
+  let em = parse_tag9404b(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-7M2"),
+    true,
+  );
+  assert_eq!(
+    find(&em, "ExposureProgram"),
+    Some(&TagValue::Str("Aperture-priority AE".into()))
+  );
+  assert_eq!(
+    find(&em, "IntelligentAuto"),
+    Some(&TagValue::Str("Off".into()))
+  );
+  assert_eq!(
+    find(&em, "LensZoomPosition"),
+    Some(&TagValue::Str("50%".into()))
+  );
+  assert!(find(&em, "FocusPosition2").is_none());
+
+  let em2 = parse_tag9404b(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCA-77M2"),
+    true,
+  );
+  assert_eq!(find(&em2, "FocusPosition2"), Some(&TagValue::I64(182)));
+  assert!(find(&em2, "LensZoomPosition").is_none());
+}
+
+#[test]
+fn tag9404c_fields() {
+  let mut plain = vec![0u8; 0x10];
+  plain[0x0b] = 4; // ExposureProgram = Auto
+  plain[0x0d] = 1; // IntelligentAuto = On
+  let em = parse_tag9404c(&process_enciphered(&encipher(&plain), false), true);
+  assert_eq!(
+    find(&em, "ExposureProgram"),
+    Some(&TagValue::Str("Auto".into()))
+  );
+  assert_eq!(
+    find(&em, "IntelligentAuto"),
+    Some(&TagValue::Str("On".into()))
+  );
+}
+
+/// Per-field availability: a block ending before 0x19 emits the early leaves but
+/// not `LensZoomPosition`.
+#[test]
+fn per_field_truncation() {
+  let mut plain = vec![0u8; 0x0e];
+  plain[0x0b] = 3;
+  plain[0x0d] = 1;
+  let em = parse_tag9404a(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-7M2"),
+    true,
+  );
+  assert!(find(&em, "ExposureProgram").is_some());
+  assert!(find(&em, "IntelligentAuto").is_some());
+  assert!(find(&em, "LensZoomPosition").is_none());
+  assert!(parse_tag9404a(&[], None, true).is_empty());
+}

--- a/src/exif/makernotes/vendors/sony/tag940a.rs
+++ b/src/exif/makernotes/vendors/sony/tag940a.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::Tag940a` (`Sony.pm:9292-9345`) — the enciphered
+//! `Tag940a` `ProcessBinaryData` block (`AFPointsSelected`).
+//!
+//! The `0x940a` Main-table row is a conditional-ARRAY SubDirectory dispatcher
+//! (`Sony.pm:2067-2074`): the `Tag940a` table is selected when `$$self{Model}
+//! =~ /^(SLT-|HV)/` (otherwise `Sony_0x940a`, `%unknownCipherData`). The block
+//! is enciphered (`PROCESS_PROC => \&ProcessEnciphered`, `Sony.pm:9293`) so the
+//! dispatcher [`process_enciphered`](super::decipher::process_enciphered)s it
+//! (once, or twice for a double-enciphered body) and hands this table the
+//! DECIPHERED bytes; `FORMAT => 'int8u'` + `FIRST_ENTRY => 0`
+//! (`Sony.pm:9296,9298`). NOTES: "These tags are currently extracted for SLT
+//! models only."
+//!
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range
+//! is in the deciphered block ([[exifast-processbinarydata-per-field]]). The
+//! ILME-FX3 is not an SLT/HV body, so ExifTool dispatches its `0x940a` as
+//! `Sony_0x940a` and this table is never selected for it.
+
+use crate::value::TagValue;
+
+/// One emitted `Tag940a` leaf — the resolved tag name and rendered value.
+pub struct Tag940aEmission {
+  /// `Name => '…'` from the bundled table.
+  pub name: &'static str,
+  /// The rendered value (`-j` PrintConv result, or `-n` raw `$val`).
+  pub value: TagValue,
+}
+
+/// `true` when `$$self{Model} =~ /^(SLT-|HV)/` selects the `Tag940a` variant
+/// (`Sony.pm:2069`). Tested against the parent `$$self{Model}`.
+#[must_use]
+pub fn selects_tag940a(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("SLT-") || m.starts_with("HV"))
+}
+
+/// Walk the DECIPHERED `Tag940a` block and emit `AFPointsSelected`.
+///
+/// `buf` is the DECIPHERED `0x940a` block — the dispatcher already confirmed the
+/// variant gate ([`selects_tag940a`]) and ran
+/// [`process_enciphered`](super::decipher::process_enciphered). `print_conv`
+/// selects `-j` (PrintConv) vs `-n` (raw `$val`).
+#[must_use]
+pub fn parse_tag940a(buf: &[u8], print_conv: bool) -> Vec<Tag940aEmission> {
+  let mut out = std::vec::Vec::new();
+
+  // 0x04 AFPointsSelected — int32u (Sony.pm:9303-9342). PrintConv is a literal
+  // hash with a BITMASK fallback (`ExifTool.pm:3614-3618`): a literal hit wins,
+  // otherwise the value decodes via DecodeBits (32-bit, no BitsPerWord).
+  if let Some(&[a, b, c, d]) = buf.get(0x04..0x08) {
+    let val = u32::from_le_bytes([a, b, c, d]);
+    out.push(Tag940aEmission {
+      name: "AFPointsSelected",
+      value: af_points_selected_value(val, print_conv),
+    });
+  }
+
+  out
+}
+
+/// `AFPointsSelected` rendered value (`Sony.pm:9304-9341`). `-n` keeps the raw
+/// `int32u` (no ValueConv). In `-j`: the literal hash is checked first
+/// (`ExifTool.pm:3616`); on a miss the value renders via `DecodeBits`
+/// (`ExifTool.pm:3617-3618`, `ExifTool.pm:6385-6407`) over the 0..32 bit labels
+/// — a labelled bit renders its name, an unlabelled set bit renders `"[n]"`,
+/// joined with `", "`. (`0` hits the literal `'(none)'`, so the empty-bitlist
+/// `"(none)"` DecodeBits case is unreachable here.)
+fn af_points_selected_value(val: u32, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(val));
+  }
+  if let Some(label) = af_points_selected_literal(val) {
+    return TagValue::Str(label.into());
+  }
+  let mut bits: Vec<String> = std::vec::Vec::new();
+  for i in 0..32u32 {
+    if val & (1u32 << i) != 0 {
+      match af_points_selected_bit(i) {
+        Some(label) => bits.push(label.to_string()),
+        None => bits.push(std::format!("[{i}]")),
+      }
+    }
+  }
+  if bits.is_empty() {
+    return TagValue::Str("(none)".into());
+  }
+  TagValue::Str(bits.join(", ").into())
+}
+
+/// `AFPointsSelected` literal-value PrintConv keys (`Sony.pm:9310-9316`).
+fn af_points_selected_literal(v: u32) -> Option<&'static str> {
+  Some(match v {
+    0 => "(none)",
+    0x0000_7801 => "Center Zone",
+    0x0001_821c => "Right Zone",
+    0x0006_05c0 => "Left Zone",
+    0x0003_ffff => "(all LA-EA4)",
+    0x7fff_ffff => "(all)",
+    0xffff_ffff => "n/a",
+    _ => return None,
+  })
+}
+
+/// `AFPointsSelected` BITMASK bit labels (`Sony.pm:9319-9339`).
+fn af_points_selected_bit(n: u32) -> Option<&'static str> {
+  Some(match n {
+    0 => "Center",
+    1 => "Top",
+    2 => "Upper-right",
+    3 => "Right",
+    4 => "Lower-right",
+    5 => "Bottom",
+    6 => "Lower-left",
+    7 => "Left",
+    8 => "Upper-left",
+    9 => "Far Right",
+    10 => "Far Left",
+    11 => "Upper-middle",
+    12 => "Near Right",
+    13 => "Lower-middle",
+    14 => "Near Left",
+    15 => "Upper Far Right",
+    16 => "Lower Far Right",
+    17 => "Lower Far Left",
+    18 => "Upper Far Left",
+    _ => return None,
+  })
+}
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "tag940a_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/tag940a_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag940a_tests.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+use super::*;
+
+/// Forward Sony cipher `c = (b·b·b) mod 249` (`Sony.pm:11521`).
+fn encipher_byte(b: u8) -> u8 {
+  if b <= 248 {
+    (((u32::from(b) * u32::from(b)) % 249 * u32::from(b)) % 249) as u8
+  } else {
+    b
+  }
+}
+
+fn encipher(plain: &[u8]) -> Vec<u8> {
+  plain.iter().map(|&b| encipher_byte(b)).collect()
+}
+
+fn process_enciphered(enc: &[u8], double_cipher: bool) -> Vec<u8> {
+  super::super::decipher::process_enciphered(enc, double_cipher)
+}
+
+fn find<'a>(em: &'a [Tag940aEmission], name: &str) -> Option<&'a TagValue> {
+  em.iter().rev().find(|e| e.name == name).map(|e| &e.value)
+}
+
+/// `Tag940a` is the SLT/HV variant only (`Sony.pm:2069`).
+#[test]
+fn selects_only_slt_hv() {
+  assert!(selects_tag940a(Some("SLT-A77V")));
+  assert!(selects_tag940a(Some("HV")));
+  assert!(!selects_tag940a(Some("ILME-FX3")));
+  assert!(!selects_tag940a(Some("ILCE-7M2")));
+  assert!(!selects_tag940a(None));
+}
+
+/// A literal-hash key wins over the BITMASK (`ExifTool.pm:3616`).
+#[test]
+fn af_points_literal_keys() {
+  let mut plain = vec![0u8; 0x10];
+  plain[0x04] = 0x01; // int32u LE = 0x00007801 ⇒ "Center Zone"
+  plain[0x05] = 0x78;
+  let em = parse_tag940a(&process_enciphered(&encipher(&plain), false), true);
+  assert_eq!(
+    find(&em, "AFPointsSelected"),
+    Some(&TagValue::Str("Center Zone".into()))
+  );
+
+  // 0 ⇒ literal "(none)".
+  let zero = parse_tag940a(&process_enciphered(&encipher(&[0u8; 0x10]), false), true);
+  assert_eq!(
+    find(&zero, "AFPointsSelected"),
+    Some(&TagValue::Str("(none)".into()))
+  );
+
+  // 0xffffffff ⇒ literal "n/a".
+  let mut p2 = vec![0u8; 0x10];
+  p2[0x04] = 0xff;
+  p2[0x05] = 0xff;
+  p2[0x06] = 0xff;
+  p2[0x07] = 0xff;
+  let em2 = parse_tag940a(&process_enciphered(&encipher(&p2), false), true);
+  assert_eq!(
+    find(&em2, "AFPointsSelected"),
+    Some(&TagValue::Str("n/a".into()))
+  );
+}
+
+/// A non-literal value decodes via DecodeBits (`ExifTool.pm:3617-3618`): bits 0
+/// (Center) and 7 (Left) set ⇒ value 0x81 ⇒ "Center, Left".
+#[test]
+fn af_points_bitmask_decode() {
+  let mut plain = vec![0u8; 0x10];
+  plain[0x04] = 0x81;
+  let em = parse_tag940a(&process_enciphered(&encipher(&plain), false), true);
+  assert_eq!(
+    find(&em, "AFPointsSelected"),
+    Some(&TagValue::Str("Center, Left".into()))
+  );
+}
+
+/// An unlabelled set bit renders `"[n]"` (`ExifTool.pm:6400`): bit 20 ⇒ "[20]".
+#[test]
+fn af_points_bitmask_unlabelled_bit() {
+  let mut plain = vec![0u8; 0x10];
+  plain[0x06] = 0x10; // int32u LE: 1 << 20 = 0x0010_0000
+  let em = parse_tag940a(&process_enciphered(&encipher(&plain), false), true);
+  assert_eq!(
+    find(&em, "AFPointsSelected"),
+    Some(&TagValue::Str("[20]".into()))
+  );
+}
+
+/// `-n` keeps the raw `int32u` (no ValueConv), even for a literal-hash value.
+#[test]
+fn af_points_raw_n() {
+  let mut plain = vec![0u8; 0x10];
+  plain[0x04] = 0x01;
+  plain[0x05] = 0x78; // 0x7801 = 30721 (a literal key in -j)
+  let em = parse_tag940a(&process_enciphered(&encipher(&plain), false), false);
+  assert_eq!(find(&em, "AFPointsSelected"), Some(&TagValue::I64(0x7801)));
+}
+
+/// Per-field availability: a 4-byte block has no int32u at 0x04.
+#[test]
+fn per_field_truncation() {
+  let plain = vec![0u8; 4];
+  let em = parse_tag940a(&process_enciphered(&encipher(&plain), false), true);
+  assert!(em.is_empty());
+  assert!(parse_tag940a(&[], true).is_empty());
+}

--- a/src/exif/makernotes/vendors/sony/tag940e.rs
+++ b/src/exif/makernotes/vendors/sony/tag940e.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::Tag940e` (`Sony.pm:9750-9795`) — the enciphered
+//! `Tag940e` `ProcessBinaryData` block (`TiffMeteringImage*`), the E-mount
+//! variant of the `0x940e` dispatcher.
+//!
+//! The `0x940e` Main-table row is a conditional-ARRAY SubDirectory dispatcher
+//! (`Sony.pm:2094-2105`):
+//!
+//! - `AFInfo` — `$$self{Model} =~ /^(SLT-|HV|ILCA-)/` ⇒ the separate large
+//!   `%Sony::AFInfo` AF-status table (`Sony.pm:9452+`), which is NOT ported here
+//!   (deferred); for those bodies this module emits nothing.
+//! - `Tag940e` — `$$self{Model} =~ /^(NEX-|ILCE-|Lunar)/` ⇒ this table.
+//! - else `Sony_0x940e` (`%unknownCipherData`) — emits nothing.
+//!
+//! The block is enciphered (`PROCESS_PROC => \&ProcessEnciphered`,
+//! `Sony.pm:9751`) so the dispatcher
+//! [`process_enciphered`](super::decipher::process_enciphered)s it (once, or
+//! twice for a double-enciphered body) and hands this table the DECIPHERED
+//! bytes; `FORMAT => 'int8u'` + `FIRST_ENTRY => 0` (`Sony.pm:9754,9755`).
+//! NOTES: "E-mount models."
+//!
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range
+//! is in the deciphered block ([[exifast-processbinarydata-per-field]]) AND its
+//! per-leaf `Condition` holds. The ILME-FX3 matches neither the `AFInfo` nor the
+//! `Tag940e` model gate (it is `ILME-`, not `ILCE-`), so ExifTool dispatches its
+//! `0x940e` as `Sony_0x940e` and this table is never selected for it.
+
+use crate::value::TagValue;
+
+/// One emitted `Tag940e` leaf — the resolved tag name and rendered value.
+pub struct Tag940eEmission {
+  /// `Name => '…'` from the bundled table.
+  pub name: &'static str,
+  /// The rendered value (`-j` PrintConv result, or `-n` raw `$val`).
+  pub value: TagValue,
+}
+
+/// `true` when `$$self{Model} =~ /^(NEX-|ILCE-|Lunar)/` selects the `Tag940e`
+/// variant (`Sony.pm:2100`). Tested against the parent `$$self{Model}`. (The
+/// `AFInfo` SLT/HV/ILCA variant is handled by a separate, deferred table.)
+#[must_use]
+pub fn selects_tag940e(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("NEX-") || m.starts_with("ILCE-") || m.starts_with("Lunar"))
+}
+
+/// Walk the DECIPHERED `Tag940e` block and emit the `TiffMeteringImage*` leaves.
+///
+/// `buf` is the DECIPHERED `0x940e` block — the dispatcher already confirmed the
+/// variant gate ([`selects_tag940e`]) and ran
+/// [`process_enciphered`](super::decipher::process_enciphered). The three leaves
+/// have NO PrintConv (raw `int8u`) / a fixed binary placeholder, so the render
+/// is identical in `-j` and `-n` and the function takes no `print_conv` flag.
+#[must_use]
+pub fn parse_tag940e(
+  buf: &[u8],
+  model: Option<&str>,
+  software: Option<&str>,
+) -> Vec<Tag940eEmission> {
+  let mut out = std::vec::Vec::new();
+
+  // All three leaves share the same `Condition` (Sony.pm:9768-9772): an
+  // ILCE-6300/6500/7M3/7RM2/7RM3(A)/7SM2/9 body (with a `\b` boundary) whose
+  // Software is not an `ILCE-9 v5.0`/`v6.0` build.
+  if !tiff_metering_condition(model, software) {
+    return out;
+  }
+
+  // 0x1a06 TiffMeteringImageWidth — int8u, no PrintConv (Sony.pm:9768).
+  if let Some(&raw) = buf.get(0x1a06) {
+    out.push(Tag940eEmission {
+      name: "TiffMeteringImageWidth",
+      value: TagValue::I64(i64::from(raw)),
+    });
+  }
+
+  // 0x1a07 TiffMeteringImageHeight — int8u, no PrintConv (Sony.pm:9769).
+  if let Some(&raw) = buf.get(0x1a07) {
+    out.push(Tag940eEmission {
+      name: "TiffMeteringImageHeight",
+      value: TagValue::I64(i64::from(raw)),
+    });
+  }
+
+  // 0x1a08 TiffMeteringImage — undef[2640], ValueConv `return undef unless
+  // length $val >= 2640; \ "Binary data 2640 bytes"` (Sony.pm:9770-9794). The
+  // scalar-ref renders to the fixed placeholder in BOTH modes; emitted only when
+  // the full 2640-byte field is in range.
+  if buf.len() >= 0x1a08 + 2640 {
+    out.push(Tag940eEmission {
+      name: "TiffMeteringImage",
+      value: TagValue::Str("(Binary data 2640 bytes, use -b option to extract)".into()),
+    });
+  }
+
+  out
+}
+
+/// The shared `TiffMeteringImage*` `Condition` (`Sony.pm:9768`): the body model
+/// matches `/^(ILCE-(6300|6500|7M3|7RM2|7RM3A?|7SM2|9))\b/` AND the Software
+/// does NOT match `/^ILCE-9 (v5.0|v6.0)/`.
+fn tiff_metering_condition(model: Option<&str>, software: Option<&str>) -> bool {
+  tiff_metering_model(model) && !software_excluded(software)
+}
+
+/// `$$self{Model} =~ /^(ILCE-(6300|6500|7M3|7RM2|7RM3A?|7SM2|9))\b/`. Every
+/// listed body ends in a word char (digit or `A`), so the Perl `\b` boundary
+/// requires the char after the prefix to be a non-word char (or end-of-string)
+/// — e.g. `ILCE-9` matches but `ILCE-9M2` does not.
+fn tiff_metering_model(model: Option<&str>) -> bool {
+  let Some(m) = model else { return false };
+  for prefix in [
+    "ILCE-6300",
+    "ILCE-6500",
+    "ILCE-7M3",
+    "ILCE-7RM2",
+    "ILCE-7RM3A",
+    "ILCE-7RM3",
+    "ILCE-7SM2",
+    "ILCE-9",
+  ] {
+    if let Some(rest) = m.strip_prefix(prefix)
+      && rest
+        .chars()
+        .next()
+        .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'))
+    {
+      return true;
+    }
+  }
+  false
+}
+
+/// `$$self{Software} =~ /^ILCE-9 (v5.0|v6.0)/` — the excluded firmware builds
+/// (the leaves are dropped for these). A `None`/non-matching Software is NOT
+/// excluded (`undef !~ /…/` is true).
+fn software_excluded(software: Option<&str>) -> bool {
+  software.is_some_and(|s| s.starts_with("ILCE-9 v5.0") || s.starts_with("ILCE-9 v6.0"))
+}
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "tag940e_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/tag940e_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag940e_tests.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+use super::*;
+
+/// Forward Sony cipher `c = (b·b·b) mod 249` (`Sony.pm:11521`).
+fn encipher_byte(b: u8) -> u8 {
+  if b <= 248 {
+    (((u32::from(b) * u32::from(b)) % 249 * u32::from(b)) % 249) as u8
+  } else {
+    b
+  }
+}
+
+fn encipher(plain: &[u8]) -> Vec<u8> {
+  plain.iter().map(|&b| encipher_byte(b)).collect()
+}
+
+fn process_enciphered(enc: &[u8], double_cipher: bool) -> Vec<u8> {
+  super::super::decipher::process_enciphered(enc, double_cipher)
+}
+
+fn find<'a>(em: &'a [Tag940eEmission], name: &str) -> Option<&'a TagValue> {
+  em.iter().rev().find(|e| e.name == name).map(|e| &e.value)
+}
+
+/// `Tag940e` is the NEX/ILCE/Lunar variant (`Sony.pm:2100`); the SLT/HV/ILCA
+/// bodies route to the (deferred) `%Sony::AFInfo` table instead.
+#[test]
+fn selects_only_emount() {
+  assert!(selects_tag940e(Some("NEX-5N")));
+  assert!(selects_tag940e(Some("ILCE-7M3")));
+  assert!(selects_tag940e(Some("Lunar")));
+  assert!(!selects_tag940e(Some("ILME-FX3"))); // ILME-, not ILCE-
+  assert!(!selects_tag940e(Some("SLT-A77V")));
+  assert!(!selects_tag940e(None));
+}
+
+/// The full block emits Width/Height (raw int8u) + the binary `TiffMeteringImage`
+/// placeholder; the `\b` boundary excludes a suffixed body (`ILCE-9M2`).
+#[test]
+fn metering_model_word_boundary() {
+  let mut plain = vec![0u8; 0x1a08 + 2640];
+  plain[0x1a06] = 44; // width
+  plain[0x1a07] = 30; // height
+  let em = parse_tag940e(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-9"),
+    None,
+  );
+  assert_eq!(
+    find(&em, "TiffMeteringImageWidth"),
+    Some(&TagValue::I64(44))
+  );
+  assert_eq!(
+    find(&em, "TiffMeteringImageHeight"),
+    Some(&TagValue::I64(30))
+  );
+  assert_eq!(
+    find(&em, "TiffMeteringImage"),
+    Some(&TagValue::Str(
+      "(Binary data 2640 bytes, use -b option to extract)".into()
+    ))
+  );
+
+  // `ILCE-9M2` ⇒ `\b` after "ILCE-9" fails ⇒ no leaves.
+  let em2 = parse_tag940e(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-9M2"),
+    None,
+  );
+  assert!(em2.is_empty());
+}
+
+/// `7RM3A?` — both `ILCE-7RM3` and `ILCE-7RM3A` match.
+#[test]
+fn metering_7rm3_optional_a() {
+  let mut plain = vec![0u8; 0x1a08];
+  plain[0x1a06] = 10;
+  plain[0x1a07] = 12;
+  for model in ["ILCE-7RM3", "ILCE-7RM3A"] {
+    let em = parse_tag940e(
+      &process_enciphered(&encipher(&plain), false),
+      Some(model),
+      None,
+    );
+    assert_eq!(
+      find(&em, "TiffMeteringImageWidth"),
+      Some(&TagValue::I64(10)),
+      "model {model}"
+    );
+  }
+}
+
+/// `Software !~ /^ILCE-9 (v5.0|v6.0)/` — an excluded firmware drops the leaves.
+#[test]
+fn software_exclusion() {
+  let mut plain = vec![0u8; 0x1a08];
+  plain[0x1a06] = 10;
+  let excluded = parse_tag940e(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-9"),
+    Some("ILCE-9 v5.00"),
+  );
+  assert!(excluded.is_empty());
+
+  let ok = parse_tag940e(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-9"),
+    Some("ILCE-9 v4.00"),
+  );
+  assert_eq!(
+    find(&ok, "TiffMeteringImageWidth"),
+    Some(&TagValue::I64(10))
+  );
+}
+
+/// Per-field availability: a block too short for the 2640-byte image still emits
+/// Width/Height; a wrong model emits nothing.
+#[test]
+fn per_field_availability() {
+  let mut plain = vec![0u8; 0x1a08 + 100];
+  plain[0x1a06] = 44;
+  plain[0x1a07] = 30;
+  let em = parse_tag940e(
+    &process_enciphered(&encipher(&plain), false),
+    Some("ILCE-7M3"),
+    None,
+  );
+  assert!(find(&em, "TiffMeteringImageWidth").is_some());
+  assert!(find(&em, "TiffMeteringImageHeight").is_some());
+  assert!(find(&em, "TiffMeteringImage").is_none());
+
+  assert!(parse_tag940e(&[], Some("ILME-FX3"), None).is_empty());
+}

--- a/src/exif/makernotes/vendors/sony/tag9416.rs
+++ b/src/exif/makernotes/vendors/sony/tag9416.rs
@@ -151,8 +151,9 @@ fn push_i16_array(
 }
 
 /// 0x0035 `ExposureProgram` — `%sonyExposureProgram3` (`Sony.pm:10044-10049`,
-/// `Sony.pm:464-499`).
-fn print_exposure_program3(v: u8) -> Option<&'static str> {
+/// `Sony.pm:464-499`). Also the `%exposureProgram2010` PrintConv shared by the
+/// `Tag9404a/b/c` `ExposureProgram` rows (re-exported from the parent module).
+pub(crate) fn print_exposure_program3(v: u8) -> Option<&'static str> {
   Some(match v {
     0 => "Program AE",
     1 => "Aperture-priority AE",

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12530,8 +12530,8 @@ fn sony_emit_binary_subdir<S: ExifSink>(
 }
 
 /// Decode a Sony Main-IFD `ProcessBinaryData` SubDirectory sub-block
-/// (`0x9050`/`0x9400`/`0x9401`/`0x9402`/`0x9406`/`0x940c`/`0x9416`/`0x202a`)
-/// and emit its ported leaves into `sink`.
+/// (`0x9050`/`0x9400`/`0x9401`/`0x9402`/`0x9403`/`0x9404`/`0x9406`/`0x940a`/
+/// `0x940c`/`0x940e`/`0x9416`/`0x202a`) and emit its ported leaves into `sink`.
 ///
 /// `entry` is the Sony Main-IFD SubDirectory row; its verbatim on-disk value
 /// bytes are `data[value_offset .. value_offset + value_size]`. Most of these
@@ -12554,7 +12554,8 @@ fn sony_emit_binary_subdir<S: ExifSink>(
 ///
 /// `double_cipher` is the file-global `$$self{DoubleCipher}` flag (latched from
 /// the 0x9400 walk): when set, EVERY enciphered 0x94xx block (0x9050/0x9400/
-/// 0x9401/0x9402/0x9406/0x940c/0x9416) is deciphered TWICE
+/// 0x9401/0x9402/0x9403/0x9404/0x9406/0x940a/0x940c/0x940e/0x9416) is deciphered
+/// TWICE
 /// (`Sony.pm:11553-11556`), not just 0x9402 — `ProcessEnciphered` is the shared
 /// `PROCESS_PROC` for all of them, so on a double-enciphered body ISOInfo/
 /// battery/lens/camera-settings would otherwise be read from once-deciphered
@@ -12571,7 +12572,8 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
 ) {
   use makernotes::vendors::sony::decipher::process_enciphered;
   use makernotes::vendors::sony::{
-    tag202a, tag900b, tag940c, tag9050, tag9400, tag9401, tag9402, tag9406, tag9416,
+    tag202a, tag900b, tag940a, tag940c, tag940e, tag9050, tag9400, tag9401, tag9402, tag9403,
+    tag9404, tag9406, tag9416,
   };
   // The verbatim on-disk value span (the enciphered cipher block, or the plain
   // `Tag202a` bytes) — the same buffer the walk read, sliced at the entry's
@@ -12623,6 +12625,36 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
         let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
       }
     }
+    // `Tag9403` — the camera/sensor-temperature block; an UNCONDITIONAL
+    // SubDirectory (`Sony.pm:1975-1978`).
+    0x9403 => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag9403::parse_tag9403(&buf, print_conv) {
+        let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
+      }
+    }
+    // `Tag9404a`/`b`/`c` — ExposureProgram/IntelligentAuto/LensZoomPosition/
+    // FocusPosition2, the variant selected by the RAW (enciphered) first + fourth
+    // value bytes (`Sony.pm:1990-2008`); a non-matching value is the unknown
+    // `Sony_0x9404` (emits nothing).
+    0x9404 if tag9404::selects_tag9404a(raw) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag9404::parse_tag9404a(&buf, model, print_conv) {
+        let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
+      }
+    }
+    0x9404 if tag9404::selects_tag9404b(raw) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag9404::parse_tag9404b(&buf, model, print_conv) {
+        let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
+      }
+    }
+    0x9404 if tag9404::selects_tag9404c(raw) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag9404::parse_tag9404c(&buf, print_conv) {
+        let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
+      }
+    }
     // `Tag9406` — battery temp/level, selected by the enciphered first+third
     // value bytes (`Sony.pm:2044`).
     0x9406 if tag9406::selects_tag9406(raw) => {
@@ -12631,10 +12663,27 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
         let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
       }
     }
+    // `Tag940a` — `AFPointsSelected`, selected by model `/^(SLT-|HV)/`
+    // (`Sony.pm:2067-2074`); SLT models only.
+    0x940a if tag940a::selects_tag940a(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag940a::parse_tag940a(&buf, print_conv) {
+        let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
+      }
+    }
     // `Tag940c` — the E-mount lens table, selected by model (`Sony.pm:2081`).
     0x940c if tag940c::selects_tag940c(model) => {
       let buf = process_enciphered(raw, double_cipher);
       for emi in tag940c::parse_tag940c(&buf, print_conv) {
+        let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
+      }
+    }
+    // `Tag940e` — `TiffMeteringImage*`, the E-mount variant selected by model
+    // `/^(NEX-|ILCE-|Lunar)/` (`Sony.pm:2094-2105`); the SLT/HV/ILCA `AFInfo`
+    // variant routes to a separate (deferred) `%Sony::AFInfo` table.
+    0x940e if tag940e::selects_tag940e(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag940e::parse_tag940e(&buf, model, software) {
         let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
       }
     }


### PR DESCRIPTION
Closes #101. Ports the 4 genuinely-missing Sony Tag9xxx enciphered 0x94xx sub-tables faithfully from ExifTool 13.59 Sony.pm (exifast already had consolidated tag9050/9400/9401/9402/9406/940c/9416):

- **Tag9403** (Sony.pm:8791) — `CameraTemperature` (int8s, TempTest2 Condition).
- **Tag9404a/b/c** (Sony.pm:8820) — raw-byte variant gate (dot-no-newline faithful to Perl no-`/s`): ExposureProgram (`%sonyExposureProgram3`), IntelligentAuto, LensZoomPosition (model-conditional), FocusPosition2.
- **Tag940a** (Sony.pm:9291) — `AFPointsSelected` (int32u literal-hash then BITMASK DecodeBits).
- **Tag940e** (Sony.pm:9750) — `TiffMeteringImageWidth/Height/Image` (shared ILCE model + Software-exclusion Condition).

Wired into the `sony_emit_enciphered_subblock` 0x94xx dispatch (model/raw-byte variant selection). **Fixtureless** (these fire for SLT/HV/NEX/ILCE/Lunar bodies not in the fixture set), so validated by **no-regression (conformance 498/0 byte-identical)** + **27 unit tests** vs Sony.pm. `build(-Dwarnings)=0 alloc_budget=1/0 conformance=498/0 typed_serde=1/0 timed=161/0 lib=4069/0 xtask=26`. **Codex: APPROVE** (R2 — the Tag9404 dot-no-newline selector fix + raw-byte-wildcard class sweep). Tag9405a/b → #97. Memory-amplification → #443.