### PR TITLE
feat(sony): port Tag2010e/g/h/i sub-tables — completes #97

### DIFF
--- a/src/exif/makernotes/vendors/sony/tag2010.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010.rs
@@ -26,15 +26,17 @@
 //! - `Tag2010g` — `/^(DSC-(QX30|RX10|RX100M3|HX60V|HX350|HX400V|WX220|WX350)|`
 //!   `ILCE-(7(R|S|M2)?|[56]000|5100|QX1)|ILCA-(68|77M2))\b/` (`Sony.pm:1159-1161`).
 //!   The `\b` (NOT `$`) means a bare `ILCE-7` does not swallow `ILCE-7RM2`.
-//! - `Tag2010h`/`i` (`Sony.pm:1162-1169`) — the remaining LARGE variants, not yet
-//!   ported: those bodies (and any unknown one) fall through to `Tag_0x2010`
-//!   (`%unknownCipherData`, emits nothing), faithful until they are ported.
+//! - `Tag2010h` — `/^(DSC-(RX0|RX1RM2|RX10M2|RX10M3|RX100M4|RX100M5|HX80|HX90V?|`
+//!   `WX500)|ILCE-(6300|6500|7RM2|7SM2)|ILCA-99M2)\b/` (`Sony.pm:1162-1164`).
+//! - `Tag2010i` (`Sony.pm:1166-1169`) — the last LARGE variant, not yet ported:
+//!   that body (and any unknown one) falls through to `Tag_0x2010`
+//!   (`%unknownCipherData`, emits nothing), faithful until it is ported.
 //! - else `Tag_0x2010` (`%unknownCipherData`) — emits nothing.
 //!
-//! The `a`-`f` model sets are pairwise disjoint and disjoint from `g`'s
-//! `\b`-anchored set, so the dispatcher tests `a`/`b`/`c`/`d`/`e`/`f`/`g`
-//! independently; a body matching `h`/`i` matches none of them and correctly
-//! falls to the unknown branch.
+//! The `a`-`f` model sets are pairwise disjoint and disjoint from the
+//! `\b`-anchored `g`/`h` sets, so the dispatcher tests
+//! `a`/`b`/`c`/`d`/`e`/`f`/`g`/`h` independently; a body matching `i` matches
+//! none of them and correctly falls to the unknown branch.
 //!
 //! ## Cipher + priority + availability
 //!
@@ -53,12 +55,13 @@
 //! used"), so it is NOT emitted in default output and is skipped here.
 //!
 //! The `a`/`b`/`c`/`d`/`f` tables have NO per-leaf model `Condition`s; their
-//! model gate lives entirely in the dispatcher. `Tag2010e`/`g` (like `Tag9405b`)
-//! DO carry per-leaf `Condition`s — for `e` the `\b`-anchored SonyISO /
-//! FocalLength offset sets and the two mutually-exclusive `AspectRatio` offsets;
-//! for both, the `LensFormat`/`LensMount`/`DistortionCorr*` DSC(-or-Stellar)
-//! exclusions and the `LensType2`/`LensType` `LensMount`-DataMember gates — so
-//! `parse_tag2010e`/`g` take the resolved `$$self{Model}`.
+//! model gate lives entirely in the dispatcher. `Tag2010e`/`g`/`h` (like
+//! `Tag9405b`) DO carry per-leaf `Condition`s — for `e` the `\b`-anchored SonyISO
+//! / FocalLength offset sets and the two mutually-exclusive `AspectRatio`
+//! offsets; for all three, the `LensFormat`/`LensMount`/`DistortionCorr*`
+//! DSC(-or-Stellar) exclusions and the `LensType2`/`LensType`
+//! `LensMount`-DataMember gates — so `parse_tag2010e`/`g`/`h` take the resolved
+//! `$$self{Model}`.
 
 use super::{amount_lens_types, lens_types};
 use crate::value::{TagValue, whole_f64_to_tag_value};
@@ -246,6 +249,35 @@ pub fn selects_tag2010g(model: Option<&str>) -> bool {
   )
 }
 
+/// `Sony.pm:1164`
+/// `/^(DSC-(RX0|RX1RM2|RX10M2|RX10M3|RX100M4|RX100M5|HX80|HX90V?|WX500)|`
+/// `ILCE-(6300|6500|7RM2|7SM2)|ILCA-99M2)\b/` — selects `Tag2010h`. The `\b`
+/// keeps `DSC-RX0` from swallowing `DSC-RX0M2` and `DSC-RX100M5` from swallowing
+/// `DSC-RX100M5A` (`Tag2010i` models); `HX90V?` expands to `DSC-HX90`/`-HX90V`.
+#[must_use]
+pub fn selects_tag2010h(model: Option<&str>) -> bool {
+  super::tag9405::starts_with_word_boundary(
+    model,
+    &[
+      "DSC-RX0",
+      "DSC-RX1RM2",
+      "DSC-RX10M2",
+      "DSC-RX10M3",
+      "DSC-RX100M4",
+      "DSC-RX100M5",
+      "DSC-HX80",
+      "DSC-HX90",
+      "DSC-HX90V",
+      "DSC-WX500",
+      "ILCE-6300",
+      "ILCE-6500",
+      "ILCE-7RM2",
+      "ILCE-7SM2",
+      "ILCA-99M2",
+    ],
+  )
+}
+
 /// `$$self{Panorama} = ($$valPt =~ /^(\0\0)?\x01\x01/)` (`Sony.pm:902`) — the
 /// `0x1003` `Panorama` SubDirectory `Condition` DataMember side-effect: a raw
 /// value that begins with `\x01\x01` (little-endian int32u 257) or
@@ -414,6 +446,18 @@ fn aspect_ratio_print(v: u8) -> Option<&'static str> {
     2 => "3:2",
     3 => "1:1",
     5 => "Panorama",
+    _ => return None,
+  })
+}
+
+/// `%selfTimerB2010` `SelfTimer` (`Sony.pm:6266-6273`) — the `Tag2010h`/`i`
+/// variant where value `1` is "Self-timer 5 or 10 s" (the new 5 s mode), vs
+/// `%selfTimer2010`'s "Self-timer 10 s".
+fn self_timer_b_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    0 => "Off",
+    1 => "Self-timer 5 or 10 s",
+    2 => "Self-timer 2 s",
     _ => return None,
   })
 }
