### PR TITLE
feat(canon): port CameraInfo mirrorless + PowerShot — completes #85

### DIFF
--- a/src/exif/makernotes/vendors/canon/camera_info.rs
+++ b/src/exif/makernotes/vendors/canon/camera_info.rs
@@ -160,25 +160,59 @@ pub fn model_is_camera_info_5dmkiii(model: Option<&str>) -> bool {
   model.is_some_and(|m| m.trim_end().ends_with("EOS 5D Mark III"))
 }
 
+/// `true` when `model` selects `%Canon::CameraInfoR6` (`Canon.pm:1448`,
+/// `$$self{Model} =~ /\bEOS R[56]$/` — the mirrorless EOS R5 or R6, end-anchored
+/// so NOT the "R6 Mark II/III").
+#[must_use]
+pub fn model_is_camera_info_r6(model: Option<&str>) -> bool {
+  model_ends_with(model, "EOS R5") || model_ends_with(model, "EOS R6")
+}
+
+/// `true` when `model` selects `%Canon::CameraInfoR6m2` (`Canon.pm:1453`,
+/// `$$self{Model} =~ /\bEOS (R6m2|R8|R50)$/` — the EOS R6 Mark II / R8 / R50).
+#[must_use]
+pub fn model_is_camera_info_r6m2(model: Option<&str>) -> bool {
+  model_ends_with(model, "EOS R6m2")
+    || model_ends_with(model, "EOS R8")
+    || model_ends_with(model, "EOS R50")
+}
+
+/// `true` when `model` selects `%Canon::CameraInfoR6m3` (`Canon.pm:1458`,
+/// `$$self{Model} =~ /\bEOS R6 Mark III$/`).
+#[must_use]
+pub fn model_is_camera_info_r6m3(model: Option<&str>) -> bool {
+  model_ends_with(model, "EOS R6 Mark III")
+}
+
+/// `true` when `model` selects `%Canon::CameraInfoG5XII` (`Canon.pm:1463`,
+/// `$$self{Model} =~ /\bG5 X Mark II$/` — the PowerShot G5 X Mark II).
+#[must_use]
+pub fn model_is_camera_info_g5xii(model: Option<&str>) -> bool {
+  model_ends_with(model, "G5 X Mark II")
+}
+
 /// Decode the `Canon::CameraInfo` block for the parent `model` via the `0x0d`
 /// model-conditional list (`Canon.pm:1308-1494`), evaluated in ExifTool's order.
 /// Ported variants: the 1-series no-Hook bodies (1D / 1DS / 1DmkII / 1DmkIIN /
 /// 1DmkIII), the 5D / 6D / 7D, and the xxxD DSLR batch (40D / 50D / 60D / 70D /
 /// 80D / 450D / 500D / 550D / 600D / 650D / 700D / 750D / 760D / 1000D, plus the
 /// 1100D / 1200D aliases), and the pro multi-Hook bodies 5DmkII (1 Hook),
-/// 1DmkIV (2 Hooks), 1DX (3 Hooks) and 5DmkIII (4 Hooks); any other model yields
-/// nothing (deferred). The mirrorless (EOS R6 / R6m2 / R6m3 / G5XII) and
-/// PowerShot count-keyed CameraInfo tables remain deferred. `print_conv`
-/// selects the
+/// 1DmkIV (2 Hooks), 1DX (3 Hooks) and 5DmkIII (4 Hooks); the mirrorless bodies
+/// EOS R6 (R5/R6), R6m2 (R6m2/R8/R50), R6m3 and the PowerShot G5XII; any other
+/// model yields nothing (deferred). The count-keyed PowerShot CameraInfo tables
+/// remain deferred. `print_conv` selects the
 /// PrintConv vs ValueConv view; `canon_lens_type` is the pre-scanned
 /// `$$self{LensType}` (the CameraSettings DataMember) that gates the
 /// `MacroMagnification` leaf (`%ciMacroMagnification`, `Canon.pm:3124-3133`).
+/// `file_type` is the container `$$self{FileType}` (`File:FileType`) gating the
+/// `%CameraInfoG5XII` JPEG/CR3 rows (`Canon.pm:4876`/`:4886`).
 #[must_use]
 pub fn parse(
   data: &[u8],
   order: ByteOrder,
   print_conv: bool,
   model: Option<&str>,
+  file_type: Option<&str>,
   canon_lens_type: Option<u16>,
 ) -> Vec<(SmolStr, TagValue)> {
   if model_is_camera_info_1d(model) {
@@ -227,6 +261,14 @@ pub fn parse(
     camera_info_750d(data, order, print_conv)
   } else if model_is_camera_info_1000d(model) {
     camera_info_1000d(data, order, print_conv, canon_lens_type)
+  } else if model_is_camera_info_r6(model) {
+    camera_info_r6(data, order, print_conv)
+  } else if model_is_camera_info_r6m2(model) {
+    camera_info_r6m2(data, order)
+  } else if model_is_camera_info_r6m3(model) {
+    camera_info_r6m3(data, order)
+  } else if model_is_camera_info_g5xii(model) {
+    camera_info_g5xii(data, order, file_type)
   } else {
     Vec::new()
   }
@@ -2571,6 +2613,77 @@ fn camera_info_1000d(
   out
 }
 
+/// `%Canon::CameraInfoR6` (`Canon.pm:4817-4840`). The mirrorless EOS R5/R6
+/// `CameraInfo` (`%binaryDataAttrs` ⇒ `FORMAT => 'int8u'`, `FIRST_ENTRY => 0`,
+/// `PRIORITY => 0`), keyed by byte offset like the DSLR `int8u` tables; emitted
+/// by ascending offset (CameraTemperature 0x09da, ShutterCount 0x0af1).
+fn camera_info_r6(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let mut push = |name: &'static str, v: TagValue| out.push((SmolStr::new_static(name), v));
+  // 0x09da CameraTemperature (`Canon.pm:4825`, int8u, `$val-128`, "$val C").
+  emit_camera_temperature(data, 0x09da, print_conv, &mut push);
+  // 0x0af1 ShutterCount (`Canon.pm:4832`, `Format => 'int32u'`, no conv).
+  emit_int32_index(data, 0x0af1, order, "ShutterCount", 0, &mut push);
+  out
+}
+
+/// `%Canon::CameraInfoR6m2` (`Canon.pm:4842-4853`). The EOS R6 Mark II / R8 / R50
+/// `CameraInfo` (int8u, byte-keyed): a single `Format => 'int32u'` ShutterCount
+/// (`Canon.pm:4848`). No PrintConv ⇒ identical in both views.
+fn camera_info_r6m2(data: &[u8], order: ByteOrder) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let mut push = |name: &'static str, v: TagValue| out.push((SmolStr::new_static(name), v));
+  // 0x0d29 ShutterCount (`Canon.pm:4848`, `Format => 'int32u'`).
+  emit_int32_index(data, 0x0d29, order, "ShutterCount", 0, &mut push);
+  out
+}
+
+/// `%Canon::CameraInfoR6m3` (`Canon.pm:4855-4866`). The EOS R6 Mark III
+/// `CameraInfo` (int8u, byte-keyed): a single `Format => 'int16u'` ImageCount
+/// (`Canon.pm:4861`, resets to 0 when the SD card is formatted).
+fn camera_info_r6m3(data: &[u8], order: ByteOrder) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let mut push = |name: &'static str, v: TagValue| out.push((SmolStr::new_static(name), v));
+  // 0x086d ImageCount (`Canon.pm:4861`, `Format => 'int16u'`, no conv).
+  if let Some(v) = u16(data, 0x086d, order) {
+    push("ImageCount", TagValue::I64(v));
+  }
+  out
+}
+
+/// `%Canon::CameraInfoG5XII` (`Canon.pm:4868-4904`). The PowerShot G5 X Mark II
+/// `CameraInfo` (int8u, byte-keyed). Every leaf is `$$self{FileType}`-gated: the
+/// JPEG rows (ShutterCount 0x0293, DirectoryIndex 0x0b21, FileIndex 0x0b2d) and
+/// the CR3 row (ShutterCount 0x0a95). No PrintConv ⇒ identical in both views.
+/// Emitted by ascending offset, exactly as `ProcessBinaryData` walks the indices.
+fn camera_info_g5xii(
+  data: &[u8],
+  order: ByteOrder,
+  file_type: Option<&str>,
+) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let mut push = |name: &'static str, v: TagValue| out.push((SmolStr::new_static(name), v));
+  let is_jpeg = file_type == Some("JPEG");
+  let is_cr3 = file_type == Some("CR3");
+  // 0x0293 ShutterCount (`Canon.pm:4871`, `Format => 'int32u'`) — JPEG only.
+  if is_jpeg {
+    emit_int32_index(data, 0x0293, order, "ShutterCount", 0, &mut push);
+  }
+  // 0x0a95 ShutterCount (`Canon.pm:4885`, `Format => 'int32u'`) — CR3 only.
+  if is_cr3 {
+    emit_int32_index(data, 0x0a95, order, "ShutterCount", 0, &mut push);
+  }
+  // 0x0b21 DirectoryIndex (`Canon.pm:4891`, `Format => 'int32u'`, no conv) — JPEG.
+  if is_jpeg {
+    emit_directory_index(data, 0x0b21, order, false, &mut push);
+  }
+  // 0x0b2d FileIndex (`Canon.pm:4897`, `Format => 'int32u'`, `$val + 1`) — JPEG.
+  if is_jpeg {
+    emit_file_index(data, 0x0b2d, order, &mut push);
+  }
+  out
+}
+
 // ─── shared per-field emitters for the int8u xxxD `CameraInfo` tables ─────────
 // Each reads at the byte offset the caller already resolved (applying any
 // firmware `Hook` shift) and pushes the rendered leaf, reusing the same value
