### PR TITLE
feat(sony): port CameraInfo(base)/AFInfo/ShotInfo sub-tables (#98, #99)

### DIFF
--- a/src/exif/makernotes/vendors/sony/afinfo.rs
+++ b/src/exif/makernotes/vendors/sony/afinfo.rs
@@ -1,0 +1,863 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::AFInfo` (`Sony.pm:9453-9748`) — the `0x940e`
+//! Main-table SubDirectory dispatched when `$$self{Model} =~ /^(SLT-|HV|ILCA-)/`
+//! (`Sony.pm:2094-2097`). An ENCIPHERED `ProcessBinaryData` block
+//! (`PROCESS_PROC => \&ProcessEnciphered`); the central dispatch deciphers it
+//! (once, or twice under `DoubleCipher`) BEFORE this parser runs, so the parser
+//! receives the already-deciphered bytes (exactly like [`super::tag940e`]).
+//!
+//! `FORMAT => 'int8u'`, `PRIORITY => 0`, so the table keys are byte offsets and
+//! EVERY leaf is `Priority => 0` — it never overrides an earlier same-name
+//! duplicate (e.g. a `CameraInfo3`/`Tag9416` `FocusMode`/`ExposureProgram`).
+//! `0x02 AFType` is a `DataMember` (`1 => 15-point`, `2 => 19-point`,
+//! `3 => 79-point`) read first; it (and `$$self{Model} =~ /^ILCA-/`) selects two
+//! mutually-exclusive decoding paths:
+//!  - SLT / HV (AFType 1/2, model `!~ /^ILCA-/`): the `%afPoint15`/`%afPoint19`
+//!    AFPoint trio, `AFStatus15`/`AFStatus19` (`int16s[18]`/`[30]`), the
+//!    int32u `AFPointsUsed` bitmask, `AFMicroAdj` and `ExposureProgram`.
+//!  - ILCA (AFType 3, model `=~ /^ILCA-/`): the `%afPoints79_940e` AFPoint trio,
+//!    the `int8u[10]` `%afPoints79` `AFPointsUsed` bitmask, `AFStatus79`
+//!    (`int16s[95]`), `AFMicroAdj` and `ExposureProgram`.
+//!
+//! Per the `ProcessBinaryData` per-field-availability contract a leaf is emitted
+//! IFF its byte range is in the block ([[exifast-processbinarydata-per-field]])
+//! AND its `AFType`/model `Condition` holds.
+
+use crate::value::TagValue;
+use smol_str::SmolStr;
+
+use super::subtables::{SubEmission, af_status_value, read_i16, read_u32};
+
+/// `AFType` (0x02) PrintConv (`Sony.pm:9482-9487`); `0` (n.a.) is unmapped.
+fn af_type(v: u8) -> Option<&'static str> {
+  Some(match v {
+    1 => "15-point",
+    2 => "19-point",
+    3 => "79-point",
+    _ => return None,
+  })
+}
+
+/// `%afPoint15` (`Sony.pm:557-575`) — the 15-point AF sensor list.
+fn af_point15(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Upper-left",
+    1 => "Left",
+    2 => "Lower-left",
+    3 => "Far Left",
+    4 => "Top (horizontal)",
+    5 => "Near Right",
+    6 => "Center (horizontal)",
+    7 => "Near Left",
+    8 => "Bottom (horizontal)",
+    9 => "Top (vertical)",
+    10 => "Center (vertical)",
+    11 => "Bottom (vertical)",
+    12 => "Far Right",
+    13 => "Upper-right",
+    14 => "Right",
+    15 => "Lower-right",
+    16 => "Upper-middle",
+    17 => "Lower-middle",
+    _ => return None,
+  })
+}
+
+/// `%afPoint19` (`Sony.pm:580-611`) — the 19-point AF sensor list.
+fn af_point19(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Upper Far Left",
+    1 => "Upper-left (horizontal)",
+    2 => "Far Left (horizontal)",
+    3 => "Left (horizontal)",
+    4 => "Lower Far Left",
+    5 => "Lower-left (horizontal)",
+    6 => "Upper-left (vertical)",
+    7 => "Left (vertical)",
+    8 => "Lower-left (vertical)",
+    9 => "Far Left (vertical)",
+    10 => "Top (horizontal)",
+    11 => "Near Right",
+    12 => "Center (horizontal)",
+    13 => "Near Left",
+    14 => "Bottom (horizontal)",
+    15 => "Top (vertical)",
+    16 => "Upper-middle",
+    17 => "Center (vertical)",
+    18 => "Lower-middle",
+    19 => "Bottom (vertical)",
+    20 => "Upper Far Right",
+    21 => "Upper-right (horizontal)",
+    22 => "Far Right (horizontal)",
+    23 => "Right (horizontal)",
+    24 => "Lower Far Right",
+    25 => "Lower-right (horizontal)",
+    26 => "Far Right (vertical)",
+    27 => "Upper-right (vertical)",
+    28 => "Right (vertical)",
+    29 => "Lower-right (vertical)",
+    _ => return None,
+  })
+}
+
+/// `%afPoints79_940e` (`Sony.pm:628-646`) — the 0-94 AFPoint numbering used by
+/// the ILCA `0x37`/`0x38`/`0x39` AFInfo rows.
+fn af_points79_940e(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "B4",
+    1 => "C4",
+    2 => "D4",
+    3 => "E4",
+    4 => "F4",
+    5 => "G4",
+    6 => "H4",
+    7 => "B3",
+    8 => "C3",
+    9 => "D3",
+    10 => "E3",
+    11 => "F3",
+    12 => "G3",
+    13 => "H3",
+    14 => "B2",
+    15 => "C2",
+    16 => "D2",
+    17 => "E2",
+    18 => "F2",
+    19 => "G2",
+    20 => "H2",
+    21 => "C1",
+    22 => "D1",
+    23 => "E1",
+    24 => "F1",
+    25 => "G1",
+    26 => "A7 Vertical",
+    27 => "A6 Vertical",
+    28 => "A5 Vertical",
+    29 => "C7 Vertical",
+    30 => "C6 Vertical",
+    31 => "C5 Vertical",
+    32 => "E7 Vertical",
+    33 => "E6 Center Vertical",
+    34 => "E5 Vertical",
+    35 => "G7 Vertical",
+    36 => "G6 Vertical",
+    37 => "G5 Vertical",
+    38 => "I7 Vertical",
+    39 => "I6 Vertical",
+    40 => "I5 Vertical",
+    41 => "A7",
+    42 => "B7",
+    43 => "C7",
+    44 => "D7",
+    45 => "E7",
+    46 => "F7",
+    47 => "G7",
+    48 => "H7",
+    49 => "I7",
+    50 => "A6",
+    51 => "B6",
+    52 => "C6",
+    53 => "D6",
+    54 => "E6 Center",
+    55 => "F6",
+    56 => "G6",
+    57 => "H6",
+    58 => "I6",
+    59 => "A5",
+    60 => "B5",
+    61 => "C5",
+    62 => "D5",
+    63 => "E5",
+    64 => "F5",
+    65 => "G5",
+    66 => "H5",
+    67 => "I5",
+    68 => "C11",
+    69 => "D11",
+    70 => "E11",
+    71 => "F11",
+    72 => "G11",
+    73 => "B10",
+    74 => "C10",
+    75 => "D10",
+    76 => "E10",
+    77 => "F10",
+    78 => "G10",
+    79 => "H10",
+    80 => "B9",
+    81 => "C9",
+    82 => "D9",
+    83 => "E9",
+    84 => "F9",
+    85 => "G9",
+    86 => "H9",
+    87 => "B8",
+    88 => "C8",
+    89 => "D8",
+    90 => "E8",
+    91 => "F8",
+    92 => "G8",
+    93 => "H8",
+    94 => "E6 Center F2.8",
+    _ => return None,
+  })
+}
+
+/// SLT `AFAreaMode` (0x0a) PrintConv (`Sony.pm:9557-9562`).
+fn af_area_mode_slt(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Wide",
+    1 => "Spot",
+    2 => "Local",
+    3 => "Zone",
+    _ => return None,
+  })
+}
+
+/// ILCA `AFAreaMode` (0x3a) PrintConv (`Sony.pm:9710-9716`).
+fn af_area_mode_ilca(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Wide",
+    1 => "Center",
+    2 => "Flexible Spot",
+    3 => "Zone",
+    4 => "Expanded Flexible Spot",
+    _ => return None,
+  })
+}
+
+/// SLT `FocusMode` (0x0b) PrintConv (`Sony.pm:9570-9577`) — note `7 => AF-D`.
+fn focus_mode_slt(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Manual",
+    2 => "AF-S",
+    3 => "AF-C",
+    4 => "AF-A",
+    6 => "DMF",
+    7 => "AF-D",
+    _ => return None,
+  })
+}
+
+/// ILCA `FocusMode` (0x05) PrintConv (`Sony.pm:9661-9668`).
+fn focus_mode_ilca(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Manual",
+    2 => "AF-S",
+    3 => "AF-C",
+    4 => "AF-A",
+    6 => "DMF",
+    _ => return None,
+  })
+}
+
+/// `%afPoints79` (`Sony.pm:615-625`) — the 79-point grid label (keys 0..=78);
+/// the ILCA `AFPointsUsed` (0x10) `int8u[10]` BITMASK lookup.
+fn af_points79(n: u32) -> Option<&'static str> {
+  Some(match n {
+    0 => "A5",
+    1 => "A6",
+    2 => "A7",
+    3 => "B2",
+    4 => "B3",
+    5 => "B4",
+    6 => "B5",
+    7 => "B6",
+    8 => "B7",
+    9 => "B8",
+    10 => "B9",
+    11 => "B10",
+    12 => "C1",
+    13 => "C2",
+    14 => "C3",
+    15 => "C4",
+    16 => "C5",
+    17 => "C6",
+    18 => "C7",
+    19 => "C8",
+    20 => "C9",
+    21 => "C10",
+    22 => "C11",
+    23 => "D1",
+    24 => "D2",
+    25 => "D3",
+    26 => "D4",
+    27 => "D5",
+    28 => "D6",
+    29 => "D7",
+    30 => "D8",
+    31 => "D9",
+    32 => "D10",
+    33 => "D11",
+    34 => "E1",
+    35 => "E2",
+    36 => "E3",
+    37 => "E4",
+    38 => "E5",
+    39 => "E6",
+    40 => "E7",
+    41 => "E8",
+    42 => "E9",
+    43 => "E10",
+    44 => "E11",
+    45 => "F1",
+    46 => "F2",
+    47 => "F3",
+    48 => "F4",
+    49 => "F5",
+    50 => "F6",
+    51 => "F7",
+    52 => "F8",
+    53 => "F9",
+    54 => "F10",
+    55 => "F11",
+    56 => "G1",
+    57 => "G2",
+    58 => "G3",
+    59 => "G4",
+    60 => "G5",
+    61 => "G6",
+    62 => "G7",
+    63 => "G8",
+    64 => "G9",
+    65 => "G10",
+    66 => "G11",
+    67 => "H2",
+    68 => "H3",
+    69 => "H4",
+    70 => "H5",
+    71 => "H6",
+    72 => "H7",
+    73 => "H8",
+    74 => "H9",
+    75 => "H10",
+    76 => "I5",
+    77 => "I6",
+    78 => "I7",
+    _ => return None,
+  })
+}
+
+/// SLT `AFPointsUsed` (0x16e) int32u BITMASK lookup (`Sony.pm:9605-9624`).
+fn af_points_used_slt_bit(n: u32) -> Option<&'static str> {
+  Some(match n {
+    0 => "Center",
+    1 => "Top",
+    2 => "Upper-right",
+    3 => "Right",
+    4 => "Lower-right",
+    5 => "Bottom",
+    6 => "Lower-left",
+    7 => "Left",
+    8 => "Upper-left",
+    9 => "Far Right",
+    10 => "Far Left",
+    11 => "Upper-middle",
+    12 => "Near Right",
+    13 => "Lower-middle",
+    14 => "Near Left",
+    15 => "Upper Far Right",
+    16 => "Lower Far Right",
+    17 => "Lower Far Left",
+    18 => "Upper Far Left",
+    _ => return None,
+  })
+}
+
+/// The 18 `AFStatus15` `int16s` leaf names (`%Sony::AFStatus15`,
+/// `Sony.pm:9802-9819`).
+const AF_STATUS15_NAMES: [&str; 18] = [
+  "AFStatusUpper-left",
+  "AFStatusLeft",
+  "AFStatusLower-left",
+  "AFStatusFarLeft",
+  "AFStatusTopHorizontal",
+  "AFStatusNearRight",
+  "AFStatusCenterHorizontal",
+  "AFStatusNearLeft",
+  "AFStatusBottomHorizontal",
+  "AFStatusTopVertical",
+  "AFStatusCenterVertical",
+  "AFStatusBottomVertical",
+  "AFStatusFarRight",
+  "AFStatusUpper-right",
+  "AFStatusRight",
+  "AFStatusLower-right",
+  "AFStatusUpper-middle",
+  "AFStatusLower-middle",
+];
+
+/// The 30 `AFStatus19` `int16s` leaf names (`%Sony::AFStatus19`,
+/// `Sony.pm:9827-9856`).
+const AF_STATUS19_NAMES: [&str; 30] = [
+  "AFStatusUpperFarLeft",
+  "AFStatusUpper-leftHorizontal",
+  "AFStatusFarLeftHorizontal",
+  "AFStatusLeftHorizontal",
+  "AFStatusLowerFarLeft",
+  "AFStatusLower-leftHorizontal",
+  "AFStatusUpper-leftVertical",
+  "AFStatusLeftVertical",
+  "AFStatusLower-leftVertical",
+  "AFStatusFarLeftVertical",
+  "AFStatusTopHorizontal",
+  "AFStatusNearRight",
+  "AFStatusCenterHorizontal",
+  "AFStatusNearLeft",
+  "AFStatusBottomHorizontal",
+  "AFStatusTopVertical",
+  "AFStatusUpper-middle",
+  "AFStatusCenterVertical",
+  "AFStatusLower-middle",
+  "AFStatusBottomVertical",
+  "AFStatusUpperFarRight",
+  "AFStatusUpper-rightHorizontal",
+  "AFStatusFarRightHorizontal",
+  "AFStatusRightHorizontal",
+  "AFStatusLowerFarRight",
+  "AFStatusLower-rightHorizontal",
+  "AFStatusFarRightVertical",
+  "AFStatusUpper-rightVertical",
+  "AFStatusRightVertical",
+  "AFStatusLower-rightVertical",
+];
+
+/// The 95 `AFStatus79` `int16s` leaf names (`%Sony::AFStatus79`,
+/// `Sony.pm:9876-9975`).
+const AF_STATUS79_NAMES: [&str; 95] = [
+  "AFStatus_00_B4",
+  "AFStatus_01_C4",
+  "AFStatus_02_D4",
+  "AFStatus_03_E4",
+  "AFStatus_04_F4",
+  "AFStatus_05_G4",
+  "AFStatus_06_H4",
+  "AFStatus_07_B3",
+  "AFStatus_08_C3",
+  "AFStatus_09_D3",
+  "AFStatus_10_E3",
+  "AFStatus_11_F3",
+  "AFStatus_12_G3",
+  "AFStatus_13_H3",
+  "AFStatus_14_B2",
+  "AFStatus_15_C2",
+  "AFStatus_16_D2",
+  "AFStatus_17_E2",
+  "AFStatus_18_F2",
+  "AFStatus_19_G2",
+  "AFStatus_20_H2",
+  "AFStatus_21_C1",
+  "AFStatus_22_D1",
+  "AFStatus_23_E1",
+  "AFStatus_24_F1",
+  "AFStatus_25_G1",
+  "AFStatus_26_A7_Vertical",
+  "AFStatus_27_A6_Vertical",
+  "AFStatus_28_A5_Vertical",
+  "AFStatus_29_C7_Vertical",
+  "AFStatus_30_C6_Vertical",
+  "AFStatus_31_C5_Vertical",
+  "AFStatus_32_E7_Vertical",
+  "AFStatus_33_E6_Center_Vertical",
+  "AFStatus_34_E5_Vertical",
+  "AFStatus_35_G7_Vertical",
+  "AFStatus_36_G6_Vertical",
+  "AFStatus_37_G5_Vertical",
+  "AFStatus_38_I7_Vertical",
+  "AFStatus_39_I6_Vertical",
+  "AFStatus_40_I5_Vertical",
+  "AFStatus_41_A7",
+  "AFStatus_42_B7",
+  "AFStatus_43_C7",
+  "AFStatus_44_D7",
+  "AFStatus_45_E7",
+  "AFStatus_46_F7",
+  "AFStatus_47_G7",
+  "AFStatus_48_H7",
+  "AFStatus_49_I7",
+  "AFStatus_50_A6",
+  "AFStatus_51_B6",
+  "AFStatus_52_C6",
+  "AFStatus_53_D6",
+  "AFStatus_54_E6_Center",
+  "AFStatus_55_F6",
+  "AFStatus_56_G6",
+  "AFStatus_57_H6",
+  "AFStatus_58_I6",
+  "AFStatus_59_A5",
+  "AFStatus_60_B5",
+  "AFStatus_61_C5",
+  "AFStatus_62_D5",
+  "AFStatus_63_E5",
+  "AFStatus_64_F5",
+  "AFStatus_65_G5",
+  "AFStatus_66_H5",
+  "AFStatus_67_I5",
+  "AFStatus_68_C11",
+  "AFStatus_69_D11",
+  "AFStatus_70_E11",
+  "AFStatus_71_F11",
+  "AFStatus_72_G11",
+  "AFStatus_73_B10",
+  "AFStatus_74_C10",
+  "AFStatus_75_D10",
+  "AFStatus_76_E10",
+  "AFStatus_77_F10",
+  "AFStatus_78_G10",
+  "AFStatus_79_H10",
+  "AFStatus_80_B9",
+  "AFStatus_81_C9",
+  "AFStatus_82_D9",
+  "AFStatus_83_E9",
+  "AFStatus_84_F9",
+  "AFStatus_85_G9",
+  "AFStatus_86_H9",
+  "AFStatus_87_B8",
+  "AFStatus_88_C8",
+  "AFStatus_89_D8",
+  "AFStatus_90_E8",
+  "AFStatus_91_F8",
+  "AFStatus_92_G8",
+  "AFStatus_93_H8",
+  "AFStatus_94_E6_Center_F2-8",
+];
+
+/// `$$self{Model} =~ /^ILCA-/`.
+fn model_is_ilca(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("ILCA-"))
+}
+
+/// A `Priority => 0` (`PRIORITY => 0` table default) AFInfo leaf.
+fn leaf(name: &'static str, value: TagValue) -> SubEmission {
+  SubEmission {
+    name,
+    value,
+    priority: 0,
+  }
+}
+
+/// Push an `int8u` hash-PrintConv leaf at byte `off` (`-j` label / `Unknown
+/// (N)`, `-n` raw int).
+fn push_hash(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  hit: impl Fn(u8) -> Option<&'static str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(leaf(
+      name,
+      super::hash_print_value(raw, hit(raw), print_conv),
+    ));
+  }
+}
+
+/// Push an `int16s` (`%afStatusInfo`) leaf at byte `off`.
+fn push_af_status(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(v) = read_i16(buf, off) {
+    out.push(leaf(name, af_status_value(v, print_conv)));
+  }
+}
+
+/// Push an `int8s` `AFMicroAdj` leaf at byte `off` (`Format => 'int8s'`, no
+/// PrintConv / ValueConv ⇒ the signed integer in both `-j` and `-n`).
+fn push_af_micro_adj(buf: &[u8], off: usize, out: &mut Vec<SubEmission>) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(leaf("AFMicroAdj", TagValue::I64(i64::from(raw as i8))));
+  }
+}
+
+/// Push the `int16s[N]` `%afStatusInfo` grid `names` starting at byte `start`.
+fn push_af_status_grid(
+  buf: &[u8],
+  start: usize,
+  names: &[&'static str],
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  for (i, name) in names.iter().enumerate() {
+    push_af_status(buf, start + i * 2, name, print_conv, out);
+  }
+}
+
+/// DecodeBits over a set of words: bit `i` of word `w` ⇒ bit number
+/// `i + bits_per_word * w` ⇒ `lookup(n)` (or `[n]` when absent), joined `", "`;
+/// no set bit ⇒ `"(none)"` (`ExifTool.pm` DecodeBits).
+fn decode_bits(
+  words: &[u32],
+  bits_per_word: u32,
+  lookup: impl Fn(u32) -> Option<&'static str>,
+) -> SmolStr {
+  let mut bit_list: Vec<String> = std::vec::Vec::new();
+  for (w, &word) in words.iter().enumerate() {
+    for i in 0..bits_per_word {
+      if word & (1u32 << i) != 0 {
+        let n = i + bits_per_word * w as u32;
+        match lookup(n) {
+          Some(label) => bit_list.push(label.to_string()),
+          None => bit_list.push(std::format!("[{n}]")),
+        }
+      }
+    }
+  }
+  if bit_list.is_empty() {
+    return SmolStr::new("(none)");
+  }
+  SmolStr::new(bit_list.join(", "))
+}
+
+/// Walk the (already-deciphered) `AFInfo` block and emit its `Priority => 0`
+/// leaves.
+///
+/// `buf` is the deciphered `0x940e` block; `model` is `$$self{Model}` (selects
+/// the SLT vs ILCA path); `print_conv` selects `-j` vs `-n`.
+#[must_use]
+pub fn parse_af_info(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+  let ilca = model_is_ilca(model);
+
+  // 0x02 AFType (DataMember) — emitted unconditionally; gates the AFType-keyed
+  // rows below.
+  let af_type_raw = buf.get(0x02).copied();
+  if let Some(raw) = af_type_raw {
+    out.push(leaf(
+      "AFType",
+      super::hash_print_value(raw, af_type(raw), print_conv),
+    ));
+  }
+
+  if !ilca {
+    // ---- SLT / HV path (model !~ /^ILCA-/) ----
+    // 0x04 AFStatusActiveSensor — int16s.
+    push_af_status(buf, 0x04, "AFStatusActiveSensor", print_conv, &mut out);
+
+    // 0x07/0x08/0x09 the AFPoint trio (AFType 1 ⇒ %afPoint15, 2 ⇒ %afPoint19).
+    match af_type_raw {
+      Some(1) => {
+        push_hash(buf, 0x07, "AFPoint", af_point15, print_conv, &mut out);
+        // 0x08 adds `255 => '(none)'`.
+        push_hash(
+          buf,
+          0x08,
+          "AFPointInFocus",
+          |v| {
+            if v == 255 {
+              Some("(none)")
+            } else {
+              af_point15(v)
+            }
+          },
+          print_conv,
+          &mut out,
+        );
+        // 0x09 adds `30 => '(out of focus)'`.
+        push_hash(
+          buf,
+          0x09,
+          "AFPointAtShutterRelease",
+          |v| {
+            if v == 30 {
+              Some("(out of focus)")
+            } else {
+              af_point15(v)
+            }
+          },
+          print_conv,
+          &mut out,
+        );
+      }
+      Some(2) => {
+        push_hash(buf, 0x07, "AFPoint", af_point19, print_conv, &mut out);
+        push_hash(
+          buf,
+          0x08,
+          "AFPointInFocus",
+          |v| {
+            if v == 255 {
+              Some("(none)")
+            } else {
+              af_point19(v)
+            }
+          },
+          print_conv,
+          &mut out,
+        );
+        push_hash(
+          buf,
+          0x09,
+          "AFPointAtShutterRelease",
+          |v| {
+            if v == 30 {
+              Some("(out of focus)")
+            } else {
+              af_point19(v)
+            }
+          },
+          print_conv,
+          &mut out,
+        );
+      }
+      _ => {}
+    }
+
+    // 0x0a AFAreaMode / 0x0b FocusMode.
+    push_hash(
+      buf,
+      0x0a,
+      "AFAreaMode",
+      af_area_mode_slt,
+      print_conv,
+      &mut out,
+    );
+    push_hash(buf, 0x0b, "FocusMode", focus_mode_slt, print_conv, &mut out);
+
+    // 0x11 AFStatus15 (AFType 1, int16s[18]) / AFStatus19 (AFType 2, int16s[30]).
+    match af_type_raw {
+      Some(1) => push_af_status_grid(buf, 0x11, &AF_STATUS15_NAMES, print_conv, &mut out),
+      Some(2) => push_af_status_grid(buf, 0x11, &AF_STATUS19_NAMES, print_conv, &mut out),
+      _ => {}
+    }
+
+    // 0x16e AFPointsUsed — int32u BITMASK (default 32-bit single word).
+    if let Some(v) = read_u32(buf, 0x16e) {
+      let value = if print_conv {
+        TagValue::Str(decode_bits(&[v], 32, af_points_used_slt_bit))
+      } else {
+        TagValue::I64(i64::from(v))
+      };
+      out.push(leaf("AFPointsUsed", value));
+    }
+
+    // 0x17d AFMicroAdj — int8s.
+    push_af_micro_adj(buf, 0x17d, &mut out);
+
+    // 0x17e ExposureProgram — %sonyExposureProgram3.
+    push_hash(
+      buf,
+      0x17e,
+      "ExposureProgram",
+      super::print_exposure_program3,
+      print_conv,
+      &mut out,
+    );
+  } else {
+    // ---- ILCA path (model =~ /^ILCA-/, AFType 3) ----
+    // 0x05 FocusMode.
+    push_hash(
+      buf,
+      0x05,
+      "FocusMode",
+      focus_mode_ilca,
+      print_conv,
+      &mut out,
+    );
+
+    // 0x10 AFPointsUsed — int8u[10] BITMASK (%afPoints79, BitsPerWord 8).
+    if let Some(words) = buf.get(0x10..0x10 + 10) {
+      let value = if print_conv {
+        let words: Vec<u32> = words.iter().map(|&b| u32::from(b)).collect();
+        TagValue::Str(decode_bits(&words, 8, af_points79))
+      } else {
+        // `-n` renders the default space-joined int8u list.
+        let parts: Vec<String> = words.iter().map(|&b| std::format!("{b}")).collect();
+        TagValue::Str(SmolStr::new(parts.join(" ")))
+      };
+      out.push(leaf("AFPointsUsed", value));
+    }
+
+    // 0x37/0x38/0x39 the AFPoint trio (AFType 3 ⇒ %afPoints79_940e).
+    if af_type_raw == Some(3) {
+      push_hash(
+        buf,
+        0x37,
+        "AFPoint",
+        |v| {
+          if v == 255 {
+            Some("(none)")
+          } else {
+            af_points79_940e(v)
+          }
+        },
+        print_conv,
+        &mut out,
+      );
+      push_hash(
+        buf,
+        0x38,
+        "AFPointInFocus",
+        |v| {
+          if v == 255 {
+            Some("(none)")
+          } else {
+            af_points79_940e(v)
+          }
+        },
+        print_conv,
+        &mut out,
+      );
+      push_hash(
+        buf,
+        0x39,
+        "AFPointAtShutterRelease",
+        |v| {
+          if v == 95 {
+            Some("(none)")
+          } else {
+            af_points79_940e(v)
+          }
+        },
+        print_conv,
+        &mut out,
+      );
+    }
+
+    // 0x3a AFAreaMode / 0x3b AFStatusActiveSensor.
+    push_hash(
+      buf,
+      0x3a,
+      "AFAreaMode",
+      af_area_mode_ilca,
+      print_conv,
+      &mut out,
+    );
+    push_af_status(buf, 0x3b, "AFStatusActiveSensor", print_conv, &mut out);
+
+    // 0x43 ExposureProgram.
+    push_hash(
+      buf,
+      0x43,
+      "ExposureProgram",
+      super::print_exposure_program3,
+      print_conv,
+      &mut out,
+    );
+
+    // 0x50 AFMicroAdj — int8s.
+    push_af_micro_adj(buf, 0x50, &mut out);
+
+    // 0x7d AFStatus79 (AFType 3, int16s[95]).
+    if af_type_raw == Some(3) {
+      push_af_status_grid(buf, 0x7d, &AF_STATUS79_NAMES, print_conv, &mut out);
+    }
+  }
+
+  out
+}
+
+#[cfg(test)]
+// The module-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "afinfo_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/afinfo_tests.rs
+++ b/src/exif/makernotes/vendors/sony/afinfo_tests.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Sony::AFInfo` (`0x940e`, SLT/HV/ILCA): the `AFType` DataMember selects the
+//! SLT (`%afPoint15`/`%afPoint19` + `AFStatus15`/`AFStatus19`) vs ILCA
+//! (`%afPoints79_940e` + `%afPoints79` bitmask + `AFStatus79`) decoding paths;
+//! every leaf is `Priority => 0`. Crafted (already-deciphered) buffers exercise
+//! both paths byte-exact vs `Sony.pm:9453-9748`.
+
+use super::*;
+use crate::value::TagValue;
+
+fn put_i16(buf: &mut [u8], off: usize, v: i16) {
+  buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn put_u32(buf: &mut [u8], off: usize, v: u32) {
+  buf[off..off + 4].copy_from_slice(&v.to_le_bytes());
+}
+
+fn get<'a>(ems: &'a [SubEmission], name: &str) -> Option<&'a SubEmission> {
+  ems.iter().find(|e| e.name == name)
+}
+
+fn find(ems: &[SubEmission], name: &str) -> Option<TagValue> {
+  get(ems, name).map(|e| e.value.clone())
+}
+
+#[test]
+fn af_type_hash() {
+  let mut buf = vec![0u8; 0x10];
+  for (raw, want) in [(1u8, "15-point"), (2, "19-point"), (3, "79-point")] {
+    buf[0x02] = raw;
+    let j = parse_af_info(&buf, Some("SLT-A77V"), true);
+    assert_eq!(find(&j, "AFType"), Some(TagValue::Str(want.into())));
+  }
+  // Unmapped (0 = n.a.) -> "Unknown (0)".
+  buf[0x02] = 0;
+  let j = parse_af_info(&buf, Some("SLT-A77V"), true);
+  assert_eq!(
+    find(&j, "AFType"),
+    Some(TagValue::Str("Unknown (0)".into()))
+  );
+}
+
+#[test]
+fn slt_aftype1_15point_path() {
+  let mut buf = vec![0u8; 0x190];
+  buf[0x02] = 1; // AFType -> 15-point
+  put_i16(&mut buf, 0x04, 35); // AFStatusActiveSensor -> Back Focus (+35)
+  buf[0x07] = 6; // AFPoint -> Center (horizontal)
+  buf[0x08] = 255; // AFPointInFocus -> (none)
+  buf[0x09] = 30; // AFPointAtShutterRelease -> (out of focus)
+  buf[0x0a] = 2; // AFAreaMode -> Local
+  buf[0x0b] = 4; // FocusMode -> AF-A
+  put_i16(&mut buf, 0x11, -32768); // AFStatus15[0] AFStatusUpper-left -> Out of Focus
+  put_u32(&mut buf, 0x16e, 0x0000_0001); // AFPointsUsed bit 0 -> Center
+  buf[0x17d] = 0xfb; // AFMicroAdj int8s -> -5
+  buf[0x17e] = 3; // ExposureProgram -> Manual
+
+  let j = parse_af_info(&buf, Some("SLT-A77V"), true);
+  assert_eq!(
+    find(&j, "AFStatusActiveSensor"),
+    Some(TagValue::Str("Back Focus (+35)".into()))
+  );
+  assert_eq!(
+    find(&j, "AFPoint"),
+    Some(TagValue::Str("Center (horizontal)".into()))
+  );
+  assert_eq!(
+    find(&j, "AFPointInFocus"),
+    Some(TagValue::Str("(none)".into()))
+  );
+  assert_eq!(
+    find(&j, "AFPointAtShutterRelease"),
+    Some(TagValue::Str("(out of focus)".into()))
+  );
+  assert_eq!(find(&j, "AFAreaMode"), Some(TagValue::Str("Local".into())));
+  assert_eq!(find(&j, "FocusMode"), Some(TagValue::Str("AF-A".into())));
+  assert_eq!(
+    find(&j, "AFStatusUpper-left"),
+    Some(TagValue::Str("Out of Focus".into()))
+  );
+  assert_eq!(
+    find(&j, "AFPointsUsed"),
+    Some(TagValue::Str("Center".into()))
+  );
+  assert_eq!(find(&j, "AFMicroAdj"), Some(TagValue::I64(-5)));
+  assert_eq!(
+    find(&j, "ExposureProgram"),
+    Some(TagValue::Str("Manual".into()))
+  );
+  // 19-point-only leaves never appear on a 15-point body.
+  assert!(find(&j, "AFStatusUpperFarLeft").is_none());
+  // Every AFInfo leaf is Priority => 0.
+  assert!(j.iter().all(|e| e.priority == 0));
+
+  // -n keeps raw ints (AFPointsUsed int32u, AFMicroAdj int8s).
+  let n = parse_af_info(&buf, Some("SLT-A77V"), false);
+  assert_eq!(find(&n, "AFPointsUsed"), Some(TagValue::I64(1)));
+  assert_eq!(find(&n, "AFMicroAdj"), Some(TagValue::I64(-5)));
+  assert_eq!(find(&n, "AFPoint"), Some(TagValue::I64(6)));
+}
+
+#[test]
+fn slt_aftype2_19point_path() {
+  let mut buf = vec![0u8; 0x60];
+  buf[0x02] = 2; // AFType -> 19-point
+  buf[0x07] = 0; // AFPoint -> Upper Far Left (%afPoint19)
+  put_i16(&mut buf, 0x11, -32768); // AFStatus19[0] AFStatusUpperFarLeft -> Out of Focus
+  put_i16(&mut buf, 0x11 + 29 * 2, 0); // AFStatus19[29] AFStatusLower-rightVertical -> In Focus
+
+  let j = parse_af_info(&buf, Some("SLT-A99V"), true);
+  assert_eq!(
+    find(&j, "AFPoint"),
+    Some(TagValue::Str("Upper Far Left".into()))
+  );
+  assert_eq!(
+    find(&j, "AFStatusUpperFarLeft"),
+    Some(TagValue::Str("Out of Focus".into()))
+  );
+  assert_eq!(
+    find(&j, "AFStatusLower-rightVertical"),
+    Some(TagValue::Str("In Focus".into()))
+  );
+  // 15-point-only AFStatus names do not appear.
+  assert!(find(&j, "AFStatusUpper-middle").is_some()); // 19-point also has this (index 16)
+  assert!(find(&j, "AFStatusLower-left").is_none()); // 15-point-only name
+}
+
+#[test]
+fn ilca_aftype3_79point_path() {
+  let mut buf = vec![0u8; 0x140];
+  buf[0x02] = 3; // AFType -> 79-point
+  buf[0x05] = 3; // FocusMode -> AF-C (ILCA hash)
+  buf[0x10] = 0x01; // AFPointsUsed int8u[10] bit 0 -> A5 (%afPoints79)
+  buf[0x37] = 54; // AFPoint -> E6 Center (%afPoints79_940e)
+  buf[0x38] = 255; // AFPointInFocus -> (none)
+  buf[0x39] = 95; // AFPointAtShutterRelease -> (none)
+  buf[0x3a] = 2; // AFAreaMode -> Flexible Spot (ILCA hash)
+  put_i16(&mut buf, 0x3b, -50); // AFStatusActiveSensor -> Front Focus (-50)
+  buf[0x43] = 4; // ExposureProgram -> Auto
+  buf[0x50] = 3; // AFMicroAdj int8s -> 3
+  put_i16(&mut buf, 0x7d, -32768); // AFStatus79[0] AFStatus_00_B4 -> Out of Focus
+
+  let j = parse_af_info(&buf, Some("ILCA-77M2"), true);
+  assert_eq!(find(&j, "AFType"), Some(TagValue::Str("79-point".into())));
+  assert_eq!(find(&j, "FocusMode"), Some(TagValue::Str("AF-C".into())));
+  assert_eq!(find(&j, "AFPointsUsed"), Some(TagValue::Str("A5".into())));
+  assert_eq!(find(&j, "AFPoint"), Some(TagValue::Str("E6 Center".into())));
+  assert_eq!(
+    find(&j, "AFPointInFocus"),
+    Some(TagValue::Str("(none)".into()))
+  );
+  assert_eq!(
+    find(&j, "AFPointAtShutterRelease"),
+    Some(TagValue::Str("(none)".into()))
+  );
+  assert_eq!(
+    find(&j, "AFAreaMode"),
+    Some(TagValue::Str("Flexible Spot".into()))
+  );
+  assert_eq!(
+    find(&j, "AFStatusActiveSensor"),
+    Some(TagValue::Str("Front Focus (-50)".into()))
+  );
+  assert_eq!(
+    find(&j, "ExposureProgram"),
+    Some(TagValue::Str("Auto".into()))
+  );
+  assert_eq!(find(&j, "AFMicroAdj"), Some(TagValue::I64(3)));
+  assert_eq!(
+    find(&j, "AFStatus_00_B4"),
+    Some(TagValue::Str("Out of Focus".into()))
+  );
+  assert_eq!(
+    find(&j, "AFStatus_94_E6_Center_F2-8"),
+    Some(TagValue::Str("In Focus".into())) // default 0 -> In Focus
+  );
+  assert!(j.iter().all(|e| e.priority == 0));
+
+  // -n: AFPointsUsed renders the space-joined int8u[10] list.
+  let n = parse_af_info(&buf, Some("ILCA-77M2"), false);
+  assert_eq!(
+    find(&n, "AFPointsUsed"),
+    Some(TagValue::Str("1 0 0 0 0 0 0 0 0 0".into()))
+  );
+}
+
+#[test]
+fn slt_and_ilca_paths_are_mutually_exclusive() {
+  // An ILCA buffer wired with SLT-style bytes: the SLT-only leaves must NOT
+  // appear (model =~ /^ILCA-/ takes the ILCA path), and vice-versa.
+  let mut buf = vec![0u8; 0x140];
+  buf[0x02] = 3;
+  let ilca = parse_af_info(&buf, Some("ILCA-99M2"), true);
+  // SLT-only AFAreaMode value "Local" / FocusMode 0x0b path absent.
+  assert!(get(&ilca, "AFStatusUpper-left").is_none()); // SLT AFStatus15 name
+
+  let mut buf2 = vec![0u8; 0x140];
+  buf2[0x02] = 3; // AFType 3 but a NON-ILCA model -> SLT path (no 79-point branch)
+  let slt = parse_af_info(&buf2, Some("SLT-A77V"), true);
+  // AFType 3 on the SLT path: no AFPoint trio (needs AFType 1/2), no AFStatus79.
+  assert!(find(&slt, "AFStatus_00_B4").is_none());
+  assert!(find(&slt, "AFPoint").is_none());
+  // AFType itself is still emitted.
+  assert_eq!(find(&slt, "AFType"), Some(TagValue::Str("79-point".into())));
+}
+
+#[test]
+fn af_points_used_none_when_no_bits_set() {
+  let mut buf = vec![0u8; 0x190];
+  buf[0x02] = 1;
+  put_u32(&mut buf, 0x16e, 0); // no bits -> (none)
+  let j = parse_af_info(&buf, Some("SLT-A77V"), true);
+  assert_eq!(
+    find(&j, "AFPointsUsed"),
+    Some(TagValue::Str("(none)".into()))
+  );
+}
+
+#[test]
+fn out_of_range_leaves_are_skipped() {
+  // A short block emits only the in-range leaves (per-field availability).
+  let mut buf = vec![0u8; 0x08];
+  buf[0x02] = 1; // AFType
+  buf[0x07] = 6; // AFPoint (in range)
+  let j = parse_af_info(&buf, Some("SLT-A77V"), true);
+  assert!(find(&j, "AFType").is_some());
+  assert!(find(&j, "AFPoint").is_some());
+  assert!(find(&j, "AFPointsUsed").is_none()); // 0x16e out of range
+  assert!(find(&j, "AFStatusUpper-left").is_none()); // 0x11 out of range
+}

--- a/src/exif/makernotes/vendors/sony/camerainfo.rs
+++ b/src/exif/makernotes/vendors/sony/camerainfo.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::CameraInfo` (`Sony.pm:2746-2896`) — the BASE `0x0010`
+//! Main-table SubDirectory dispatched when `$count == 368 || 5478`
+//! (`Sony.pm:720-726`), a plain (un-enciphered) `ProcessBinaryData` block of
+//! camera info for the DSLR-A700 (368) and A850/A900 (5478).
+//!
+//! `ByteOrder => 'BigEndian'`, default `int8u` format — so UNLIKE the
+//! little-endian `CameraInfo2`/`CameraInfo3` the inline `%afStatusInfo` `int16s`
+//! grid reads BIG-endian (via [`super::subtables::read_i16_be`]). The A700/A850/
+//! A900 have a 23-sensor + F2.8 AF layout, so this is a DISTINCT table from the
+//! 9-point `CameraInfo2` (different `AFPointSelected`/`AFPoint` lists, 24
+//! `AFStatus*` leaves vs 12).
+//!
+//! Per the `ProcessBinaryData` per-field-availability contract each tag is
+//! emitted IFF its byte range is in the block
+//! ([[exifast-processbinarydata-per-field]]) AND its model `Condition` holds
+//! (the `AFMicroAdj*` trio is A850/A900-only). `0x00 LensSpec` is decoded by the
+//! SAME `ConvLensSpec`/`PrintLensSpec` chain as the Main-IFD `0xb02a` leaf, but
+//! the A700/A850/A900 use a DIFFERENT int16 byte ordering: the ValueConv is
+//! `ConvLensSpec(pack('v*', unpack('n*', $val)))` (`Sony.pm:2749-2755`) — each
+//! of the 4 `undef[8]` int16 words is read big-endian and re-packed
+//! little-endian (a per-pair byte swap) before the shared chain. It IS emitted
+//! here: the canonical value usually matches the Main `0xb02a` leaf (which wins
+//! the last-wins dedup when present), but a body may carry this CameraInfo copy
+//! WITHOUT a Main `0xb02a` leaf, where ExifTool still surfaces LensSpec.
+
+use crate::exif::ifd::RawValue;
+use crate::value::TagValue;
+
+use super::subtables::{SubEmission, af_status_value, read_i16_be};
+
+/// `FocusModeSetting` (0x14) PrintConv (`Sony.pm:2768-2774`) — note the extra
+/// `4 => DMF` (shared shape with `CameraInfo2`'s 0x15).
+fn focus_mode_setting(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Manual",
+    1 => "AF-S",
+    2 => "AF-C",
+    3 => "AF-A",
+    4 => "DMF",
+    _ => return None,
+  })
+}
+
+/// `AFPointSelected` (0x15) PrintConv (`Sony.pm:2779-2792`) — the A700/A850/A900
+/// 9-direction list PLUS `10 => Far Right` / `11 => Far Left` (A700 only).
+fn af_point_selected(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Auto",
+    1 => "Center",
+    2 => "Top",
+    3 => "Upper-right",
+    4 => "Right",
+    5 => "Lower-right",
+    6 => "Bottom",
+    7 => "Lower-left",
+    8 => "Left",
+    9 => "Upper-left",
+    10 => "Far Right",
+    11 => "Far Left",
+    _ => return None,
+  })
+}
+
+/// `AFPoint` (0x19) PrintConv (`Sony.pm:2821-2846`) — the active AF sensor for
+/// the A700/A850/A900 23-point + F2.8 layout.
+fn af_point(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Upper-left",
+    1 => "Left",
+    2 => "Lower-left",
+    3 => "Far Left",
+    4 => "Bottom Assist-left",
+    5 => "Bottom",
+    6 => "Bottom Assist-right",
+    7 => "Center (7)",
+    8 => "Center (horizontal)",
+    9 => "Center (9)",
+    10 => "Center (10)",
+    11 => "Center (11)",
+    12 => "Center (12)",
+    13 => "Center (vertical)",
+    14 => "Center (14)",
+    15 => "Top Assist-left",
+    16 => "Top",
+    17 => "Top Assist-right",
+    18 => "Far Right",
+    19 => "Upper-right",
+    20 => "Right",
+    21 => "Lower-right",
+    22 => "Center F2.8",
+    _ => return None,
+  })
+}
+
+/// The 24 `%afStatusInfo` `int16s` leaves at OFFSETS `0x1e..=0x4c` (step 2),
+/// in table order (`Sony.pm:2850-2873`).
+const AF_STATUS_NAMES: [&str; 24] = [
+  "AFStatusActiveSensor",       // 0x1e
+  "AFStatusUpper-left",         // 0x20
+  "AFStatusLeft",               // 0x22
+  "AFStatusLower-left",         // 0x24
+  "AFStatusFarLeft",            // 0x26
+  "AFStatusBottomAssist-left",  // 0x28
+  "AFStatusBottom",             // 0x2a
+  "AFStatusBottomAssist-right", // 0x2c
+  "AFStatusCenter-7",           // 0x2e
+  "AFStatusCenter-horizontal",  // 0x30
+  "AFStatusCenter-9",           // 0x32
+  "AFStatusCenter-10",          // 0x34
+  "AFStatusCenter-11",          // 0x36
+  "AFStatusCenter-12",          // 0x38
+  "AFStatusCenter-vertical",    // 0x3a
+  "AFStatusCenter-14",          // 0x3c
+  "AFStatusTopAssist-left",     // 0x3e
+  "AFStatusTop",                // 0x40
+  "AFStatusTopAssist-right",    // 0x42
+  "AFStatusFarRight",           // 0x44
+  "AFStatusUpper-right",        // 0x46
+  "AFStatusRight",              // 0x48
+  "AFStatusLower-right",        // 0x4a
+  "AFStatusCenterF2-8",         // 0x4c
+];
+
+/// `$$self{Model} =~ /^DSLR-A(850|900)\b/` — the `AFMicroAdj*` trio condition
+/// (`Sony.pm:2876`/`:2882`/`:2892`); the A700 (368-byte block) never matches.
+fn model_is_a850_900(model: Option<&str>) -> bool {
+  let Some(m) = model else { return false };
+  for tail in ["DSLR-A850", "DSLR-A900"] {
+    if let Some(rest) = m.strip_prefix(tail) {
+      // The prefix ends in a digit (word char), so `\b` requires the NEXT char
+      // to be a non-word char (or end-of-string).
+      if rest
+        .chars()
+        .next()
+        .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'))
+      {
+        return true;
+      }
+    }
+  }
+  false
+}
+
+/// Push a simple `int8u` hash-PrintConv leaf at byte `off`.
+fn push_hash(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  hit: impl Fn(u8) -> Option<&'static str>,
+  print_conv: bool,
+  out: &mut Vec<SubEmission>,
+) {
+  if let Some(&raw) = buf.get(off) {
+    out.push(SubEmission::new(
+      name,
+      super::hash_print_value(raw, hit(raw), print_conv),
+    ));
+  }
+}
+
+/// Walk the base `CameraInfo` block and emit the AF/focus leaves (`Priority => 1`,
+/// the table default).
+///
+/// `buf` is the verbatim (un-enciphered) `0x0010` block; `model` is
+/// `$$self{Model}` (gates the A850/A900-only `AFMicroAdj*` trio); `print_conv`
+/// selects `-j` vs `-n`.
+#[must_use]
+pub fn parse_camera_info(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+
+  // 0x00 LensSpec (`Sony.pm:2749-2755`) — `Format => 'undef[8]'`. The
+  // A700/A850/A900 store the LensSpec with a DIFFERENT int16 byte ordering than
+  // the Main `0xb02a` leaf: the ValueConv is
+  // `ConvLensSpec(pack('v*', unpack('n*', $val)))`, i.e. each of the 4 int16
+  // words is read big-endian and re-packed little-endian (a per-pair byte swap
+  // `b0b1b2b3b4b5b6b7` -> `b1b0b3b2b5b4b7b6`) before the SAME
+  // `ConvLensSpec`/`PrintLensSpec` chain the Main `0xb02a` leaf uses. Emitted
+  // IFF the 8-byte range is in the block (per-field availability).
+  if let Some(&[b0, b1, b2, b3, b4, b5, b6, b7]) = buf.get(0x00..0x08) {
+    let reordered = RawValue::Bytes(std::vec![b1, b0, b3, b2, b5, b4, b7, b6]);
+    out.push(SubEmission::new(
+      "LensSpec",
+      super::SonyPrintConv::LensSpec.apply(&reordered, print_conv),
+    ));
+  }
+
+  push_hash(
+    buf,
+    0x14,
+    "FocusModeSetting",
+    focus_mode_setting,
+    print_conv,
+    &mut out,
+  );
+  push_hash(
+    buf,
+    0x15,
+    "AFPointSelected",
+    af_point_selected,
+    print_conv,
+    &mut out,
+  );
+  push_hash(buf, 0x19, "AFPoint", af_point, print_conv, &mut out);
+
+  // 0x1e..=0x4c `%afStatusInfo` grid (Sony.pm:2850-2873) — `int16s`, BIG-endian.
+  for (i, name) in AF_STATUS_NAMES.iter().enumerate() {
+    let off = 0x1e + i * 2;
+    if let Some(v) = read_i16_be(buf, off) {
+      out.push(SubEmission::new(name, af_status_value(v, print_conv)));
+    }
+  }
+
+  // The A850/A900-only `AFMicroAdj*` trio (Sony.pm:2874-2894).
+  if model_is_a850_900(model) {
+    // 0x130 AFMicroAdjValue — int8u, `ValueConv => '$val - 20'` (no PrintConv),
+    // so `-j` and `-n` both render the signed integer `$val - 20`.
+    if let Some(&raw) = buf.get(0x130) {
+      out.push(SubEmission::new(
+        "AFMicroAdjValue",
+        TagValue::I64(i64::from(raw) - 20),
+      ));
+    }
+    // 0x131 AFMicroAdjMode — `Mask => 0x80` ⇒ `($val & 0x80) >> 7`, PrintConv
+    // `{0 => Off, 1 => On}`.
+    if let Some(&raw) = buf.get(0x131) {
+      let masked = (raw & 0x80) >> 7;
+      let hit = match masked {
+        0 => Some("Off"),
+        1 => Some("On"),
+        _ => None,
+      };
+      out.push(SubEmission::new(
+        "AFMicroAdjMode",
+        super::hash_print_value(masked, hit, print_conv),
+      ));
+    }
+    // 0x131.1 AFMicroAdjRegisteredLenses — `Mask => 0x7f` ⇒ `$val & 0x7f` (no
+    // PrintConv) ⇒ the integer.
+    if let Some(&raw) = buf.get(0x131) {
+      out.push(SubEmission::new(
+        "AFMicroAdjRegisteredLenses",
+        TagValue::I64(i64::from(raw & 0x7f)),
+      ));
+    }
+  }
+
+  out
+}
+
+#[cfg(test)]
+// The module-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "camerainfo_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/camerainfo_tests.rs
+++ b/src/exif/makernotes/vendors/sony/camerainfo_tests.rs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! Base `%Sony::CameraInfo` (`0x0010`, A700/A850/A900): the BIG-endian
+//! `%afStatusInfo` grid, the 23-point `AFPoint` list, the `Far Right`/`Far Left`
+//! `AFPointSelected` values, and the A850/A900-only `AFMicroAdj*` `Mask` trio
+//! render byte-exact vs `Sony.pm:2746-2896`.
+
+use super::*;
+use crate::value::TagValue;
+
+fn put_i16_be(buf: &mut [u8], off: usize, v: i16) {
+  buf[off..off + 2].copy_from_slice(&v.to_be_bytes());
+}
+
+fn find(ems: &[SubEmission], name: &str) -> Option<TagValue> {
+  ems.iter().find(|e| e.name == name).map(|e| e.value.clone())
+}
+
+#[test]
+fn focus_af_point_hashes() {
+  let mut buf = vec![0u8; 0x50];
+  buf[0x14] = 4; // FocusModeSetting -> DMF
+  buf[0x15] = 10; // AFPointSelected -> Far Right (A700-only value)
+  buf[0x19] = 22; // AFPoint -> Center F2.8 (top of the 23-point list)
+
+  let j = parse_camera_info(&buf, Some("DSLR-A700"), true);
+  assert_eq!(
+    find(&j, "FocusModeSetting"),
+    Some(TagValue::Str("DMF".into()))
+  );
+  assert_eq!(
+    find(&j, "AFPointSelected"),
+    Some(TagValue::Str("Far Right".into()))
+  );
+  assert_eq!(
+    find(&j, "AFPoint"),
+    Some(TagValue::Str("Center F2.8".into()))
+  );
+
+  // -n keeps the raw integers.
+  let n = parse_camera_info(&buf, Some("DSLR-A700"), false);
+  assert_eq!(find(&n, "AFPoint"), Some(TagValue::I64(22)));
+}
+
+#[test]
+fn af_point_hash_miss_renders_unknown() {
+  let mut buf = vec![0u8; 0x50];
+  buf[0x15] = 99; // unmapped AFPointSelected
+  let j = parse_camera_info(&buf, None, true);
+  assert_eq!(
+    find(&j, "AFPointSelected"),
+    Some(TagValue::Str("Unknown (99)".into()))
+  );
+}
+
+#[test]
+fn af_status_grid_int16s_big_endian() {
+  let mut buf = vec![0u8; 0x50];
+  put_i16_be(&mut buf, 0x1e, 35); // AFStatusActiveSensor -> Back Focus (+35)
+  put_i16_be(&mut buf, 0x20, -93); // AFStatusUpper-left -> Front Focus (-93)
+  put_i16_be(&mut buf, 0x4c, 0); // AFStatusCenterF2-8 -> In Focus
+
+  let j = parse_camera_info(&buf, None, true);
+  assert_eq!(
+    find(&j, "AFStatusActiveSensor"),
+    Some(TagValue::Str("Back Focus (+35)".into()))
+  );
+  assert_eq!(
+    find(&j, "AFStatusUpper-left"),
+    Some(TagValue::Str("Front Focus (-93)".into()))
+  );
+  assert_eq!(
+    find(&j, "AFStatusCenterF2-8"),
+    Some(TagValue::Str("In Focus".into()))
+  );
+  // -n keeps the raw signed integer (big-endian decode).
+  let n = parse_camera_info(&buf, None, false);
+  assert_eq!(find(&n, "AFStatusUpper-left"), Some(TagValue::I64(-93)));
+}
+
+#[test]
+fn af_micro_adj_trio_a850_a900_only() {
+  let mut buf = vec![0u8; 0x132];
+  buf[0x130] = 30; // AFMicroAdjValue -> 30 - 20 = 10
+  buf[0x131] = 0x83; // Mask 0x80 -> 1 -> On; Mask 0x7f -> 3
+
+  // A900 -> the trio is emitted.
+  let j = parse_camera_info(&buf, Some("DSLR-A900"), true);
+  assert_eq!(find(&j, "AFMicroAdjValue"), Some(TagValue::I64(10)));
+  assert_eq!(find(&j, "AFMicroAdjMode"), Some(TagValue::Str("On".into())));
+  assert_eq!(
+    find(&j, "AFMicroAdjRegisteredLenses"),
+    Some(TagValue::I64(3))
+  );
+
+  // A700 (same bytes) -> the A850/A900-only trio is suppressed by `Condition`.
+  let a700 = parse_camera_info(&buf, Some("DSLR-A700"), true);
+  assert!(find(&a700, "AFMicroAdjValue").is_none());
+  assert!(find(&a700, "AFMicroAdjMode").is_none());
+  assert!(find(&a700, "AFMicroAdjRegisteredLenses").is_none());
+}
+
+#[test]
+fn af_micro_adj_mode_off() {
+  let mut buf = vec![0u8; 0x132];
+  buf[0x131] = 0x00; // Mask 0x80 -> 0 -> Off
+  let j = parse_camera_info(&buf, Some("DSLR-A850"), true);
+  assert_eq!(
+    find(&j, "AFMicroAdjMode"),
+    Some(TagValue::Str("Off".into()))
+  );
+}
+
+#[test]
+fn lens_spec_offset0_emitted_with_int16_byteswap() {
+  // The A700/A850/A900 store LensSpec (0x00, undef[8]) with a per-int16 byte
+  // swap (`ConvLensSpec(pack('v*', unpack('n*', $val)))`, Sony.pm:2749-2755).
+  // The on-disk bytes below reorder to `40 00 18 00 55 35 56 40`, which the
+  // SHARED ConvLensSpec/PrintLensSpec chain decodes to "PZ 18-55mm F3.5-5.6
+  // Reflex" (verified vs bundled ExifTool 13.59). Emitted even when NO Main
+  // 0xb02a leaf accompanies the block.
+  let buf = [0x00u8, 0x40, 0x00, 0x18, 0x35, 0x55, 0x40, 0x56];
+
+  let j = parse_camera_info(&buf, Some("DSLR-A900"), true);
+  assert_eq!(
+    find(&j, "LensSpec"),
+    Some(TagValue::Str("PZ 18-55mm F3.5-5.6 Reflex".into()))
+  );
+  // -n is the ConvLensSpec value string (post-byteswap).
+  let n = parse_camera_info(&buf, Some("DSLR-A900"), false);
+  assert_eq!(
+    find(&n, "LensSpec"),
+    Some(TagValue::Str("40 18 55 3.5 5.6 40".into()))
+  );
+}
+
+#[test]
+fn lens_spec_offset0_bounded_under_8_bytes() {
+  // Per-field availability: a block shorter than the undef[8] LensSpec emits no
+  // LensSpec leaf (no out-of-bounds read).
+  let buf = [0x00u8, 0x40, 0x00, 0x18, 0x35, 0x55, 0x40]; // 7 bytes
+  let j = parse_camera_info(&buf, Some("DSLR-A900"), true);
+  assert!(find(&j, "LensSpec").is_none());
+}
+
+#[test]
+fn out_of_range_leaves_are_skipped() {
+  // A truncated block emits only the in-range leaves (per-field availability).
+  let buf = vec![0u8; 0x20];
+  let j = parse_camera_info(&buf, Some("DSLR-A900"), true);
+  assert!(find(&j, "FocusModeSetting").is_some()); // 0x14 in range
+  assert!(find(&j, "AFStatusActiveSensor").is_some()); // 0x1e..0x20 in range
+  assert!(find(&j, "AFStatusLeft").is_none()); // 0x22 out of range
+  assert!(find(&j, "AFMicroAdjValue").is_none()); // 0x130 out of range
+}