@@ -1836,6 +1880,214 @@ pub fn parse_tag2010g(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<
   push_u8_hash(
     buf,
     0x1958,
+    "AspectRatio",
+    print_conv,
+    aspect_ratio_print,
+    &mut out,
+  );
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010h` block (`Sony.pm:7121-7268`).
+///
+/// Structurally `Tag2010g` with: `SelfTimer` via `%selfTimerB2010` (value `1` =
+/// "Self-timer 5 or 10 s"), `SonyISO` at 0x0346, the lens / distortion rows at
+/// 0x18cc-0x18f5, and `AspectRatio` at 0x192c. `model` drives the
+/// `Model !~ /^DSC-/` exclusions + the `LensMount` gate; `print_conv` selects
+/// `-j`/`-n`.
+#[must_use]
+pub fn parse_tag2010h(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<Tag2010Emission> {
+  use super::tag9405::{model_is_dsc, print_lens_format, print_lens_mount, print_no_yes};
+  let mut out = std::vec::Vec::new();
+  let not_dsc = !model_is_dsc(model);
+
+  push_release_mode2_u32(buf, 0x0004, "ReleaseMode2", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x0050,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x020c,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0210,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0218,
+    "SelfTimer",
+    print_conv,
+    self_timer_b_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x021c,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x0222, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x0224, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x0228,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x022c,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x0230, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x0246,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0247,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x024b,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0258,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x025c,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x025d,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x0264, 3, "WB_RGBLevels", &mut out);
+  push_focal_length(buf, 0x032c, "FocalLength", print_conv, &mut out);
+  push_focal_length(buf, 0x032e, "MinFocalLength", print_conv, &mut out);
+  push_focal_length_nonzero(buf, 0x0330, "MaxFocalLength", print_conv, &mut out);
+  push_sony_iso(buf, 0x0346, "SonyISO", print_conv, &mut out);
+  // 0x0388 / 0x0398 MeterInfo (Unknown SubDirectory, model-conditioned) — skipped.
+  // 0x18cc DistortionCorrParams int16s[16] — Condition Model !~ /^DSC-/.
+  if not_dsc {
+    push_i16_array(buf, 0x18cc, 16, "DistortionCorrParams", &mut out);
+  }
+  // 0x18ed LensFormat — same Condition.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18ed,
+      "LensFormat",
+      print_conv,
+      print_lens_format,
+      &mut out,
+    );
+  }
+  // 0x18ee LensMount — DataMember (raw always latched, drives LensType2/LensType);
+  // the tag is emitted iff Model !~ /^DSC-/.
+  let lens_mount = buf.get(0x18ee).copied();
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18ee,
+      "LensMount",
+      print_conv,
+      print_lens_mount,
+      &mut out,
+    );
+  }
+  // 0x18ef LensType2 — Condition LensMount == 2 (E-mount, %sonyLensTypes2).
+  push_lens_type(
+    buf,
+    0x18ef,
+    "LensType2",
+    lens_mount == Some(2),
+    lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x18f2 LensType — Condition LensMount == 1 (A-mount, %sonyLensTypes).
+  push_lens_type(
+    buf,
+    0x18f2,
+    "LensType",
+    lens_mount == Some(1),
+    amount_lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x18f4 DistortionCorrParamsPresent — Condition Model !~ /^DSC-/.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18f4,
+      "DistortionCorrParamsPresent",
+      print_conv,
+      print_no_yes,
+      &mut out,
+    );
+  }
+  // 0x18f5 DistortionCorrParamsNumber — same Condition.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18f5,
+      "DistortionCorrParamsNumber",
+      print_conv,
+      distortion_corr_params_number_print,
+      &mut out,
+    );
+  }
+  push_u8_hash(
+    buf,
+    0x192c,
     "AspectRatio",
     print_conv,
     aspect_ratio_print,

--- a/src/exif/makernotes/vendors/sony/tag2010.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010.rs
@@ -11,7 +11,8 @@
 //! ## Variant dispatch
 //!
 //! The `0x2010` Main-table row is a conditional-ARRAY SubDirectory dispatcher
-//! (`Sony.pm:1100-1173`) selected by the EXACT (`$`-anchored) `$$self{Model}`:
+//! (`Sony.pm:1100-1173`) selected by `$$self{Model}` — the `a`-`f` rows are
+//! `$`-anchored EXACT matches, the `g`/`h`/`i` rows `\b`-anchored prefix sets:
 //!
 //! - `Tag2010a` — `/^NEX-5N$/` (`Sony.pm:1128`).
 //! - `Tag2010b` — `/^(SLT-A(65|77)V?|NEX-(7|VG20E)|Lunar)$/` (`Sony.pm:1132`).
@@ -28,15 +29,15 @@
 //!   The `\b` (NOT `$`) means a bare `ILCE-7` does not swallow `ILCE-7RM2`.
 //! - `Tag2010h` — `/^(DSC-(RX0|RX1RM2|RX10M2|RX10M3|RX100M4|RX100M5|HX80|HX90V?|`
 //!   `WX500)|ILCE-(6300|6500|7RM2|7SM2)|ILCA-99M2)\b/` (`Sony.pm:1162-1164`).
-//! - `Tag2010i` (`Sony.pm:1166-1169`) — the last LARGE variant, not yet ported:
-//!   that body (and any unknown one) falls through to `Tag_0x2010`
-//!   (`%unknownCipherData`, emits nothing), faithful until it is ported.
-//! - else `Tag_0x2010` (`%unknownCipherData`) — emits nothing.
+//! - `Tag2010i` — `/^(ILCE-(6100A?|6400A?|6600|7C|7M3|7RM3A?|7RM4A?|9|9M2)|`
+//!   `DSC-(RX10M4|RX100M6|RX100M5A|RX100M7A?|HX95|HX99|RX0M2)|`
+//!   `ZV-(1[AF]?|1M2|E10))\b/` (`Sony.pm:1166-1169`).
+//! - else `Tag_0x2010` (`%unknownCipherData`) — an unknown / newer body, emits
+//!   nothing (faithful: ExifTool's `%unknownCipherData` extracts nothing either).
 //!
 //! The `a`-`f` model sets are pairwise disjoint and disjoint from the
-//! `\b`-anchored `g`/`h` sets, so the dispatcher tests
-//! `a`/`b`/`c`/`d`/`e`/`f`/`g`/`h` independently; a body matching `i` matches
-//! none of them and correctly falls to the unknown branch.
+//! `\b`-anchored `g`/`h`/`i` sets, so the dispatcher tests every variant
+//! (`a`..`i`) independently; a body matching none falls to the unknown branch.
 //!
 //! ## Cipher + priority + availability
 //!
@@ -55,13 +56,13 @@
 //! used"), so it is NOT emitted in default output and is skipped here.
 //!
 //! The `a`/`b`/`c`/`d`/`f` tables have NO per-leaf model `Condition`s; their
-//! model gate lives entirely in the dispatcher. `Tag2010e`/`g`/`h` (like
+//! model gate lives entirely in the dispatcher. `Tag2010e`/`g`/`h`/`i` (like
 //! `Tag9405b`) DO carry per-leaf `Condition`s — for `e` the `\b`-anchored SonyISO
 //! / FocalLength offset sets and the two mutually-exclusive `AspectRatio`
-//! offsets; for all three, the `LensFormat`/`LensMount`/`DistortionCorr*`
+//! offsets; for all four, the `LensFormat`/`LensMount`/`DistortionCorr*`
 //! DSC(-or-Stellar) exclusions and the `LensType2`/`LensType`
-//! `LensMount`-DataMember gates — so `parse_tag2010e`/`g`/`h` take the resolved
-//! `$$self{Model}`.
+//! `LensMount`-DataMember gates — so `parse_tag2010e`/`g`/`h`/`i` take the
+//! resolved `$$self{Model}`.
 
 use super::{amount_lens_types, lens_types};
 use crate::value::{TagValue, whole_f64_to_tag_value};
@@ -274,6 +275,47 @@ pub fn selects_tag2010h(model: Option<&str>) -> bool {
       "ILCE-7RM2",
       "ILCE-7SM2",
       "ILCA-99M2",
+    ],
+  )
+}
+
+/// `Sony.pm:1168`
+/// `/^(ILCE-(6100A?|6400A?|6600|7C|7M3|7RM3A?|7RM4A?|9|9M2)|`
+/// `DSC-(RX10M4|RX100M6|RX100M5A|RX100M7A?|HX95|HX99|RX0M2)|`
+/// `ZV-(1[AF]?|1M2|E10))\b/` — selects `Tag2010i`. The `A?`/`[AF]?` optionals
+/// expand to their base + suffixed stems (`ILCE-9`/`-9M2`, `ZV-1`/`-1A`/`-1F`);
+/// the `\b` boundary distinguishes e.g. `ILCE-9` from `ILCE-9M2`.
+#[must_use]
+pub fn selects_tag2010i(model: Option<&str>) -> bool {
+  super::tag9405::starts_with_word_boundary(
+    model,
+    &[
+      "ILCE-6100",
+      "ILCE-6100A",
+      "ILCE-6400",
+      "ILCE-6400A",
+      "ILCE-6600",
+      "ILCE-7C",
+      "ILCE-7M3",
+      "ILCE-7RM3",
+      "ILCE-7RM3A",
+      "ILCE-7RM4",
+      "ILCE-7RM4A",
+      "ILCE-9",
+      "ILCE-9M2",
+      "DSC-RX10M4",
+      "DSC-RX100M6",
+      "DSC-RX100M5A",
+      "DSC-RX100M7",
+      "DSC-RX100M7A",
+      "DSC-HX95",
+      "DSC-HX99",
+      "DSC-RX0M2",
+      "ZV-1",
+      "ZV-1A",
+      "ZV-1F",
+      "ZV-1M2",
+      "ZV-E10",
     ],
   )
 }
@@ -2088,6 +2130,215 @@ pub fn parse_tag2010h(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<
   push_u8_hash(
     buf,
     0x192c,
+    "AspectRatio",
+    print_conv,
+    aspect_ratio_print,
+    &mut out,
+  );
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010i` block (`Sony.pm:7270-7405`).
+///
+/// `Tag2010h` repacked at lower offsets: the scalar block is at 0x004e-0x0252
+/// (note `Quality2` is at 0x0247, where `g`/`h` had a second `PictureProfile`),
+/// FocalLength / SonyISO at 0x030a-0x0320, the lens / distortion rows at
+/// 0x17d0-0x17f9, and `AspectRatio` at 0x188c. `SelfTimer` is `%selfTimerB2010`.
+/// `model` drives the `Model !~ /^DSC-/` exclusions + the `LensMount` gate;
+/// `print_conv` selects `-j`/`-n`.
+#[must_use]
+pub fn parse_tag2010i(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<Tag2010Emission> {
+  use super::tag9405::{model_is_dsc, print_lens_format, print_lens_mount, print_no_yes};
+  let mut out = std::vec::Vec::new();
+  let not_dsc = !model_is_dsc(model);
+
+  push_release_mode2_u32(buf, 0x0004, "ReleaseMode2", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x004e,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0204,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0208,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0210,
+    "SelfTimer",
+    print_conv,
+    self_timer_b_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0211,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x0217, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x0219, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x021b,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x021f,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x0223, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x0237,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0238,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x023c,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0247,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x024b,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x024c,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x0252, 3, "WB_RGBLevels", &mut out);
+  push_focal_length(buf, 0x030a, "FocalLength", print_conv, &mut out);
+  push_focal_length(buf, 0x030c, "MinFocalLength", print_conv, &mut out);
+  push_focal_length_nonzero(buf, 0x030e, "MaxFocalLength", print_conv, &mut out);
+  push_sony_iso(buf, 0x0320, "SonyISO", print_conv, &mut out);
+  // 0x036d MeterInfo (Unknown SubDirectory, MeterInfo9) — skipped.
+  // 0x17d0 DistortionCorrParams int16s[16] — Condition Model !~ /^DSC-/.
+  if not_dsc {
+    push_i16_array(buf, 0x17d0, 16, "DistortionCorrParams", &mut out);
+  }
+  // 0x17f1 LensFormat — same Condition.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x17f1,
+      "LensFormat",
+      print_conv,
+      print_lens_format,
+      &mut out,
+    );
+  }
+  // 0x17f2 LensMount — DataMember (raw always latched, drives LensType2/LensType);
+  // the tag is emitted iff Model !~ /^DSC-/.
+  let lens_mount = buf.get(0x17f2).copied();
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x17f2,
+      "LensMount",
+      print_conv,
+      print_lens_mount,
+      &mut out,
+    );
+  }
+  // 0x17f3 LensType2 — Condition LensMount == 2 (E-mount, %sonyLensTypes2).
+  push_lens_type(
+    buf,
+    0x17f3,
+    "LensType2",
+    lens_mount == Some(2),
+    lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x17f6 LensType — Condition LensMount == 1 (A-mount, %sonyLensTypes).
+  push_lens_type(
+    buf,
+    0x17f6,
+    "LensType",
+    lens_mount == Some(1),
+    amount_lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x17f8 DistortionCorrParamsPresent — Condition Model !~ /^DSC-/.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x17f8,
+      "DistortionCorrParamsPresent",
+      print_conv,
+      print_no_yes,
+      &mut out,
+    );
+  }
+  // 0x17f9 DistortionCorrParamsNumber — same Condition.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x17f9,
+      "DistortionCorrParamsNumber",
+      print_conv,
+      distortion_corr_params_number_print,
+      &mut out,
+    );
+  }
+  push_u8_hash(
+    buf,
+    0x188c,
     "AspectRatio",
     print_conv,
     aspect_ratio_print,

--- a/src/exif/makernotes/vendors/sony/tag2010.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010.rs
@@ -23,15 +23,18 @@
 //!   `/^(DSC-(HX300|HX50|HX50V|TX30|WX60|WX80|WX200|WX300))$/` AND
 //!   `not $$self{Panorama}` (`Sony.pm:1147-1153`).
 //! - `Tag2010f` — `/^(DSC-(RX100M2|QX10|QX100))$/` (`Sony.pm:1156`).
-//! - `Tag2010g`/`h`/`i` (`Sony.pm:1159-1169`) — the remaining LARGE variants, not
-//!   yet ported: those bodies (and any unknown one) fall through to `Tag_0x2010`
+//! - `Tag2010g` — `/^(DSC-(QX30|RX10|RX100M3|HX60V|HX350|HX400V|WX220|WX350)|`
+//!   `ILCE-(7(R|S|M2)?|[56]000|5100|QX1)|ILCA-(68|77M2))\b/` (`Sony.pm:1159-1161`).
+//!   The `\b` (NOT `$`) means a bare `ILCE-7` does not swallow `ILCE-7RM2`.
+//! - `Tag2010h`/`i` (`Sony.pm:1162-1169`) — the remaining LARGE variants, not yet
+//!   ported: those bodies (and any unknown one) fall through to `Tag_0x2010`
 //!   (`%unknownCipherData`, emits nothing), faithful until they are ported.
 //! - else `Tag_0x2010` (`%unknownCipherData`) — emits nothing.
 //!
-//! Because the model sets are pairwise disjoint (and disjoint from the deferred
-//! `g`/`h`/`i` sets), the dispatcher tests `a`/`b`/`c`/`d`/`e`/`f` independently;
-//! a body matching `g`/`h`/`i` matches none of them and correctly falls to the
-//! unknown branch.
+//! The `a`-`f` model sets are pairwise disjoint and disjoint from `g`'s
+//! `\b`-anchored set, so the dispatcher tests `a`/`b`/`c`/`d`/`e`/`f`/`g`
+//! independently; a body matching `h`/`i` matches none of them and correctly
+//! falls to the unknown branch.
 //!
 //! ## Cipher + priority + availability
 //!
@@ -50,12 +53,12 @@
 //! used"), so it is NOT emitted in default output and is skipped here.
 //!
 //! The `a`/`b`/`c`/`d`/`f` tables have NO per-leaf model `Condition`s; their
-//! model gate lives entirely in the dispatcher. `Tag2010e` (like `Tag9405b`)
-//! DOES carry per-leaf `Condition`s — the `\b`-anchored SonyISO / FocalLength
-//! offset sets, the `LensFormat`/`LensMount`/`DistortionCorr*` DSC(-or-Stellar)
-//! exclusions, the `LensType2`/`LensType` `LensMount`-DataMember gates, and the
-//! two mutually-exclusive `AspectRatio` offsets — so `parse_tag2010e` takes the
-//! resolved `$$self{Model}`.
+//! model gate lives entirely in the dispatcher. `Tag2010e`/`g` (like `Tag9405b`)
+//! DO carry per-leaf `Condition`s — for `e` the `\b`-anchored SonyISO /
+//! FocalLength offset sets and the two mutually-exclusive `AspectRatio` offsets;
+//! for both, the `LensFormat`/`LensMount`/`DistortionCorr*` DSC(-or-Stellar)
+//! exclusions and the `LensType2`/`LensType` `LensMount`-DataMember gates — so
+//! `parse_tag2010e`/`g` take the resolved `$$self{Model}`.
 
 use super::{amount_lens_types, lens_types};
 use crate::value::{TagValue, whole_f64_to_tag_value};
@@ -208,6 +211,39 @@ pub fn selects_tag2010e(model: Option<&str>, panorama: bool) -> bool {
         "DSC-WX300",
       ],
     ))
+}
+
+/// `Sony.pm:1160`
+/// `/^(DSC-(QX30|RX10|RX100M3|HX60V|HX350|HX400V|WX220|WX350)|`
+/// `ILCE-(7(R|S|M2)?|[56]000|5100|QX1)|ILCA-(68|77M2))\b/` — selects `Tag2010g`.
+/// The `\b` word boundary means a bare `ILCE-7` does NOT swallow `ILCE-7RM2` /
+/// `ILCE-7SM2` (`Tag2010h` models): `ILCE-(7(R|S|M2)?...)` expands to
+/// `ILCE-7`/`-7R`/`-7S`/`-7M2`, then `\b`.
+#[must_use]
+pub fn selects_tag2010g(model: Option<&str>) -> bool {
+  super::tag9405::starts_with_word_boundary(
+    model,
+    &[
+      "DSC-QX30",
+      "DSC-RX10",
+      "DSC-RX100M3",
+      "DSC-HX60V",
+      "DSC-HX350",
+      "DSC-HX400V",
+      "DSC-WX220",
+      "DSC-WX350",
+      "ILCE-7",
+      "ILCE-7R",
+      "ILCE-7S",
+      "ILCE-7M2",
+      "ILCE-5000",
+      "ILCE-6000",
+      "ILCE-5100",
+      "ILCE-QX1",
+      "ILCA-68",
+      "ILCA-77M2",
+    ],
+  )
 }
 
 /// `$$self{Panorama} = ($$valPt =~ /^(\0\0)?\x01\x01/)` (`Sony.pm:902`) — the