@@ -3790,6 +3903,19 @@ fn read_string(data: &[u8], off: usize, len: usize) -> Option<String> {
 mod tests {
   use super::*;
 
+  /// The pre-mirrorless `parse` arity (no `$$self{FileType}`/PowerShot context)
+  /// the per-model unit tests drive. `file_type` defaults to `None` — every
+  /// model-table row these tests exercise is `FileType`-independent.
+  fn parse_model(
+    data: &[u8],
+    order: ByteOrder,
+    print_conv: bool,
+    model: Option<&str>,
+    canon_lens_type: Option<u16>,
+  ) -> Vec<(SmolStr, TagValue)> {
+    super::parse(data, order, print_conv, model, None, canon_lens_type)
+  }
+
   /// Build a CameraInfo5D blob with the named bytes set (the rest zero).
   fn blob() -> Vec<u8> {
     let mut b = vec![0u8; 0x120];
@@ -3815,7 +3941,7 @@ mod tests {
   #[test]
   fn camera_info_5d_print_values() {
     let data = blob();
-    let em = parse(&data, ByteOrder::Little, true, Some("Canon EOS 5D"), None);
+    let em = parse_model(&data, ByteOrder::Little, true, Some("Canon EOS 5D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -3851,7 +3977,7 @@ mod tests {
   #[test]
   fn camera_info_5d_numeric_iso() {
     let data = blob();
-    let em = parse(&data, ByteOrder::Little, false, Some("Canon EOS 5D"), None);
+    let em = parse_model(&data, ByteOrder::Little, false, Some("Canon EOS 5D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::I64(400)));
     assert_eq!(find("FileIndex"), Some(TagValue::I64(1428)));
@@ -3873,7 +3999,7 @@ mod tests {
     // A model handled by no table yields nothing (the mirrorless R-series
     // CameraInfo tables remain deferred to a later chunk).
     assert!(
-      parse(
+      parse_model(
         &[0u8; 0x120],
         ByteOrder::Little,
         true,
@@ -3914,7 +4040,7 @@ mod tests {
     b[0x133..0x137].copy_from_slice(&100u32.to_le_bytes()); // FileIndex + 1 = 101
     b[0x13f..0x143].copy_from_slice(&100u32.to_le_bytes()); // DirectoryIndex - 1 = 99
     b[0x92b..0x934].copy_from_slice(b"EF24-70mm"); // LensModel string[64]
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -3944,10 +4070,10 @@ mod tests {
     assert_eq!(find("DirectoryIndex"), Some(TagValue::I64(99)));
     assert_eq!(find("LensModel"), Some(TagValue::Str("EF24-70mm".into())));
     // MacroMagnification is gated on the pre-scanned LensType == 124.
-    let em2 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 40D"), Some(50));
+    let em2 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 40D"), Some(50));
     assert!(em2.iter().all(|(k, _)| k != "MacroMagnification"));
     // -n view: ISO / FileIndex render as bare integers.
-    let emn = parse(&b, ByteOrder::Little, false, Some("Canon EOS 40D"), None);
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS 40D"), None);
     let findn = |n: &str| emn.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(findn("ISO"), Some(TagValue::I64(400)));
     assert_eq!(findn("FileIndex"), Some(TagValue::I64(101)));
@@ -3959,7 +4085,7 @@ mod tests {
   fn camera_info_40d_truncated_per_field() {
     let mut b = vec![0u8; 0x80];
     b[0x06] = 88; // ISO 400 (in range)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 40D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 40D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert!(find("FirmwareVersion").is_none());
@@ -3987,7 +4113,7 @@ mod tests {
     b[0x15a..0x160].copy_from_slice(b"2.6.1\0"); // version prefix at 0x15a ⇒ CanonFirm 1
     b[0x197..0x19b].copy_from_slice(&200u32.to_le_bytes()); // FileIndex @ 0x19b-4
     b[0x1a3..0x1a7].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex @ 0x1a7-4
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 50D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 50D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -4024,7 +4150,7 @@ mod tests {
     b[0x15e..0x164].copy_from_slice(b"1.0.3\0"); // version prefix at 0x15e ⇒ CanonFirm 2
     b[0x19b..0x19f].copy_from_slice(&200u32.to_le_bytes()); // FileIndex @ 0x19b
     b[0x1a7..0x1ab].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex @ 0x1a7
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 50D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 50D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("MaxFocalLength"), Some(TagValue::Str("100 mm".into())));
     assert_eq!(find("FirmwareVersion"), Some(TagValue::Str("1.0.3".into())));
@@ -4038,7 +4164,7 @@ mod tests {
   fn dispatch_anchored_5dmkii() {
     let mut b = vec![0u8; 0x400];
     b[0x17e..0x184].copy_from_slice(b"1.0.6\0"); // CanonFirm 2
-    let mk2 = parse(
+    let mk2 = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4046,7 +4172,7 @@ mod tests {
       None,
     );
     assert!(mk2.iter().any(|(k, _)| k == "FirmwareVersion"));
-    let plain = parse(&b, ByteOrder::Little, true, Some("Canon EOS 5D"), None);
+    let plain = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 5D"), None);
     assert!(plain.iter().all(|(k, _)| k != "FirmwareVersion"));
   }
 
@@ -4077,7 +4203,7 @@ mod tests {
     b[0x1bb..0x1bf].copy_from_slice(&200u32.to_le_bytes()); // FileIndex ⇒ +1 = 201
     b[0x1c7..0x1cb].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex ⇒ -1 = 199
     b[0x2f7..0x2fb].copy_from_slice(&5i32.to_le_bytes()); // PSInfo ContrastStandard = 5
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4143,7 +4269,7 @@ mod tests {
     b[0x197..0x19b].copy_from_slice(&500u32.to_le_bytes());
     b[0x1a3..0x1a7].copy_from_slice(&500u32.to_le_bytes());
     b[0x2d3..0x2d7].copy_from_slice(&7i32.to_le_bytes());
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4171,7 +4297,7 @@ mod tests {
     b[0xeb] = 0x69; // MaxFocalLength 105 (Hook entry, still emitted)
     b[0x17e..0x184].copy_from_slice(b"badfw\0"); // not a version ⇒ CanonFirm 0
     b[0x1bb..0x1bf].copy_from_slice(&200u32.to_le_bytes()); // nominal FileIndex (dropped)
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4194,7 +4320,7 @@ mod tests {
     let mut b = vec![0u8; 0x400];
     b[0x1b] = 75; // 75 ⇒ 1.0x
     b[0x17e..0x184].copy_from_slice(b"1.0.6\0"); // CanonFirm 2
-    let with = parse(
+    let with = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4208,7 +4334,7 @@ mod tests {
         .map(|(_, v)| v.clone()),
       Some(TagValue::Str("1.0x".into()))
     );
-    let without = parse(
+    let without = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4252,7 +4378,7 @@ mod tests {
     b[0x22c..0x230].copy_from_slice(&200u32.to_le_bytes()); // FileIndex ⇒ 201
     b[0x238..0x23c].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex ⇒ 199
     b[0x368..0x36c].copy_from_slice(&5i32.to_le_bytes()); // PSInfo ContrastStandard
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4304,7 +4430,7 @@ mod tests {
     b[0x227..0x22b].copy_from_slice(&500u32.to_le_bytes());
     b[0x233..0x237].copy_from_slice(&500u32.to_le_bytes());
     b[0x363..0x367].copy_from_slice(&7i32.to_le_bytes());
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4331,7 +4457,7 @@ mod tests {
     b[0x56] = 0x00;
     b[0x57] = 0x64; // FocusDistanceLower at 0x56 (Hook entry, still emitted)
     b[0x22c..0x230].copy_from_slice(&200u32.to_le_bytes()); // nominal FileIndex (dropped)
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4379,7 +4505,7 @@ mod tests {
     b[0x2d0..0x2d4].copy_from_slice(&200u32.to_le_bytes()); // FileIndex ⇒ 201
     b[0x2dc..0x2e0].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex ⇒ 199
     b[0x3f4..0x3f8].copy_from_slice(&5i32.to_le_bytes()); // PSInfo2 ContrastStandard
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -4417,7 +4543,7 @@ mod tests {
     b[0x2c1..0x2c5].copy_from_slice(&500u32.to_le_bytes()); // FileIndex 0x2d0 ⇒ 0x2c1 (-15)
     b[0x2cd..0x2d1].copy_from_slice(&500u32.to_le_bytes()); // DirectoryIndex 0x2dc ⇒ 0x2cd (-15)
     b[0x3e5..0x3e9].copy_from_slice(&7i32.to_le_bytes()); // PSInfo2 0x3f4 ⇒ 0x3e5 (-15)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(find("FocalLength"), Some(TagValue::Str("50 mm".into())));
@@ -4442,7 +4568,7 @@ mod tests {
     b[0x1af] = 0x18; // MinFocalLength 0x1a9 ⇒ 0x1ae (+5)
     b[0x1b0] = 0x00;
     b[0x1b1] = 0x69; // MaxFocalLength 0x1ab ⇒ 0x1b0 (+5)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(find("FocalLength"), Some(TagValue::Str("50 mm".into())));
@@ -4464,7 +4590,7 @@ mod tests {
     b[0x1a4] = 0x00;
     b[0x1a5] = 0x69; // MaxFocalLength 0x1ab ⇒ 0x1a4 (-7, still emits)
     b[0x2d0..0x2d4].copy_from_slice(&200u32.to_le_bytes()); // nominal FileIndex (dropped)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS-1D X"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -4516,7 +4642,7 @@ mod tests {
     b[0x298..0x29c].copy_from_slice(&300u32.to_le_bytes()); // DirectoryIndex ⇒ 299
     b[0x29c..0x2a0].copy_from_slice(&400u32.to_le_bytes()); // DirectoryIndex2 ⇒ 399
     b[0x3b0..0x3b4].copy_from_slice(&5i32.to_le_bytes()); // PSInfo2 ContrastStandard
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4569,7 +4695,7 @@ mod tests {
     b[0x154..0x159].copy_from_slice(&[0xab, 0xcd, 0xef, 0x12, 0x34]); // LensSerial 0x164 ⇒ 0x154 (-16)
     b[0x27c..0x280].copy_from_slice(&500u32.to_le_bytes()); // FileIndex 0x28c ⇒ 0x27c (-16)
     b[0x3a0..0x3a4].copy_from_slice(&7i32.to_le_bytes()); // PSInfo2 0x3b0 ⇒ 0x3a0 (-16)
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4611,7 +4737,7 @@ mod tests {
     b[0x162] = 0x00;
     b[0x163] = 0x69; // MaxFocalLength 0x157 ⇒ 0x162 (+11)
     b[0x16f..0x174].copy_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05]); // LensSerial 0x164 ⇒ 0x16f (+11)
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4646,7 +4772,7 @@ mod tests {
     b[0x23] = 0x00;
     b[0x24] = 0x32; // FocalLength nominal (shifted out)
     b[0x23c..0x240].copy_from_slice(&200u32.to_le_bytes()); // nominal FW region (no version)
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4695,7 +4821,7 @@ mod tests {
     b[0x133..0x137].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex PLAIN = 200
     b[0x13f..0x143].copy_from_slice(&200u32.to_le_bytes()); // FileIndex + 1 = 201
     b[0x933..0x93e].copy_from_slice(b"EF-S18-55mm"); // LensModel
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 450D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 450D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -4730,7 +4856,7 @@ mod tests {
     b[0x190..0x196].copy_from_slice(b"1.1.1\0"); // FirmwareVersion (valid)
     b[0x1d3..0x1d7].copy_from_slice(&200u32.to_le_bytes()); // FileIndex 201
     b[0x1df..0x1e3].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex 199
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 500D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 500D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(
       find("HighlightTonePriority"),
@@ -4752,7 +4878,7 @@ mod tests {
     assert_eq!(find("DirectoryIndex"), Some(TagValue::I64(199)));
     // The RawConv drops a non-version FirmwareVersion string.
     b[0x190..0x196].copy_from_slice(b"BADVER");
-    let em2 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 500D"), None);
+    let em2 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 500D"), None);
     assert!(em2.iter().all(|(k, _)| k != "FirmwareVersion"));
   }
 
@@ -4775,7 +4901,7 @@ mod tests {
     b[0x1a4..0x1aa].copy_from_slice(b"2.0.0\0"); // FirmwareVersion (valid)
     b[0x1e4..0x1e8].copy_from_slice(&200u32.to_le_bytes()); // FileIndex 201
     b[0x1f0..0x1f4].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex 199
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 550D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 550D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(
       find("HighlightTonePriority"),
@@ -4825,7 +4951,7 @@ mod tests {
     b[0x137..0x13b].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex PLAIN = 200
     b[0x143..0x147].copy_from_slice(&200u32.to_le_bytes()); // FileIndex + 1 = 201
     b[0x937..0x943].copy_from_slice(b"EF-S55-250mm"); // LensModel
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -4857,12 +4983,12 @@ mod tests {
       Some(TagValue::Str("EF-S55-250mm".into()))
     );
     // -n view: FlashModel renders the masked raw integer.
-    let emn = parse(&b, ByteOrder::Little, false, Some("Canon EOS 1000D"), None);
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS 1000D"), None);
     let findn = |n: &str| emn.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(findn("FlashModel"), Some(TagValue::I64(17)));
     // A FlashModel value absent from %flashModel ⇒ decimal "Unknown (N)".
     b[0x13] = 0x7f; // 127 (not in the hash)
-    let em2 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 1000D"), None);
+    let em2 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 1000D"), None);
     assert_eq!(
       em2
         .iter()
@@ -4945,7 +5071,7 @@ mod tests {
     b[0x456..0x45a].copy_from_slice(&2i32.to_le_bytes()); // ContrastAuto (0x3c6+0x90)
     b[0x466..0x46a].copy_from_slice(&1i32.to_le_bytes()); // FilterEffectAuto (0x3c6+0xa0)
     b[0x4b6..0x4b8].copy_from_slice(&0x81u16.to_le_bytes()); // UserDef1PictureStyle (0x3c6+0xf0)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 6D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 6D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -4984,7 +5110,7 @@ mod tests {
       Some(TagValue::Str("Standard".into()))
     );
     // -n view: WhiteBalance / LensType render as bare masked integers.
-    let emn = parse(&b, ByteOrder::Little, false, Some("Canon EOS 6D"), None);
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS 6D"), None);
     let findn = |n: &str| emn.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(findn("WhiteBalance"), Some(TagValue::I64(2)));
     assert_eq!(findn("LensType"), Some(TagValue::I64(1)));
@@ -5039,7 +5165,7 @@ mod tests {
     b[0x321..0x325].copy_from_slice(&3i32.to_le_bytes()); // PSInfo2(60D) ContrastStandard
 
     // 60D proper:
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 60D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 60D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(find("FocalLength"), Some(TagValue::Str("50 mm".into())));
@@ -5062,7 +5188,7 @@ mod tests {
     assert_eq!(find("ContrastStandard"), Some(TagValue::I64(3))); // from 0x321
 
     // 1200D alias:
-    let em2 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 1200D"), None);
+    let em2 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 1200D"), None);
     let find2 = |n: &str| em2.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(
       find2("CameraOrientation"),
@@ -5117,7 +5243,7 @@ mod tests {
     b[0x3cf..0x3d3].copy_from_slice(&4i32.to_le_bytes()); // PSInfo2 ContrastStandard
     b[0x45f..0x463].copy_from_slice(&2i32.to_le_bytes()); // PSInfo2 ContrastAuto (0x3cf+0x90)
     b[0x4bf..0x4c1].copy_from_slice(&0x86u16.to_le_bytes()); // UserDef1PictureStyle (0x3cf+0xf0)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 70D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 70D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -5152,7 +5278,7 @@ mod tests {
     // The 70D table has no WhiteBalance row.
     assert!(find("WhiteBalance").is_none());
     // -n view: LensType renders the bare integer.
-    let emn = parse(&b, ByteOrder::Little, false, Some("Canon EOS 70D"), None);
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS 70D"), None);
     assert_eq!(
       emn
         .iter()
@@ -5208,7 +5334,7 @@ mod tests {
     b[0x2fb..0x2ff].copy_from_slice(&6i32.to_le_bytes()); // PSInfo2 ContrastStandard
     b[0x39b..0x39f].copy_from_slice(&1i32.to_le_bytes()); // PSInfo2 FilterEffectAuto (0x2fb+0xa0)
     b[0x3eb..0x3ed].copy_from_slice(&0x83u16.to_le_bytes()); // UserDef1PictureStyle (0x2fb+0xf0)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 600D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 600D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(
       find("HighlightTonePriority"),
@@ -5252,7 +5378,7 @@ mod tests {
       Some(TagValue::Str("Landscape".into()))
     );
     // 1100D alias yields the identical table.
-    let em2 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 1100D"), None);
+    let em2 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 1100D"), None);
     let find2 = |n: &str| em2.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(
       find2("FirmwareVersion"),
@@ -5261,10 +5387,10 @@ mod tests {
     assert_eq!(find2("ContrastStandard"), Some(TagValue::I64(6)));
     // The RawConv guard drops a non-version FirmwareVersion string.
     b[0x19b..0x1a1].copy_from_slice(b"BADVER");
-    let em3 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 600D"), None);
+    let em3 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 600D"), None);
     assert!(em3.iter().all(|(k, _)| k != "FirmwareVersion"));
     // -n view: WhiteBalance / LensType render as bare integers.
-    let emn = parse(&b, ByteOrder::Little, false, Some("Canon EOS 600D"), None);
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS 600D"), None);
     let findn = |n: &str| emn.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(findn("WhiteBalance"), Some(TagValue::I64(2)));
     assert_eq!(findn("LensType"), Some(TagValue::I64(1)));
@@ -5323,7 +5449,7 @@ mod tests {
     b[0x21b..0x221].copy_from_slice(b"1.0.1\0");
     b[0x270..0x274].copy_from_slice(&100u32.to_le_bytes()); // FileIndex + 1 = 101
     b[0x27c..0x280].copy_from_slice(&100u32.to_le_bytes()); // DirectoryIndex - 1 = 99
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 650D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 650D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(find("FocalLength"), Some(TagValue::Str("50 mm".into())));
@@ -5353,7 +5479,7 @@ mod tests {
     b2[0x220..0x226].copy_from_slice(b"2.1.1\0");
     b2[0x274..0x278].copy_from_slice(&200u32.to_le_bytes()); // FileIndex + 1 = 201
     b2[0x280..0x284].copy_from_slice(&200u32.to_le_bytes()); // DirectoryIndex - 1 = 199
-    let em2 = parse(&b2, ByteOrder::Little, true, Some("Canon EOS 700D"), None);
+    let em2 = parse_model(&b2, ByteOrder::Little, true, Some("Canon EOS 700D"), None);
     let find2 = |n: &str| em2.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(
       find2("FirmwareVersion"),
@@ -5404,7 +5530,7 @@ mod tests {
     b[0x48] = 0x50;
     b[0x49] = 0x14; // ColorTemperature int16u = 5200
     b[0x4b] = 0x81; // PictureStyle Standard
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS-1D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS-1D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert!(find("ExposureTime").is_some());
     assert_eq!(find("FocalLength"), Some(TagValue::Str("50 mm".into())));
@@ -5419,7 +5545,7 @@ mod tests {
     assert_eq!(find("ColorTemperature"), Some(TagValue::I64(5200)));
     assert_eq!(find("PictureStyle"), Some(TagValue::Str("Standard".into())));
     // -n view: LensType renders the bare int16uRev value (10).
-    let emn = parse(&b, ByteOrder::Little, false, Some("Canon EOS-1D"), None);
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS-1D"), None);
     assert_eq!(
       emn
         .iter()
@@ -5443,7 +5569,7 @@ mod tests {
     b[0x4e] = 0x88;
     b[0x4f] = 0x13; // ColorTemperature int16u = 5000
     b[0x51] = 0x82; // PictureStyle Portrait
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS-1DS"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS-1DS"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("FocalLength"), Some(TagValue::Str("50 mm".into())));
     assert_eq!(
@@ -5462,7 +5588,7 @@ mod tests {
   fn camera_info_1d_truncated_per_field() {
     let mut b = vec![0u8; 0x05];
     b[0x04] = 0x20; // ExposureTime (in range)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS-1D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS-1D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert!(find("ExposureTime").is_some());
     assert!(find("FocalLength").is_none());
@@ -5509,7 +5635,7 @@ mod tests {
     b[0x72] = 0x03; // Sharpness plain int8s = 3
     b[0x73] = 0x00; // Contrast Normal
     b[0x75..0x78].copy_from_slice(b"100"); // ISO string[5]
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -5536,7 +5662,7 @@ mod tests {
     assert_eq!(find("Contrast"), Some(TagValue::Str("Normal".into())));
     assert_eq!(find("ISO"), Some(TagValue::Str("100".into())));
     // -n view: LensType / CanonImageSize / Saturation render as bare values.
-    let emn = parse(
+    let emn = parse_model(
       &b,
       ByteOrder::Little,
       false,
@@ -5569,7 +5695,7 @@ mod tests {
     b[0x76] = 0xfd; // Saturation -3
     b[0x77] = 0x00; // ColorTone Normal
     b[0x79..0x7c].copy_from_slice(b"200"); // ISO string[5]
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -5636,7 +5762,7 @@ mod tests {
     b[0x2aa..0x2ae].copy_from_slice(&3i32.to_le_bytes()); // PSInfo ContrastStandard
     b[0x45a..0x45e].copy_from_slice(&1_370_690_080u32.to_le_bytes()); // TimeStamp1
     b[0x45e..0x462].copy_from_slice(&1_370_690_080u32.to_le_bytes()); // TimeStamp
-    let em = parse(
+    let em = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -5682,7 +5808,7 @@ mod tests {
       Some(TagValue::Str("2013:06:08 11:14:40".into()))
     );
     // -n view: LensType renders the bare int16uRev value.
-    let emn = parse(
+    let emn = parse_model(
       &b,
       ByteOrder::Little,
       false,
@@ -5697,7 +5823,7 @@ mod tests {
       Some(TagValue::I64(1))
     );
     // The 1DSmkIII shares the table but has NO TimeStamp1 leaf.
-    let ems = parse(
+    let ems = parse_model(
       &b,
       ByteOrder::Little,
       true,
@@ -5752,7 +5878,7 @@ mod tests {
     b[0x45a..0x460].copy_from_slice(b"1.0.1\0"); // FirmwareVersion (no guard)
     b[0x4ae..0x4b2].copy_from_slice(&100u32.to_le_bytes()); // FileIndex + 1 = 101
     b[0x4ba..0x4be].copy_from_slice(&100u32.to_le_bytes()); // DirectoryIndex - 1 = 99
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 80D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 80D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(
@@ -5783,7 +5909,7 @@ mod tests {
     assert!(find("PictureStyle").is_none());
     // FirmwareVersion (0x45a) has NO RawConv guard — a non-version string emits.
     b[0x45a..0x460].copy_from_slice(b"BADVER");
-    let em2 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 80D"), None);
+    let em2 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 80D"), None);
     assert_eq!(
       em2
         .iter()
@@ -5792,7 +5918,7 @@ mod tests {
       Some(TagValue::Str("BADVER".into()))
     );
     // -n view: LensType renders the bare int16uRev value.
-    let emn = parse(&b, ByteOrder::Little, false, Some("Canon EOS 80D"), None);
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS 80D"), None);
     assert_eq!(
       emn
         .iter()
@@ -5822,7 +5948,7 @@ mod tests {
     b[0x187] = 0x0a; // MinFocalLength int16uRev = 10
     b[0x189] = 0xc8; // MaxFocalLength int16uRev = 200
     b[0x449..0x44f].copy_from_slice(b"6.7.2\0"); // FirmwareVersion @ 0x449 (valid)
-    let em = parse(&b, ByteOrder::Little, true, Some("Canon EOS 750D"), None);
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 750D"), None);
     let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
     assert_eq!(find("ISO"), Some(TagValue::Str("400".into())));
     assert_eq!(find("FocalLength"), Some(TagValue::Str("50 mm".into())));
@@ -5841,7 +5967,7 @@ mod tests {
     // Only the 0x449 location holds a valid version (0x43d is zeroed).
     assert_eq!(find("FirmwareVersion"), Some(TagValue::Str("6.7.2".into())));
     // 760D alias yields the identical table.
-    let em2 = parse(&b, ByteOrder::Little, true, Some("Canon EOS 760D"), None);
+    let em2 = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS 760D"), None);
     assert_eq!(
       em2
         .iter()
@@ -5853,7 +5979,7 @@ mod tests {
     let mut b3 = b.clone();
     b3[0x449..0x44f].copy_from_slice(b"\0\0\0\0\0\0");
     b3[0x43d..0x443].copy_from_slice(b"1.2.3\0");
-    let em3 = parse(&b3, ByteOrder::Little, true, Some("Canon EOS 760D"), None);
+    let em3 = parse_model(&b3, ByteOrder::Little, true, Some("Canon EOS 760D"), None);
     assert_eq!(
       em3
         .iter()
@@ -5864,7 +5990,164 @@ mod tests {
     // The RawConv guard drops a non-version string at either location.
     let mut b4 = b.clone();
     b4[0x449..0x44f].copy_from_slice(b"BADVER");
-    let em4 = parse(&b4, ByteOrder::Little, true, Some("Canon EOS 750D"), None);
+    let em4 = parse_model(&b4, ByteOrder::Little, true, Some("Canon EOS 750D"), None);
     assert!(em4.iter().all(|(k, _)| k != "FirmwareVersion"));
+  }
+
+  // ─── mirrorless CameraInfo tables (R6 / R6m2 / R6m3 / G5XII) ────────────────
+
+  #[test]
+  fn camera_info_r6_dispatch_and_leaves() {
+    // `/\bEOS R[56]$/` — the EOS R5/R6 only, NOT the R6m2 nor the R6 Mark III.
+    assert!(model_is_camera_info_r6(Some("Canon EOS R5")));
+    assert!(model_is_camera_info_r6(Some("Canon EOS R6")));
+    assert!(!model_is_camera_info_r6(Some("Canon EOS R6m2")));
+    assert!(!model_is_camera_info_r6(Some("Canon EOS R6 Mark III")));
+    assert!(!model_is_camera_info_r6(Some("Canon EOS R7")));
+
+    let mut b = vec![0u8; 0x0b00];
+    b[0x09da] = 200; // CameraTemperature raw ⇒ 200 - 128 = 72
+    b[0x0af1..0x0af5].copy_from_slice(&74_565u32.to_le_bytes()); // ShutterCount int32u
+    // Emission walks ascending offset: CameraTemperature (0x09da), ShutterCount (0x0af1).
+    let em = parse_model(&b, ByteOrder::Little, true, Some("Canon EOS R6"), None);
+    assert_eq!(
+      em.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
+      ["CameraTemperature", "ShutterCount"]
+    );
+    let find = |n: &str| em.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(
+      find("CameraTemperature"),
+      Some(TagValue::Str("72 C".into()))
+    );
+    assert_eq!(find("ShutterCount"), Some(TagValue::I64(74_565)));
+    // -n view: the temperature renders as the bare ValueConv integer.
+    let emn = parse_model(&b, ByteOrder::Little, false, Some("Canon EOS R5"), None);
+    let findn = |n: &str| emn.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(findn("CameraTemperature"), Some(TagValue::I64(72)));
+    assert_eq!(findn("ShutterCount"), Some(TagValue::I64(74_565)));
+    // A blob too short for ShutterCount emits only the in-range leaf (no panic).
+    let short = parse_model(
+      &b[..0x0a00],
+      ByteOrder::Little,
+      true,
+      Some("Canon EOS R6"),
+      None,
+    );
+    assert_eq!(
+      short.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
+      ["CameraTemperature"]
+    );
+  }
+
+  #[test]
+  fn camera_info_r6m2_shutter_count() {
+    // `/\bEOS (R6m2|R8|R50)$/`.
+    assert!(model_is_camera_info_r6m2(Some("Canon EOS R6m2")));
+    assert!(model_is_camera_info_r6m2(Some("Canon EOS R8")));
+    assert!(model_is_camera_info_r6m2(Some("Canon EOS R50")));
+    assert!(!model_is_camera_info_r6m2(Some("Canon EOS R6")));
+    assert!(!model_is_camera_info_r6m2(Some("Canon EOS R5")));
+
+    let mut b = vec![0u8; 0x0d40];
+    b[0x0d29..0x0d2d].copy_from_slice(&1_000_000u32.to_le_bytes());
+    // No PrintConv ⇒ identical in both views.
+    for pc in [true, false] {
+      let em = parse_model(&b, ByteOrder::Little, pc, Some("Canon EOS R8"), None);
+      assert_eq!(
+        em.iter()
+          .map(|(k, v)| (k.as_str(), v.clone()))
+          .collect::<Vec<_>>(),
+        vec![("ShutterCount", TagValue::I64(1_000_000))]
+      );
+    }
+  }
+
+  #[test]
+  fn camera_info_r6m3_image_count_int16u() {
+    assert!(model_is_camera_info_r6m3(Some("Canon EOS R6 Mark III")));
+    assert!(!model_is_camera_info_r6m3(Some("Canon EOS R6")));
+    assert!(!model_is_camera_info_r6m3(Some("Canon EOS R6m2")));
+
+    let mut b = vec![0u8; 0x0900];
+    b[0x086d..0x086f].copy_from_slice(&0x1234u16.to_le_bytes()); // 4660
+    let em = parse_model(
+      &b,
+      ByteOrder::Big,
+      true,
+      Some("Canon EOS R6 Mark III"),
+      None,
+    );
+    // Big-endian read of the LE-written bytes ⇒ 0x3412 = 13330.
+    assert_eq!(
+      em.iter()
+        .map(|(k, v)| (k.as_str(), v.clone()))
+        .collect::<Vec<_>>(),
+      vec![("ImageCount", TagValue::I64(0x3412))]
+    );
+    let le = parse_model(
+      &b,
+      ByteOrder::Little,
+      true,
+      Some("Canon EOS R6 Mark III"),
+      None,
+    );
+    assert_eq!(
+      le.first().map(|(_, v)| v.clone()),
+      Some(TagValue::I64(0x1234))
+    );
+  }
+
+  #[test]
+  fn camera_info_g5xii_filetype_gated() {
+    // `/\bG5 X Mark II$/` — the PowerShot G5 X Mark II.
+    assert!(model_is_camera_info_g5xii(Some(
+      "Canon PowerShot G5 X Mark II"
+    )));
+    assert!(!model_is_camera_info_g5xii(Some("Canon PowerShot G5 X")));
+
+    let mut b = vec![0u8; 0x0b40];
+    b[0x0293..0x0297].copy_from_slice(&111u32.to_le_bytes()); // ShutterCount (JPEG)
+    b[0x0a95..0x0a99].copy_from_slice(&222u32.to_le_bytes()); // ShutterCount (CR3)
+    b[0x0b21..0x0b25].copy_from_slice(&50u32.to_le_bytes()); // DirectoryIndex (JPEG)
+    b[0x0b2d..0x0b31].copy_from_slice(&1_427u32.to_le_bytes()); // FileIndex ⇒ +1 = 1428
+
+    // JPEG: ShutterCount(0x0293), DirectoryIndex(0x0b21), FileIndex(0x0b2d)+1.
+    let jpeg = camera_info_g5xii(&b, ByteOrder::Little, Some("JPEG"));
+    assert_eq!(
+      jpeg.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
+      ["ShutterCount", "DirectoryIndex", "FileIndex"]
+    );
+    let jf = |n: &str| jpeg.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(jf("ShutterCount"), Some(TagValue::I64(111)));
+    assert_eq!(jf("DirectoryIndex"), Some(TagValue::I64(50)));
+    assert_eq!(jf("FileIndex"), Some(TagValue::I64(1_428)));
+
+    // CR3: only the 0x0a95 ShutterCount.
+    let cr3 = camera_info_g5xii(&b, ByteOrder::Little, Some("CR3"));
+    assert_eq!(
+      cr3
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.clone()))
+        .collect::<Vec<_>>(),
+      vec![("ShutterCount", TagValue::I64(222))]
+    );
+
+    // Any other / unknown FileType ⇒ nothing (every row is FileType-gated).
+    assert!(camera_info_g5xii(&b, ByteOrder::Little, Some("MP4")).is_empty());
+    assert!(camera_info_g5xii(&b, ByteOrder::Little, None).is_empty());
+
+    // Routed through the 0x0d dispatch with the container `$$self{FileType}`.
+    let routed = super::parse(
+      &b,
+      ByteOrder::Little,
+      true,
+      Some("Canon PowerShot G5 X Mark II"),
+      Some("JPEG"),
+      None,
+    );
+    assert_eq!(
+      routed.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
+      ["ShutterCount", "DirectoryIndex", "FileIndex"]
+    );
   }
 }

--- a/src/exif/makernotes/vendors/canon/camera_info.rs
+++ b/src/exif/makernotes/vendors/canon/camera_info.rs
@@ -61,8 +61,9 @@ pub fn model_is_camera_info_6d(model: Option<&str>) -> bool {
 /// `true` when `model` selects `%Canon::CameraInfo1D` (`Canon.pm:1312`,
 /// `$$self{Model} =~ /\b1DS?$/` — the original 1D or 1DS, case-sensitive `S`).
 /// The dispatch `Condition` also assigns `$$self{CameraInfoCount} = $count`
-/// (the record byte length, since `FORMAT => 'int8u'`) — a side-effect read only
-/// by the deferred count-keyed tables (5DmkII / PowerShot / Unknown).
+/// (`Canon.pm:1312`) — a side-effect read by the count-keyed tables that follow
+/// the model rows: the ported `CameraInfoPowerShot`/`PowerShot2` (their
+/// `CameraTemperature` row) and the still-deferred `CameraInfoUnknown*`.
 #[must_use]
 pub fn model_is_camera_info_1d(model: Option<&str>) -> bool {
   model_is_1d_proper(model) || model_is_1ds(model)
@@ -198,15 +199,22 @@ pub fn model_is_camera_info_g5xii(model: Option<&str>) -> bool {
 /// 80D / 450D / 500D / 550D / 600D / 650D / 700D / 750D / 760D / 1000D, plus the
 /// 1100D / 1200D aliases), and the pro multi-Hook bodies 5DmkII (1 Hook),
 /// 1DmkIV (2 Hooks), 1DX (3 Hooks) and 5DmkIII (4 Hooks); the mirrorless bodies
-/// EOS R6 (R5/R6), R6m2 (R6m2/R8/R50), R6m3 and the PowerShot G5XII; any other
-/// model yields nothing (deferred). The count-keyed PowerShot CameraInfo tables
-/// remain deferred. `print_conv` selects the
+/// EOS R6 (R5/R6), R6m2 (R6m2/R8/R50), R6m3 and the PowerShot G5XII; then — after
+/// the model-conditional rows, keyed by the `0x0d` entry's `$count` + `$format`
+/// (`Canon.pm:1466-1479`) rather than the model — the `int32u`
+/// CameraInfoPowerShot (count 138/148) and CameraInfoPowerShot2 (count
+/// 156/162/167/171/264) tables. Only the `CameraInfoUnknown*` catch-alls
+/// (`Canon.pm:1480-1494`) stay deferred; any other model/count yields nothing.
+/// `print_conv` selects the
 /// PrintConv vs ValueConv view; `canon_lens_type` is the pre-scanned
 /// `$$self{LensType}` (the CameraSettings DataMember) that gates the
 /// `MacroMagnification` leaf (`%ciMacroMagnification`, `Canon.pm:3124-3133`).
 /// `file_type` is the container `$$self{FileType}` (`File:FileType`) gating the
-/// `%CameraInfoG5XII` JPEG/CR3 rows (`Canon.pm:4876`/`:4886`).
+/// `%CameraInfoG5XII` JPEG/CR3 rows (`Canon.pm:4876`/`:4886`). `count` and
+/// `is_int32u` are the `0x0d` entry's `$count` and `$format eq "int32u"` — the
+/// PowerShot `Condition` keys (`Canon.pm:1468`/`:1475`).
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn parse(
   data: &[u8],
   order: ByteOrder,
@@ -214,6 +222,8 @@ pub fn parse(
   model: Option<&str>,
   file_type: Option<&str>,
   canon_lens_type: Option<u16>,
+  count: usize,
+  is_int32u: bool,
 ) -> Vec<(SmolStr, TagValue)> {
   if model_is_camera_info_1d(model) {
     camera_info_1d(data, order, print_conv, model)
@@ -269,7 +279,20 @@ pub fn parse(
     camera_info_r6m3(data, order)
   } else if model_is_camera_info_g5xii(model) {
     camera_info_g5xii(data, order, file_type)
+  } else if is_int32u && (count == 138 || count == 148) {
+    // `%Canon::CameraInfoPowerShot` (`Canon.pm:1466-1469`): the model-conditional
+    // rows above all failed, so ExifTool keys on the `0x0d` entry's `$format eq
+    // "int32u"` and `$count` (138/148) instead of the model. `count` IS
+    // `$$self{CameraInfoCount}` (set by the 1D row's side-effecting `Condition`,
+    // `Canon.pm:1312`), which the in-table `CameraTemperature` row also reads.
+    parse_camera_info_powershot(data, order, print_conv, count)
+  } else if is_int32u && matches!(count, 156 | 162 | 167 | 171 | 264) {
+    // `%Canon::CameraInfoPowerShot2` (`Canon.pm:1471-1479`), counts
+    // 156/162/167/171/264 — same int32u gate.
+    parse_camera_info_powershot2(data, order, print_conv, count)
   } else {
+    // The `CameraInfoUnknown32`/`Unknown16`/`Unknown` catch-alls
+    // (`Canon.pm:1480-1494`) stay deferred (#85).
     Vec::new()
   }
 }
@@ -2684,6 +2707,159 @@ fn camera_info_g5xii(
   out
 }
 
+// ─── count-selected PowerShot `CameraInfo` tables (Canon.pm:5711-5847) ────────
+// Dispatched (`Canon.pm:1466-1479`) AFTER the model-conditional rows, by the
+// `0x0d` entry's `$format eq "int32u"` + `$count`, NOT the model. Unlike the
+// model tables (`undef`-format, byte-keyed), these are `FORMAT => 'int32s'`,
+// `FIRST_ENTRY => 0`, `PRIORITY => 0`: a `ProcessBinaryData` index `i` reads an
+// `int32s` at byte offset `i * 4` (`ExifTool.pm:9957`, `$entry = int($index) *
+// $formatSize{int32s}`). The on-disk value is read as `int32u[$count]`, so the
+// caller widens each word back to 4 bytes (`reserialize_int32_array`); the int16
+// blob the model tables use would truncate every word. The shared leaf set
+// (ISO/FNumber/ExposureTime/Rotation/CameraTemperature) carries NO `RawConv`
+// guard, so every in-range field emits.
+
+/// `%Canon::CameraInfoPowerShot` (`Canon.pm:5711-5768`) — counts 138/148. The
+/// `CameraTemperature` leaf sits at index `CameraInfoCount - 3` (135 for 138, 145
+/// for 148), each gated on its exact count (`Canon.pm:5751`/`:5758`).
+fn parse_camera_info_powershot(
+  data: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+  count: usize,
+) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let mut push = |name: &'static str, v: TagValue| out.push((SmolStr::new_static(name), v));
+  emit_powershot_iso(data, 0x00, order, print_conv, &mut push);
+  emit_powershot_fnumber(data, 0x05, order, print_conv, &mut push);
+  emit_powershot_exposure_time(data, 0x06, order, print_conv, &mut push);
+  emit_powershot_rotation(data, 0x17, order, &mut push);
+  // CameraTemperature at index `count - 3` (135 for count 138, 145 for 148).
+  if count == 138 {
+    emit_powershot_camera_temperature(data, 135, order, print_conv, &mut push);
+  } else if count == 148 {
+    emit_powershot_camera_temperature(data, 145, order, print_conv, &mut push);
+  }
+  out
+}
+
+/// `%Canon::CameraInfoPowerShot2` (`Canon.pm:5771-5847`) — counts
+/// 156/162/167/171/264. The `CameraTemperature` leaf sits at index
+/// `CameraInfoCount - 3` (153/159/164/168/261), each gated on its exact count
+/// (`Canon.pm:5809`-`:5846`).
+fn parse_camera_info_powershot2(
+  data: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+  count: usize,
+) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  let mut push = |name: &'static str, v: TagValue| out.push((SmolStr::new_static(name), v));
+  emit_powershot_iso(data, 0x01, order, print_conv, &mut push);
+  emit_powershot_fnumber(data, 0x06, order, print_conv, &mut push);
+  emit_powershot_exposure_time(data, 0x07, order, print_conv, &mut push);
+  emit_powershot_rotation(data, 0x18, order, &mut push);
+  // CameraTemperature at index `count - 3`.
+  let temp_index = match count {
+    156 => 153,
+    162 => 159,
+    167 => 164,
+    171 => 168,
+    264 => 261,
+    _ => return out,
+  };
+  emit_powershot_camera_temperature(data, temp_index, order, print_conv, &mut push);
+  out
+}
+
+// The PowerShot `int32s` leaf emitters. Each takes the `ProcessBinaryData` index
+// (the table key) and reads at byte offset `index * 4` (the `int32s` stride).
+
+/// `ISO` (`Canon.pm:5722`/`:5784`) — `100*exp((($val-411)/96)*log(2))`, PrintConv
+/// `sprintf("%.0f")`. No `RawConv`.
+fn emit_powershot_iso<F: FnMut(&'static str, TagValue)>(
+  data: &[u8],
+  index: usize,
+  order: ByteOrder,
+  print_conv: bool,
+  push: &mut F,
+) {
+  if let Some(raw) = i32s(data, index * 4, order) {
+    let vc = 100.0 * (((raw as f64 - 411.0) / 96.0) * std::f64::consts::LN_2).exp();
+    push(
+      "ISO",
+      value_or_print(print_conv, vc, std::format!("{vc:.0}")),
+    );
+  }
+}
+
+/// `FNumber` (`Canon.pm:5730`/`:5792`) — `exp($val/192*log(2))`, PrintConv
+/// `sprintf("%.2g")`. No `RawConv`.
+fn emit_powershot_fnumber<F: FnMut(&'static str, TagValue)>(
+  data: &[u8],
+  index: usize,
+  order: ByteOrder,
+  print_conv: bool,
+  push: &mut F,
+) {
+  if let Some(raw) = i32s(data, index * 4, order) {
+    let vc = (raw as f64 / 192.0 * std::f64::consts::LN_2).exp();
+    push("FNumber", value_or_print(print_conv, vc, format_g2(vc)));
+  }
+}
+
+/// `ExposureTime` (`Canon.pm:5738`/`:5800`) — `exp(-$val/96*log(2))`, PrintConv
+/// `PrintExposureTime`. No `RawConv`.
+fn emit_powershot_exposure_time<F: FnMut(&'static str, TagValue)>(
+  data: &[u8],
+  index: usize,
+  order: ByteOrder,
+  print_conv: bool,
+  push: &mut F,
+) {
+  if let Some(raw) = i32s(data, index * 4, order) {
+    let vc = (-(raw as f64) / 96.0 * std::f64::consts::LN_2).exp();
+    push(
+      "ExposureTime",
+      value_or_print(print_conv, vc, print_exposure_time(vc)),
+    );
+  }
+}
+
+/// `Rotation` (`Canon.pm:5746`/`:5808`) — plain `int32s`, no conv (identical in
+/// both views).
+fn emit_powershot_rotation<F: FnMut(&'static str, TagValue)>(
+  data: &[u8],
+  index: usize,
+  order: ByteOrder,
+  push: &mut F,
+) {
+  if let Some(raw) = i32s(data, index * 4, order) {
+    push("Rotation", TagValue::I64(raw));
+  }
+}
+
+/// `CameraTemperature` (`Canon.pm:5751`+/`:5809`+) — raw `int32s`, PrintConv
+/// `"$val C"` (no ValueConv).
+fn emit_powershot_camera_temperature<F: FnMut(&'static str, TagValue)>(
+  data: &[u8],
+  index: usize,
+  order: ByteOrder,
+  print_conv: bool,
+  push: &mut F,
+) {
+  if let Some(raw) = i32s(data, index * 4, order) {
+    push(
+      "CameraTemperature",
+      if print_conv {
+        TagValue::Str(SmolStr::from(std::format!("{raw} C")))
+      } else {
+        TagValue::I64(raw)
+      },
+    );
+  }
+}
+
 // ─── shared per-field emitters for the int8u xxxD `CameraInfo` tables ─────────
 // Each reads at the byte offset the caller already resolved (applying any
 // firmware `Hook` shift) and pushes the rendered leaf, reusing the same value
@@ -3903,9 +4079,10 @@ fn read_string(data: &[u8], off: usize, len: usize) -> Option<String> {
 mod tests {
   use super::*;
 
-  /// The pre-mirrorless `parse` arity (no `$$self{FileType}`/PowerShot context)
-  /// the per-model unit tests drive. `file_type` defaults to `None` — every
-  /// model-table row these tests exercise is `FileType`-independent.
+  /// The model-table `parse` arity the per-model unit tests drive. `file_type`
+  /// defaults to `None` (every model-table row these tests exercise is
+  /// `FileType`-independent); `count`/`is_int32u` are `0`/`false`, so the
+  /// count-keyed PowerShot arms never fire — these tests reach a table by MODEL.
   fn parse_model(
     data: &[u8],
     order: ByteOrder,
@@ -3913,7 +4090,16 @@ mod tests {
     model: Option<&str>,
     canon_lens_type: Option<u16>,
   ) -> Vec<(SmolStr, TagValue)> {
-    super::parse(data, order, print_conv, model, None, canon_lens_type)
+    super::parse(
+      data,
+      order,
+      print_conv,
+      model,
+      None,
+      canon_lens_type,
+      0,
+      false,
+    )
   }
 
   /// Build a CameraInfo5D blob with the named bytes set (the rest zero).
@@ -3996,8 +4182,8 @@ mod tests {
     assert!(model_is_camera_info_5dmkii(Some("Canon EOS 5D Mark II")));
     assert!(!model_is_camera_info_5dmkii(Some("Canon EOS 5D")));
     assert!(!model_is_camera_info_5dmkii(Some("Canon EOS 5D Mark III")));
-    // A model handled by no table yields nothing (the mirrorless R-series
-    // CameraInfo tables remain deferred to a later chunk).
+    // A short blob yields nothing even for a ported table: the R6 leaves sit at
+    // 0x09da+ (CameraTemperature) / 0x0af1 (ShutterCount), past this 0x120 blob.
     assert!(
       parse_model(
         &[0u8; 0x120],
@@ -6137,6 +6323,7 @@ mod tests {
     assert!(camera_info_g5xii(&b, ByteOrder::Little, None).is_empty());
 
     // Routed through the 0x0d dispatch with the container `$$self{FileType}`.
+    // G5XII is reached by MODEL, so the count/format keys are inert here.
     let routed = super::parse(
       &b,
       ByteOrder::Little,
@@ -6144,10 +6331,195 @@ mod tests {
       Some("Canon PowerShot G5 X Mark II"),
       Some("JPEG"),
       None,
+      0,
+      false,
     );
     assert_eq!(
       routed.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
       ["ShutterCount", "DirectoryIndex", "FileIndex"]
     );
+  }
+
+  /// Build an `int32s` PowerShot blob of `count` elements (little-endian) with the
+  /// named `(index, value)` words set; every other word is zero. Mirrors how the
+  /// dispatch widens the on-disk `int32u[$count]` value to its byte blob.
+  fn ps_blob(count: usize, words: &[(usize, i32)]) -> Vec<u8> {
+    let mut b = vec![0u8; count * 4];
+    for &(idx, v) in words {
+      b[idx * 4..idx * 4 + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    b
+  }
+
+  /// `%CameraInfoPowerShot` (`Canon.pm:5711`) — the model rows fail, so the
+  /// int32u + count(138/148) gate selects it; `CameraTemperature` tracks the count
+  /// (index 135 for 138, 145 for 148).
+  #[test]
+  fn camera_info_powershot_count_138_and_148() {
+    // ISO 507 ⇒ 200; FNumber 192 ⇒ f/2; ExposureTime 384 ⇒ 1/16; Rotation plain.
+    let b138 = ps_blob(
+      138,
+      &[(0x00, 507), (0x05, 192), (0x06, 384), (0x17, 6), (135, 35)],
+    );
+    let out = super::parse(
+      &b138,
+      ByteOrder::Little,
+      true,
+      Some("Canon PowerShot A450"),
+      None,
+      None,
+      138,
+      true,
+    );
+    let get = |n: &str| out.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(get("ISO"), Some(TagValue::Str("200".into())));
+    assert_eq!(get("FNumber"), Some(TagValue::Str("2".into())));
+    assert_eq!(get("ExposureTime"), Some(TagValue::Str("1/16".into())));
+    assert_eq!(get("Rotation"), Some(TagValue::I64(6)));
+    assert_eq!(get("CameraTemperature"), Some(TagValue::Str("35 C".into())));
+
+    // count 148: CameraTemperature reads index 145, NOT 135 (the 138 row's index).
+    let b148 = ps_blob(148, &[(135, 99), (145, 40)]);
+    let out = super::parse(&b148, ByteOrder::Little, true, None, None, None, 148, true);
+    let temp = out
+      .iter()
+      .find(|(k, _)| k == "CameraTemperature")
+      .map(|(_, v)| v.clone());
+    assert_eq!(temp, Some(TagValue::Str("40 C".into())));
+  }
+
+  /// `%CameraInfoPowerShot2` (`Canon.pm:5771`) — each count selects its own
+  /// `CameraTemperature` index (`Canon.pm:5809`-`:5846`).
+  #[test]
+  fn camera_info_powershot2_all_counts() {
+    for &(count, temp_idx) in &[
+      (156usize, 153usize),
+      (162, 159),
+      (167, 164),
+      (171, 168),
+      (264, 261),
+    ] {
+      let b = ps_blob(
+        count,
+        &[
+          (0x01, 507),
+          (0x06, 192),
+          (0x07, 96),
+          (0x18, 3),
+          (temp_idx, 22),
+        ],
+      );
+      let out = super::parse(&b, ByteOrder::Little, true, None, None, None, count, true);
+      let get = |n: &str| out.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+      assert_eq!(
+        get("ISO"),
+        Some(TagValue::Str("200".into())),
+        "count {count}"
+      );
+      assert_eq!(
+        get("FNumber"),
+        Some(TagValue::Str("2".into())),
+        "count {count}"
+      );
+      assert_eq!(
+        get("ExposureTime"),
+        Some(TagValue::Str("0.5".into())),
+        "count {count}"
+      );
+      assert_eq!(get("Rotation"), Some(TagValue::I64(3)), "count {count}");
+      assert_eq!(
+        get("CameraTemperature"),
+        Some(TagValue::Str("22 C".into())),
+        "count {count}"
+      );
+    }
+  }
+
+  /// The `$format eq "int32u"` gate AND the model-first dispatch order
+  /// (`Canon.pm:1466`-`:1479`, evaluated after every model row).
+  #[test]
+  fn camera_info_powershot_format_and_model_gates() {
+    let b = ps_blob(138, &[(0x00, 507), (135, 35)]);
+    // Right count, but `$format` is not int32u ⇒ the PowerShot rows never fire.
+    assert!(super::parse(&b, ByteOrder::Little, true, None, None, None, 138, false).is_empty());
+    // int32u but an UNLISTED count ⇒ nothing (the deferred `CameraInfoUnknown*`).
+    assert!(
+      super::parse(
+        &ps_blob(100, &[(0x00, 507)]),
+        ByteOrder::Little,
+        true,
+        None,
+        None,
+        None,
+        100,
+        true,
+      )
+      .is_empty()
+    );
+    // A matching MODEL precedes the count keys: a G5 X Mark II at int32u/138 routes
+    // to G5XII, so the PowerShot ISO/CameraTemperature leaves are NOT emitted.
+    let routed = super::parse(
+      &b,
+      ByteOrder::Little,
+      true,
+      Some("Canon PowerShot G5 X Mark II"),
+      Some("JPEG"),
+      None,
+      138,
+      true,
+    );
+    assert!(
+      routed
+        .iter()
+        .all(|(k, _)| k != "ISO" && k != "CameraTemperature")
+    );
+  }
+
+  /// The numeric (`-n`) view: the ValueConv floats render bare-int / `F64` exactly
+  /// like the model tables (`value_or_print`).
+  #[test]
+  fn camera_info_powershot_numeric_view() {
+    let b = ps_blob(138, &[(0x00, 507), (0x05, 192), (0x06, 96), (135, 35)]);
+    let out = super::parse(&b, ByteOrder::Little, false, None, None, None, 138, true);
+    let get = |n: &str| out.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(get("ISO"), Some(TagValue::I64(200)));
+    assert_eq!(get("FNumber"), Some(TagValue::I64(2)));
+    assert_eq!(get("ExposureTime"), Some(TagValue::F64(0.5)));
+    assert_eq!(get("CameraTemperature"), Some(TagValue::I64(35)));
+  }
+
+  /// `int32s` signed decode + per-field availability (a truncated blob drops the
+  /// out-of-range leaves while the in-range ones still emit).
+  #[test]
+  fn camera_info_powershot_signed_and_truncation() {
+    let mut b = ps_blob(138, &[(0x17, -1)]);
+    b[135 * 4..135 * 4 + 4].copy_from_slice(&(-5i32).to_le_bytes());
+    let out = super::parse(&b, ByteOrder::Little, true, None, None, None, 138, true);
+    let get = |n: &str| out.iter().find(|(k, _)| k == n).map(|(_, v)| v.clone());
+    assert_eq!(get("Rotation"), Some(TagValue::I64(-1)));
+    assert_eq!(get("CameraTemperature"), Some(TagValue::Str("-5 C".into())));
+
+    // Truncate to 28 bytes: indices 0/5/6 (bytes 0..28) survive; Rotation (index
+    // 23 ⇒ byte 92) and CameraTemperature (index 135) fall out of range.
+    let full = ps_blob(
+      138,
+      &[(0x00, 507), (0x05, 192), (0x06, 96), (0x17, 6), (135, 35)],
+    );
+    let out = super::parse(
+      &full[..28],
+      ByteOrder::Little,
+      true,
+      None,
+      None,
+      None,
+      138,
+      true,
+    );
+    let names: Vec<_> = out.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(names.contains(&"ISO"));
+    assert!(names.contains(&"FNumber"));
+    assert!(names.contains(&"ExposureTime"));
+    assert!(!names.contains(&"Rotation"));
+    assert!(!names.contains(&"CameraTemperature"));
   }
 }

--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -366,13 +366,17 @@ impl MakerNotesCanon {
 /// the IFD0 `Model` of a preceding in-sample `0x8769` `ExifIFD` block
 /// (Canon.pm:10739-10751), used to evaluate model-conditional Canon sub-tables
 /// (`Canon::ShotInfo` `CameraTemperature`, `Canon::FileInfo` position 1); `None`
-/// when no preceding `0x8769` set one. `file_type` is `None` (a `.mov`/`.cr3`
-/// container is never "CRW", so the ShotInfo CRW clause stays off).
+/// when no preceding `0x8769` set one. `file_type` is the container's
+/// `$$self{FileType}` (the CNCV `OverrideFileType` `"CR3"`/`"CRM"`/`"MP4"`,
+/// `Canon.pm:9669`) — it gates the model-conditional `%CameraInfoG5XII` CR3
+/// ShutterCount row (`$$self{FileType} eq "CR3"`, `Canon.pm:4885`) while leaving
+/// the ShotInfo position-22 CRW clause off (no CR3/CRM/MP4 container is "CRW").
 #[must_use]
 pub fn redispatch_ctmd_makernote(
   tiff_block: &[u8],
   print_conv: bool,
   model: Option<&str>,
+  file_type: Option<&str>,
 ) -> Vec<VendorEmission> {
   // TIFF header: `[II/MM][0x2a][ifd0_offset:u32]` (8 bytes). Bail on a short /
   // unrecognized header (ExifTool's `ProcessTIFF` would `return 0`).
@@ -397,17 +401,20 @@ pub fn redispatch_ctmd_makernote(
   // Route through the SAME isolated shared-`Walker` helper the static-file
   // `-j`/`-n` dispatch uses (`exif::canon_makernote_isolated`) — byte-identical
   // to the retired `parse_in_tiff` oracle for this self-contained TIFF block
-  // (base 0, the Canon Main IFD at `ifd0_offset`). A `.cr3`/`.mov` container is
-  // never "CRW", so `file_type` is `None` (the ShotInfo CRW clause stays off);
-  // only the emissions are needed here (the typed slot is `-j`-only and is
-  // discarded).
+  // (base 0, the Canon Main IFD at `ifd0_offset`). The container `file_type`
+  // (`$$self{FileType}`) is THREADED through so the model-conditional
+  // `%CameraInfoG5XII` CR3 ShutterCount row (`$$self{FileType} eq "CR3"`,
+  // `Canon.pm:4885`) fires on a real PowerShot G5 X Mark II `.cr3`; no
+  // CR3/CRM/MP4 container is "CRW", so the ShotInfo position-22 CRW clause stays
+  // off regardless. Only the emissions are needed here (the typed slot is
+  // `-j`-only and is discarded).
   let (emissions, _typed) = crate::exif::canon_makernote_isolated(
     tiff_block,
     ifd0_offset,
     mn_len,
     order,
     model,
-    /* file_type */ None,
+    file_type,
     print_conv,
   );
   emissions

--- a/src/exif/makernotes/vendors/canon/tags.rs
+++ b/src/exif/makernotes/vendors/canon/tags.rs
@@ -35,8 +35,10 @@
 //!   invariant test guards the whole set. The child leaves stay Phase-2
 //!   deferred (see the #62 umbrella).
 //! - Model-specific `CanonCameraInfoXXX` conditional sub-directories at
-//!   tag 0x0d (`Canon.pm:1307-1494`) are DEFERRED — each model has its
-//!   own micro-table.
+//!   tag 0x0d (`Canon.pm:1307-1494`) are WALKED (issue #85): the per-model
+//!   micro-tables plus the count-selected PowerShot / PowerShot2 tables (see
+//!   [`super::camera_info`]); only the `CameraInfoUnknown*` catch-alls remain
+//!   deferred.
 //! - `CustomFunctionsXXX` at tag 0x0f (`Canon.pm:1500-1582`) are
 //!   DEFERRED — each model has its own micro-table.
 //! - `ColorData1..12` (`Canon.pm:7435-8941`) are decoded in `colordata.rs`
@@ -162,8 +164,10 @@ pub enum SubTable {
   ColorBalance,
   /// `CanonCameraInfo` conditional SubDirectory list — Main tag 0x0d
   /// (`Canon.pm:1308-1494`). Per-model `Canon::CameraInfo<Model>` micro-tables.
-  /// DEFERRED (children unported, issue #85): `is_walked() == false` so the
-  /// parent pointer is suppressed (no bogus raw value).
+  /// WALKED (`is_walked() == true`, issue #85): the dispatch decodes the
+  /// model-conditional bodies and the count-selected PowerShot / PowerShot2
+  /// tables (see [`super::camera_info`]); only the `CameraInfoUnknown*`
+  /// catch-alls (`Canon.pm:1480-1494`) stay deferred.
   CameraInfo,
   /// `%Canon::CropInfo` (`Canon.pm:1880-1882`) — Main tag 0x98. DEFERRED.
   CropInfo,
@@ -340,13 +344,15 @@ impl SubTable {
   /// Faithful to the `Priority => 0` rows of the sub-tables this port WALKS
   /// (`is_walked`): `Canon::ShotInfo` `BaseISO` (`Canon.pm:2789`), `FNumber`
   /// (`:2959`), `ExposureTime` (`:2973`/`:2986` — both conditional-list
-  /// branches); `Canon::FocalLength` `FocalLength` (`:2710`). The other walked
-  /// tables (`CameraSettings`/`FileInfo`/`AFInfo`/`AFInfo2`/`AFInfo3`/
-  /// `SensorInfo`/`ColorBalance`) carry NO `Priority => 0` row. The NON-walked
-  /// tables that DO (`CameraInfo*` `OwnerName`/`LensSerialNumber`, `Processing`
-  /// `Sharpness`, `LensInfo` `LensSerialNumber`, `Composite` `ISO`) never reach
-  /// here — their parent pointer is suppressed (`is_walked() == false`) so no
-  /// leaf is emitted.
+  /// branches); `Canon::FocalLength` `FocalLength` (`:2710`); EVERY
+  /// `Canon::CameraInfo*` leaf (the tables are `PRIORITY => 0`, `Canon.pm:3781`
+  /// etc., the count-selected PowerShot tables included); `Canon::Processing`
+  /// `Sharpness` (`:7220`); and `Canon::LensInfo` `LensSerialNumber` (`:9143`) —
+  /// all WALKED. The other walked tables (`CameraSettings`/`FileInfo`/`AFInfo`/
+  /// `AFInfo2`/`AFInfo3`/`SensorInfo`/`ColorBalance`) carry NO `Priority => 0`
+  /// row. A still-deferred table that DOES (e.g. `Composite` `ISO`) never reaches
+  /// here — its parent pointer is suppressed (`is_walked() == false`) so no leaf
+  /// is emitted.
   ///
   /// A `Priority => 0` Canon leaf NEVER overrides an earlier same-`(doc,
   /// family1, name)` duplicate (`ExifTool.pm:9544-9560`): this matters for the

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -10892,6 +10892,12 @@ fn emit_entry<S: ExifSink>(
           canon_focal_units,
           canon_lens_type,
           canon_focal_length_blob,
+          // `$count`/`$format` — the `0x0d` IFD entry's element count (`value_size
+          // / format size`) and on-disk format, the PowerShot `Condition` keys
+          // (`Canon.pm:1466`-`:1479`). `byte_size().max(1)` guards the `Unknown(_)`
+          // zero size; every non-CameraInfo sub-table ignores both.
+          entry.value_size() / entry.on_disk_format().byte_size().max(1),
+          entry.on_disk_format(),
           out,
         ),
         // A STILL-DEFERRED SubDirectory (`is_walked() == false` — CameraInfo /
@@ -11749,6 +11755,12 @@ fn emit_canon_subtable<S: ExifSink>(
   // readable 0x02 exists; the FocalLength arm then emits nothing (the oracle's
   // `if let Some(ref bytes) = focal_length_data` is likewise a no-op).
   canon_focal_length_blob: Option<&[u8]>,
+  // The `0x0d` CameraInfo entry's `$count` and `$format` (the IFD entry's
+  // count + on-disk format), the keys ExifTool's count-selected PowerShot
+  // `Condition`s read (`Canon.pm:1466`-`:1479`) AFTER the model rows. Consumed
+  // ONLY by the `CameraInfo` arm; every other sub-table ignores them.
+  entry_count: usize,
+  entry_format: Format,
   out: &mut S,
 ) -> Result<(), core::convert::Infallible> {
   use makernotes::vendors::canon::tags::SubTable;
@@ -11814,12 +11826,34 @@ fn emit_canon_subtable<S: ExifSink>(
     SubTable::MeasuredColor => measured_color::parse(&blob, order, print_conv),
     // CameraInfo (0x0d) — model-conditional list (`Canon.pm:1308-1494`); the
     // ported variants are 5D / 7D, the xxxD DSLR batch, the pro multi-Hook bodies,
-    // and the mirrorless R6 / R6m2 / R6m3 / G5XII, all `PRIORITY => 0` (threaded
-    // via `tag_priority`). `canon_lens_type` is the pre-scanned `$$self{LensType}`
-    // gating the `MacroMagnification` leaf; `file_type` is `$$self{FileType}`
-    // gating the G5XII JPEG/CR3 rows. AFMicroAdj (0x4013).
+    // the mirrorless R6 / R6m2 / R6m3 / G5XII, and the count-selected PowerShot /
+    // PowerShot2 tables, all `PRIORITY => 0` (threaded via `tag_priority`).
+    // `canon_lens_type` is the pre-scanned `$$self{LensType}` gating the
+    // `MacroMagnification` leaf; `file_type` is `$$self{FileType}` gating the
+    // G5XII JPEG/CR3 rows. The model tables are `undef`-format (read as verbatim
+    // `Bytes` ⇒ the int16 `blob` equals them); the PowerShot tables are the only
+    // `int32u`-format variant (`$format eq "int32u"`, `Canon.pm:1468`), whose
+    // int32 words the int16 `blob` would truncate — so widen each word to 4 bytes
+    // (`reserialize_int32_array`, the AFMicroAdj treatment) for that case.
     SubTable::CameraInfo => {
-      camera_info::parse(&blob, order, print_conv, model, file_type, canon_lens_type)
+      let is_int32u = entry_format == Format::Int32u;
+      let ci_blob32;
+      let ci_data: &[u8] = if is_int32u {
+        ci_blob32 = makernotes::vendors::canon::reserialize_int32_array(raw, order);
+        &ci_blob32
+      } else {
+        &blob
+      };
+      camera_info::parse(
+        ci_data,
+        order,
+        print_conv,
+        model,
+        file_type,
+        canon_lens_type,
+        entry_count,
+        is_int32u,
+      )
     }
     // AFMicroAdj is `FORMAT => 'int32s'` — its IFD entry is read as `int32u[N]`,
     // so the value words must be widened back to 4 bytes each (the shared `blob`
@@ -24522,6 +24556,8 @@ mod tests {
         /* canon_focal_units */ Some(10),
         /* canon_lens_type */ Some(124),
         /* canon_focal_length_blob */ Some(focal_length.as_slice()),
+        /* entry_count */ 0,
+        /* entry_format */ Format::Undef,
         &mut sink,
       );
     }
@@ -24547,6 +24583,8 @@ mod tests {
         /* canon_focal_units */ None,
         None,
         /* canon_focal_length_blob */ Some(focal_length.as_slice()),
+        /* entry_count */ 0,
+        /* entry_format */ Format::Undef,
         &mut sink,
       );
     }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -11813,11 +11813,14 @@ fn emit_canon_subtable<S: ExifSink>(
     SubTable::Processing => processing::parse(&blob, order, print_conv, model),
     SubTable::MeasuredColor => measured_color::parse(&blob, order, print_conv),
     // CameraInfo (0x0d) — model-conditional list (`Canon.pm:1308-1494`); the
-    // ported variants are 5D / 7D and the xxxD DSLR batch (40D / 50D / 450D /
-    // 500D / 550D / 1000D), all `PRIORITY => 0` (threaded via `tag_priority`).
-    // `canon_lens_type` is the pre-scanned `$$self{LensType}` gating the
-    // `MacroMagnification` leaf. AFMicroAdj (0x4013).
-    SubTable::CameraInfo => camera_info::parse(&blob, order, print_conv, model, canon_lens_type),
+    // ported variants are 5D / 7D, the xxxD DSLR batch, the pro multi-Hook bodies,
+    // and the mirrorless R6 / R6m2 / R6m3 / G5XII, all `PRIORITY => 0` (threaded
+    // via `tag_priority`). `canon_lens_type` is the pre-scanned `$$self{LensType}`
+    // gating the `MacroMagnification` leaf; `file_type` is `$$self{FileType}`
+    // gating the G5XII JPEG/CR3 rows. AFMicroAdj (0x4013).
+    SubTable::CameraInfo => {
+      camera_info::parse(&blob, order, print_conv, model, file_type, canon_lens_type)
+    }
     // AFMicroAdj is `FORMAT => 'int32s'` — its IFD entry is read as `int32u[N]`,
     // so the value words must be widened back to 4 bytes each (the shared `blob`
     // above truncates every word to `int16`, which would shift every leaf).

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -11074,6 +11074,9 @@ impl crate::emit::Taggable for Meta<'_> {
             doc_n,
             print_conv,
             self.cr3().model(),
+            // `$$self{FileType}` (the CNCV `OverrideFileType`) for the G5XII CR3
+            // gate on the CTMD `MakerNoteCanon` re-dispatch.
+            self.cr3().override_file_type(),
             &mut ctmd_scratch,
           );
         }
@@ -15686,6 +15689,11 @@ fn emit_ctmd_exif_info(
   // model-conditional Canon sub-tables (AFInfo2 `AFPointsSelected`) resolve
   // against the body Model exactly as ExifTool's persisted object state does.
   file_model: Option<&str>,
+  // The container `$$self{FileType}` (the CNCV `OverrideFileType`, `Canon.pm:9669`
+  // — `"CR3"`/`"CRM"`/`"MP4"`), threaded into the `MakerNoteCanon` re-dispatch so
+  // the `%CameraInfoG5XII` CR3 ShutterCount row (`$$self{FileType} eq "CR3"`,
+  // `Canon.pm:4885`) gates faithfully on the CTMD path too.
+  file_type: Option<&str>,
   out: &mut std::vec::Vec<crate::emit::EmittedTag>,
 ) {
   use crate::emit::{EmittedTag, Taggable};
@@ -15759,6 +15767,7 @@ fn emit_ctmd_exif_info(
         // The CTMD sample's own `0x8769` Model, else the file-walk CMT1 Model
         // (ExifTool's persisted `$$self{Model}`).
         info.model().or(file_model),
+        file_type,
       );
       let group = scoped("MakerNotes", track);
       for e in emissions {

--- a/src/formats/quicktime_brands.rs
+++ b/src/formats/quicktime_brands.rs
@@ -1656,7 +1656,11 @@ fn render_exif_block(
 /// Render a CMT3 Canon-MakerNote block (a self-contained TIFF whose IFD0 IS the
 /// Canon MakerNote) into `MakerNotes:Canon` [`EmittedTag`]s for the requested
 /// mode, threading `model` (`$$self{Model}` of the most-recent PRECEDING CMT1)
-/// into `Canon::Main` for its model-conditional sub-tables. Routes through
+/// into `Canon::Main` for its model-conditional sub-tables. `file_type` is the
+/// container `$$self{FileType}` (the CNCV `OverrideFileType`, `Canon.pm:9669` —
+/// `"CR3"`/`"CRM"`/`"MP4"`), threaded so the `%CameraInfoG5XII` CR3 ShutterCount
+/// row (`$$self{FileType} eq "CR3"`, `Canon.pm:4885`) fires on a real PowerShot
+/// G5 X Mark II `.cr3`. Routes through
 /// [`redispatch_ctmd_makernote`](crate::exif::makernotes::vendors::canon::redispatch_ctmd_makernote)
 /// (the SAME `ProcessTIFF`-under-`Canon::Main` machinery CTMD's `0x927c` uses).
 #[cfg(feature = "alloc")]
@@ -1664,33 +1668,36 @@ fn render_cmt3_block(
   body: &[u8],
   print_conv: bool,
   model: Option<&str>,
+  file_type: Option<&str>,
 ) -> Vec<crate::emit::EmittedTag> {
   use crate::emit::EmittedTag;
   use crate::value::Group;
-  crate::exif::makernotes::vendors::canon::redispatch_ctmd_makernote(body, print_conv, model)
-    .into_iter()
-    .map(|e| {
-      // Preserve each emission's family-1 group OVERRIDE (the
-      // `CanonCustom::Functions2` 0x0099 leaves group under `CanonCustom`,
-      // `CanonCustom.pm:229`, NOT the parent `Canon`); the default is `Canon`.
-      let group1 = e.group1_override().unwrap_or("Canon");
-      // Carry the emission's ExifTool `Priority => N` too — `0` for the
-      // `Canon::ShotInfo` FNumber/ExposureTime/BaseISO, `Canon::FocalLength`
-      // FocalLength, `Canon::LensInfo` LensSerialNumber and every
-      // `%Canon::CameraInfo*` leaf (`tags::tag_priority`, `ExifTool.pm:9544-9560`).
-      // A `Priority => 0` CMT3 leaf must NEVER override an earlier same-`(doc,
-      // family1, name)` value, so the sink's priority-aware dedup needs the REAL
-      // priority, not the `EmittedTag::new` default `1` (which would let a later
-      // priority-0 duplicate wrongly win).
-      EmittedTag::new_with_priority(
-        Group::new("MakerNotes", group1),
-        smol_str::SmolStr::new(e.name()),
-        e.value().clone(),
-        e.unknown(),
-        e.priority(),
-      )
-    })
-    .collect()
+  crate::exif::makernotes::vendors::canon::redispatch_ctmd_makernote(
+    body, print_conv, model, file_type,
+  )
+  .into_iter()
+  .map(|e| {
+    // Preserve each emission's family-1 group OVERRIDE (the
+    // `CanonCustom::Functions2` 0x0099 leaves group under `CanonCustom`,
+    // `CanonCustom.pm:229`, NOT the parent `Canon`); the default is `Canon`.
+    let group1 = e.group1_override().unwrap_or("Canon");
+    // Carry the emission's ExifTool `Priority => N` too — `0` for the
+    // `Canon::ShotInfo` FNumber/ExposureTime/BaseISO, `Canon::FocalLength`
+    // FocalLength, `Canon::LensInfo` LensSerialNumber and every
+    // `%Canon::CameraInfo*` leaf (`tags::tag_priority`, `ExifTool.pm:9544-9560`).
+    // A `Priority => 0` CMT3 leaf must NEVER override an earlier same-`(doc,
+    // family1, name)` value, so the sink's priority-aware dedup needs the REAL
+    // priority, not the `EmittedTag::new` default `1` (which would let a later
+    // priority-0 duplicate wrongly win).
+    EmittedTag::new_with_priority(
+      Group::new("MakerNotes", group1),
+      smol_str::SmolStr::new(e.name()),
+      e.value().clone(),
+      e.unknown(),
+      e.priority(),
+    )
+  })
+  .collect()
 }
 
 /// Render a CMT4 GPS block (walked top-level against the GPS table) into
@@ -1844,8 +1851,20 @@ pub fn walk_canon_uuid_with_state(
           Cr3CmtKind::Cmt3,
           Cr3Block::at(h.body_abs_start, h.body.len() as u64),
         );
-        let print = render_cmt3_block(h.body, true, current_model.as_deref());
-        let value = render_cmt3_block(h.body, false, current_model.as_deref());
+        // `$$self{FileType}` for the `%CameraInfoG5XII` CR3 gate (Canon.pm:4885):
+        // the CNCV `OverrideFileType` (`"CR3"`/`"CRM"`/`"MP4"`), set by the
+        // PRECEDING CNCV box in this SAME Canon `uuid` walk (file order), exactly
+        // as ExifTool's sequential `$$self{FileType}` is set before CMT3's
+        // SubDirectory runs. Captured OWNED to release the `&out` borrow before
+        // the `&mut out` push below.
+        let file_type = out.override_file_type().map(SmolStr::from);
+        let print = render_cmt3_block(h.body, true, current_model.as_deref(), file_type.as_deref());
+        let value = render_cmt3_block(
+          h.body,
+          false,
+          current_model.as_deref(),
+          file_type.as_deref(),
+        );
         out.push_cmt_tags(print, value);
       }
       // CMT4 — GPS (`GPS::Main`).
@@ -3850,14 +3869,14 @@ mod tests {
   fn render_cmt3_block_preserves_canon_priority_zero() {
     let body = cmt3_shotinfo_body();
     let emissions =
-      crate::exif::makernotes::vendors::canon::redispatch_ctmd_makernote(&body, true, None);
+      crate::exif::makernotes::vendors::canon::redispatch_ctmd_makernote(&body, true, None, None);
     // The block DOES yield a `Priority => 0` emission (BaseISO) — else the test
     // could not tell the fix apart from the bug.
     assert!(
       emissions.iter().any(|e| e.priority() == 0),
       "the ShotInfo body must yield a Priority => 0 emission: {emissions:?}"
     );
-    let rendered = render_cmt3_block(&body, true, None);
+    let rendered = render_cmt3_block(&body, true, None, None);
     assert_eq!(
       rendered.len(),
       emissions.len(),
@@ -3887,6 +3906,70 @@ mod tests {
     assert!(
       !crate::tagmap::dedup_override(base.priority(), 1),
       "a Priority => 0 CMT3 leaf must not override an earlier value"
+    );
+  }
+
+  /// A CMT3 Canon-MakerNote TIFF block whose IFD0 has ONE entry: a `CameraInfo`
+  /// (0x0d) SubDirectory read as `undef[0x0b40]` (verbatim bytes — the format the
+  /// model-keyed `%Canon::CameraInfo*` tables use), with the `%CameraInfoG5XII`
+  /// CR3 `ShutterCount` (0x0a95, `int32u`, `Canon.pm:4885`) set. (LE: header 8 +
+  /// IFD 18 + the 2880-byte value at offset 26.)
+  fn cmt3_g5xii_camerainfo_body() -> Vec<u8> {
+    let mut t: Vec<u8> = std::vec![b'I', b'I', 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00];
+    t.extend_from_slice(&1u16.to_le_bytes()); // 1 IFD0 entry
+    t.extend_from_slice(&0x000du16.to_le_bytes()); // tag 0x0d CanonCameraInfo
+    t.extend_from_slice(&7u16.to_le_bytes()); // format undef (verbatim bytes)
+    t.extend_from_slice(&0x0b40u32.to_le_bytes()); // count 2880 bytes
+    t.extend_from_slice(&26u32.to_le_bytes()); // out-of-line value pointer
+    t.extend_from_slice(&0u32.to_le_bytes()); // next-IFD = 0
+    // 2880-byte `undef` value: zeros up to 0x0a95, the CR3 ShutterCount int32u,
+    // then zero-pad to 0x0b40. Built by extension (no panicking index).
+    let mut blob: Vec<u8> = std::vec![0u8; 0x0a95];
+    blob.extend_from_slice(&7_654_321u32.to_le_bytes()); // CR3 ShutterCount (0x0a95)
+    blob.resize(0x0b40, 0u8);
+    t.extend_from_slice(&blob);
+    t
+  }
+
+  /// INTEGRATED CMT3 path: a G5 X Mark II `CameraInfo` routed through the REAL
+  /// `render_cmt3_block` → `redispatch_ctmd_makernote` → `canon_makernote_isolated`
+  /// chain (NOT the direct `camera_info::parse`). The `%CameraInfoG5XII` CR3
+  /// `ShutterCount` row is `$$self{FileType} eq "CR3"`-gated (`Canon.pm:4885`), so
+  /// it fires ONLY when the container `file_type` THREADS through — proving the
+  /// CR3 `FileType` reaches the gate. (The bug hard-coded `file_type = None` in
+  /// `redispatch_ctmd_makernote`, dropping the row on a real CR3.)
+  #[test]
+  fn render_cmt3_block_threads_g5xii_cr3_file_type() {
+    use crate::value::TagValue;
+    fn shutter_count(tags: &[crate::emit::EmittedTag]) -> Option<&crate::emit::EmittedTag> {
+      tags.iter().find(|t| t.tag().name() == "ShutterCount")
+    }
+    let body = cmt3_g5xii_camerainfo_body();
+    let model = Some("Canon PowerShot G5 X Mark II");
+
+    // CR3 container ($$self{FileType} eq "CR3") → the 0x0a95 ShutterCount FIRES,
+    // under `MakerNotes:Canon`.
+    let cr3 = render_cmt3_block(&body, true, model, Some("CR3"));
+    let sc = shutter_count(&cr3)
+      .unwrap_or_else(|| panic!("CR3 FileType must thread through to emit the G5XII row: {cr3:?}"));
+    assert_eq!(sc.tag().value_ref(), &TagValue::I64(7_654_321));
+    assert_eq!(sc.tag().group_ref().family0(), "MakerNotes");
+    assert_eq!(sc.tag().group_ref().family1(), "Canon");
+
+    // The OLD hard-coded `None` → the CR3 row is DROPPED (the bug); this is the
+    // input the fix has to repair, so without it the test could not tell them apart.
+    let none = render_cmt3_block(&body, true, model, None);
+    assert!(
+      shutter_count(&none).is_none(),
+      "with no FileType the CR3-gated ShutterCount must NOT emit (the pre-fix bug): {none:?}"
+    );
+
+    // A non-CR3 Canon container (e.g. a G5 X Mark II `.mp4`, CNCV "CanonMP4") is
+    // also dropped: the gate is an EXACT `eq "CR3"`, NOT `ne "JPEG"`.
+    let mp4 = render_cmt3_block(&body, true, model, Some("MP4"));
+    assert!(
+      shutter_count(&mp4).is_none(),
+      "the G5XII CR3 row is exact-`eq \"CR3\"`-gated, so MP4 must not emit it: {mp4:?}"
     );
   }
 


### PR DESCRIPTION
Closes #85. Final chunk of the Canon CameraInfo per-model port — the mirrorless CameraInfoR6 (EOS R5/R6), R6m2 (R6m2/R8/R50), R6m3, G5XII (PowerShot G5 X Mark II), and the count-dispatched CameraInfoPowerShot (138/148) + CameraInfoPowerShot2 (156/162/167/171/264, int32s). With chunks 1-4 (5D/7D + 40D/50D/450D/500D/550D/1000D + PSInfo2 group + 1D-series/80D/750D + pro multi-Hook 5DmkII/1DmkIV/1DX/5DmkIII), this completes all 32 CameraInfo tables (only CameraInfoUnknown* deferred).

- PowerShot count-dispatch threads the 0x0d entry count+format (strict int32u gate) + CameraInfoCount; int32 entries widened via reserialize_int32_array.
- **CR3 FileType threading**: the real CNCV-derived FileType (CR3/CRM/MP4, mirroring ExifTool OverrideFileType) now threads through render_cmt3_block → redispatch_ctmd_makernote → canon_makernote_isolated, so G5XII's exact-eq-CR3 ShutterCount fires on the real CR3 CMT3 path (and correctly stays off for MP4/CRM).

**Fixtureless** (active CR2/CR3 use 5D/7D), validated by **no-regression (conformance 498/0 byte-identical)** + unit tests incl an integrated CMT3 test. build=0 conformance=498/0 alloc_budget=ok lib=4228/0 xtask=26. **Codex: APPROVE** (R3 — the CR3 FileType-threading + class sweep). Memory-amplification to issue 443.