--- a/src/exif/makernotes/vendors/sony/mod.rs
+++ b/src/exif/makernotes/vendors/sony/mod.rs
@@ -42,10 +42,13 @@
 //!   color-data sub-tables in `Sony::Tag9405a/b`, `Tag2010x`, etc.; raw-
 //!   processing-only.
 //! - **Sony per-model CameraInfo<XXX>** — `CameraInfo` / `CameraInfo2` /
-//!   `CameraInfo3` / `CameraInfoUnknown` (`Sony.pm:2722-3170`) — each
-//!   gated by `$count`; defer.
-//! - **Sony AFInfo / FocusInfo** (`Sony.pm:3171-3502`, `9431-9876`) —
-//!   AF-point sensor data; defer.
+//!   `CameraInfo3` / `CameraInfoUnknown` (`Sony.pm:2722-3170`), each gated by
+//!   `$count`: the base/`2`/`3` tables are ported
+//!   (`camerainfo`/`camerainfo2`/`camerainfo3`); only `CameraInfoUnknown`
+//!   stays raw.
+//! - **Sony AFInfo / FocusInfo / ShotInfo** (`Sony.pm:6113`, `:9453`, plus
+//!   `FocusInfo`) — AF-point / face / shot sensor data, ported in
+//!   `afinfo`/`focusinfo`/`shotinfo`.
 //! - **Sony CustomFunctions** — no dedicated CustomFunctions tag table
 //!   in Sony.pm (Canon-style); Sony embeds these in the per-model
 //!   CameraSettings sub-tables which are themselves deferred.