@@ -1597,6 +1633,214 @@ pub fn parse_tag2010e(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<
       &mut out,
     );
   }
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010g` block (`Sony.pm:6980-7119`).
+///
+/// `buf` is the DECIPHERED `0x2010` block; `model` drives the `Model !~ /^DSC-/`
+/// lens / distortion-correction exclusions and the `LensMount` DataMember (which
+/// gates `LensType2`/`LensType`). The FocalLength / SonyISO / AspectRatio rows
+/// are unconditional here (unlike `Tag2010e`). `print_conv` selects `-j`/`-n`.
+#[must_use]
+pub fn parse_tag2010g(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<Tag2010Emission> {
+  use super::tag9405::{model_is_dsc, print_lens_format, print_lens_mount, print_no_yes};
+  let mut out = std::vec::Vec::new();
+  let not_dsc = !model_is_dsc(model);
+
+  // 0x0004 ReleaseMode2 (int32u) — NOT at 0x0008 for this variant.
+  push_release_mode2_u32(buf, 0x0004, "ReleaseMode2", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x0050,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x020c,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0210,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0218,
+    "SelfTimer",
+    print_conv,
+    self_timer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x021c,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x0222, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x0224, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x0228,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x022c,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x0230, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x0246,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0247,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x024b,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x0258,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x025c,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x025d,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x0264, 3, "WB_RGBLevels", &mut out);
+  push_focal_length(buf, 0x032c, "FocalLength", print_conv, &mut out);
+  push_focal_length(buf, 0x032e, "MinFocalLength", print_conv, &mut out);
+  push_focal_length_nonzero(buf, 0x0330, "MaxFocalLength", print_conv, &mut out);
+  push_sony_iso(buf, 0x0344, "SonyISO", print_conv, &mut out);
+  // 0x0388 MeterInfo (Unknown SubDirectory) — skipped.
+  // 0x189c DistortionCorrParams int16s[16] — Condition Model !~ /^DSC-/.
+  if not_dsc {
+    push_i16_array(buf, 0x189c, 16, "DistortionCorrParams", &mut out);
+  }
+  // 0x18bd LensFormat — same Condition.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18bd,
+      "LensFormat",
+      print_conv,
+      print_lens_format,
+      &mut out,
+    );
+  }
+  // 0x18be LensMount — DataMember (raw always latched, drives LensType2/LensType);
+  // the tag is emitted iff Model !~ /^DSC-/.
+  let lens_mount = buf.get(0x18be).copied();
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18be,
+      "LensMount",
+      print_conv,
+      print_lens_mount,
+      &mut out,
+    );
+  }
+  // 0x18bf LensType2 — Condition LensMount == 2 (E-mount, %sonyLensTypes2).
+  push_lens_type(
+    buf,
+    0x18bf,
+    "LensType2",
+    lens_mount == Some(2),
+    lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x18c2 LensType — Condition LensMount == 1 (A-mount, %sonyLensTypes).
+  push_lens_type(
+    buf,
+    0x18c2,
+    "LensType",
+    lens_mount == Some(1),
+    amount_lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x18c4 DistortionCorrParamsPresent — Condition Model !~ /^DSC-/.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18c4,
+      "DistortionCorrParamsPresent",
+      print_conv,
+      print_no_yes,
+      &mut out,
+    );
+  }
+  // 0x18c5 DistortionCorrParamsNumber — same Condition.
+  if not_dsc {
+    push_u8_hash(
+      buf,
+      0x18c5,
+      "DistortionCorrParamsNumber",
+      print_conv,
+      distortion_corr_params_number_print,
+      &mut out,
+    );
+  }
+  push_u8_hash(
+    buf,
+    0x1958,
+    "AspectRatio",
+    print_conv,
+    aspect_ratio_print,
+    &mut out,
+  );
   out
 }
 

--- a/src/exif/makernotes/vendors/sony/tag2010.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010.rs
@@ -18,17 +18,20 @@
 //! - `Tag2010c` — `/^(SLT-A(37|57)|NEX-F3)$/` (`Sony.pm:1136`).
 //! - `Tag2010d` — `/^(DSC-(HX10V|HX20V|HX30V|HX200V|TX66|TX200V|TX300V|WX50|WX70|`
 //!   `WX100|WX150))$/` AND `not $$self{Panorama}` (`Sony.pm:1140-1145`).
-//! - `Tag2010e` (`Sony.pm:1147-1153`), `Tag2010g`/`h`/`i` (`Sony.pm:1162-1173`) —
-//!   the LARGER variants, not yet ported: those bodies (and any unknown one) fall
-//!   through to `Tag_0x2010` (`%unknownCipherData`, emits nothing), which is
-//!   faithful until they are ported.
+//! - `Tag2010e` — `/^(SLT-A99V?|HV|SLT-A58|ILCE-(3000|3500)|NEX-(3N|5R|5T|6|`
+//!   `VG900|VG30E)|DSC-(RX100|RX1|RX1R)|Stellar)$/`, OR
+//!   `/^(DSC-(HX300|HX50|HX50V|TX30|WX60|WX80|WX200|WX300))$/` AND
+//!   `not $$self{Panorama}` (`Sony.pm:1147-1153`).
 //! - `Tag2010f` — `/^(DSC-(RX100M2|QX10|QX100))$/` (`Sony.pm:1156`).
+//! - `Tag2010g`/`h`/`i` (`Sony.pm:1159-1169`) — the remaining LARGE variants, not
+//!   yet ported: those bodies (and any unknown one) fall through to `Tag_0x2010`
+//!   (`%unknownCipherData`, emits nothing), faithful until they are ported.
 //! - else `Tag_0x2010` (`%unknownCipherData`) — emits nothing.
 //!
 //! Because the model sets are pairwise disjoint (and disjoint from the deferred
-//! `e`/`g`/`h`/`i` sets), the dispatcher tests `a`/`b`/`c`/`d`/`f` independently;
-//! a body matching `e`/`g`/`h`/`i` matches none of them and correctly falls to
-//! the unknown branch.
+//! `g`/`h`/`i` sets), the dispatcher tests `a`/`b`/`c`/`d`/`e`/`f` independently;
+//! a body matching `g`/`h`/`i` matches none of them and correctly falls to the
+//! unknown branch.
 //!
 //! ## Cipher + priority + availability
 //!
@@ -46,10 +49,17 @@
 //! `Unknown => 1` (`Sony.pm:7456-7458` — "Extracted only if the Unknown option is
 //! used"), so it is NOT emitted in default output and is skipped here.
 //!
-//! These tables have NO per-leaf model `Condition`s (unlike `Tag9405b`); the
-//! model gate lives entirely in the dispatcher.
+//! The `a`/`b`/`c`/`d`/`f` tables have NO per-leaf model `Condition`s; their
+//! model gate lives entirely in the dispatcher. `Tag2010e` (like `Tag9405b`)
+//! DOES carry per-leaf `Condition`s — the `\b`-anchored SonyISO / FocalLength
+//! offset sets, the `LensFormat`/`LensMount`/`DistortionCorr*` DSC(-or-Stellar)
+//! exclusions, the `LensType2`/`LensType` `LensMount`-DataMember gates, and the
+//! two mutually-exclusive `AspectRatio` offsets — so `parse_tag2010e` takes the
+//! resolved `$$self{Model}`.
 
+use super::{amount_lens_types, lens_types};
 use crate::value::{TagValue, whole_f64_to_tag_value};
+use smol_str::SmolStr;
 
 /// One emitted `Tag2010a`..`Tag2010f` leaf — the resolved tag name and rendered
 /// value.
@@ -154,6 +164,50 @@ pub fn selects_tag2010d(model: Option<&str>, panorama: bool) -> bool {
 #[must_use]
 pub fn selects_tag2010f(model: Option<&str>) -> bool {
   model_eq_any(model, &["DSC-RX100M2", "DSC-QX10", "DSC-QX100"])
+}
+
+/// `Sony.pm:1148-1153` — selects `Tag2010e`. Two `$`-anchored alternations: the
+/// first (`SLT-A99V?|HV|SLT-A58|ILCE-(3000|3500)|NEX-(3N|5R|5T|6|VG900|VG30E)|`
+/// `DSC-(RX100|RX1|RX1R)|Stellar`) is unconditional; the second
+/// (`DSC-(HX300|HX50|HX50V|TX30|WX60|WX80|WX200|WX300)`) additionally requires
+/// `not $$self{Panorama}` (the `0x1003` DataMember latched earlier in the walk,
+/// like `Tag2010d`). `SLT-A99V?` expands to `SLT-A99`/`SLT-A99V`.
+#[must_use]
+pub fn selects_tag2010e(model: Option<&str>, panorama: bool) -> bool {
+  model_eq_any(
+    model,
+    &[
+      "SLT-A99",
+      "SLT-A99V",
+      "HV",
+      "SLT-A58",
+      "ILCE-3000",
+      "ILCE-3500",
+      "NEX-3N",
+      "NEX-5R",
+      "NEX-5T",
+      "NEX-6",
+      "NEX-VG900",
+      "NEX-VG30E",
+      "DSC-RX100",
+      "DSC-RX1",
+      "DSC-RX1R",
+      "Stellar",
+    ],
+  ) || (!panorama
+    && model_eq_any(
+      model,
+      &[
+        "DSC-HX300",
+        "DSC-HX50",
+        "DSC-HX50V",
+        "DSC-TX30",
+        "DSC-WX60",
+        "DSC-WX80",
+        "DSC-WX200",
+        "DSC-WX300",
+      ],
+    ))
 }
 
 /// `$$self{Panorama} = ($$valPt =~ /^(\0\0)?\x01\x01/)` (`Sony.pm:902`) — the
@@ -314,7 +368,9 @@ fn picture_profile_print(v: u8) -> Option<&'static str> {
   })
 }
 
-/// `Tag2010f` `0x192c` `AspectRatio` PrintConv hash (`Sony.pm:6970-6978`).
+/// `AspectRatio` PrintConv hash — `Tag2010f` `0x192c` (`Sony.pm:6970-6978`),
+/// shared by the `Tag2010e`/`g`/`h`/`i` `AspectRatio` rows
+/// (`Sony.pm:6870`/`7109`/`7256`/`7397`).
 fn aspect_ratio_print(v: u8) -> Option<&'static str> {
   Some(match v {
     0 => "16:9",
@@ -322,6 +378,16 @@ fn aspect_ratio_print(v: u8) -> Option<&'static str> {
     2 => "3:2",
     3 => "1:1",
     5 => "Panorama",
+    _ => return None,
+  })
+}
+
+/// `DistortionCorrParamsNumber` PrintConv `{ 11 => '11 (APS-C)', 16 => '16
+/// (Full-frame)' }` (`Sony.pm:6863`/`7103`/`7252`/`7393`).
+fn distortion_corr_params_number_print(v: u8) -> Option<&'static str> {
+  Some(match v {
+    11 => "11 (APS-C)",
+    16 => "16 (Full-frame)",
     _ => return None,
   })
 }
@@ -531,6 +597,64 @@ fn push_focal_length(
     TagValue::Str(std::format!("{v:.1} mm").into())
   } else {
     whole_f64_to_tag_value(v)
+  };
+  out.push(Tag2010Emission { name, value });
+}
+
+/// `MaxFocalLength` for the `e`/`g`/`h`/`i` variants — as [`push_focal_length`]
+/// but with the `RawConv => '$val || undef'` (`Sony.pm:6795`/`7032` etc.): a RAW
+/// int16u of `0` (a fixed-focal-length lens) yields `undef`, so the tag is NOT
+/// emitted.
+fn push_focal_length_nonzero(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  print_conv: bool,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  let Some(raw) = read_u16(buf, off) else {
+    return;
+  };
+  if raw == 0 {
+    return;
+  }
+  let v = f64::from(raw) / 10.0;
+  let value = if print_conv {
+    TagValue::Str(std::format!("{v:.1} mm").into())
+  } else {
+    whole_f64_to_tag_value(v)
+  };
+  out.push(Tag2010Emission { name, value });
+}
+
+/// A `LensType2` (E-mount, `%sonyLensTypes2`) or `LensType` (A-mount,
+/// `%sonyLensTypes`) row — int16u, `gated` by the caller on the `LensMount`
+/// DataMember (`$$self{LensMount} == 2` / `== 1`). A hash MISS renders
+/// `"Unknown ($val)"` (`-j`) / the raw int16u (`-n`); `PrintInt => 1` is a
+/// `BuildTagLookup`-only doc flag, not a runtime directive. Mirrors the
+/// `Tag9405` `push_lens_type` (`Sony.pm:6837-6854` etc.).
+fn push_lens_type(
+  buf: &[u8],
+  off: usize,
+  name: &'static str,
+  gated: bool,
+  lookup: impl Fn(u32) -> Option<SmolStr>,
+  print_conv: bool,
+  out: &mut std::vec::Vec<Tag2010Emission>,
+) {
+  if !gated {
+    return;
+  }
+  let Some(raw) = read_u16(buf, off) else {
+    return;
+  };
+  let value = if print_conv {
+    match lookup(u32::from(raw)) {
+      Some(label) => TagValue::Str(label),
+      None => TagValue::Str(SmolStr::from(std::format!("Unknown ({raw})"))),
+    }
+  } else {
+    TagValue::I64(i64::from(raw))
   };
   out.push(Tag2010Emission { name, value });
 }
