### PR TITLE
feat(sony): port Tag2010a/b/c/d/f shot-info sub-tables + 0x2010 dispatch (#97 chunk 1)

### DIFF
--- a/src/exif/makernotes/vendors/sony/mod.rs
+++ b/src/exif/makernotes/vendors/sony/mod.rs
@@ -91,6 +91,7 @@ pub mod printconv;
 pub mod shotinfo;
 pub mod sr2;
 pub mod subtables;
+pub mod tag2010;
 pub mod tag202a;
 pub mod tag900b;
 pub mod tag9050;

--- a/src/exif/makernotes/vendors/sony/tag2010.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010.rs
@@ -1,0 +1,1212 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Sony::Tag2010a`..`Tag2010f` (`Sony.pm:6464-6980`) — the
+//! enciphered `0x2010` `ProcessBinaryData` shot-info blocks (release / self-timer
+//! / flash mode, gain / brightness / exposure compensation, DRO / HDR /
+//! PictureProfile / PictureEffect, metering / exposure program, white-balance
+//! `WB_RGBLevels`, SonyISO, distortion-correction params, and — for the DSC
+//! variants — focal-length / aspect-ratio).
+//!
+//! ## Variant dispatch
+//!
+//! The `0x2010` Main-table row is a conditional-ARRAY SubDirectory dispatcher
+//! (`Sony.pm:1100-1173`) selected by the EXACT (`$`-anchored) `$$self{Model}`:
+//!
+//! - `Tag2010a` — `/^NEX-5N$/` (`Sony.pm:1128`).
+//! - `Tag2010b` — `/^(SLT-A(65|77)V?|NEX-(7|VG20E)|Lunar)$/` (`Sony.pm:1132`).
+//! - `Tag2010c` — `/^(SLT-A(37|57)|NEX-F3)$/` (`Sony.pm:1136`).
+//! - `Tag2010d` — `/^(DSC-(HX10V|HX20V|HX30V|HX200V|TX66|TX200V|TX300V|WX50|WX70|`
+//!   `WX100|WX150))$/` AND `not $$self{Panorama}` (`Sony.pm:1140-1145`).
+//! - `Tag2010e` (`Sony.pm:1147-1153`), `Tag2010g`/`h`/`i` (`Sony.pm:1162-1173`) —
+//!   the LARGER variants, not yet ported: those bodies (and any unknown one) fall
+//!   through to `Tag_0x2010` (`%unknownCipherData`, emits nothing), which is
+//!   faithful until they are ported.
+//! - `Tag2010f` — `/^(DSC-(RX100M2|QX10|QX100))$/` (`Sony.pm:1156`).
+//! - else `Tag_0x2010` (`%unknownCipherData`) — emits nothing.
+//!
+//! Because the model sets are pairwise disjoint (and disjoint from the deferred
+//! `e`/`g`/`h`/`i` sets), the dispatcher tests `a`/`b`/`c`/`d`/`f` independently;
+//! a body matching `e`/`g`/`h`/`i` matches none of them and correctly falls to
+//! the unknown branch.
+//!
+//! ## Cipher + priority + availability
+//!
+//! Every `Tag2010x` table is `PROCESS_PROC => \&ProcessEnciphered`,
+//! `FORMAT => 'int8u'`, `FIRST_ENTRY => 0`, `PRIORITY => 0` (`Sony.pm:6464-6473`
+//! etc.). The dispatcher [`process_enciphered`](super::decipher::process_enciphered)s
+//! the block (using `$$self{DoubleCipher}`, which `0x2010 < 0x9400` in IFD-tag
+//! order leaves unset on a well-formed file) and hands the per-variant parser the
+//! DECIPHERED bytes. Each emitted leaf rides `PRIORITY => 0`, so it never
+//! overrides an earlier same-name duplicate.
+//!
+//! Per the `ProcessBinaryData` contract each tag is emitted IFF its byte range is
+//! in the deciphered block ([[exifast-processbinarydata-per-field]]). The
+//! `MeterInfo` `IS_SUBDIR` row (`0x04b0`/`0x04b4`/`0x0490`/`0x050c`/`0x01e0`) is
+//! `Unknown => 1` (`Sony.pm:7456-7458` — "Extracted only if the Unknown option is
+//! used"), so it is NOT emitted in default output and is skipped here.
+//!
+//! These tables have NO per-leaf model `Condition`s (unlike `Tag9405b`); the
+//! model gate lives entirely in the dispatcher.
+
+use crate::value::{TagValue, whole_f64_to_tag_value};
+
+/// One emitted `Tag2010a`..`Tag2010f` leaf — the resolved tag name and rendered
+/// value.
+pub struct Tag2010Emission {
+  /// `Name => '…'` from the bundled table.
+  pub name: &'static str,
+  /// The rendered value (`-j` PrintConv result, or `-n` raw `$val`/ValueConv).
+  pub value: TagValue,
+}
+
+// --- byte readers ------------------------------------------------------------
+
+/// Read a little-endian `int16u` at byte `off` of the deciphered block.
+fn read_u16(buf: &[u8], off: usize) -> Option<u16> {
+  match buf.get(off..off.checked_add(2)?) {
+    Some(&[a, b]) => Some(u16::from_le_bytes([a, b])),
+    _ => None,
+  }
+}
+
+/// Read a little-endian `int16s` at byte `off` of the deciphered block.
+fn read_i16(buf: &[u8], off: usize) -> Option<i16> {
+  match buf.get(off..off.checked_add(2)?) {
+    Some(&[a, b]) => Some(i16::from_le_bytes([a, b])),
+    _ => None,
+  }
+}
+
+/// Read a little-endian `int32u` at byte `off` of the deciphered block.
+fn read_u32_le(buf: &[u8], off: usize) -> Option<u32> {
+  match buf.get(off..off.checked_add(4)?) {
+    Some(&[a, b, c, d]) => Some(u32::from_le_bytes([a, b, c, d])),
+    _ => None,
+  }
+}
+
+// --- variant model gates (EXACT `$`-anchored `$$self{Model}` match) ----------
+
+/// `true` when `model` equals any of `stems` exactly (the Perl `/^(…)$/`
+/// whole-string alternation used by the `0x2010` dispatcher `Condition`s).
+fn model_eq_any(model: Option<&str>, stems: &[&str]) -> bool {
+  let Some(m) = model else { return false };
+  stems.contains(&m)
+}
+
+/// `Sony.pm:1128` `/^NEX-5N$/` — selects `Tag2010a`.
+#[must_use]
+pub fn selects_tag2010a(model: Option<&str>) -> bool {
+  model == Some("NEX-5N")
+}
+
+/// `Sony.pm:1132` `/^(SLT-A(65|77)V?|NEX-(7|VG20E)|Lunar)$/` — selects
+/// `Tag2010b`. The `V?` makes the trailing `V` optional (SLT-A65/A65V/A77/A77V).
+#[must_use]
+pub fn selects_tag2010b(model: Option<&str>) -> bool {
+  model_eq_any(
+    model,
+    &[
+      "SLT-A65",
+      "SLT-A65V",
+      "SLT-A77",
+      "SLT-A77V",
+      "NEX-7",
+      "NEX-VG20E",
+      "Lunar",
+    ],
+  )
+}
+
+/// `Sony.pm:1136` `/^(SLT-A(37|57)|NEX-F3)$/` — selects `Tag2010c`.
+#[must_use]
+pub fn selects_tag2010c(model: Option<&str>) -> bool {
+  model_eq_any(model, &["SLT-A37", "SLT-A57", "NEX-F3"])
+}
+
+/// `Sony.pm:1140-1145` `/^(DSC-(HX10V|HX20V|HX30V|HX200V|TX66|TX200V|TX300V|`
+/// `WX50|WX70|WX100|WX150))$/` AND `not $$self{Panorama}` — selects `Tag2010d`.
+/// The `panorama` flag is the file-global `$$self{Panorama}` DataMember
+/// (`Sony.pm:902`), latched on the `0x1003` walk before `0x2010`.
+#[must_use]
+pub fn selects_tag2010d(model: Option<&str>, panorama: bool) -> bool {
+  !panorama
+    && model_eq_any(
+      model,
+      &[
+        "DSC-HX10V",
+        "DSC-HX20V",
+        "DSC-HX30V",
+        "DSC-HX200V",
+        "DSC-TX66",
+        "DSC-TX200V",
+        "DSC-TX300V",
+        "DSC-WX50",
+        "DSC-WX70",
+        "DSC-WX100",
+        "DSC-WX150",
+      ],
+    )
+}
+
+/// `Sony.pm:1156` `/^(DSC-(RX100M2|QX10|QX100))$/` — selects `Tag2010f`.
+#[must_use]
+pub fn selects_tag2010f(model: Option<&str>) -> bool {
+  model_eq_any(model, &["DSC-RX100M2", "DSC-QX10", "DSC-QX100"])
+}
+
+/// `$$self{Panorama} = ($$valPt =~ /^(\0\0)?\x01\x01/)` (`Sony.pm:902`) — the
+/// `0x1003` `Panorama` SubDirectory `Condition` DataMember side-effect: a raw
+/// value that begins with `\x01\x01` (little-endian int32u 257) or
+/// `\0\0\x01\x01` (big-endian) latches `$$self{Panorama}`. Tested against the
+/// RAW on-disk `0x1003` value bytes.
+#[must_use]
+pub fn detects_panorama(raw: &[u8]) -> bool {
+  raw.starts_with(&[0x01, 0x01]) || raw.starts_with(&[0x00, 0x00, 0x01, 0x01])
+}
+
+// --- PrintConv hashes (shared `%…2010` Tag2010 hashes) -----------------------
+
+/// `%releaseMode2010` `ReleaseMode3` (`Sony.pm:6245-6256`).
+fn release_mode3_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Normal",
+    1 => "Continuous",
+    2 => "Bracketing",
+    4 => "Continuous - Burst",
+    5 => "Continuous - Speed/Advance Priority",
+    6 => "Normal - Self-timer",
+    9 => "Single Burst Shooting",
+    _ => return None,
+  })
+}
+
+/// `%selfTimer2010` `SelfTimer` (`Sony.pm:6258-6265`).
+fn self_timer_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "Self-timer 10 s",
+    2 => "Self-timer 2 s",
+    _ => return None,
+  })
+}
+
+/// `%flashMode2010` `FlashMode` (`Sony.pm:6365-6376`).
+fn flash_mode_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Autoflash",
+    1 => "Fill-flash",
+    2 => "Flash Off",
+    3 => "Slow Sync",
+    4 => "Rear Sync",
+    6 => "Wireless",
+    _ => return None,
+  })
+}
+
+/// `%dynamicRangeOptimizer2010` `DynamicRangeOptimizer` (`Sony.pm:6293-6305`).
+fn dynamic_range_optimizer_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "Auto",
+    3 => "Lv1",
+    4 => "Lv2",
+    5 => "Lv3",
+    6 => "Lv4",
+    7 => "Lv5",
+    8 => "n/a",
+    _ => return None,
+  })
+}
+
+/// `%hdr2010` `HDRSetting` (`Sony.pm:6306-6318`).
+fn hdr_setting_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "HDR Auto",
+    3 => "HDR 1 EV",
+    5 => "HDR 2 EV",
+    7 => "HDR 3 EV",
+    9 => "HDR 4 EV",
+    11 => "HDR 5 EV",
+    13 => "HDR 6 EV",
+    _ => return None,
+  })
+}
+
+/// `%pictureEffect2010` `PictureEffect2` (`Sony.pm:6327-6346`).
+fn picture_effect2_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "Toy Camera",
+    2 => "Pop Color",
+    3 => "Posterization",
+    4 => "Retro Photo",
+    5 => "Soft High Key",
+    6 => "Partial Color",
+    7 => "High Contrast Monochrome",
+    8 => "Soft Focus",
+    9 => "HDR Painting",
+    10 => "Rich-tone Monochrome",
+    11 => "Miniature",
+    12 => "Water Color",
+    13 => "Illustration",
+    _ => return None,
+  })
+}
+
+/// `%quality2010` `Quality2` (`Sony.pm:6347-6354`).
+fn quality2_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "JPEG",
+    1 => "RAW",
+    2 => "RAW + JPEG",
+    _ => return None,
+  })
+}
+
+/// `%meteringMode2010` `MeteringMode` (`Sony.pm:6355-6364`).
+fn metering_mode_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Multi-segment",
+    2 => "Center-weighted average",
+    3 => "Spot",
+    4 => "Average",
+    5 => "Highlight",
+    _ => return None,
+  })
+}
+
+/// `%pictureProfile2010` `PictureProfile` (`Sony.pm:6382-6417`) — the FULL hash
+/// (value `2` has no label → a miss). Distinct from `Tag9416`'s deliberately
+/// truncated FX3-range copy.
+fn picture_profile_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Gamma Still - Standard/Neutral (PP2)",
+    1 => "Gamma Still - Portrait",
+    3 => "Gamma Still - Night View/Portrait",
+    4 => "Gamma Still - B&W/Sepia",
+    5 => "Gamma Still - Clear",
+    6 => "Gamma Still - Deep",
+    7 => "Gamma Still - Light",
+    8 => "Gamma Still - Vivid",
+    9 => "Gamma Still - Real",
+    10 => "Gamma Movie (PP1)",
+    22 => "Gamma ITU709 (PP3 or PP4)",
+    24 => "Gamma Cine1 (PP5)",
+    25 => "Gamma Cine2 (PP6)",
+    26 => "Gamma Cine3",
+    27 => "Gamma Cine4",
+    28 => "Gamma S-Log2 (PP7)",
+    29 => "Gamma ITU709 (800%)",
+    31 => "Gamma S-Log3 (PP8 or PP9)",
+    33 => "Gamma HLG2 (PP10)",
+    34 => "Gamma HLG3",
+    36 => "Off",
+    37 => "FL",
+    38 => "VV2",
+    39 => "IN",
+    40 => "SH",
+    48 => "FL2",
+    49 => "FL3",
+    _ => return None,
+  })
+}
+
+/// `Tag2010f` `0x192c` `AspectRatio` PrintConv hash (`Sony.pm:6970-6978`).
+fn aspect_ratio_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "16:9",
+    1 => "4:3",
+    2 => "3:2",
+    3 => "1:1",
+    5 => "Panorama",
+    _ => return None,
+  })
+}
+
+// --- value pushers -----------------------------------------------------------
+
+/// An `int8u` row whose PrintConv is a lookup hash. A hash MISS renders
+/// `"Unknown ($val)"` in `-j` / the raw `$val` in `-n` ([`super::hash_print_value`]).
+fn push_u8_hash(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  hash: impl Fn(u8) -> Option<&'static str>,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(&raw) = buf.get(off) else { return };
+  out.push(Tag2010Emission {
+    name,
+    value: super::hash_print_value(raw, hash(raw), print_conv),
+  });
+}
+
+/// `%releaseMode2, Format => 'int32u'` (`Sony.pm:6512` etc.) — the `ReleaseMode2`
+/// hash applied to an `int32u`. A value `> 255` (or an unmapped one) is a hash
+/// MISS → `"Unknown ($val)"` in `-j` (the FULL `int32u`) / the raw int in `-n`.
+fn push_release_mode2_u32(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(raw) = read_u32_le(buf, off) else {
+    return;
+  };
+  let hit = u8::try_from(raw).ok().and_then(super::release_mode2_print);
+  let value = match (print_conv, hit) {
+    (true, Some(s)) => TagValue::Str(s.into()),
+    (true, None) => TagValue::Str(std::format!("Unknown ({raw})").into()),
+    (false, _) => TagValue::I64(i64::from(raw)),
+  };
+  out.push(Tag2010Emission { name, value });
+}
+
+/// `SonyISO` — int16u, `ValueConv => '100 * 2**(16 - $val/256)'`,
+/// `PrintConv => 'sprintf("%.0f",$val)'` (`Sony.pm:6553-6559` etc.).
+fn push_sony_iso(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(raw) = read_u16(buf, off) else {
+    return;
+  };
+  let iso = 100.0 * 2f64.powf(16.0 - f64::from(raw) / 256.0);
+  let value = if print_conv {
+    TagValue::Str(std::format!("{iso:.0}").into())
+  } else {
+    whole_f64_to_tag_value(iso)
+  };
+  out.push(Tag2010Emission { name, value });
+}
+
+/// `%gain2010` `StopsAboveBaseISO` — int16u, `ValueConv => '16 - $val/256'`,
+/// `PrintConv => '$val ? sprintf("%.1f",$val) : $val'` (`Sony.pm:6274-6286`).
+fn push_gain2010(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(raw) = read_u16(buf, off) else {
+    return;
+  };
+  let stops = 16.0 - f64::from(raw) / 256.0;
+  // `$val ? sprintf("%.1f",$val) : $val` — a ValueConv of exactly 0 prints the
+  // bare ValueConv result (integer `0`); otherwise "%.1f".
+  let value = if print_conv && stops != 0.0 {
+    TagValue::Str(std::format!("{stops:.1}").into())
+  } else {
+    whole_f64_to_tag_value(stops)
+  };
+  out.push(Tag2010Emission { name, value });
+}
+
+/// `%brightnessValue2010` `BrightnessValue` — int16u, `ValueConv =>
+/// '$val/256 - 56.6'`, no PrintConv (`Sony.pm:6287-6292`). Same value in `-j`/`-n`.
+fn push_brightness_value(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(raw) = read_u16(buf, off) else {
+    return;
+  };
+  let v = f64::from(raw) / 256.0 - 56.6;
+  out.push(Tag2010Emission {
+    name,
+    value: whole_f64_to_tag_value(v),
+  });
+}
+
+/// `%exposureComp2010` `ExposureCompensation` — int16s, `ValueConv =>
+/// '-$val/256'`, `PrintConv => '$val ? sprintf("%+.1f",$val) : 0'`
+/// (`Sony.pm:6319-6326`). `-n` keeps the ValueConv; `-j` shows a signed `%.1f`
+/// for a non-zero value, else the bare integer `0`.
+fn push_exposure_comp(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(raw) = read_i16(buf, off) else {
+    return;
+  };
+  let v = -f64::from(raw) / 256.0;
+  let value = if print_conv {
+    if raw != 0 {
+      TagValue::Str(std::format!("{v:+.1}").into())
+    } else {
+      TagValue::I64(0)
+    }
+  } else {
+    whole_f64_to_tag_value(v)
+  };
+  out.push(Tag2010Emission { name, value });
+}
+
+/// `%sequenceImageNumber`/`%sequenceFileNumber` — int32u, `ValueConv =>
+/// '$val + 1'` (`Sony.pm:6180-6194`). Same value in `-j`/`-n`.
+fn push_sequence_plus1(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  if let Some(raw) = read_u32_le(buf, off) {
+    out.push(Tag2010Emission {
+      name,
+      value: TagValue::I64(i64::from(raw) + 1),
+    });
+  }
+}
+
+/// `%sonyDateTime2010` `SonyDateTime` — `undef[7]`, `ValueConv` unpacks
+/// `('vC*')` → `"%.4d:%.2d:%.2d %.2d:%.2d:%.2d"`, `PrintConv => ConvertDateTime`
+/// (identity under default options) (`Sony.pm:6229-6244`). Same value in `-j`/`-n`.
+/// Emitted IFF all 7 bytes are in range.
+fn push_sony_date_time(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(end) = off.checked_add(7) else {
+    return;
+  };
+  // `unpack('vC*')`: the year is a little-endian int16u (2 bytes); month, day,
+  // hour, minute, second are the next five int8u.
+  let Some(&[y0, y1, mon, day, hour, min, sec]) = buf.get(off..end) else {
+    return;
+  };
+  let year = u16::from_le_bytes([y0, y1]);
+  let s = std::format!("{year:04}:{mon:02}:{day:02} {hour:02}:{min:02}:{sec:02}");
+  out.push(Tag2010Emission {
+    name,
+    value: TagValue::Str(s.into()),
+  });
+}
+
+/// `DigitalZoomRatio` — int8u, `ValueConv => '$val/16'`, no PrintConv
+/// (`Sony.pm:6597`/`6724`). Same value in `-j`/`-n`.
+fn push_digital_zoom_ratio(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(&raw) = buf.get(off) else { return };
+  let v = f64::from(raw) / 16.0;
+  out.push(Tag2010Emission {
+    name,
+    value: whole_f64_to_tag_value(v),
+  });
+}
+
+/// `FocalLength`/`MinFocalLength`/`MaxFocalLength` — int16u, `ValueConv =>
+/// '$val / 10'`, `PrintConv => 'sprintf("%.1f mm",$val)'` (`Sony.pm:6932-6958`).
+fn push_focal_length(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(raw) = read_u16(buf, off) else {
+    return;
+  };
+  let v = f64::from(raw) / 10.0;
+  let value = if print_conv {
+    TagValue::Str(std::format!("{v:.1} mm").into())
+  } else {
+    whole_f64_to_tag_value(v)
+  };
+  out.push(Tag2010Emission { name, value });
+}
+
+/// An `int16u[count]` array row (`WB_RGBLevels`) — space-joined for BOTH `-j`
+/// and `-n` (no PrintConv). Emitted IFF the whole `count`-element span is in
+/// range.
+fn push_u16_array(
+  buf: &[u8],
+  off: usize,
+  count: usize,
+  name: &'static str,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(end) = count.checked_mul(2).and_then(|n| off.checked_add(n)) else {
+    return;
+  };
+  let Some(span) = buf.get(off..end) else {
+    return;
+  };
+  let mut joined = std::string::String::new();
+  for (i, pair) in span.chunks_exact(2).enumerate() {
+    use core::fmt::Write;
+    if i > 0 {
+      joined.push(' ');
+    }
+    let v = match pair {
+      &[lo, hi] => u16::from_le_bytes([lo, hi]),
+      _ => continue,
+    };
+    let _ = write!(joined, "{v}");
+  }
+  out.push(Tag2010Emission {
+    name,
+    value: TagValue::Str(joined.into()),
+  });
+}
+
+/// An `int16s[count]` array row (`DistortionCorrParams`) — space-joined for BOTH
+/// `-j` and `-n` (no PrintConv). Emitted IFF the whole `count`-element span is in
+/// range.
+fn push_i16_array(
+  buf: &[u8],
+  off: usize,
+  count: usize,
+  name: &'static str,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(end) = count.checked_mul(2).and_then(|n| off.checked_add(n)) else {
+    return;
+  };
+  let Some(span) = buf.get(off..end) else {
+    return;
+  };
+  let mut joined = std::string::String::new();
+  for (i, pair) in span.chunks_exact(2).enumerate() {
+    use core::fmt::Write;
+    if i > 0 {
+      joined.push(' ');
+    }
+    let v = match pair {
+      &[lo, hi] => i16::from_le_bytes([lo, hi]),
+      _ => continue,
+    };
+    let _ = write!(joined, "{v}");
+  }
+  out.push(Tag2010Emission {
+    name,
+    value: TagValue::Str(joined.into()),
+  });
+}
+
+// --- parsers -----------------------------------------------------------------
+
+/// Walk the DECIPHERED `Tag2010a` block (`Sony.pm:6464-6499`).
+///
+/// `buf` is the DECIPHERED `0x2010` block (the dispatcher already ran
+/// [`process_enciphered`](super::decipher::process_enciphered)); `print_conv`
+/// selects `-j` (PrintConv) vs `-n` (raw `$val`/ValueConv).
+#[must_use]
+pub fn parse_tag2010a(buf: &[u8], print_conv: bool) -> Vec<Tag2010Emission> {
+  let mut out = std::vec::Vec::new();
+  // 0x04b0 MeterInfo (Unknown SubDirectory) — skipped.
+  push_u8_hash(
+    buf,
+    0x1128,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x112c,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1134,
+    "SelfTimer",
+    print_conv,
+    self_timer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1138,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x113e, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x1140, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x1144,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1148,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x114c, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x115e,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x115f,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1163,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1170,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1174,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1175,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x117c, 3, "WB_RGBLevels", &mut out);
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010b` block (`Sony.pm:6501-6567`).
+#[must_use]
+pub fn parse_tag2010b(buf: &[u8], print_conv: bool) -> Vec<Tag2010Emission> {
+  let mut out = std::vec::Vec::new();
+  push_sequence_plus1(buf, 0x0000, "SequenceImageNumber", &mut out);
+  push_sequence_plus1(buf, 0x0004, "SequenceFileNumber", &mut out);
+  push_release_mode2_u32(buf, 0x0008, "ReleaseMode2", print_conv, &mut out);
+  push_sony_date_time(buf, 0x01b6, "SonyDateTime", &mut out);
+  push_u8_hash(
+    buf,
+    0x0324,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  // 0x04b4 MeterInfo (Unknown SubDirectory) — skipped.
+  push_u8_hash(
+    buf,
+    0x1128,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x112c,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1134,
+    "SelfTimer",
+    print_conv,
+    self_timer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1138,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x113e, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x1140, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x1144,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1148,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x114c, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x1162,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1163,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1167,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1174,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1178,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1179,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x1180, 3, "WB_RGBLevels", &mut out);
+  push_sony_iso(buf, 0x1218, "SonyISO", print_conv, &mut out);
+  push_i16_array(buf, 0x1a23, 16, "DistortionCorrParams", &mut out);
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010c` block (`Sony.pm:6569-6633`).
+#[must_use]
+pub fn parse_tag2010c(buf: &[u8], print_conv: bool) -> Vec<Tag2010Emission> {
+  let mut out = std::vec::Vec::new();
+  push_sequence_plus1(buf, 0x0000, "SequenceImageNumber", &mut out);
+  push_sequence_plus1(buf, 0x0004, "SequenceFileNumber", &mut out);
+  push_release_mode2_u32(buf, 0x0008, "ReleaseMode2", print_conv, &mut out);
+  push_digital_zoom_ratio(buf, 0x0200, "DigitalZoomRatio", &mut out);
+  push_sony_date_time(buf, 0x0210, "SonyDateTime", &mut out);
+  push_u8_hash(
+    buf,
+    0x0300,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  // 0x0490 MeterInfo (Unknown SubDirectory) — skipped.
+  push_u8_hash(
+    buf,
+    0x1104,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1108,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1110,
+    "SelfTimer",
+    print_conv,
+    self_timer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1114,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x111a, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x111c, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x1120,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1124,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x1128, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x113e,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x113f,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1143,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1150,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1154,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1155,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x115c, 3, "WB_RGBLevels", &mut out);
+  push_sony_iso(buf, 0x11f4, "SonyISO", print_conv, &mut out);
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010d` block (`Sony.pm:6635-6695`).
+#[must_use]
+pub fn parse_tag2010d(buf: &[u8], print_conv: bool) -> Vec<Tag2010Emission> {
+  let mut out = std::vec::Vec::new();
+  push_sequence_plus1(buf, 0x0000, "SequenceImageNumber", &mut out);
+  push_sequence_plus1(buf, 0x0004, "SequenceFileNumber", &mut out);
+  push_release_mode2_u32(buf, 0x0008, "ReleaseMode2", print_conv, &mut out);
+  push_sony_date_time(buf, 0x01fe, "SonyDateTime", &mut out);
+  push_u8_hash(
+    buf,
+    0x037c,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  // 0x050c MeterInfo (Unknown SubDirectory) — skipped.
+  push_u8_hash(
+    buf,
+    0x1180,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1184,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x118c,
+    "SelfTimer",
+    print_conv,
+    self_timer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1190,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x1196, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x1198, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x119c,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11a0,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11ba,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11bb,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11bf,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11d0,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11d1,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x11d8, 3, "WB_RGBLevels", &mut out);
+  push_sony_iso(buf, 0x1270, "SonyISO", print_conv, &mut out);
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010f` block (`Sony.pm:6893-6978`).
+#[must_use]
+pub fn parse_tag2010f(buf: &[u8], print_conv: bool) -> Vec<Tag2010Emission> {
+  let mut out = std::vec::Vec::new();
+  // 0x0004 ReleaseMode2 (int32u) — NOT at 0x0008 for this variant.
+  push_release_mode2_u32(buf, 0x0004, "ReleaseMode2", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x0050,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  // 0x01e0 MeterInfo (Unknown SubDirectory) — skipped.
+  push_u8_hash(
+    buf,
+    0x1014,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1018,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1020,
+    "SelfTimer",
+    print_conv,
+    self_timer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1024,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x102a, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x102c, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x1030,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1034,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x1038, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x104e,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x104f,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1053,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1060,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1064,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1065,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x106c, 3, "WB_RGBLevels", &mut out);
+  push_focal_length(buf, 0x1134, "FocalLength", print_conv, &mut out);
+  push_focal_length(buf, 0x1136, "MinFocalLength", print_conv, &mut out);
+  push_focal_length(buf, 0x1138, "MaxFocalLength", print_conv, &mut out);
+  push_sony_iso(buf, 0x113c, "SonyISO", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x192c,
+    "AspectRatio",
+    print_conv,
+    aspect_ratio_print,
+    &mut out,
+  );
+  out
+}
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is relaxed for the test
+// module, which indexes fixed-layout byte buffers directly (an out-of-range
+// index is a test-assertion failure, not a shipped panic).
+#[allow(clippy::indexing_slicing)]
+#[path = "tag2010_tests.rs"]
+mod tests;

--- a/src/exif/makernotes/vendors/sony/tag2010_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010_tests.rs
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+use super::*;
+
+fn put_u16(buf: &mut [u8], off: usize, v: u16) {
+  buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn put_i16(buf: &mut [u8], off: usize, v: i16) {
+  buf[off..off + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn put_u32(buf: &mut [u8], off: usize, v: u32) {
+  buf[off..off + 4].copy_from_slice(&v.to_le_bytes());
+}
+
+/// The parsers take the ALREADY-DECIPHERED block (the dispatcher deciphers
+/// centrally), so the unit tests pass plaintext buffers directly.
+fn find<'a>(em: &'a [Tag2010Emission], name: &str) -> Option<&'a TagValue> {
+  em.iter().rev().find(|e| e.name == name).map(|e| &e.value)
+}
+
+/// First (walk-order) occurrence — used to target the `int32u` `ReleaseMode2`
+/// row (`0x0008`/`0x0004`), which precedes the later `int8u` `ReleaseMode2`
+/// (`0x112c`/`0x1018`) the sink keeps last-wins.
+fn find_first<'a>(em: &'a [Tag2010Emission], name: &str) -> Option<&'a TagValue> {
+  em.iter().find(|e| e.name == name).map(|e| &e.value)
+}
+
+fn as_str(tv: &TagValue) -> &str {
+  match tv {
+    TagValue::Str(s) => s.as_str(),
+    other => panic!("expected Str, got {other:?}"),
+  }
+}
+
+fn count(em: &[Tag2010Emission], name: &str) -> usize {
+  em.iter().filter(|e| e.name == name).count()
+}
+
+// --- dispatch model gates ($-anchored exact match) ---------------------------
+
+#[test]
+fn variant_gates_are_exact() {
+  // Tag2010a: ONLY exactly "NEX-5N".
+  assert!(selects_tag2010a(Some("NEX-5N")));
+  assert!(!selects_tag2010a(Some("NEX-5NX"))); // $-anchor: no trailing chars
+  assert!(!selects_tag2010a(Some("NEX-5")));
+  assert!(!selects_tag2010a(Some("XNEX-5N"))); // ^-anchor
+  assert!(!selects_tag2010a(None));
+
+  // Tag2010b: the SLT-A65/A77 (optional V), NEX-7/VG20E, Lunar set.
+  for m in [
+    "SLT-A65",
+    "SLT-A65V",
+    "SLT-A77",
+    "SLT-A77V",
+    "NEX-7",
+    "NEX-VG20E",
+    "Lunar",
+  ] {
+    assert!(selects_tag2010b(Some(m)), "{m} should select b");
+  }
+  assert!(!selects_tag2010b(Some("SLT-A65VX"))); // exact
+  assert!(!selects_tag2010b(Some("NEX-70")));
+  assert!(!selects_tag2010b(Some("NEX-5N")));
+
+  // Tag2010c.
+  for m in ["SLT-A37", "SLT-A57", "NEX-F3"] {
+    assert!(selects_tag2010c(Some(m)), "{m} should select c");
+  }
+  assert!(!selects_tag2010c(Some("SLT-A37V")));
+
+  // Tag2010f.
+  for m in ["DSC-RX100M2", "DSC-QX10", "DSC-QX100"] {
+    assert!(selects_tag2010f(Some(m)), "{m} should select f");
+  }
+  assert!(!selects_tag2010f(Some("DSC-RX100M3"))); // a g-variant model, not f
+
+  // Cross-exclusion: each model selects exactly one variant.
+  assert!(!selects_tag2010b(Some("NEX-5N")) && !selects_tag2010c(Some("NEX-5N")));
+  assert!(!selects_tag2010f(Some("SLT-A65")));
+}
+
+/// `Tag2010d` requires the model AND `not $$self{Panorama}`.
+#[test]
+fn tag2010d_gate_honors_panorama() {
+  for m in [
+    "DSC-HX10V",
+    "DSC-HX20V",
+    "DSC-HX30V",
+    "DSC-HX200V",
+    "DSC-TX66",
+    "DSC-TX200V",
+    "DSC-TX300V",
+    "DSC-WX50",
+    "DSC-WX70",
+    "DSC-WX100",
+    "DSC-WX150",
+  ] {
+    assert!(
+      selects_tag2010d(Some(m), false),
+      "{m} should select d (no panorama)"
+    );
+    assert!(!selects_tag2010d(Some(m), true), "{m} panorama → NOT d");
+  }
+  assert!(!selects_tag2010d(Some("DSC-HX300"), false)); // an e-variant model
+  assert!(!selects_tag2010d(None, false));
+}
+
+/// `$$self{Panorama} = ($$valPt =~ /^(\0\0)?\x01\x01/)`.
+#[test]
+fn detects_panorama_le_and_be() {
+  assert!(detects_panorama(&[0x01, 0x01, 0x00, 0x00])); // little-endian 257
+  assert!(detects_panorama(&[0x00, 0x00, 0x01, 0x01])); // big-endian 257
+  assert!(!detects_panorama(&[0x00, 0x00, 0x00, 0x00]));
+  assert!(!detects_panorama(&[0x01, 0x00])); // 1, not 257
+  assert!(!detects_panorama(&[0x00, 0x00, 0x01])); // truncated
+  assert!(!detects_panorama(&[]));
+}
+
+// --- Tag2010a ----------------------------------------------------------------
+
+fn tag2010a_block() -> Vec<u8> {
+  let mut p = vec![0u8; 0x1190];
+  p[0x1128] = 1; // ReleaseMode3 → Continuous
+  p[0x112c] = 2; // ReleaseMode2 → Continuous - Exposure Bracketing
+  p[0x1134] = 2; // SelfTimer → Self-timer 2 s
+  p[0x1138] = 1; // FlashMode → Fill-flash
+  put_u16(&mut p, 0x113e, 512); // StopsAboveBaseISO → 14.0
+  put_u16(&mut p, 0x1140, 15000); // BrightnessValue
+  p[0x1144] = 5; // DynamicRangeOptimizer → Lv3
+  p[0x1148] = 1; // HDRSetting → HDR Auto
+  put_i16(&mut p, 0x114c, -256); // ExposureCompensation → +1.0
+  p[0x115e] = 8; // PictureProfile (first)
+  p[0x115f] = 10; // PictureProfile (second, wins)
+  p[0x1163] = 1; // PictureEffect2 → Toy Camera
+  p[0x1170] = 2; // Quality2 → RAW + JPEG
+  p[0x1174] = 3; // MeteringMode → Spot
+  p[0x1175] = 2; // ExposureProgram (%sonyExposureProgram3)
+  put_u16(&mut p, 0x117c, 7000); // WB_RGBLevels[0]
+  put_u16(&mut p, 0x117c + 2, 4096); // WB_RGBLevels[1]
+  put_u16(&mut p, 0x117c + 4, 6500); // WB_RGBLevels[2]
+  p
+}
+
+#[test]
+fn tag2010a_print() {
+  let p = tag2010a_block();
+  let em = parse_tag2010a(&p, true);
+  assert_eq!(
+    find(&em, "ReleaseMode3"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("Continuous - Exposure Bracketing".into()))
+  );
+  assert_eq!(
+    find(&em, "SelfTimer"),
+    Some(&TagValue::Str("Self-timer 2 s".into()))
+  );
+  assert_eq!(
+    find(&em, "FlashMode"),
+    Some(&TagValue::Str("Fill-flash".into()))
+  );
+  assert_eq!(
+    find(&em, "StopsAboveBaseISO"),
+    Some(&TagValue::Str("14.0".into()))
+  );
+  assert_eq!(
+    find(&em, "BrightnessValue"),
+    Some(&whole_f64_to_tag_value(15000.0 / 256.0 - 56.6))
+  );
+  assert_eq!(
+    find(&em, "DynamicRangeOptimizer"),
+    Some(&TagValue::Str("Lv3".into()))
+  );
+  assert_eq!(
+    find(&em, "HDRSetting"),
+    Some(&TagValue::Str("HDR Auto".into()))
+  );
+  assert_eq!(
+    find(&em, "ExposureCompensation"),
+    Some(&TagValue::Str("+1.0".into()))
+  );
+  // Two PictureProfile rows (0x115e, 0x115f); both emitted, 0x115f wins last.
+  assert_eq!(count(&em, "PictureProfile"), 2);
+  assert_eq!(
+    find(&em, "PictureProfile"),
+    Some(&TagValue::Str("Gamma Movie (PP1)".into()))
+  );
+  assert_eq!(
+    find(&em, "PictureEffect2"),
+    Some(&TagValue::Str("Toy Camera".into()))
+  );
+  assert_eq!(
+    find(&em, "Quality2"),
+    Some(&TagValue::Str("RAW + JPEG".into()))
+  );
+  assert_eq!(
+    find(&em, "MeteringMode"),
+    Some(&TagValue::Str("Spot".into()))
+  );
+  assert!(find(&em, "ExposureProgram").is_some());
+  assert_eq!(
+    find(&em, "WB_RGBLevels"),
+    Some(&TagValue::Str("7000 4096 6500".into()))
+  );
+}
+
+#[test]
+fn tag2010a_raw() {
+  let p = tag2010a_block();
+  let em = parse_tag2010a(&p, false);
+  assert_eq!(find(&em, "ReleaseMode3"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "ReleaseMode2"), Some(&TagValue::I64(2)));
+  assert_eq!(find(&em, "StopsAboveBaseISO"), Some(&TagValue::I64(14)));
+  assert_eq!(find(&em, "ExposureCompensation"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "PictureProfile"), Some(&TagValue::I64(10)));
+  // Array rows render the same space-joined string in -n.
+  assert_eq!(
+    find(&em, "WB_RGBLevels"),
+    Some(&TagValue::Str("7000 4096 6500".into()))
+  );
+}
+
+// --- Tag2010b (sequence / date / int32u ReleaseMode2 / SonyISO / distortion) --
+
+#[test]
+fn tag2010b_scalars() {
+  let mut p = vec![0u8; 0x1a50];
+  put_u32(&mut p, 0x0000, 4); // SequenceImageNumber → 5
+  put_u32(&mut p, 0x0004, 0); // SequenceFileNumber → 1
+  put_u32(&mut p, 0x0008, 3); // ReleaseMode2 (int32u) → DRO or White Balance Bracketing
+  // SonyDateTime undef[7]: year=2013, 08:15 12:34:56.
+  put_u16(&mut p, 0x01b6, 2013);
+  p[0x01b6 + 2] = 8;
+  p[0x01b6 + 3] = 15;
+  p[0x01b6 + 4] = 12;
+  p[0x01b6 + 5] = 34;
+  p[0x01b6 + 6] = 56;
+  put_u16(&mut p, 0x1218, 2048); // SonyISO → 25600
+  put_i16(&mut p, 0x1a23, 6); // DistortionCorrParams[0]
+  put_i16(&mut p, 0x1a23 + 2, -7); // DistortionCorrParams[1]
+
+  let em = parse_tag2010b(&p, true);
+  assert_eq!(find(&em, "SequenceImageNumber"), Some(&TagValue::I64(5)));
+  assert_eq!(find(&em, "SequenceFileNumber"), Some(&TagValue::I64(1)));
+  // The int32u ReleaseMode2 (0x0008) is the FIRST of two same-named rows (the
+  // int8u 0x112c follows; the sink keeps it last-wins).
+  assert_eq!(
+    find_first(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("DRO or White Balance Bracketing".into()))
+  );
+  assert_eq!(
+    find(&em, "SonyDateTime"),
+    Some(&TagValue::Str("2013:08:15 12:34:56".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  let dcp = as_str(find(&em, "DistortionCorrParams").unwrap());
+  assert_eq!(dcp.split(' ').count(), 16);
+  assert!(dcp.starts_with("6 -7 "));
+}
+
+/// `ReleaseMode2` with `Format => 'int32u'`: a value `> 255` is a hash miss →
+/// `"Unknown ($val)"` carrying the FULL int32u; `-n` keeps the raw int.
+#[test]
+fn tag2010b_release_mode2_int32u_miss() {
+  let mut p = vec![0u8; 0x10];
+  put_u32(&mut p, 0x0008, 300);
+  let em = parse_tag2010b(&p, true);
+  assert_eq!(
+    find(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("Unknown (300)".into()))
+  );
+  let em_n = parse_tag2010b(&p, false);
+  assert_eq!(find(&em_n, "ReleaseMode2"), Some(&TagValue::I64(300)));
+}
+
+// --- Tag2010c (DigitalZoomRatio) ---------------------------------------------
+
+#[test]
+fn tag2010c_digital_zoom_and_iso() {
+  let mut p = vec![0u8; 0x1200];
+  p[0x0200] = 24; // DigitalZoomRatio → 24/16 = 1.5 (no PrintConv → both modes)
+  put_u16(&mut p, 0x11f4, 1792); // SonyISO → 100*2^(16-7) = 51200
+  p[0x1143] = 0; // PictureEffect2 → Off
+  let em = parse_tag2010c(&p, true);
+  assert_eq!(find(&em, "DigitalZoomRatio"), Some(&TagValue::F64(1.5)));
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("51200".into())));
+  assert_eq!(
+    find(&em, "PictureEffect2"),
+    Some(&TagValue::Str("Off".into()))
+  );
+  // -n keeps DigitalZoomRatio identical (no PrintConv).
+  let em_n = parse_tag2010c(&p, false);
+  assert_eq!(find(&em_n, "DigitalZoomRatio"), Some(&TagValue::F64(1.5)));
+}
+
+// --- Tag2010d (no ExposureCompensation / Quality2) ---------------------------
+
+#[test]
+fn tag2010d_offsets_and_absent_rows() {
+  let mut p = vec![0u8; 0x1280];
+  p[0x1180] = 1; // ReleaseMode3 → Continuous
+  put_u16(&mut p, 0x1196, 512); // StopsAboveBaseISO → 14.0
+  p[0x11d0] = 0; // MeteringMode → Multi-segment
+  p[0x11d1] = 2; // ExposureProgram
+  put_u16(&mut p, 0x1270, 2048); // SonyISO → 25600
+  let em = parse_tag2010d(&p, true);
+  assert_eq!(
+    find(&em, "ReleaseMode3"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "StopsAboveBaseISO"),
+    Some(&TagValue::Str("14.0".into()))
+  );
+  assert_eq!(
+    find(&em, "MeteringMode"),
+    Some(&TagValue::Str("Multi-segment".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  // Tag2010d has NO ExposureCompensation / Quality2 rows.
+  assert!(find(&em, "ExposureCompensation").is_none());
+  assert!(find(&em, "Quality2").is_none());
+}
+
+// --- Tag2010f (ReleaseMode2 @0x0004, focal lengths, aspect ratio) ------------
+
+#[test]
+fn tag2010f_focal_and_aspect() {
+  let mut p = vec![0u8; 0x1940];
+  put_u32(&mut p, 0x0004, 1); // ReleaseMode2 (int32u, NOT at 0x08) → Continuous
+  put_u16(&mut p, 0x1134, 240); // FocalLength → 24.0 mm
+  put_u16(&mut p, 0x1136, 100); // MinFocalLength → 10.0 mm
+  put_u16(&mut p, 0x1138, 0); // MaxFocalLength → 0.0 mm (no RawConv drop in f)
+  put_u16(&mut p, 0x113c, 2048); // SonyISO → 25600
+  p[0x192c] = 2; // AspectRatio → 3:2
+  let em = parse_tag2010f(&p, true);
+  // The int32u ReleaseMode2 (0x0004) is the FIRST of two same-named rows (the
+  // int8u 0x1018 follows; the sink keeps it last-wins).
+  assert_eq!(
+    find_first(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(
+    find(&em, "MinFocalLength"),
+    Some(&TagValue::Str("10.0 mm".into()))
+  );
+  assert_eq!(
+    find(&em, "MaxFocalLength"),
+    Some(&TagValue::Str("0.0 mm".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("3:2".into())));
+
+  let em_n = parse_tag2010f(&p, false);
+  assert_eq!(find(&em_n, "FocalLength"), Some(&TagValue::I64(24)));
+  assert_eq!(find(&em_n, "MaxFocalLength"), Some(&TagValue::I64(0)));
+}
+
+// --- shared-conversion edges -------------------------------------------------
+
+/// `StopsAboveBaseISO` ValueConv of exactly 0 prints the bare integer `0`;
+/// `ExposureCompensation` of 0 prints `0`, a negative `int16s` prints `-X.X`.
+#[test]
+fn gain_zero_and_exposure_comp_signs() {
+  let mut p = vec![0u8; 0x1190];
+  put_u16(&mut p, 0x113e, 4096); // StopsAboveBaseISO = 16 - 16 = 0 → bare 0
+  put_i16(&mut p, 0x114c, 256); // ExposureCompensation = -256/256 = -1.0
+  let em = parse_tag2010a(&p, true);
+  assert_eq!(find(&em, "StopsAboveBaseISO"), Some(&TagValue::I64(0)));
+  assert_eq!(
+    find(&em, "ExposureCompensation"),
+    Some(&TagValue::Str("-1.0".into()))
+  );
+
+  // ExposureCompensation = 0 → bare integer 0 (both modes).
+  let zero = vec![0u8; 0x1190];
+  let em0 = parse_tag2010a(&zero, true);
+  assert_eq!(find(&em0, "ExposureCompensation"), Some(&TagValue::I64(0)));
+}
+
+/// `%pictureProfile2010` is the FULL hash — value 37 → "FL" (which `Tag9416`'s
+/// truncated copy lacks); value 2 has no label → a miss.
+#[test]
+fn picture_profile_full_hash() {
+  let mut p = vec![0u8; 0x1190];
+  p[0x115f] = 37; // FL
+  let em = parse_tag2010a(&p, true);
+  assert_eq!(
+    find(&em, "PictureProfile"),
+    Some(&TagValue::Str("FL".into()))
+  );
+
+  let mut p2 = vec![0u8; 0x1190];
+  p2[0x115e] = 2; // no label
+  p2[0x115f] = 2;
+  let em2 = parse_tag2010a(&p2, true);
+  assert_eq!(
+    find(&em2, "PictureProfile"),
+    Some(&TagValue::Str("Unknown (2)".into()))
+  );
+}
+
+/// Per-field availability: a buffer ending before an offset emits the earlier
+/// leaves only; an empty buffer emits nothing.
+#[test]
+fn per_field_truncation() {
+  let mut p = vec![0u8; 0x1140]; // ends just before BrightnessValue (0x1140)
+  p[0x1128] = 1; // ReleaseMode3
+  put_u16(&mut p, 0x113e, 512); // StopsAboveBaseISO
+  let em = parse_tag2010a(&p, true);
+  assert!(find(&em, "ReleaseMode3").is_some());
+  assert!(find(&em, "StopsAboveBaseISO").is_some());
+  assert!(find(&em, "BrightnessValue").is_none()); // 0x1140 out of range
+  assert!(find(&em, "WB_RGBLevels").is_none());
+
+  assert!(parse_tag2010a(&[], true).is_empty());
+  assert!(parse_tag2010b(&[], true).is_empty());
+  assert!(parse_tag2010c(&[], true).is_empty());
+  assert!(parse_tag2010d(&[], true).is_empty());
+  assert!(parse_tag2010f(&[], true).is_empty());
+}

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12380,6 +12380,13 @@ pub(in crate::exif) fn sony_makernote_isolated(
   // 0x9400 < 0x9402 in IFD-tag order, so this is observed BEFORE the 0x9402 entry
   // that consumes it — the same set-on-9400/read-on-9402 object-flag ordering.
   let mut double_cipher = false;
+  // `$$self{Panorama}` (`Sony.pm:902`) — ASSIGNED as a SIDE EFFECT of the `0x1003`
+  // `Panorama` SubDirectory `Condition` (`$$self{Panorama} = ($$valPt =~
+  // /^(\0\0)?\x01\x01/)`): each readable 0x1003 re-evaluates it to the match result
+  // (true for a little-/big-endian int32u 257, false otherwise), last-wins.
+  // `0x1003 < 0x2010` in IFD-tag order, so it is observed BEFORE the `0x2010` entry
+  // whose `Tag2010d` dispatch (`Sony.pm:1140-1145`) gates on `not Panorama`.
+  let mut panorama = false;
   {
     let mut sink = VendorEmissionSink::new(&mut emissions);
     for entry in &w.entries {
@@ -12398,6 +12405,21 @@ pub(in crate::exif) fn sony_makernote_isolated(
         && sony::tag9400::detects_double_cipher(raw)
       {
         double_cipher = true;
+      }
+      // 0x1003's `Panorama` Condition side-effect (`Sony.pm:902`): the Perl
+      // `Condition` is an ASSIGNMENT — `$$self{Panorama} = ($$valPt =~
+      // /^(\0\0)?\x01\x01/)` — so EACH readable 0x1003 RE-EVALUATES the flag to the
+      // match RESULT (true on a little-/big-endian int32u 257, FALSE otherwise),
+      // NOT a one-way latch: a later non-matching 0x1003 CLEARS an earlier match, so
+      // the LAST 0x1003 before 0x2010 controls the `Tag2010d` `not $$self{Panorama}`
+      // gate. An unreadable/absent 0x1003 leaves the flag untouched — ExifTool only
+      // evaluates the `Condition` (and so only assigns) when the value is read.
+      // 0x1003 precedes 0x2010 in IFD-tag order.
+      if entry.tag_id == 0x1003
+        && let Some(end) = entry.value_offset().checked_add(entry.value_size())
+        && let Some(raw) = data.get(entry.value_offset()..end)
+      {
+        panorama = sony::tag2010::detects_panorama(raw);
       }
       // Only `ResolvedConv::Sony` entries live in this run; the resolved `SonyTag`
       // rides in the entry's `conv`. A defensive non-Sony conv (never produced
@@ -12431,6 +12453,7 @@ pub(in crate::exif) fn sony_makernote_isolated(
         model,
         software,
         double_cipher,
+        panorama,
         print_conv,
         &mut sink,
       );
@@ -12540,8 +12563,9 @@ fn sony_emit_binary_subdir<S: ExifSink>(
 }
 
 /// Decode a Sony Main-IFD `ProcessBinaryData` SubDirectory sub-block
-/// (`0x9050`/`0x9400`/`0x9401`/`0x9402`/`0x9403`/`0x9404`/`0x9406`/`0x940a`/
-/// `0x940c`/`0x940e`/`0x9416`/`0x202a`) and emit its ported leaves into `sink`.
+/// (`0x2010`/`0x9050`/`0x9400`/`0x9401`/`0x9402`/`0x9403`/`0x9404`/`0x9406`/
+/// `0x940a`/`0x940c`/`0x940e`/`0x9416`/`0x202a`) and emit its ported leaves into
+/// `sink`.
 ///
 /// `entry` is the Sony Main-IFD SubDirectory row; its verbatim on-disk value
 /// bytes are `data[value_offset .. value_offset + value_size]`. Most of these
@@ -12570,6 +12594,11 @@ fn sony_emit_binary_subdir<S: ExifSink>(
 /// `PROCESS_PROC` for all of them, so on a double-enciphered body ISOInfo/
 /// battery/lens/camera-settings would otherwise be read from once-deciphered
 /// garbage.
+///
+/// `panorama` is the file-global `$$self{Panorama}` DataMember (`Sony.pm:902`,
+/// latched on the earlier 0x1003 walk); it gates the `0x2010` `Tag2010d` variant
+/// (`Sony.pm:1140-1145`). `0x2010` is enciphered too, but precedes 0x9400 in
+/// IFD-tag order, so `double_cipher` is normally unset when its block is read.
 fn sony_emit_enciphered_subblock<S: ExifSink>(
   data: &[u8],
   group1: &str,
@@ -12577,13 +12606,14 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
   model: Option<&str>,
   software: Option<&str>,
   double_cipher: bool,
+  panorama: bool,
   print_conv: bool,
   out: &mut S,
 ) {
   use makernotes::vendors::sony::decipher::process_enciphered;
   use makernotes::vendors::sony::{
-    afinfo, tag202a, tag900b, tag940a, tag940c, tag940e, tag9050, tag9400, tag9401, tag9402,
-    tag9403, tag9404, tag9405, tag9406, tag9416,
+    afinfo, tag202a, tag900b, tag940a, tag940c, tag940e, tag2010, tag9050, tag9400, tag9401,
+    tag9402, tag9403, tag9404, tag9405, tag9406, tag9416,
   };
   // The verbatim on-disk value span (the enciphered cipher block, or the plain
   // `Tag202a` bytes) — the same buffer the walk read, sliced at the entry's
@@ -12604,6 +12634,55 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
   // are correctly (double-)deciphered. `0x202a` is the lone plain block and is
   // never deciphered.
   match entry.tag_id() {
+    // `Tag2010a`/`b`/`c`/`d`/`f` — the enciphered `0x2010` shot-info / WB block
+    // (release / self-timer / flash, gain / brightness / exposure-comp, DRO / HDR
+    // / PictureProfile / PictureEffect, metering / exposure program, WB_RGBLevels,
+    // SonyISO, distortion params, + DSC focal-length / aspect-ratio). The variant
+    // is selected by the EXACT (`$`-anchored) `$$self{Model}` (`Sony.pm:1100-1173`).
+    // The LARGER `e`/`g`/`h`/`i` variants are not yet ported, so their bodies (and
+    // any unknown one) fall through to `Tag_0x2010` (`%unknownCipherData`, emits
+    // nothing) — faithful until they are ported. `Tag2010d` additionally requires
+    // `not $$self{Panorama}` (the `0x1003` DataMember latched earlier in the walk).
+    // Every `Tag2010x` table is `PRIORITY => 0` (`Sony.pm:6473` etc.), so each leaf
+    // rides priority 0 (never overrides an earlier same-name duplicate). `0x2010 <
+    // 0x9400` in IFD-tag order, so `double_cipher` is normally unset at this point
+    // (ExifTool single-deciphers `0x2010`); it is threaded for consistency and to
+    // honor ExifTool's encounter-order `DoubleCipher` semantics.
+    0x2010 if tag2010::selects_tag2010a(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010a(&buf, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010b(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010b(&buf, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010c(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010c(&buf, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010d(model, panorama) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010d(&buf, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010f(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010f(&buf, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
     // `Tag9050c` — selected by model (`Sony.pm:1810`).
     0x9050 if sony_tag9050c_model(model) => {
       let buf = process_enciphered(raw, double_cipher);
@@ -22718,6 +22797,92 @@ mod tests {
         out.is_none(),
         "print_conv={print_conv}: a SEMC (SonyEricsson) blob with a non-`^SONY` Make \
          routes away from %Sony::Main ⇒ sony_makernote_isolated must return None"
+      );
+    }
+  }
+
+  /// `$$self{Panorama}` (`Sony.pm:902`) is an ASSIGNMENT, not a one-way latch:
+  /// `Condition => '$$self{Panorama} = ($$valPt =~ /^(\0\0)?\x01\x01/)'` RE-EVALUATES
+  /// the flag on EVERY readable `0x1003`, so a later non-matching `0x1003` CLEARS an
+  /// earlier match. A duplicate / out-of-order MakerNote whose LAST `0x1003` before
+  /// `0x2010` is non-matching must leave `Panorama` FALSE — so the `Tag2010d`
+  /// `not $$self{Panorama}` gate (`Sony.pm:1140-1145`) passes and the enciphered
+  /// `0x2010` block decodes as `Tag2010d` (its `SequenceImageNumber` leaf appears).
+  /// Before the fix the OR-latch kept a stale `true` and `0x2010` fell through to
+  /// `%unknownCipherData`, emitting nothing. Model `DSC-HX10V` selects `Tag2010d`.
+  #[test]
+  #[cfg(feature = "alloc")]
+  fn sony_isolated_last_0x1003_non_match_clears_panorama_decodes_tag2010d() {
+    // Two `0x1003` (Panorama) entries before `0x2010`: the FIRST matches (LE int32u
+    // 257 ⇒ `\x01\x01..`), the SECOND is all-zero (non-match) ⇒ the last assignment
+    // CLEARS `Panorama`. The `0x2010` value is a 16-byte all-zero cipher block:
+    // decipher is a per-byte substitution with `0x00 ↦ 0x00`, so the plaintext is
+    // all-zero and `parse_tag2010d` emits `SequenceImageNumber` (u32 @0x0000 + 1).
+    let zero_2010 = [0u8; 0x10];
+    let entries: &[(u16, u16, u32, &[u8], &[u8])] = &[
+      (0x1003, 7, 4, &[0x01, 0x01, 0x00, 0x00], &[]), // matches → Panorama = true
+      (0x1003, 7, 4, &[0x00, 0x00, 0x00, 0x00], &[]), // non-match → CLEARS to false
+      (0x2010, 7, 0x10, &[], &zero_2010),
+    ];
+    let blob = crafted_sony_blob(entries);
+    for print_conv in [true, false] {
+      let (emissions, _typed) = sony_makernote_isolated(
+        &blob,
+        0,
+        blob.len(),
+        12,
+        ByteOrder::Little,
+        Some("SONY"),
+        Some("DSC-HX10V"),
+        None,
+        print_conv,
+      )
+      .expect("the SONY DSC prefix routes to %Sony::Main");
+      assert!(
+        emissions.iter().any(|e| e.name() == "SequenceImageNumber"),
+        "pc={print_conv}: the LAST 0x1003 before 0x2010 is non-matching ⇒ Panorama=false \
+         ⇒ Tag2010d decodes (SequenceImageNumber present); the OR-latch bug kept a stale \
+         true and suppressed it. emitted: {:?}",
+        emissions.iter().map(|e| e.name()).collect::<Vec<_>>()
+      );
+    }
+  }
+
+  /// The reverse: the LAST `0x1003` before `0x2010` MATCHES (a panorama image), so
+  /// the assignment SETS `Panorama` true and the `Tag2010d` `not $$self{Panorama}`
+  /// gate FAILS — the `0x2010` block falls through to `%unknownCipherData` and emits
+  /// no `Tag2010d` leaf. Pins that the assignment honors a trailing match as well as
+  /// a trailing clear, not just last-wins in one direction. (This direction holds
+  /// under BOTH the buggy latch and the fix — the leading non-match never set the
+  /// flag — so it guards the symmetric case alongside the discriminating test above.)
+  #[test]
+  #[cfg(feature = "alloc")]
+  fn sony_isolated_last_0x1003_match_sets_panorama_suppresses_tag2010d() {
+    let zero_2010 = [0u8; 0x10];
+    let entries: &[(u16, u16, u32, &[u8], &[u8])] = &[
+      (0x1003, 7, 4, &[0x00, 0x00, 0x00, 0x00], &[]), // non-match
+      (0x1003, 7, 4, &[0x01, 0x01, 0x00, 0x00], &[]), // matches → SETS Panorama = true
+      (0x2010, 7, 0x10, &[], &zero_2010),
+    ];
+    let blob = crafted_sony_blob(entries);
+    for print_conv in [true, false] {
+      let (emissions, _typed) = sony_makernote_isolated(
+        &blob,
+        0,
+        blob.len(),
+        12,
+        ByteOrder::Little,
+        Some("SONY"),
+        Some("DSC-HX10V"),
+        None,
+        print_conv,
+      )
+      .expect("the SONY DSC prefix routes to %Sony::Main");
+      assert!(
+        !emissions.iter().any(|e| e.name() == "SequenceImageNumber"),
+        "pc={print_conv}: the LAST 0x1003 before 0x2010 matches ⇒ Panorama=true ⇒ Tag2010d \
+         is gated OFF (no SequenceImageNumber). emitted: {:?}",
+        emissions.iter().map(|e| e.name()).collect::<Vec<_>>()
       );
     }
   }


### PR DESCRIPTION
Advances #97 (Sony color-data). Ports the **Tag2010 0x2010 dispatcher + variants a/b/c/d/f** faithfully from ExifTool 13.59 Sony.pm (the smaller half of the 9-variant series). Mirrors the merged 0x9405 cipher dispatch.

- **Variant selectors** model-exact (a=NEX-5N; b=SLT-A65/77V/NEX-7/VG20E/Lunar; c=SLT-A37/57/NEX-F3; d=DSC-HX/TX/WX **AND not-Panorama**; f=DSC-RX100M2/QX10/QX100); e/g/h/i correctly fall through to the unknown table until chunk 2.
- **Panorama DataMember** threaded from the 0x1003 walk (0x1003 < 0x2010 in tag order) as a faithful **assignment** (each readable 0x1003 re-evaluates, last-wins — matching Sony.pm:902), gating variant d.
- Reuses shared 2010 hashes (releaseMode2, exposureProgram2010); ports the **full** PictureProfile (tag9416's copy truncates it), ReleaseMode3/DRO/HDR/etc; PRIORITY 0; ExposureTime rational emits /.

**Fixtureless** (the 3 active raws match no a-i model), validated by **no-regression (conformance 498/0 byte-identical)** + **15 unit tests** vs Sony.pm. `build(-Dwarnings)=0 alloc_budget=ok conformance=498/0 typed_serde=1/0 timed=161/0 lib=4119/0 xtask=26`. **Codex: APPROVE** (R2 — the Panorama assign-not-latch fix). **Remaining on #97:** Tag2010 **e/g/h/i** (chunk 2). Memory-amplification → #443.