@@ -70,7 +73,9 @@
 
 #![deny(clippy::indexing_slicing)]
 
+pub mod afinfo;
 pub mod amount_lens_types;
+pub mod camerainfo;
 pub mod camerainfo2;
 pub mod camerainfo3;
 pub mod camerasettings;
@@ -83,6 +88,7 @@ pub mod minoltaraw;
 pub mod model_ids;
 pub mod moreinfo;
 pub mod printconv;
+pub mod shotinfo;
 pub mod sr2;
 pub mod subtables;
 pub mod tag202a;

--- a/src/exif/makernotes/vendors/sony/shotinfo.rs
+++ b/src/exif/makernotes/vendors/sony/shotinfo.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::ShotInfo` (`Sony.pm:6113-6177`) — the `0x3000`
+//! Main-table SubDirectory (DSC / Xperia bodies), a plain (un-enciphered)
+//! `ProcessBinaryData` block. `ByteOrder` is little-endian (`# 0x00 - byte order
+//! 'II'`), default `int8u` format, so the table keys are byte offsets.
+//!
+//! The block opens with three `DataMember`s — `FaceInfoOffset` (0x02),
+//! `FacesDetected` (0x30) and `FaceInfoLength` (0x32) — plus `MetaVersion`
+//! (0x34). Those gate the two `IS_SUBDIR` rows: `FaceInfo1` (`Sony.pm:10246`,
+//! face stride 0x20) at byte 0x48 and `FaceInfo2` (`Sony.pm:10295`, face stride
+//! 0x25) at byte 0x5e — each emitting `Face<N>Position` (`int16u[4]`: top, left,
+//! height, width) IFF `$$self{FacesDetected} >= N` (the per-face `RawConv`).
+//!
+//! Per the `ProcessBinaryData` per-field-availability contract a leaf is emitted
+//! IFF its byte range is in the block ([[exifast-processbinarydata-per-field]]).
+
+use crate::value::TagValue;
+use smol_str::SmolStr;
+
+use super::subtables::{SubEmission, read_u16};
+
+/// Read a little-endian `string[n]` at byte `off`: the bytes up to (not
+/// including) the first NUL, decoded lossily (`$val =~ s/\0.*//s`,
+/// `ExifTool.pm` string handling). `None` if the full `n`-byte field is out of
+/// range (per-field availability).
+fn read_string(buf: &[u8], off: usize, n: usize) -> Option<SmolStr> {
+  let field = buf.get(off..off.checked_add(n)?)?;
+  let end = field.iter().position(|&b| b == 0).unwrap_or(field.len());
+  // `end <= field.len()`, so `get` is always `Some`; using it (not a slice
+  // index) keeps the module's `#![deny(clippy::indexing_slicing)]` satisfied.
+  let text = field.get(..end)?;
+  Some(SmolStr::new(String::from_utf8_lossy(text)))
+}
+
+/// `int16u[4]` `Face<N>Position` value (`top, left, height, width`): the four
+/// little-endian `int16u` rendered as ExifTool's default space-joined integer
+/// list. `None` if the 8-byte field is out of range.
+fn read_face_position(buf: &[u8], off: usize) -> Option<TagValue> {
+  let a = read_u16(buf, off)?;
+  let b = read_u16(buf, off.checked_add(2)?)?;
+  let c = read_u16(buf, off.checked_add(4)?)?;
+  let d = read_u16(buf, off.checked_add(6)?)?;
+  Some(TagValue::Str(SmolStr::new(std::format!("{a} {b} {c} {d}"))))
+}
+
+/// Push the `Face1Position..Face8Position` leaves of a `FaceInfo` SubDirectory
+/// whose block starts at byte `start` with per-face byte `stride`. `Face<N>` is
+/// emitted IFF `faces_detected >= N` (the per-face `RawConv`) AND its 8-byte
+/// field is in range.
+fn push_face_info(
+  buf: &[u8],
+  start: usize,
+  stride: usize,
+  faces_detected: u16,
+  out: &mut Vec<SubEmission>,
+) {
+  const NAMES: [&str; 8] = [
+    "Face1Position",
+    "Face2Position",
+    "Face3Position",
+    "Face4Position",
+    "Face5Position",
+    "Face6Position",
+    "Face7Position",
+    "Face8Position",
+  ];
+  for (i, name) in NAMES.iter().enumerate() {
+    // `RawConv => '$$self{FacesDetected} < N ? undef : $val'` (N = i + 1).
+    if u32::from(faces_detected) < (i as u32 + 1) {
+      continue;
+    }
+    let Some(off) = start.checked_add(i * stride) else {
+      break;
+    };
+    if let Some(v) = read_face_position(buf, off) {
+      out.push(SubEmission::new(name, v));
+    }
+  }
+}
+
+/// Walk the `ShotInfo` block and emit its leaves (`Priority => 1`, the table
+/// default).
+///
+/// `buf` is the verbatim (un-enciphered) `0x3000` block; `print_conv` selects
+/// `-j` vs `-n` (the only PrintConv here, `SonyDateTime`'s `ConvertDateTime`, is
+/// identity under default options, so the two render identically).
+#[must_use]
+pub fn parse_shot_info(buf: &[u8], _print_conv: bool) -> Vec<SubEmission> {
+  let mut out = std::vec::Vec::new();
+
+  // DataMembers (read first; gate the FaceInfo SubDirectories below).
+  let face_info_offset = read_u16(buf, 0x02);
+  let faces_detected = read_u16(buf, 0x30);
+  let face_info_length = read_u16(buf, 0x32);
+
+  // 0x02 FaceInfoOffset — int16u DataMember, emitted as a plain leaf.
+  if let Some(v) = face_info_offset {
+    out.push(SubEmission::new(
+      "FaceInfoOffset",
+      TagValue::I64(i64::from(v)),
+    ));
+  }
+  // 0x06 SonyDateTime — string[20], PrintConv ConvertDateTime (identity).
+  if let Some(s) = read_string(buf, 0x06, 20) {
+    out.push(SubEmission::new("SonyDateTime", TagValue::Str(s)));
+  }
+  // 0x1a SonyImageHeight / 0x1c SonyImageWidth — int16u.
+  if let Some(v) = read_u16(buf, 0x1a) {
+    out.push(SubEmission::new(
+      "SonyImageHeight",
+      TagValue::I64(i64::from(v)),
+    ));
+  }
+  if let Some(v) = read_u16(buf, 0x1c) {
+    out.push(SubEmission::new(
+      "SonyImageWidth",
+      TagValue::I64(i64::from(v)),
+    ));
+  }
+  // 0x30 FacesDetected / 0x32 FaceInfoLength — int16u DataMembers, emitted.
+  if let Some(v) = faces_detected {
+    out.push(SubEmission::new(
+      "FacesDetected",
+      TagValue::I64(i64::from(v)),
+    ));
+  }
+  if let Some(v) = face_info_length {
+    out.push(SubEmission::new(
+      "FaceInfoLength",
+      TagValue::I64(i64::from(v)),
+    ));
+  }
+  // 0x34 MetaVersion — string[16] DataMember.
+  if let Some(s) = read_string(buf, 0x34, 16) {
+    out.push(SubEmission::new("MetaVersion", TagValue::Str(s)));
+  }
+
+  // 0x48 FaceInfo1 — `FacesDetected and FaceInfoOffset == 0x48 and
+  // FaceInfoLength == 0x20` (Sony.pm:6159-6166), face stride 0x20.
+  if faces_detected.is_some_and(|f| f != 0)
+    && face_info_offset == Some(0x48)
+    && face_info_length == Some(0x20)
+  {
+    push_face_info(buf, 0x48, 0x20, faces_detected.unwrap_or(0), &mut out);
+  }
+  // 0x5e FaceInfo2 — `FacesDetected and FaceInfoOffset == 0x5e and
+  // FaceInfoLength == 0x25` (Sony.pm:6168-6175), face stride 0x25.
+  if faces_detected.is_some_and(|f| f != 0)
+    && face_info_offset == Some(0x5e)
+    && face_info_length == Some(0x25)
+  {
+    push_face_info(buf, 0x5e, 0x25, faces_detected.unwrap_or(0), &mut out);
+  }
+
+  out
+}
+
+#[cfg(test)]
+// The module-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "shotinfo_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/shotinfo_tests.rs
+++ b/src/exif/makernotes/vendors/sony/shotinfo_tests.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Sony::ShotInfo` (`0x3000`): the scalar DataMembers / image dims / date /
+//! version render byte-exact, and the `FaceInfo1`/`FaceInfo2` SubDirectories
+//! descend only when their `FaceInfoOffset`/`FaceInfoLength`/`FacesDetected`
+//! `Condition` holds — emitting `Face<N>Position` for `N <= FacesDetected`
+//! (`Sony.pm:6113-6177`, `:10246`, `:10295`).
+
+use super::*;
+use crate::value::TagValue;
+
+fn put_u16(buf: &mut [u8], off: usize, v: u16) {
+  buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn put_str(buf: &mut [u8], off: usize, s: &str) {
+  buf[off..off + s.len()].copy_from_slice(s.as_bytes());
+}
+
+fn find(ems: &[SubEmission], name: &str) -> Option<TagValue> {
+  ems.iter().find(|e| e.name == name).map(|e| e.value.clone())
+}
+
+/// A 0x80-byte block wired for `FaceInfo1` (offset 0x48, length 0x20) with two
+/// detected faces.
+fn faceinfo1_block() -> Vec<u8> {
+  let mut buf = vec![0u8; 0x80];
+  put_u16(&mut buf, 0x02, 0x48); // FaceInfoOffset
+  put_str(&mut buf, 0x06, "2010:08:15 12:34:56"); // SonyDateTime (19 chars + NUL)
+  put_u16(&mut buf, 0x1a, 1080); // SonyImageHeight
+  put_u16(&mut buf, 0x1c, 1920); // SonyImageWidth
+  put_u16(&mut buf, 0x30, 2); // FacesDetected
+  put_u16(&mut buf, 0x32, 0x20); // FaceInfoLength
+  put_str(&mut buf, 0x34, "DC7303320222000"); // MetaVersion (15 chars + NUL)
+  // Face1Position @0x48, Face2Position @0x68 (stride 0x20), int16u[4].
+  for (i, v) in [100u16, 200, 50, 50].iter().enumerate() {
+    put_u16(&mut buf, 0x48 + i * 2, *v);
+  }
+  for (i, v) in [10u16, 20, 30, 40].iter().enumerate() {
+    put_u16(&mut buf, 0x68 + i * 2, *v);
+  }
+  buf
+}
+
+#[test]
+fn scalar_leaves_and_datamembers() {
+  let buf = faceinfo1_block();
+  let j = parse_shot_info(&buf, true);
+  assert_eq!(find(&j, "FaceInfoOffset"), Some(TagValue::I64(0x48)));
+  assert_eq!(
+    find(&j, "SonyDateTime"),
+    Some(TagValue::Str("2010:08:15 12:34:56".into()))
+  );
+  assert_eq!(find(&j, "SonyImageHeight"), Some(TagValue::I64(1080)));
+  assert_eq!(find(&j, "SonyImageWidth"), Some(TagValue::I64(1920)));
+  assert_eq!(find(&j, "FacesDetected"), Some(TagValue::I64(2)));
+  assert_eq!(find(&j, "FaceInfoLength"), Some(TagValue::I64(0x20)));
+  assert_eq!(
+    find(&j, "MetaVersion"),
+    Some(TagValue::Str("DC7303320222000".into()))
+  );
+}
+
+#[test]
+fn faceinfo1_descends_and_honours_faces_detected() {
+  let buf = faceinfo1_block();
+  let j = parse_shot_info(&buf, true);
+  // 2 faces detected -> Face1/Face2 only (int16u[4], space-joined).
+  assert_eq!(
+    find(&j, "Face1Position"),
+    Some(TagValue::Str("100 200 50 50".into()))
+  );
+  assert_eq!(
+    find(&j, "Face2Position"),
+    Some(TagValue::Str("10 20 30 40".into()))
+  );
+  assert!(find(&j, "Face3Position").is_none()); // FacesDetected(2) < 3
+}
+
+#[test]
+fn faceinfo2_descends_with_stride_0x25() {
+  let mut buf = vec![0u8; 0x90];
+  put_u16(&mut buf, 0x02, 0x5e); // FaceInfoOffset
+  put_u16(&mut buf, 0x30, 1); // FacesDetected
+  put_u16(&mut buf, 0x32, 0x25); // FaceInfoLength
+  for (i, v) in [11u16, 22, 33, 44].iter().enumerate() {
+    put_u16(&mut buf, 0x5e + i * 2, *v); // Face1Position @0x5e
+  }
+  let j = parse_shot_info(&buf, true);
+  assert_eq!(
+    find(&j, "Face1Position"),
+    Some(TagValue::Str("11 22 33 44".into()))
+  );
+  assert!(find(&j, "Face2Position").is_none()); // FacesDetected(1) < 2
+}
+
+#[test]
+fn faceinfo_not_descended_when_condition_fails() {
+  // FaceInfoOffset 0x48 but FaceInfoLength 0x25 (FaceInfo1 wants 0x20) -> no
+  // FaceInfo1; FaceInfo2 wants offset 0x5e -> no FaceInfo2 either.
+  let mut buf = faceinfo1_block();
+  put_u16(&mut buf, 0x32, 0x25);
+  let j = parse_shot_info(&buf, true);
+  assert!(find(&j, "Face1Position").is_none());
+  // The scalar leaves are unaffected.
+  assert_eq!(find(&j, "FacesDetected"), Some(TagValue::I64(2)));
+}
+
+#[test]
+fn zero_faces_detected_suppresses_face_subdir() {
+  let mut buf = faceinfo1_block();
+  put_u16(&mut buf, 0x30, 0); // FacesDetected = 0
+  let j = parse_shot_info(&buf, true);
+  assert!(find(&j, "Face1Position").is_none());
+}
+
+#[test]
+fn out_of_range_leaves_are_skipped() {
+  // A short block (0x1c bytes) emits only the in-range scalar leaves.
+  let mut buf = vec![0u8; 0x1c];
+  put_u16(&mut buf, 0x02, 5);
+  put_u16(&mut buf, 0x1a, 720);
+  let j = parse_shot_info(&buf, true);
+  assert_eq!(find(&j, "FaceInfoOffset"), Some(TagValue::I64(5)));
+  assert_eq!(find(&j, "SonyImageHeight"), Some(TagValue::I64(720))); // 0x1a..0x1c in range
+  assert!(find(&j, "SonyImageWidth").is_none()); // 0x1c..0x1e out of range
+  assert!(find(&j, "FacesDetected").is_none()); // 0x30 out of range
+}

--- a/src/exif/makernotes/vendors/sony/subtables.rs
+++ b/src/exif/makernotes/vendors/sony/subtables.rs
@@ -66,6 +66,21 @@ pub fn read_i16(buf: &[u8], off: usize) -> Option<i16> {
   }
 }
 
+/// Read a big-endian `int16s` at byte `off` of the block (`None` if the 2-byte
+/// range is out of bounds).
+///
+/// The base `%Sony::CameraInfo` SubDirectory (A700/A850/A900) is declared
+/// `ByteOrder => 'BigEndian'` (`Sony.pm:725`), so UNLIKE the little-endian
+/// `CameraInfo2`/`CameraInfo3` its inline `%afStatusInfo` `int16s` grid reads
+/// big-endian.
+#[must_use]
+pub fn read_i16_be(buf: &[u8], off: usize) -> Option<i16> {
+  match buf.get(off..off + 2) {
+    Some(&[a, b]) => Some(i16::from_be_bytes([a, b])),
+    _ => None,
+  }
+}
+
 /// Read a little-endian `int32u` at byte `off` of the block.
 #[must_use]
 pub fn read_u32(buf: &[u8], off: usize) -> Option<u32> {

--- a/src/exif/makernotes/vendors/sony/tag940e.rs
+++ b/src/exif/makernotes/vendors/sony/tag940e.rs
@@ -9,8 +9,8 @@
 //! (`Sony.pm:2094-2105`):
 //!
 //! - `AFInfo` — `$$self{Model} =~ /^(SLT-|HV|ILCA-)/` ⇒ the separate large
-//!   `%Sony::AFInfo` AF-status table (`Sony.pm:9452+`), which is NOT ported here
-//!   (deferred); for those bodies this module emits nothing.
+//!   `%Sony::AFInfo` AF-status table (`Sony.pm:9452+`), ported in [`super::afinfo`];
+//!   for those bodies this module emits nothing.
 //! - `Tag940e` — `$$self{Model} =~ /^(NEX-|ILCE-|Lunar)/` ⇒ this table.
 //! - else `Sony_0x940e` (`%unknownCipherData`) — emits nothing.
 //!
@@ -39,7 +39,8 @@ pub struct Tag940eEmission {
 
 /// `true` when `$$self{Model} =~ /^(NEX-|ILCE-|Lunar)/` selects the `Tag940e`
 /// variant (`Sony.pm:2100`). Tested against the parent `$$self{Model}`. (The
-/// `AFInfo` SLT/HV/ILCA variant is handled by a separate, deferred table.)
+/// `AFInfo` SLT/HV/ILCA variant is handled by the separate [`super::afinfo`]
+/// table.)
 #[must_use]
 pub fn selects_tag940e(model: Option<&str>) -> bool {
   model.is_some_and(|m| m.starts_with("NEX-") || m.starts_with("ILCE-") || m.starts_with("Lunar"))

--- a/src/exif/makernotes/vendors/sony/tags.rs
+++ b/src/exif/makernotes/vendors/sony/tags.rs
@@ -151,8 +151,9 @@ pub fn format_override(id: u16) -> Option<Format> {
 #[non_exhaustive]
 pub enum SubTable {
   /// `%Sony::CameraInfo`/`CameraInfo2`/`CameraInfo3`/`CameraInfoUnknown`
-  /// dispatcher at 0x0010 (`Sony.pm:716-747`). Per-`count` conditional;
-  /// deferred.
+  /// dispatcher at 0x0010 (`Sony.pm:716-747`). Per-`count` conditional; the
+  /// base (368/5478), `2` (5506/6118) and `3` (15360) tables are ported in
+  /// `camerainfo`/`camerainfo2`/`camerainfo3` (`CameraInfoUnknown` stays raw).
   CameraInfo,
   /// `%Sony::FocusInfo`/`MoreInfo` dispatcher at 0x0020 (`Sony.pm:750-769`).
   /// Deferred.
@@ -164,7 +165,7 @@ pub enum SubTable {
   /// `%Sony::ExtraInfo`/`ExtraInfo2`/`ExtraInfo3` dispatcher at 0x0116
   /// (`Sony.pm:856-873`). Deferred.
   ExtraInfo,
-  /// `%Sony::ShotInfo` at 0x3000 (`Sony.pm:1768-1771`). Deferred.
+  /// `%Sony::ShotInfo` at 0x3000 (`Sony.pm:1768-1771`). Ported in `shotinfo`.
   ShotInfo,
   /// `%Sony::Tag2010a`..`Tag2010i` dispatcher at 0x2010 (`Sony.pm:1100-1173`)
   /// — model-specific. Deferred.
@@ -174,8 +175,8 @@ pub enum SubTable {
   /// `Tag900b`/`Tag202a` series (`Sony.pm:1573-2118`) — model-specific
   /// deciphered shot/AF/lens info. Deferred.
   Tag9xxx,
-  /// `%Sony::AFInfo`/`Tag940e` dispatcher at 0x940e (`Sony.pm:2094-2105`).
-  /// Deferred.
+  /// `%Sony::AFInfo`/`Tag940e` dispatcher at 0x940e (`Sony.pm:2094-2105`). Both
+  /// ported: `afinfo` (SLT/HV/ILCA `%AFInfo`) and `tag940e` (E-mount `Tag940e`).
   AfInfo,
   /// `%Sony::Panorama` at 0x1003 (`Sony.pm:898-904`). Deferred.
   Panorama,

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12469,7 +12469,8 @@ fn sony_emit_binary_subdir<S: ExifSink>(
   out: &mut S,
 ) {
   use makernotes::vendors::sony::{
-    camerainfo2, camerainfo3, camerasettings, camerasettings3, extrainfo3, focusinfo, moreinfo,
+    camerainfo, camerainfo2, camerainfo3, camerasettings, camerasettings3, extrainfo3, focusinfo,
+    moreinfo, shotinfo,
   };
   let off = entry.value_offset();
   let Some(end) = off.checked_add(entry.value_size()) else {
@@ -12479,6 +12480,12 @@ fn sony_emit_binary_subdir<S: ExifSink>(
     return;
   };
   let emissions = match entry.tag_id() {
+    // base `CameraInfo` — `$count == 368 || 5478` (Sony.pm:720-726), BigEndian.
+    // The A700 (368) / A850/A900 (5478) generation; dispatched BEFORE the
+    // little-endian `CameraInfo2`/`CameraInfo3` count gates.
+    0x0010 if entry.value_size() == 368 || entry.value_size() == 5478 => {
+      camerainfo::parse_camera_info(raw, model, print_conv)
+    }
     // `CameraInfo2` — `$count == 5506 || 6118` (Sony.pm:728-734), LittleEndian.
     // The A200-A390 generation; dispatched BEFORE `CameraInfo3`'s 15360 gate.
     0x0010 if entry.value_size() == 5506 || entry.value_size() == 6118 => {
@@ -12511,6 +12518,9 @@ fn sony_emit_binary_subdir<S: ExifSink>(
     // `ExtraInfo3` — the final (non-conditional) `ExtraInfo` ARRAY branch
     // (Sony.pm:150-167); the A33 writes this variant.
     0x0116 => extrainfo3::parse_extra_info3(raw, model, print_conv),
+    // `ShotInfo` — the (un-enciphered) `0x3000` SubDirectory (DSC / Xperia
+    // bodies); unconditional ARRAY branch (Sony.pm:1769-1771).
+    0x3000 => shotinfo::parse_shot_info(raw, print_conv),
     _ => return,
   };
   // Each leaf carries its ExifTool `Priority => N` (the table-level `PRIORITY`,
@@ -12572,8 +12582,8 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
 ) {
   use makernotes::vendors::sony::decipher::process_enciphered;
   use makernotes::vendors::sony::{
-    tag202a, tag900b, tag940a, tag940c, tag940e, tag9050, tag9400, tag9401, tag9402, tag9403,
-    tag9404, tag9406, tag9416,
+    afinfo, tag202a, tag900b, tag940a, tag940c, tag940e, tag9050, tag9400, tag9401, tag9402,
+    tag9403, tag9404, tag9406, tag9416,
   };
   // The verbatim on-disk value span (the enciphered cipher block, or the plain
   // `Tag202a` bytes) — the same buffer the walk read, sliced at the entry's
@@ -12678,9 +12688,27 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
         let Ok(()) = out.write_vendor_value("MakerNotes", group1, emi.name, emi.value, false);
       }
     }
+    // `AFInfo` — the SLT/HV/ILCA variant of 0x940e (`$$self{Model} =~
+    // /^(SLT-|HV|ILCA-)/`, `Sony.pm:2094-2097`), dispatched BEFORE the E-mount
+    // `Tag940e` (matching ExifTool's conditional-ARRAY order). `PRIORITY => 0`,
+    // so each leaf rides priority 0 (never overrides an earlier same-name
+    // duplicate, e.g. a `CameraInfo3` `FocusMode`).
+    0x940e if sony_selects_afinfo(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in afinfo::parse_af_info(&buf, model, print_conv) {
+        let Ok(()) = out.write_vendor_value_with_priority(
+          "MakerNotes",
+          group1,
+          emi.name,
+          emi.value,
+          false,
+          emi.priority,
+        );
+      }
+    }
     // `Tag940e` — `TiffMeteringImage*`, the E-mount variant selected by model
     // `/^(NEX-|ILCE-|Lunar)/` (`Sony.pm:2094-2105`); the SLT/HV/ILCA `AFInfo`