@@ -1200,6 +1324,279 @@ pub fn parse_tag2010f(buf: &[u8], print_conv: bool) -> Vec<Tag2010Emission> {
     aspect_ratio_print,
     &mut out,
   );
+  out
+}
+
+/// Walk the DECIPHERED `Tag2010e` block (`Sony.pm:6697-6891`).
+///
+/// `buf` is the DECIPHERED `0x2010` block; `model` drives the per-leaf model
+/// `Condition`s — the `\b`-anchored SonyISO / FocalLength sets, the
+/// `LensFormat`/`LensMount`/`DistortionCorr*` DSC(-or-Stellar) exclusions, and
+/// the two mutually-exclusive `AspectRatio` offsets. `print_conv` selects
+/// `-j`/`-n`.
+#[must_use]
+pub fn parse_tag2010e(buf: &[u8], model: Option<&str>, print_conv: bool) -> Vec<Tag2010Emission> {
+  use super::tag9405::{
+    model_is_dsc, model_is_dsc_or_stellar, print_lens_format, print_lens_mount, print_no_yes,
+    starts_with_word_boundary,
+  };
+  let mut out = std::vec::Vec::new();
+  let not_dsc_or_stellar = !model_is_dsc_or_stellar(model);
+
+  push_sequence_plus1(buf, 0x0000, "SequenceImageNumber", &mut out);
+  push_sequence_plus1(buf, 0x0004, "SequenceFileNumber", &mut out);
+  push_release_mode2_u32(buf, 0x0008, "ReleaseMode2", print_conv, &mut out);
+  push_digital_zoom_ratio(buf, 0x021c, "DigitalZoomRatio", &mut out);
+  push_sony_date_time(buf, 0x022c, "SonyDateTime", &mut out);
+  push_u8_hash(
+    buf,
+    0x0328,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  // 0x04b8 MeterInfo (Unknown SubDirectory) — skipped.
+  push_u8_hash(
+    buf,
+    0x115c,
+    "ReleaseMode3",
+    print_conv,
+    release_mode3_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1160,
+    "ReleaseMode2",
+    print_conv,
+    super::release_mode2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1168,
+    "SelfTimer",
+    print_conv,
+    self_timer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x116c,
+    "FlashMode",
+    print_conv,
+    flash_mode_print,
+    &mut out,
+  );
+  push_gain2010(buf, 0x1172, "StopsAboveBaseISO", print_conv, &mut out);
+  push_brightness_value(buf, 0x1174, "BrightnessValue", &mut out);
+  push_u8_hash(
+    buf,
+    0x1178,
+    "DynamicRangeOptimizer",
+    print_conv,
+    dynamic_range_optimizer_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x117c,
+    "HDRSetting",
+    print_conv,
+    hdr_setting_print,
+    &mut out,
+  );
+  push_exposure_comp(buf, 0x1180, "ExposureCompensation", print_conv, &mut out);
+  push_u8_hash(
+    buf,
+    0x1196,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x1197,
+    "PictureProfile",
+    print_conv,
+    picture_profile_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x119b,
+    "PictureEffect2",
+    print_conv,
+    picture_effect2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11a8,
+    "Quality2",
+    print_conv,
+    quality2_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11ac,
+    "MeteringMode",
+    print_conv,
+    metering_mode_print,
+    &mut out,
+  );
+  push_u8_hash(
+    buf,
+    0x11ad,
+    "ExposureProgram",
+    print_conv,
+    super::print_exposure_program3,
+    &mut out,
+  );
+  push_u16_array(buf, 0x11b4, 3, "WB_RGBLevels", &mut out);
+  // 0x1254 SonyISO — Condition
+  // /^(SLT-(A99|A99V)|NEX-(5R|5T|6|VG900|VG30E)|DSC-RX100|Stellar|HV)\b/.
+  if starts_with_word_boundary(
+    model,
+    &[
+      "SLT-A99",
+      "SLT-A99V",
+      "NEX-5R",
+      "NEX-5T",
+      "NEX-6",
+      "NEX-VG900",
+      "NEX-VG30E",
+      "DSC-RX100",
+      "Stellar",
+      "HV",
+    ],
+  ) {
+    push_sony_iso(buf, 0x1254, "SonyISO", print_conv, &mut out);
+  }
+  // 0x1258 SonyISO — Condition /^(DSC-(RX1|RX1R))\b/.
+  if starts_with_word_boundary(model, &["DSC-RX1", "DSC-RX1R"]) {
+    push_sony_iso(buf, 0x1258, "SonyISO", print_conv, &mut out);
+  }
+  // 0x1278-0x1280 FocalLength / MinFocalLength / MaxFocalLength / SonyISO —
+  // Condition
+  // /^(SLT-A58|ILCE-(3000|3500)|NEX-3N|DSC-(HX300|HX50V|WX60|WX80|WX200|WX300|TX30))\b/.
+  if starts_with_word_boundary(
+    model,
+    &[
+      "SLT-A58",
+      "ILCE-3000",
+      "ILCE-3500",
+      "NEX-3N",
+      "DSC-HX300",
+      "DSC-HX50V",
+      "DSC-WX60",
+      "DSC-WX80",
+      "DSC-WX200",
+      "DSC-WX300",
+      "DSC-TX30",
+    ],
+  ) {
+    push_focal_length(buf, 0x1278, "FocalLength", print_conv, &mut out);
+    push_focal_length(buf, 0x127a, "MinFocalLength", print_conv, &mut out);
+    push_focal_length_nonzero(buf, 0x127c, "MaxFocalLength", print_conv, &mut out);
+    push_sony_iso(buf, 0x1280, "SonyISO", print_conv, &mut out);
+  }
+  // 0x1870 DistortionCorrParams int16s[16] — Condition Model !~ /^(DSC-|Stellar)/.
+  if not_dsc_or_stellar {
+    push_i16_array(buf, 0x1870, 16, "DistortionCorrParams", &mut out);
+  }
+  // 0x1891 LensFormat — same Condition.
+  if not_dsc_or_stellar {
+    push_u8_hash(
+      buf,
+      0x1891,
+      "LensFormat",
+      print_conv,
+      print_lens_format,
+      &mut out,
+    );
+  }
+  // 0x1892 LensMount — DataMember (raw always latched, drives LensType2/LensType);
+  // the tag is emitted iff Model !~ /^(DSC-|Stellar)/.
+  let lens_mount = buf.get(0x1892).copied();
+  if not_dsc_or_stellar {
+    push_u8_hash(
+      buf,
+      0x1892,
+      "LensMount",
+      print_conv,
+      print_lens_mount,
+      &mut out,
+    );
+  }
+  // 0x1893 LensType2 — Condition LensMount == 2 (E-mount, %sonyLensTypes2).
+  push_lens_type(
+    buf,
+    0x1893,
+    "LensType2",
+    lens_mount == Some(2),
+    lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x1896 LensType — Condition LensMount == 1 (A-mount, %sonyLensTypes).
+  push_lens_type(
+    buf,
+    0x1896,
+    "LensType",
+    lens_mount == Some(1),
+    amount_lens_types::lookup_name,
+    print_conv,
+    &mut out,
+  );
+  // 0x1898 DistortionCorrParamsPresent — Condition Model !~ /^(DSC-|Stellar)/.
+  if not_dsc_or_stellar {
+    push_u8_hash(
+      buf,
+      0x1898,
+      "DistortionCorrParamsPresent",
+      print_conv,
+      print_no_yes,
+      &mut out,
+    );
+  }
+  // 0x1899 DistortionCorrParamsNumber — Condition Model !~ /^DSC-/ (NOT Stellar).
+  if !model_is_dsc(model) {
+    push_u8_hash(
+      buf,
+      0x1899,
+      "DistortionCorrParamsNumber",
+      print_conv,
+      distortion_corr_params_number_print,
+      &mut out,
+    );
+  }
+  // 0x192c AspectRatio — Condition Model !~ /^(DSC-RX100|Stellar)\b/.
+  // 0x1a88 AspectRatio — Condition Model =~ /^(DSC-RX100|Stellar)\b/.
+  let aspect_rx100_stellar = starts_with_word_boundary(model, &["DSC-RX100", "Stellar"]);
+  if !aspect_rx100_stellar {
+    push_u8_hash(
+      buf,
+      0x192c,
+      "AspectRatio",
+      print_conv,
+      aspect_ratio_print,
+      &mut out,
+    );
+  }
+  if aspect_rx100_stellar {
+    push_u8_hash(
+      buf,
+      0x1a88,
+      "AspectRatio",
+      print_conv,
+      aspect_ratio_print,
+      &mut out,
+    );
+  }
   out
 }
 

--- a/src/exif/makernotes/vendors/sony/tag2010_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010_tests.rs
@@ -806,6 +806,135 @@ fn tag2010g_ilca_amount_lens() {
   assert!(find(&em, "LensType2").is_none());
 }
 
+// --- Tag2010h (\b-anchored dispatch, %selfTimerB2010, SonyISO@0x0346) ---------
+
+/// `selects_tag2010h`: the `\b` keeps `DSC-RX0`/`DSC-RX100M5` from swallowing
+/// the `Tag2010i` models `DSC-RX0M2`/`DSC-RX100M5A`.
+#[test]
+fn tag2010h_gate_word_boundary() {
+  for m in [
+    "DSC-RX0",
+    "DSC-RX1RM2",
+    "DSC-RX10M2",
+    "DSC-RX10M3",
+    "DSC-RX100M4",
+    "DSC-RX100M5",
+    "DSC-HX80",
+    "DSC-HX90",
+    "DSC-HX90V",
+    "DSC-WX500",
+    "ILCE-6300",
+    "ILCE-6500",
+    "ILCE-7RM2",
+    "ILCE-7SM2",
+    "ILCA-99M2",
+  ] {
+    assert!(selects_tag2010h(Some(m)), "{m} should select h");
+  }
+  assert!(!selects_tag2010h(Some("DSC-RX0M2"))); // i: \b fails before M
+  assert!(!selects_tag2010h(Some("DSC-RX100M5A"))); // i
+  assert!(!selects_tag2010h(Some("DSC-RX10"))); // g
+  assert!(!selects_tag2010h(Some("DSC-RX100"))); // e
+  // ILCE-7RM2 routes to h, not g.
+  assert!(!selects_tag2010g(Some("ILCE-7RM2")));
+  assert!(!selects_tag2010h(None));
+}
+
+/// `ILCE-7RM2` (E-mount): `%selfTimerB2010` SelfTimer (value 1 = "5 or 10 s"),
+/// SonyISO at 0x0346, AspectRatio at 0x192c, and E-mount `LensType2` at 0x18ef.
+#[test]
+fn tag2010h_ilce7rm2_selftimer_b_and_emount() {
+  let mut p = vec![0u8; 0x1a00];
+  put_u32(&mut p, 0x0004, 1); // ReleaseMode2 int32u → Continuous
+  p[0x0218] = 1; // SelfTimer (%selfTimerB2010) → Self-timer 5 or 10 s
+  put_u16(&mut p, 0x0222, 512); // StopsAboveBaseISO → 14.0
+  put_u16(&mut p, 0x032c, 240); // FocalLength → 24.0 mm
+  put_u16(&mut p, 0x0346, 2048); // SonyISO → 25600
+  p[0x18ed] = 2; // LensFormat → Full-frame
+  p[0x18ee] = 2; // LensMount → E-mount
+  put_u16(&mut p, 0x18ef, 32784); // LensType2 → Sony E 16mm F2.8
+  p[0x18f5] = 11; // DistortionCorrParamsNumber → 11 (APS-C)
+  p[0x192c] = 2; // AspectRatio → 3:2
+
+  let em = parse_tag2010h(&p, Some("ILCE-7RM2"), true);
+  assert_eq!(
+    find_first(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "SelfTimer"),
+    Some(&TagValue::Str("Self-timer 5 or 10 s".into()))
+  );
+  assert_eq!(
+    find(&em, "StopsAboveBaseISO"),
+    Some(&TagValue::Str("14.0".into()))
+  );
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("E-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType2"),
+    Some(&TagValue::Str("Sony E 16mm F2.8".into()))
+  );
+  assert!(find(&em, "LensType").is_none());
+  assert_eq!(
+    find(&em, "DistortionCorrParamsNumber"),
+    Some(&TagValue::Str("11 (APS-C)".into()))
+  );
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("3:2".into())));
+}
+
+/// `DSC-RX0`: unconditional FocalLength / SonyISO / AspectRatio emit; the
+/// `Model !~ /^DSC-/` lens / distortion-correction rows are suppressed.
+#[test]
+fn tag2010h_dsc_rx0_suppression() {
+  let mut p = vec![0u8; 0x1a00];
+  put_u16(&mut p, 0x032c, 240); // FocalLength (unconditional)
+  put_u16(&mut p, 0x0346, 2048); // SonyISO (unconditional)
+  p[0x18ed] = 2; // LensFormat byte (DSC → suppressed)
+  p[0x18ee] = 1; // LensMount byte (DSC → suppressed)
+  p[0x18f4] = 1; // DistortionCorrParamsPresent (DSC → suppressed)
+  p[0x18f5] = 16; // DistortionCorrParamsNumber (DSC → suppressed)
+  p[0x192c] = 1; // AspectRatio (unconditional) → 4:3
+
+  let em = parse_tag2010h(&p, Some("DSC-RX0"), true);
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("4:3".into())));
+  assert!(find(&em, "LensFormat").is_none());
+  assert!(find(&em, "LensMount").is_none());
+  assert!(find(&em, "DistortionCorrParamsPresent").is_none());
+  assert!(find(&em, "DistortionCorrParamsNumber").is_none());
+}
+
+/// `ILCA-99M2` (A-mount): the A-mount `LensType` at 0x18f2 gated by
+/// `LensMount == 1`.
+#[test]
+fn tag2010h_ilca99m2_amount_lens() {
+  let mut p = vec![0u8; 0x1a00];
+  p[0x18ee] = 1; // LensMount → A-mount
+  put_u16(&mut p, 0x18f2, 18); // LensType (A-mount)
+  let em = parse_tag2010h(&p, Some("ILCA-99M2"), true);
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("A-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType"),
+    Some(&TagValue::Str("Minolta AF 28-80mm F3.5-5.6 II".into()))
+  );
+  assert!(find(&em, "LensType2").is_none());
+}
+
 // --- shared-conversion edges -------------------------------------------------
 
 /// `StopsAboveBaseISO` ValueConv of exactly 0 prints the bare integer `0`;
@@ -870,4 +999,5 @@ fn per_field_truncation() {
   assert!(parse_tag2010e(&[], Some("SLT-A99V"), true).is_empty());
   assert!(parse_tag2010f(&[], true).is_empty());
   assert!(parse_tag2010g(&[], Some("ILCE-7M2"), true).is_empty());
+  assert!(parse_tag2010h(&[], Some("ILCE-7RM2"), true).is_empty());
 }

--- a/src/exif/makernotes/vendors/sony/tag2010_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010_tests.rs
@@ -935,6 +935,176 @@ fn tag2010h_ilca99m2_amount_lens() {
   assert!(find(&em, "LensType2").is_none());
 }
 
+// --- Tag2010i (repacked offsets: Quality2@0x0247, SonyISO@0x0320, %selfTimerB) -
+
+/// `selects_tag2010i`: the `A?`/`[AF]?` optionals expand to base+suffix stems;
+/// the `\b` distinguishes `ILCE-9` from `ILCE-9M2` and keeps `DSC-RX0M2` out of
+/// `Tag2010h` (whose `DSC-RX0` stem fails the boundary before `M`).
+#[test]
+fn tag2010i_gate_word_boundary() {
+  for m in [
+    "ILCE-6100",
+    "ILCE-6100A",
+    "ILCE-6400",
+    "ILCE-6400A",
+    "ILCE-6600",
+    "ILCE-7C",
+    "ILCE-7M3",
+    "ILCE-7RM3",
+    "ILCE-7RM3A",
+    "ILCE-7RM4",
+    "ILCE-7RM4A",
+    "ILCE-9",
+    "ILCE-9M2",
+    "DSC-RX10M4",
+    "DSC-RX100M6",
+    "DSC-RX100M5A",
+    "DSC-RX100M7",
+    "DSC-RX100M7A",
+    "DSC-HX95",
+    "DSC-HX99",
+    "DSC-RX0M2",
+    "ZV-1",
+    "ZV-1A",
+    "ZV-1F",
+    "ZV-1M2",
+    "ZV-E10",
+  ] {
+    assert!(selects_tag2010i(Some(m)), "{m} should select i");
+  }
+  assert!(!selects_tag2010i(Some("ILCE-9X"))); // \b fails before X
+  assert!(!selects_tag2010i(Some("DSC-RX0"))); // h
+  assert!(!selects_tag2010i(Some("ILCE-7RM2"))); // h
+  assert!(!selects_tag2010i(Some("ILCE-7M2"))); // g
+  assert!(!selects_tag2010h(Some("DSC-RX0M2"))); // routes to i, not h
+  assert!(!selects_tag2010i(None));
+}
+
+/// `ILCE-9` (E-mount): the repacked scalar block (Quality2 at 0x0247 where
+/// `g`/`h` have a second PictureProfile), SonyISO at 0x0320, the
+/// `%selfTimerB2010` SelfTimer at 0x0210, the E-mount `LensType2` at 0x17f3, and
+/// AspectRatio at 0x188c.
+#[test]
+fn tag2010i_ilce9_emount_scalars() {
+  let mut p = vec![0u8; 0x1900];
+  put_u32(&mut p, 0x0004, 1); // ReleaseMode2 int32u → Continuous
+  p[0x004e] = 1; // DynamicRangeOptimizer (first) → Auto
+  p[0x021b] = 1; // DynamicRangeOptimizer (second, last-wins) → Auto
+  p[0x0204] = 1; // ReleaseMode3 → Continuous
+  p[0x0210] = 1; // SelfTimer (%selfTimerB2010) → Self-timer 5 or 10 s
+  put_u16(&mut p, 0x0217, 512); // StopsAboveBaseISO → 14.0
+  p[0x0237] = 8; // PictureProfile (first) → Gamma Still - Vivid
+  p[0x0238] = 8; // PictureProfile (second, last-wins) → Gamma Still - Vivid
+  p[0x0247] = 1; // Quality2 → RAW (NOT a PictureProfile here)
+  p[0x024b] = 3; // MeteringMode → Spot
+  put_u16(&mut p, 0x0252, 7000);
+  put_u16(&mut p, 0x0252 + 2, 4096);
+  put_u16(&mut p, 0x0252 + 4, 6500);
+  put_u16(&mut p, 0x030a, 240); // FocalLength → 24.0 mm
+  put_u16(&mut p, 0x0320, 2048); // SonyISO → 25600
+  p[0x17f1] = 2; // LensFormat → Full-frame
+  p[0x17f2] = 2; // LensMount → E-mount
+  put_u16(&mut p, 0x17f3, 32784); // LensType2 → Sony E 16mm F2.8
+  p[0x17f9] = 16; // DistortionCorrParamsNumber → 16 (Full-frame)
+  p[0x188c] = 2; // AspectRatio → 3:2
+
+  let em = parse_tag2010i(&p, Some("ILCE-9"), true);
+  assert_eq!(
+    find_first(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "DynamicRangeOptimizer"),
+    Some(&TagValue::Str("Auto".into()))
+  );
+  assert_eq!(
+    find(&em, "ReleaseMode3"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "SelfTimer"),
+    Some(&TagValue::Str("Self-timer 5 or 10 s".into()))
+  );
+  assert_eq!(
+    find(&em, "StopsAboveBaseISO"),
+    Some(&TagValue::Str("14.0".into()))
+  );
+  assert_eq!(count(&em, "PictureProfile"), 2);
+  assert_eq!(
+    find(&em, "PictureProfile"),
+    Some(&TagValue::Str("Gamma Still - Vivid".into()))
+  );
+  assert_eq!(find(&em, "Quality2"), Some(&TagValue::Str("RAW".into())));
+  assert_eq!(
+    find(&em, "WB_RGBLevels"),
+    Some(&TagValue::Str("7000 4096 6500".into()))
+  );
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("E-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType2"),
+    Some(&TagValue::Str("Sony E 16mm F2.8".into()))
+  );
+  assert!(find(&em, "LensType").is_none());
+  assert_eq!(
+    find(&em, "DistortionCorrParamsNumber"),
+    Some(&TagValue::Str("16 (Full-frame)".into()))
+  );
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("3:2".into())));
+}
+
+/// `DSC-RX0M2`: unconditional FocalLength / SonyISO / AspectRatio emit; the
+/// `Model !~ /^DSC-/` lens / distortion-correction rows are suppressed.
+#[test]
+fn tag2010i_dsc_rx0m2_suppression() {
+  let mut p = vec![0u8; 0x1900];
+  put_u16(&mut p, 0x030a, 240); // FocalLength (unconditional)
+  put_u16(&mut p, 0x0320, 2048); // SonyISO (unconditional)
+  p[0x17f1] = 2; // LensFormat byte (DSC → suppressed)
+  p[0x17f2] = 1; // LensMount byte (DSC → suppressed)
+  p[0x17f8] = 1; // DistortionCorrParamsPresent (DSC → suppressed)
+  p[0x17f9] = 11; // DistortionCorrParamsNumber (DSC → suppressed)
+  p[0x188c] = 1; // AspectRatio (unconditional) → 4:3
+
+  let em = parse_tag2010i(&p, Some("DSC-RX0M2"), true);
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("4:3".into())));
+  assert!(find(&em, "LensFormat").is_none());
+  assert!(find(&em, "LensMount").is_none());
+  assert!(find(&em, "DistortionCorrParamsPresent").is_none());
+  assert!(find(&em, "DistortionCorrParamsNumber").is_none());
+}
+
+/// A-mount lens on an E-mount body (e.g. via an LA-EA adapter): `LensMount == 1`
+/// at 0x17f2 emits the A-mount `LensType` at 0x17f6.
+#[test]
+fn tag2010i_amount_lens() {
+  let mut p = vec![0u8; 0x1900];
+  p[0x17f2] = 1; // LensMount → A-mount
+  put_u16(&mut p, 0x17f6, 18); // LensType (A-mount)
+  let em = parse_tag2010i(&p, Some("ILCE-9M2"), true);
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("A-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType"),
+    Some(&TagValue::Str("Minolta AF 28-80mm F3.5-5.6 II".into()))
+  );
+  assert!(find(&em, "LensType2").is_none());
+}
+
 // --- shared-conversion edges -------------------------------------------------
 
 /// `StopsAboveBaseISO` ValueConv of exactly 0 prints the bare integer `0`;
@@ -1000,4 +1170,5 @@ fn per_field_truncation() {
   assert!(parse_tag2010f(&[], true).is_empty());
   assert!(parse_tag2010g(&[], Some("ILCE-7M2"), true).is_empty());
   assert!(parse_tag2010h(&[], Some("ILCE-7RM2"), true).is_empty());
+  assert!(parse_tag2010i(&[], Some("ILCE-9"), true).is_empty());
 }

--- a/src/exif/makernotes/vendors/sony/tag2010_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010_tests.rs
@@ -644,6 +644,168 @@ fn tag2010e_raw_mode_and_lens_type_miss() {
   );
 }
 