-    // variant routes to a separate (deferred) `%Sony::AFInfo` table.
+    // variant routes to the separate `%Sony::AFInfo` table above.
     0x940e if tag940e::selects_tag940e(model) => {
       let buf = process_enciphered(raw, double_cipher);
       for emi in tag940e::parse_tag940e(&buf, model, software) {
@@ -12714,6 +12742,13 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
     }
     _ => {}
   }
+}
+
+/// `AFInfo` 0x940e model `Condition` (`Sony.pm:2096`):
+/// `$$self{Model} =~ /^(SLT-|HV|ILCA-)/`. Selects the SLT/HV/ILCA `%Sony::AFInfo`
+/// table over the E-mount `Tag940e`.
+fn sony_selects_afinfo(model: Option<&str>) -> bool {
+  model.is_some_and(|m| m.starts_with("SLT-") || m.starts_with("HV") || m.starts_with("ILCA-"))
 }
 
 /// `Tag9050c` model `Condition` (`Sony.pm:1810`):


### PR DESCRIPTION
Closes #98 and #99. Ports 3 genuinely-missing Sony sub-tables faithfully from ExifTool 13.59 Sony.pm (exifast had CameraInfo2/3 + FocusInfo but not these):

- **CameraInfo (base)** [#98] — BigEndian (A700/A850/A900, count 368/5478): index-0 `LensSpec` (A700/A850/A900-specific int16 byte-pair swap, ExifTool-cross-verified), 24-leaf `%afStatusInfo` grid, 23-point AFPoint, A850/A900-only AFMicroAdj* Mask trio.
- **AFInfo** [#99] — PRIORITY 0; `AFType` DataMember selects SLT (`%afPoint15/19` + AFStatus15/19 + int32u bitmask) vs ILCA (`%afPoints79` + AFStatus79); wired as a 0x940e sibling **before** Tag940e (SLT/HV/ILCA vs NEX/ILCE/Lunar — mutually exclusive by model).
- **ShotInfo** [#99] — scalars + conditional FaceInfo1/FaceInfo2 face-position sub-dirs (FacesDetected-gated).

**Fixtureless** (confirmed via `-v3` that the 3 active Sony raws use CameraInfo2/3 + FocusInfo, not these), so validated by **no-regression (conformance 498/0 byte-identical)** + **21 unit tests** vs Sony.pm. `build(-Dwarnings)=0 alloc_budget=pass conformance=498/0 typed_serde=1/0 timed=161/0 lib=4090/0 xtask=26`. **Codex: APPROVE** (R2 — the base CameraInfo offset-0 LensSpec byte-order fix). Memory-amplification → #443.