+// --- Tag2010g (\b-anchored dispatch, unconditional focal/iso/aspect, lens) ----
+
+/// `selects_tag2010g`: a `\b`-anchored prefix set. The `\b` keeps a bare
+/// `ILCE-7` from swallowing the `Tag2010h` models `ILCE-7RM2`/`ILCE-7SM2`.
+#[test]
+fn tag2010g_gate_word_boundary() {
+  for m in [
+    "DSC-QX30",
+    "DSC-RX10",
+    "DSC-RX100M3",
+    "DSC-HX60V",
+    "DSC-HX350",
+    "DSC-HX400V",
+    "DSC-WX220",
+    "DSC-WX350",
+    "ILCE-7",
+    "ILCE-7R",
+    "ILCE-7S",
+    "ILCE-7M2",
+    "ILCE-5000",
+    "ILCE-6000",
+    "ILCE-5100",
+    "ILCE-QX1",
+    "ILCA-68",
+    "ILCA-77M2",
+  ] {
+    assert!(selects_tag2010g(Some(m)), "{m} should select g");
+  }
+  assert!(!selects_tag2010g(Some("ILCE-7RM2"))); // h: \b fails before M
+  assert!(!selects_tag2010g(Some("ILCE-7SM2"))); // h
+  assert!(!selects_tag2010g(Some("DSC-RX10M2"))); // h
+  assert!(!selects_tag2010g(Some("DSC-RX100"))); // e (exact)
+  assert!(!selects_tag2010g(Some("ILCE-6300"))); // h
+  assert!(!selects_tag2010g(None));
+}
+
+/// `ILCE-7M2` (E-mount): the 0x0004 ReleaseMode2, the scalar block, the
+/// unconditional FocalLength / SonyISO / AspectRatio rows, and the E-mount
+/// `LensType2` gated by `LensMount == 2`.
+#[test]
+fn tag2010g_ilce7m2_emount_scalars() {
+  let mut p = vec![0u8; 0x1a00];
+  put_u32(&mut p, 0x0004, 1); // ReleaseMode2 int32u @0x0004 → Continuous
+  p[0x0050] = 1; // DynamicRangeOptimizer (first)
+  p[0x0228] = 1; // DynamicRangeOptimizer (second, last-wins)
+  p[0x020c] = 1; // ReleaseMode3 → Continuous
+  p[0x0218] = 1; // SelfTimer (%selfTimer2010) → Self-timer 10 s
+  put_u16(&mut p, 0x0222, 512); // StopsAboveBaseISO → 14.0
+  p[0x0258] = 1; // Quality2 → RAW
+  p[0x025c] = 3; // MeteringMode → Spot
+  put_u16(&mut p, 0x0264, 7000);
+  put_u16(&mut p, 0x0264 + 2, 4096);
+  put_u16(&mut p, 0x0264 + 4, 6500);
+  put_u16(&mut p, 0x032c, 240); // FocalLength → 24.0 mm
+  put_u16(&mut p, 0x032e, 100); // MinFocalLength → 10.0 mm
+  put_u16(&mut p, 0x0330, 0); // MaxFocalLength raw 0 → dropped
+  put_u16(&mut p, 0x0344, 2048); // SonyISO → 25600
+  p[0x18bd] = 2; // LensFormat → Full-frame
+  p[0x18be] = 2; // LensMount → E-mount
+  put_u16(&mut p, 0x18bf, 32784); // LensType2 → Sony E 16mm F2.8
+  p[0x18c4] = 1; // DistortionCorrParamsPresent → Yes
+  p[0x18c5] = 16; // DistortionCorrParamsNumber → 16 (Full-frame)
+  p[0x1958] = 2; // AspectRatio → 3:2
+
+  let em = parse_tag2010g(&p, Some("ILCE-7M2"), true);
+  assert_eq!(
+    find_first(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "ReleaseMode3"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(
+    find(&em, "SelfTimer"),
+    Some(&TagValue::Str("Self-timer 10 s".into()))
+  );
+  assert_eq!(
+    find(&em, "StopsAboveBaseISO"),
+    Some(&TagValue::Str("14.0".into()))
+  );
+  assert_eq!(find(&em, "Quality2"), Some(&TagValue::Str("RAW".into())));
+  assert_eq!(
+    find(&em, "WB_RGBLevels"),
+    Some(&TagValue::Str("7000 4096 6500".into()))
+  );
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(
+    find(&em, "MinFocalLength"),
+    Some(&TagValue::Str("10.0 mm".into()))
+  );
+  assert!(find(&em, "MaxFocalLength").is_none()); // raw 0 → dropped
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(
+    find(&em, "LensFormat"),
+    Some(&TagValue::Str("Full-frame".into()))
+  );
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("E-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType2"),
+    Some(&TagValue::Str("Sony E 16mm F2.8".into()))
+  );
+  assert!(find(&em, "LensType").is_none());
+  assert_eq!(
+    find(&em, "DistortionCorrParamsNumber"),
+    Some(&TagValue::Str("16 (Full-frame)".into()))
+  );
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("3:2".into())));
+}
+
+/// `DSC-RX10`: the FocalLength / SonyISO / AspectRatio rows are unconditional
+/// (emit for DSC), but the `Model !~ /^DSC-/` lens / distortion-correction rows
+/// are suppressed.
+#[test]
+fn tag2010g_dsc_rx10_suppression() {
+  let mut p = vec![0u8; 0x1a00];
+  put_u16(&mut p, 0x032c, 240); // FocalLength (unconditional) → 24.0 mm
+  put_u16(&mut p, 0x0344, 2048); // SonyISO (unconditional) → 25600
+  p[0x18bd] = 2; // LensFormat byte (DSC → suppressed)
+  p[0x18be] = 1; // LensMount byte (DSC → suppressed)
+  p[0x18c4] = 1; // DistortionCorrParamsPresent (DSC → suppressed)
+  p[0x18c5] = 11; // DistortionCorrParamsNumber (DSC → suppressed)
+  p[0x1958] = 1; // AspectRatio (unconditional) → 4:3
+
+  let em = parse_tag2010g(&p, Some("DSC-RX10"), true);
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("4:3".into())));
+  assert!(find(&em, "LensFormat").is_none());
+  assert!(find(&em, "LensMount").is_none());
+  assert!(find(&em, "DistortionCorrParams").is_none());
+  assert!(find(&em, "DistortionCorrParamsPresent").is_none());
+  assert!(find(&em, "DistortionCorrParamsNumber").is_none());
+}
+
+/// `ILCA-77M2` (A-mount): the A-mount `LensType` gated by `LensMount == 1`.
+#[test]
+fn tag2010g_ilca_amount_lens() {
+  let mut p = vec![0u8; 0x1a00];
+  p[0x18be] = 1; // LensMount → A-mount
+  put_u16(&mut p, 0x18c2, 18); // LensType (A-mount)
+  let em = parse_tag2010g(&p, Some("ILCA-77M2"), true);
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("A-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType"),
+    Some(&TagValue::Str("Minolta AF 28-80mm F3.5-5.6 II".into()))
+  );
+  assert!(find(&em, "LensType2").is_none());
+}
+
 // --- shared-conversion edges -------------------------------------------------
 
 /// `StopsAboveBaseISO` ValueConv of exactly 0 prints the bare integer `0`;
@@ -707,4 +869,5 @@ fn per_field_truncation() {
   assert!(parse_tag2010d(&[], true).is_empty());
   assert!(parse_tag2010e(&[], Some("SLT-A99V"), true).is_empty());
   assert!(parse_tag2010f(&[], true).is_empty());
+  assert!(parse_tag2010g(&[], Some("ILCE-7M2"), true).is_empty());
 }

--- a/src/exif/makernotes/vendors/sony/tag2010_tests.rs
+++ b/src/exif/makernotes/vendors/sony/tag2010_tests.rs
@@ -366,6 +366,284 @@ fn tag2010f_focal_and_aspect() {
   assert_eq!(find(&em_n, "MaxFocalLength"), Some(&TagValue::I64(0)));
 }
 
+// --- Tag2010e (per-leaf conditions, lens-mount/-type, two AspectRatio offsets) --
+
+/// `selects_tag2010e`: first alternation is `$`-anchored unconditional; the
+/// second is gated by `not $$self{Panorama}`.
+#[test]
+fn tag2010e_gate_exact_and_panorama() {
+  for m in [
+    "SLT-A99",
+    "SLT-A99V",
+    "HV",
+    "SLT-A58",
+    "ILCE-3000",
+    "ILCE-3500",
+    "NEX-3N",
+    "NEX-5R",
+    "NEX-5T",
+    "NEX-6",
+    "NEX-VG900",
+    "NEX-VG30E",
+    "DSC-RX100",
+    "DSC-RX1",
+    "DSC-RX1R",
+    "Stellar",
+  ] {
+    assert!(selects_tag2010e(Some(m), false), "{m} should select e");
+    assert!(
+      selects_tag2010e(Some(m), true),
+      "{m} selects e even under panorama (first alternation)"
+    );
+  }
+  for m in [
+    "DSC-HX300",
+    "DSC-HX50",
+    "DSC-HX50V",
+    "DSC-TX30",
+    "DSC-WX60",
+    "DSC-WX80",
+    "DSC-WX200",
+    "DSC-WX300",
+  ] {
+    assert!(
+      selects_tag2010e(Some(m), false),
+      "{m} selects e (no panorama)"
+    );
+    assert!(!selects_tag2010e(Some(m), true), "{m} panorama → NOT e");
+  }
+  // `$`-anchored exact: no trailing chars; a g-variant model is NOT e.
+  assert!(!selects_tag2010e(Some("DSC-RX100M3"), false)); // g
+  assert!(!selects_tag2010e(Some("SLT-A99VX"), false));
+  assert!(!selects_tag2010e(Some("ILCE-3000X"), false));
+  assert!(!selects_tag2010e(None, false));
+}
+
+/// `SLT-A99V` (A-mount): cond-A SonyISO (0x1254), the full scalar block, and the
+/// A-mount `LensType` (0x1896) gated by `LensMount == 1`.
+#[test]
+fn tag2010e_slt_a99v_scalars_and_amount_lens() {
+  let mut p = vec![0u8; 0x1b00];
+  put_u32(&mut p, 0x0000, 9); // SequenceImageNumber → 10
+  put_u32(&mut p, 0x0008, 1); // ReleaseMode2 int32u → Continuous
+  p[0x021c] = 24; // DigitalZoomRatio → 24/16 = 1.5
+  p[0x0328] = 1; // DynamicRangeOptimizer (first row) → Auto
+  p[0x1178] = 1; // DynamicRangeOptimizer (second row, last-wins) → Auto
+  p[0x115c] = 1; // ReleaseMode3 → Continuous
+  p[0x1168] = 2; // SelfTimer → Self-timer 2 s
+  p[0x116c] = 1; // FlashMode → Fill-flash
+  put_u16(&mut p, 0x1172, 512); // StopsAboveBaseISO → 14.0
+  p[0x119b] = 1; // PictureEffect2 → Toy Camera
+  p[0x11a8] = 1; // Quality2 → RAW
+  p[0x11ac] = 3; // MeteringMode → Spot
+  put_u16(&mut p, 0x11b4, 7000);
+  put_u16(&mut p, 0x11b4 + 2, 4096);
+  put_u16(&mut p, 0x11b4 + 4, 6500);
+  put_u16(&mut p, 0x1254, 2048); // SonyISO (cond A) → 25600
+  p[0x1891] = 2; // LensFormat → Full-frame
+  p[0x1892] = 1; // LensMount → A-mount
+  put_u16(&mut p, 0x1896, 18); // LensType (A-mount)
+  p[0x1898] = 1; // DistortionCorrParamsPresent → Yes
+  p[0x1899] = 16; // DistortionCorrParamsNumber → 16 (Full-frame)
+  p[0x192c] = 2; // AspectRatio (non-RX100/Stellar offset) → 3:2
+
+  let em = parse_tag2010e(&p, Some("SLT-A99V"), true);
+  assert_eq!(find(&em, "SequenceImageNumber"), Some(&TagValue::I64(10)));
+  assert_eq!(
+    find_first(&em, "ReleaseMode2"),
+    Some(&TagValue::Str("Continuous".into()))
+  );
+  assert_eq!(find(&em, "DigitalZoomRatio"), Some(&TagValue::F64(1.5)));
+  // Two DynamicRangeOptimizer rows (0x0328, 0x1178); both emit, last-wins "Auto".
+  assert_eq!(
+    find(&em, "DynamicRangeOptimizer"),
+    Some(&TagValue::Str("Auto".into()))
+  );
+  assert_eq!(count(&em, "DynamicRangeOptimizer"), 2);
+  assert_eq!(
+    find(&em, "SelfTimer"),
+    Some(&TagValue::Str("Self-timer 2 s".into()))
+  );
+  assert_eq!(
+    find(&em, "StopsAboveBaseISO"),
+    Some(&TagValue::Str("14.0".into()))
+  );
+  assert_eq!(find(&em, "Quality2"), Some(&TagValue::Str("RAW".into())));
+  assert_eq!(
+    find(&em, "WB_RGBLevels"),
+    Some(&TagValue::Str("7000 4096 6500".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(
+    find(&em, "LensFormat"),
+    Some(&TagValue::Str("Full-frame".into()))
+  );
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("A-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType"),
+    Some(&TagValue::Str("Minolta AF 28-80mm F3.5-5.6 II".into()))
+  );
+  assert!(find(&em, "LensType2").is_none()); // LensMount == 1 → only A-mount
+  assert_eq!(
+    find(&em, "DistortionCorrParamsPresent"),
+    Some(&TagValue::Str("Yes".into()))
+  );
+  assert_eq!(
+    find(&em, "DistortionCorrParamsNumber"),
+    Some(&TagValue::Str("16 (Full-frame)".into()))
+  );
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("3:2".into())));
+  assert!(find(&em, "FocalLength").is_none()); // cond C does not apply to SLT-A99V
+}
+
+/// `ILCE-3000` (E-mount): cond-C FocalLength / MinFocalLength / MaxFocalLength /
+/// SonyISO (0x1278-0x1280) and the E-mount `LensType2` gated by `LensMount == 2`.
+#[test]
+fn tag2010e_ilce_focal_and_emount_lens() {
+  let mut p = vec![0u8; 0x1b00];
+  put_u16(&mut p, 0x1278, 240); // FocalLength → 24.0 mm
+  put_u16(&mut p, 0x127a, 100); // MinFocalLength → 10.0 mm
+  put_u16(&mut p, 0x127c, 700); // MaxFocalLength → 70.0 mm (nonzero)
+  put_u16(&mut p, 0x1280, 2048); // SonyISO (cond C) → 25600
+  p[0x1892] = 2; // LensMount → E-mount
+  put_u16(&mut p, 0x1893, 32784); // LensType2 (E-mount) → Sony E 16mm F2.8
+  p[0x192c] = 1; // AspectRatio → 4:3
+
+  let em = parse_tag2010e(&p, Some("ILCE-3000"), true);
+  assert_eq!(
+    find(&em, "FocalLength"),
+    Some(&TagValue::Str("24.0 mm".into()))
+  );
+  assert_eq!(
+    find(&em, "MinFocalLength"),
+    Some(&TagValue::Str("10.0 mm".into()))
+  );
+  assert_eq!(
+    find(&em, "MaxFocalLength"),
+    Some(&TagValue::Str("70.0 mm".into()))
+  );
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(
+    find(&em, "LensMount"),
+    Some(&TagValue::Str("E-mount".into()))
+  );
+  assert_eq!(
+    find(&em, "LensType2"),
+    Some(&TagValue::Str("Sony E 16mm F2.8".into()))
+  );
+  assert!(find(&em, "LensType").is_none()); // LensMount == 2 → only E-mount
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("4:3".into())));
+}
+
+/// `MaxFocalLength` carries `RawConv => '$val || undef'`: a raw int16u of `0`
+/// (fixed-focal lens) is NOT emitted, while `FocalLength` (no RawConv) is.
+#[test]
+fn tag2010e_maxfocal_zero_dropped() {
+  let mut p = vec![0u8; 0x1b00];
+  put_u16(&mut p, 0x1278, 240); // FocalLength present
+  put_u16(&mut p, 0x127c, 0); // MaxFocalLength raw 0 → undef → dropped
+  let em = parse_tag2010e(&p, Some("ILCE-3000"), true);
+  assert!(find(&em, "FocalLength").is_some());
+  assert!(find(&em, "MaxFocalLength").is_none());
+}
+
+/// `DSC-RX100`: cond-A SonyISO (0x1254, NOT the RX1 0x1258); the DSC class
+/// suppresses LensFormat/LensMount/DistortionCorr*; AspectRatio comes from the
+/// 0x1a88 (RX100/Stellar) offset, NOT 0x192c.
+#[test]
+fn tag2010e_dsc_rx100_suppression_and_aspect_offset() {
+  let mut p = vec![0u8; 0x1b00];
+  put_u16(&mut p, 0x1254, 2048); // SonyISO (cond A includes DSC-RX100) → 25600
+  put_u16(&mut p, 0x1258, 1000); // would-be RX1 offset — must NOT emit for RX100
+  p[0x1891] = 2; // LensFormat byte (DSC → suppressed)
+  p[0x1892] = 1; // LensMount byte (DSC → suppressed)
+  p[0x1898] = 1; // DistortionCorrParamsPresent byte (DSC → suppressed)
+  p[0x1899] = 16; // DistortionCorrParamsNumber byte (DSC → suppressed)
+  p[0x192c] = 2; // AspectRatio @0x192c — must NOT emit for RX100
+  p[0x1a88] = 1; // AspectRatio @0x1a88 → 4:3 (RX100 offset)
+
+  let em = parse_tag2010e(&p, Some("DSC-RX100"), true);
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(count(&em, "SonyISO"), 1); // only 0x1254
+  assert!(find(&em, "LensFormat").is_none());
+  assert!(find(&em, "LensMount").is_none());
+  assert!(find(&em, "DistortionCorrParamsPresent").is_none());
+  assert!(find(&em, "DistortionCorrParamsNumber").is_none());
+  assert!(find(&em, "DistortionCorrParams").is_none());
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("4:3".into())));
+  assert_eq!(count(&em, "AspectRatio"), 1); // only 0x1a88
+}
+
+/// `DSC-RX1`: cond-B SonyISO at 0x1258 (NOT the cond-A 0x1254).
+#[test]
+fn tag2010e_dsc_rx1_iso_offset() {
+  let mut p = vec![0u8; 0x1b00];
+  put_u16(&mut p, 0x1254, 1000); // cond A — must NOT emit for RX1
+  put_u16(&mut p, 0x1258, 2048); // cond B → 25600
+  let em = parse_tag2010e(&p, Some("DSC-RX1"), true);
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::Str("25600".into())));
+  assert_eq!(count(&em, "SonyISO"), 1);
+}
+
+/// `Stellar` quirk: `DistortionCorrParamsNumber` is gated `Model !~ /^DSC-/`
+/// ONLY (so Stellar EMITS it), while LensFormat/LensMount/DistortionCorrParams-
+/// Present are gated `Model !~ /^(DSC-|Stellar)/` (so Stellar suppresses them);
+/// AspectRatio uses the 0x1a88 (RX100/Stellar) offset.
+#[test]
+fn tag2010e_stellar_distortion_number_quirk() {
+  let mut p = vec![0u8; 0x1b00];
+  p[0x1891] = 2; // LensFormat byte (Stellar → suppressed)
+  p[0x1892] = 1; // LensMount byte (suppressed)
+  p[0x1898] = 1; // DistortionCorrParamsPresent (suppressed)
+  p[0x1899] = 11; // DistortionCorrParamsNumber → 11 (APS-C) — EMITS for Stellar
+  p[0x1a88] = 2; // AspectRatio @0x1a88 → 3:2
+
+  let em = parse_tag2010e(&p, Some("Stellar"), true);
+  assert!(find(&em, "LensFormat").is_none());
+  assert!(find(&em, "LensMount").is_none());
+  assert!(find(&em, "DistortionCorrParamsPresent").is_none());
+  assert_eq!(
+    find(&em, "DistortionCorrParamsNumber"),
+    Some(&TagValue::Str("11 (APS-C)".into()))
+  );
+  assert_eq!(find(&em, "AspectRatio"), Some(&TagValue::Str("3:2".into())));
+}
+
+/// The cond-A SonyISO `\b`-anchored "DSC-RX100" stem must NOT swallow
+/// "DSC-RX100M3" (a g-variant model): `\b` fails before the word char `M`.
+#[test]
+fn tag2010e_sonyiso_word_boundary() {
+  let mut p = vec![0u8; 0x1b00];
+  put_u16(&mut p, 0x1254, 2048); // cond-A SonyISO
+  assert!(find(&parse_tag2010e(&p, Some("DSC-RX100"), true), "SonyISO").is_some());
+  assert!(find(&parse_tag2010e(&p, Some("DSC-RX100M3"), true), "SonyISO").is_none());
+}
+
+/// `-n` (raw): SonyISO keeps the integer ValueConv; `LensType2` is the raw
+/// int16u; a hash MISS on `LensType2` renders `"Unknown ($val)"` under `-j`.
+#[test]
+fn tag2010e_raw_mode_and_lens_type_miss() {
+  let mut p = vec![0u8; 0x1b00];
+  put_u16(&mut p, 0x1280, 2048); // SonyISO (cond C)
+  p[0x1892] = 2; // E-mount
+  put_u16(&mut p, 0x1893, 32784); // LensType2
+  let em = parse_tag2010e(&p, Some("ILCE-3000"), false);
+  assert_eq!(find(&em, "SonyISO"), Some(&TagValue::I64(25600)));
+  assert_eq!(find(&em, "LensType2"), Some(&TagValue::I64(32784)));
+
+  let mut p2 = vec![0u8; 0x1b00];
+  p2[0x1892] = 2; // E-mount
+  put_u16(&mut p2, 0x1893, 9999); // not in %sonyLensTypes2
+  let em2 = parse_tag2010e(&p2, Some("ILCE-3000"), true);
+  assert_eq!(
+    find(&em2, "LensType2"),
+    Some(&TagValue::Str("Unknown (9999)".into()))
+  );
+}
+
 // --- shared-conversion edges -------------------------------------------------
 
 /// `StopsAboveBaseISO` ValueConv of exactly 0 prints the bare integer `0`;
@@ -427,5 +705,6 @@ fn per_field_truncation() {
   assert!(parse_tag2010b(&[], true).is_empty());
   assert!(parse_tag2010c(&[], true).is_empty());
   assert!(parse_tag2010d(&[], true).is_empty());
+  assert!(parse_tag2010e(&[], Some("SLT-A99V"), true).is_empty());
   assert!(parse_tag2010f(&[], true).is_empty());
 }

--- a/src/exif/makernotes/vendors/sony/tag9405.rs
+++ b/src/exif/makernotes/vendors/sony/tag9405.rs
@@ -94,14 +94,16 @@ pub fn selects_tag9405b(raw: &[u8]) -> bool {
 // --- model `Condition` predicates --------------------------------------------
 
 /// `$$self{Model} =~ /^(DSC-|Stellar)/` — the `Tag9405a` exclusion class
-/// (`Sony.pm:8902` etc.): a `None` model does NOT match.
-fn model_is_dsc_or_stellar(model: Option<&str>) -> bool {
+/// (`Sony.pm:8902` etc.): a `None` model does NOT match. Shared with the
+/// `Tag2010e` lens / distortion-correction `Condition`s (`Sony.pm:6812` etc.).
+pub(crate) fn model_is_dsc_or_stellar(model: Option<&str>) -> bool {
   model.is_some_and(|m| m.starts_with("DSC-") || m.starts_with("Stellar"))
 }
 
 /// `$$self{Model} =~ /^DSC-/` — the `Tag9405b` exclusion class (`Sony.pm:9046`
-/// etc.).
-fn model_is_dsc(model: Option<&str>) -> bool {
+/// etc.). Shared with the `Tag2010e`/`g`/`h`/`i` lens / distortion-correction
+/// `Condition`s (`Sony.pm:6862`/`7054` etc.).
+pub(crate) fn model_is_dsc(model: Option<&str>) -> bool {
   model.is_some_and(|m| m.starts_with("DSC-"))
 }
 
@@ -114,8 +116,10 @@ fn model_is_dsc_or_zv(model: Option<&str>) -> bool {
 /// `model` starts with any `stem`, then a Perl `\b` word boundary (the next
 /// char is NOT `[A-Za-z0-9_]`, or end-of-string). Used for the `…\b`-anchored
 /// `VignettingCorrParams`/`ChromaticAberrationCorrParams` conditions, where a
-/// bare `ILCE-7` must NOT swallow `ILCE-7M2`/`ILCE-7RM2`/…
-fn starts_with_word_boundary(model: Option<&str>, stems: &[&str]) -> bool {
+/// bare `ILCE-7` must NOT swallow `ILCE-7M2`/`ILCE-7RM2`/… Shared with the
+/// `Tag2010g`/`h`/`i` dispatch `Condition`s and the `Tag2010e` per-leaf
+/// SonyISO / FocalLength / AspectRatio `\b`-anchored `Condition`s.
+pub(crate) fn starts_with_word_boundary(model: Option<&str>, stems: &[&str]) -> bool {
   let Some(m) = model else { return false };
   stems.iter().any(|stem| {
     m.strip_prefix(stem).is_some_and(|rest| {
@@ -293,8 +297,8 @@ fn model_cacp_0x03b8(model: Option<&str>) -> bool {
 // --- PrintConv hashes --------------------------------------------------------
 
 /// `{ 0 => 'No', 1 => 'Yes' }` — `DistortionCorrParamsPresent`
-/// (`Sony.pm:8889`/`9046`).
-fn print_no_yes(v: u8) -> Option<&'static str> {
+/// (`Sony.pm:8889`/`9046`). Shared with `Tag2010e`/`g`/`h`/`i`.
+pub(crate) fn print_no_yes(v: u8) -> Option<&'static str> {
   Some(match v {
     0 => "No",
     1 => "Yes",
@@ -313,8 +317,8 @@ fn print_distortion_correction(v: u8) -> Option<&'static str> {
 }
 
 /// `{ 0 => 'Unknown', 1 => 'APS-C', 2 => 'Full-frame' }` — `LensFormat`
-/// (`Sony.pm:8908`/`9062`).
-fn print_lens_format(v: u8) -> Option<&'static str> {
+/// (`Sony.pm:8908`/`9062`). Shared with `Tag2010e`/`g`/`h`/`i`.
+pub(crate) fn print_lens_format(v: u8) -> Option<&'static str> {
   Some(match v {
     0 => "Unknown",
     1 => "APS-C",
@@ -324,8 +328,8 @@ fn print_lens_format(v: u8) -> Option<&'static str> {
 }
 
 /// `{ 0 => 'Unknown', 1 => 'A-mount', 2 => 'E-mount' }` — `LensMount`
-/// (`Sony.pm:8923`/`9079`).
-fn print_lens_mount(v: u8) -> Option<&'static str> {
+/// (`Sony.pm:8923`/`9079`). Shared with `Tag2010e`/`g`/`h`/`i`.
+pub(crate) fn print_lens_mount(v: u8) -> Option<&'static str> {
   Some(match v {
     0 => "Unknown",
     1 => "A-mount",

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12634,17 +12634,16 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
   // are correctly (double-)deciphered. `0x202a` is the lone plain block and is
   // never deciphered.
   match entry.tag_id() {
-    // `Tag2010a`/`b`/`c`/`d`/`e`/`f`/`g`/`h` — the enciphered `0x2010` shot-info /
-    // WB block (release / self-timer / flash, gain / brightness / exposure-comp,
-    // DRO / HDR / PictureProfile / PictureEffect, metering / exposure program,
-    // WB_RGBLevels, SonyISO, distortion params, + DSC focal-length / aspect-ratio, +
-    // the `e`/`g`/`h` lens-mount / lens-type / distortion-correction rows). `a`-`f`
-    // are selected by the EXACT (`$`-anchored) `$$self{Model}`; `g`/`h` by
-    // `\b`-anchored model sets (`Sony.pm:1100-1173`). The remaining LARGE `i`
-    // variant is not yet ported, so its body (and any unknown one) falls through to
-    // `Tag_0x2010` (`%unknownCipherData`, emits nothing) — faithful until it is
-    // ported. `Tag2010d`/`e` additionally require `not $$self{Panorama}` (the
-    // `0x1003` DataMember latched earlier in the walk; for `e` only the second model
+    // `Tag2010a`..`i` — the enciphered `0x2010` shot-info / WB block (release /
+    // self-timer / flash, gain / brightness / exposure-comp, DRO / HDR /
+    // PictureProfile / PictureEffect, metering / exposure program, WB_RGBLevels,
+    // SonyISO, distortion params, + DSC focal-length / aspect-ratio, + the
+    // `e`/`g`/`h`/`i` lens-mount / lens-type / distortion-correction rows). `a`-`f`
+    // are selected by the EXACT (`$`-anchored) `$$self{Model}`; `g`/`h`/`i` by
+    // `\b`-anchored model sets (`Sony.pm:1100-1173`). A body matching none falls
+    // through to `Tag_0x2010` (`%unknownCipherData`, emits nothing — faithful).
+    // `Tag2010d`/`e` additionally require `not $$self{Panorama}` (the `0x1003`
+    // DataMember latched earlier in the walk; for `e` only the second model
     // alternation is panorama-gated).
     // Every `Tag2010x` table is `PRIORITY => 0` (`Sony.pm:6473` etc.), so each leaf
     // rides priority 0 (never overrides an earlier same-name duplicate). `0x2010 <
@@ -12703,6 +12702,13 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
     0x2010 if tag2010::selects_tag2010h(model) => {
       let buf = process_enciphered(raw, double_cipher);
       for emi in tag2010::parse_tag2010h(&buf, model, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010i(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010i(&buf, model, print_conv) {
         let Ok(()) =
           out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
       }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12634,17 +12634,18 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
   // are correctly (double-)deciphered. `0x202a` is the lone plain block and is
   // never deciphered.
   match entry.tag_id() {
-    // `Tag2010a`/`b`/`c`/`d`/`e`/`f` — the enciphered `0x2010` shot-info / WB block
-    // (release / self-timer / flash, gain / brightness / exposure-comp, DRO / HDR
-    // / PictureProfile / PictureEffect, metering / exposure program, WB_RGBLevels,
-    // SonyISO, distortion params, + DSC focal-length / aspect-ratio, + the `e`
-    // lens-mount / lens-type / distortion-correction rows). The variant is selected
-    // by the EXACT (`$`-anchored) `$$self{Model}` (`Sony.pm:1100-1173`). The
-    // remaining LARGE `g`/`h`/`i` variants are not yet ported, so their bodies (and
-    // any unknown one) fall through to `Tag_0x2010` (`%unknownCipherData`, emits
-    // nothing) — faithful until they are ported. `Tag2010d`/`e` additionally
-    // require `not $$self{Panorama}` (the `0x1003` DataMember latched earlier in the
-    // walk; for `e` only the second model alternation is panorama-gated).
+    // `Tag2010a`/`b`/`c`/`d`/`e`/`f`/`g` — the enciphered `0x2010` shot-info / WB
+    // block (release / self-timer / flash, gain / brightness / exposure-comp, DRO /
+    // HDR / PictureProfile / PictureEffect, metering / exposure program,
+    // WB_RGBLevels, SonyISO, distortion params, + DSC focal-length / aspect-ratio, +
+    // the `e`/`g` lens-mount / lens-type / distortion-correction rows). `a`-`f` are
+    // selected by the EXACT (`$`-anchored) `$$self{Model}`; `g` by a `\b`-anchored
+    // model set (`Sony.pm:1100-1173`). The remaining LARGE `h`/`i` variants are not
+    // yet ported, so their bodies (and any unknown one) fall through to `Tag_0x2010`
+    // (`%unknownCipherData`, emits nothing) — faithful until they are ported.
+    // `Tag2010d`/`e` additionally require `not $$self{Panorama}` (the `0x1003`
+    // DataMember latched earlier in the walk; for `e` only the second model
+    // alternation is panorama-gated).
     // Every `Tag2010x` table is `PRIORITY => 0` (`Sony.pm:6473` etc.), so each leaf
     // rides priority 0 (never overrides an earlier same-name duplicate). `0x2010 <
     // 0x9400` in IFD-tag order, so `double_cipher` is normally unset at this point
@@ -12688,6 +12689,13 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
     0x2010 if tag2010::selects_tag2010f(model) => {
       let buf = process_enciphered(raw, double_cipher);
       for emi in tag2010::parse_tag2010f(&buf, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010g(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010g(&buf, model, print_conv) {
         let Ok(()) =
           out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
       }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12634,17 +12634,17 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
   // are correctly (double-)deciphered. `0x202a` is the lone plain block and is
   // never deciphered.
   match entry.tag_id() {
-    // `Tag2010a`/`b`/`c`/`d`/`e`/`f`/`g` — the enciphered `0x2010` shot-info / WB
-    // block (release / self-timer / flash, gain / brightness / exposure-comp, DRO /
-    // HDR / PictureProfile / PictureEffect, metering / exposure program,
+    // `Tag2010a`/`b`/`c`/`d`/`e`/`f`/`g`/`h` — the enciphered `0x2010` shot-info /
+    // WB block (release / self-timer / flash, gain / brightness / exposure-comp,
+    // DRO / HDR / PictureProfile / PictureEffect, metering / exposure program,
     // WB_RGBLevels, SonyISO, distortion params, + DSC focal-length / aspect-ratio, +
-    // the `e`/`g` lens-mount / lens-type / distortion-correction rows). `a`-`f` are
-    // selected by the EXACT (`$`-anchored) `$$self{Model}`; `g` by a `\b`-anchored
-    // model set (`Sony.pm:1100-1173`). The remaining LARGE `h`/`i` variants are not
-    // yet ported, so their bodies (and any unknown one) fall through to `Tag_0x2010`
-    // (`%unknownCipherData`, emits nothing) — faithful until they are ported.
-    // `Tag2010d`/`e` additionally require `not $$self{Panorama}` (the `0x1003`
-    // DataMember latched earlier in the walk; for `e` only the second model
+    // the `e`/`g`/`h` lens-mount / lens-type / distortion-correction rows). `a`-`f`
+    // are selected by the EXACT (`$`-anchored) `$$self{Model}`; `g`/`h` by
+    // `\b`-anchored model sets (`Sony.pm:1100-1173`). The remaining LARGE `i`
+    // variant is not yet ported, so its body (and any unknown one) falls through to
+    // `Tag_0x2010` (`%unknownCipherData`, emits nothing) — faithful until it is
+    // ported. `Tag2010d`/`e` additionally require `not $$self{Panorama}` (the
+    // `0x1003` DataMember latched earlier in the walk; for `e` only the second model
     // alternation is panorama-gated).
     // Every `Tag2010x` table is `PRIORITY => 0` (`Sony.pm:6473` etc.), so each leaf
     // rides priority 0 (never overrides an earlier same-name duplicate). `0x2010 <
@@ -12696,6 +12696,13 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
     0x2010 if tag2010::selects_tag2010g(model) => {
       let buf = process_enciphered(raw, double_cipher);
       for emi in tag2010::parse_tag2010g(&buf, model, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010h(model) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010h(&buf, model, print_conv) {
         let Ok(()) =
           out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
       }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -12634,15 +12634,17 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
   // are correctly (double-)deciphered. `0x202a` is the lone plain block and is
   // never deciphered.
   match entry.tag_id() {
-    // `Tag2010a`/`b`/`c`/`d`/`f` — the enciphered `0x2010` shot-info / WB block
+    // `Tag2010a`/`b`/`c`/`d`/`e`/`f` — the enciphered `0x2010` shot-info / WB block
     // (release / self-timer / flash, gain / brightness / exposure-comp, DRO / HDR
     // / PictureProfile / PictureEffect, metering / exposure program, WB_RGBLevels,
-    // SonyISO, distortion params, + DSC focal-length / aspect-ratio). The variant
-    // is selected by the EXACT (`$`-anchored) `$$self{Model}` (`Sony.pm:1100-1173`).
-    // The LARGER `e`/`g`/`h`/`i` variants are not yet ported, so their bodies (and
+    // SonyISO, distortion params, + DSC focal-length / aspect-ratio, + the `e`
+    // lens-mount / lens-type / distortion-correction rows). The variant is selected
+    // by the EXACT (`$`-anchored) `$$self{Model}` (`Sony.pm:1100-1173`). The
+    // remaining LARGE `g`/`h`/`i` variants are not yet ported, so their bodies (and
     // any unknown one) fall through to `Tag_0x2010` (`%unknownCipherData`, emits
-    // nothing) — faithful until they are ported. `Tag2010d` additionally requires
-    // `not $$self{Panorama}` (the `0x1003` DataMember latched earlier in the walk).
+    // nothing) — faithful until they are ported. `Tag2010d`/`e` additionally
+    // require `not $$self{Panorama}` (the `0x1003` DataMember latched earlier in the
+    // walk; for `e` only the second model alternation is panorama-gated).
     // Every `Tag2010x` table is `PRIORITY => 0` (`Sony.pm:6473` etc.), so each leaf
     // rides priority 0 (never overrides an earlier same-name duplicate). `0x2010 <
     // 0x9400` in IFD-tag order, so `double_cipher` is normally unset at this point
@@ -12672,6 +12674,13 @@ fn sony_emit_enciphered_subblock<S: ExifSink>(
     0x2010 if tag2010::selects_tag2010d(model, panorama) => {
       let buf = process_enciphered(raw, double_cipher);
       for emi in tag2010::parse_tag2010d(&buf, print_conv) {
+        let Ok(()) =
+          out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
+      }
+    }
+    0x2010 if tag2010::selects_tag2010e(model, panorama) => {
+      let buf = process_enciphered(raw, double_cipher);
+      for emi in tag2010::parse_tag2010e(&buf, model, print_conv) {
         let Ok(()) =
           out.write_vendor_value_with_priority("MakerNotes", group1, emi.name, emi.value, false, 0);
       }


### PR DESCRIPTION
Closes #97. Ports the remaining 4 Sony Tag2010 enciphered 0x2010 variants (e/g/h/i, the large ones) faithfully from ExifTool 13.59 Sony.pm, completing the Tag2010 a-i series (chunk 1 a/b/c/d/f + dispatcher already on main) and the #97 color-data scope (Tag9405a/b + ISOInfo + Tag2010 a-i all done).

- **e** dollar-anchored exact (SLT-A99V/HV/A58/ILCE-3000/NEX-3N/RX100/RX1/Stellar + the not-Panorama DSC-HX/TX/WX set); **g/h/i** word-boundary prefix sets (g=ILCE-7-series/ILCA/DSC, h=RX0/ILCE-6300/7RM2, i=ILCE-6100/9M2/ZV) — the boundary discrimination correct (ILCE-7 does not swallow ILCE-7RM2).
- Reuses the shared 2010 hashes + tag9405 model predicates (no duplication); faithful per-leaf Conditions (LensMount DataMember → LensType2/LensType, MaxFocalLength zero-drop, the i 0x0247 Quality2 repack, selfTimerB2010). PRIORITY 0; ExifTool a-to-i dispatch order; unknown fall-through preserved.

**Fixtureless** (the 3 active raws match no e/g/h/i model), validated by **no-regression (conformance 498/0 byte-identical)** + **21 unit tests** vs Sony.pm. build=0 alloc_budget=0 conformance=498/0 typed_serde=0 timed=161/0 lib=4140/0 xtask=26. **Codex: APPROVE** (clean, no findings). Memory-amplification to issue 443.