### PR TITLE
feat(panasonic): port FaceDet/FaceRec/TimeInfo/Subdir + Leica2-9 sub-tables (#105)

### DIFF
--- a/src/exif/makernotes/vendors/leica/data1.rs
+++ b/src/exif/makernotes/vendors/leica/data1.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Panasonic::Data1` (`Panasonic.pm:1970-1987`).
+//!
+//! Leica M9 `Data1` binary block, reached via the `%Panasonic::Subdir` tag
+//! `0x3901` SubDirectory (`Panasonic.pm:1927-1930`). A `ProcessBinaryData` table
+//! with the DEFAULT `FORMAT => 'int8u'` (numeric keys are byte offsets),
+//! `TAG_PREFIX => 'Leica_Data1'`, `FIRST_ENTRY => 0`. The emitted tag carries
+//! the family-1 group `Leica`.
+//!
+//! One position (`Panasonic.pm:1978-1986`):
+//!
+//! - byte 0x16 (22) `LensType`, `int32u`, `Priority => 0` —
+//!   `ValueConv => '(($val >> 2) & 0xffff) . " " . ($val & 0x3)'` (note the
+//!   `& 0xffff` mask the IFD-level `LensType` lacks), then the `%leicaLensTypes`
+//!   lookup (the full `"id bits"` key, then the leading-integer `OTHER`
+//!   fallback). `-n` keeps the `"id bits"` ValueConv string.
+//!
+//! `Priority => 0` makes this LensType NOT override a higher-priority sibling
+//! (e.g. the Subdir `0x3405 LensType`) in ExifTool's de-dup; exifast emits the
+//! faithful VALUE and leaves de-dup ordering to the emission engine.
+//!
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
+//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+
+#![deny(clippy::indexing_slicing)]
+
+use super::lens_types;
+use crate::exif::ifd::{ByteOrder, get_u32};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Decode the `Panasonic::Data1` binary block (`Panasonic.pm:1970-1987`) into
+/// the `(Name, TagValue)` emission pairs.
+///
+/// `data` is the raw `$$valPt` block; `order` the inherited Subdir byte order
+/// (consumed by the int32u read). Per-field availability: `LensType` is emitted
+/// only when its int32u (bytes 22..26) is in range.
+#[must_use]
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // byte 22 LensType int32u.
+  if let Some(raw) = get_u32(data, 22, order) {
+    out.push((SmolStr::new_static("LensType"), lens_type(raw, print_conv)));
+  }
+  out
+}
+
+/// Data1 `LensType` (`Panasonic.pm:1983`): `ValueConv => '(($val >> 2) & 0xffff)
+/// . " " . ($val & 0x3)'` then the `%leicaLensTypes` lookup (full `"id bits"`
+/// key, then the leading-integer `OTHER` fallback). `-n` keeps the ValueConv
+/// string.
+fn lens_type(raw: u32, print_conv: bool) -> TagValue {
+  let id = (raw >> 2) & 0xffff;
+  let bits = raw & 0x3;
+  let value_conv = std::format!("{id} {bits}");
+  if !print_conv {
+    return TagValue::Str(SmolStr::from(value_conv));
+  }
+  if let Some(name) = lens_types::lookup_name(&value_conv) {
+    return TagValue::Str(name);
+  }
+  let id_key = std::format!("{id}");
+  if let Some(name) = lens_types::lookup_name(&id_key) {
+    return TagValue::Str(name);
+  }
+  // No match ⇒ ExifTool keeps the ValueConv string.
+  TagValue::Str(SmolStr::from(value_conv))
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// `LensType` at byte 22. Oracle: int32u `(5 << 2) = 20` ⇒ id 5 bits 0 ⇒
+  /// `"5"` ⇒ "Summilux-M 50mm f/1.4 (II)" (`-j`) / `"5 0"` (`-n`).
+  #[test]
+  fn lens_type_at_offset_22() {
+    let mut blob = std::vec![0u8; 26];
+    blob[22..26].copy_from_slice(&20u32.to_le_bytes());
+    assert_eq!(
+      find(&parse(&blob, ByteOrder::Little, true), "LensType"),
+      Some(TagValue::Str("Summilux-M 50mm f/1.4 (II)".into()))
+    );
+    assert_eq!(
+      find(&parse(&blob, ByteOrder::Little, false), "LensType"),
+      Some(TagValue::Str("5 0".into()))
+    );
+  }
+
+  /// The `& 0xffff` mask: an id whose pre-mask `>> 2` exceeds 16 bits wraps.
+  /// `raw = ((0x10005) << 2) | 0` ⇒ `>> 2 = 0x10005`, `& 0xffff = 5` ⇒ id 5.
+  #[test]
+  fn lens_type_masks_id_to_16_bits() {
+    let raw: u32 = 0x10005u32 << 2;
+    let mut blob = std::vec![0u8; 26];
+    blob[22..26].copy_from_slice(&raw.to_le_bytes());
+    // id = (raw >> 2) & 0xffff = 5 ⇒ "5 0" ⇒ resolves like id 5.
+    assert_eq!(
+      find(&parse(&blob, ByteOrder::Little, false), "LensType"),
+      Some(TagValue::Str("5 0".into()))
+    );
+  }
+
+  /// A block too short to reach byte 22 omits LensType.
+  #[test]
+  fn short_block_omits() {
+    assert!(parse(&[0u8; 10], ByteOrder::Little, true).is_empty());
+  }
+}

--- a/src/exif/makernotes/vendors/leica/data1.rs
+++ b/src/exif/makernotes/vendors/leica/data1.rs
@@ -18,11 +18,14 @@
 //!   fallback). `-n` keeps the `"id bits"` ValueConv string.
 //!
 //! `Priority => 0` makes this LensType NOT override a higher-priority sibling
-//! (e.g. the Subdir `0x3405 LensType`) in ExifTool's de-dup; exifast emits the
-//! faithful VALUE and leaves de-dup ordering to the emission engine.
+//! (e.g. the Subdir `0x3405 LensType`) in ExifTool's de-dup: [`parse`] rides the
+//! `0` out as the emission triple's priority, which the capture loop emits via
+//! `write_vendor_value_with_priority(.., 0)`, so the shared de-dup keeps the
+//! higher-priority `0x3405` value when both are present (`ExifTool.pm:9544-9560`).
 //!
-//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
-//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue,
+//! Priority)` emission triples the dispatch site wraps in the `Leica` family-1
+//! group.
 
 #![deny(clippy::indexing_slicing)]
 
@@ -33,17 +36,23 @@ use smol_str::SmolStr;
 use std::vec::Vec;
 
 /// Decode the `Panasonic::Data1` binary block (`Panasonic.pm:1970-1987`) into
-/// the `(Name, TagValue)` emission pairs.
+/// the `(Name, TagValue, Priority)` emission triples.
 ///
 /// `data` is the raw `$$valPt` block; `order` the inherited Subdir byte order
 /// (consumed by the int32u read). Per-field availability: `LensType` is emitted
-/// only when its int32u (bytes 22..26) is in range.
+/// only when its int32u (bytes 22..26) is in range. Its `Priority => 0`
+/// (`Panasonic.pm:1981`) is the triple's third element, so the capture loop emits
+/// it with priority `0` and it never overrides a higher-priority sibling.
 #[must_use]
-pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
-  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
-  // byte 22 LensType int32u.
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue, u8)> {
+  let mut out: Vec<(SmolStr, TagValue, u8)> = Vec::new();
+  // byte 22 LensType int32u, `Priority => 0` (Panasonic.pm:1981).
   if let Some(raw) = get_u32(data, 22, order) {
-    out.push((SmolStr::new_static("LensType"), lens_type(raw, print_conv)));
+    out.push((
+      SmolStr::new_static("LensType"),
+      lens_type(raw, print_conv),
+      0,
+    ));
   }
   out
 }
@@ -75,8 +84,10 @@ fn lens_type(raw: u32, print_conv: bool) -> TagValue {
 mod tests {
   use super::*;
 
-  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
-    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  fn find(em: &[(SmolStr, TagValue, u8)], name: &str) -> Option<TagValue> {
+    em.iter()
+      .find(|(k, ..)| k == name)
+      .map(|(_, v, _)| v.clone())
   }
 
   /// `LensType` at byte 22. Oracle: int32u `(5 << 2) = 20` ⇒ id 5 bits 0 ⇒
@@ -92,6 +103,15 @@ mod tests {
     assert_eq!(
       find(&parse(&blob, ByteOrder::Little, false), "LensType"),
       Some(TagValue::Str("5 0".into()))
+    );
+    // `Priority => 0` (Panasonic.pm:1981) rides out as the emission triple's
+    // third element.
+    assert_eq!(
+      parse(&blob, ByteOrder::Little, true)
+        .iter()
+        .find(|(k, ..)| k == "LensType")
+        .map(|(.., p)| *p),
+      Some(0u8)
     );
   }
 

--- a/src/exif/makernotes/vendors/leica/focus_info.rs
+++ b/src/exif/makernotes/vendors/leica/focus_info.rs
@@ -21,8 +21,9 @@
 //!
 //! `-n` carries the ValueConv number (`$val / 1000`); `-j` the PrintConv string.
 //!
-//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
-//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue,
+//! Priority)` emission triples the dispatch site wraps in the `Leica` family-1
+//! group.
 
 #![deny(clippy::indexing_slicing)]
 
@@ -32,15 +33,18 @@ use smol_str::SmolStr;
 use std::vec::Vec;
 
 /// Decode the `Panasonic::FocusInfo` binary block (`Panasonic.pm:2084-2109`)
-/// into the `(Name, TagValue)` emission pairs.
+/// into the `(Name, TagValue, Priority)` emission triples.
 ///
 /// `data` is the raw `$$valPt` block; `order` the inherited parent Leica byte
 /// order. Per-field availability: each position is emitted only when its int16u
 /// is in range (FocalLength additionally drops a zero raw via its `RawConv`).
+/// `FocusDistance` takes the default `Priority => 1`; `FocalLength` carries
+/// `Priority => 0` (`Panasonic.pm:2102`) as the triple's third element, so the
+/// capture loop emits it with priority `0`.
 #[must_use]
-pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
-  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
-  // key 0 (byte 0) FocusDistance int16u.
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue, u8)> {
+  let mut out: Vec<(SmolStr, TagValue, u8)> = Vec::new();
+  // key 0 (byte 0) FocusDistance int16u — default `Priority => 1`.
   if let Some(raw) = get_u16(data, 0, order) {
     let v = f64::from(raw) / 1000.0;
     let value = if print_conv {
@@ -53,9 +57,9 @@ pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, T
     } else {
       TagValue::F64(v)
     };
-    out.push((SmolStr::new_static("FocusDistance"), value));
+    out.push((SmolStr::new_static("FocusDistance"), value, 1));
   }
-  // key 1 (byte 2) FocalLength int16u — RawConv drops a zero raw.
+  // key 1 (byte 2) FocalLength int16u — RawConv drops a zero raw; `Priority => 0`.
   if let Some(raw) = get_u16(data, 2, order) {
     // `RawConv => '$val ? $val : undef'`.
     if raw != 0 {
@@ -65,7 +69,8 @@ pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, T
       } else {
         TagValue::F64(v)
       };
-      out.push((SmolStr::new_static("FocalLength"), value));
+      // `Priority => 0` (Panasonic.pm:2102).
+      out.push((SmolStr::new_static("FocalLength"), value, 0));
     }
   }
   out
@@ -88,8 +93,14 @@ fn fmt_milli(v: f64) -> String {
 mod tests {
   use super::*;
 
-  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
-    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  fn find(em: &[(SmolStr, TagValue, u8)], name: &str) -> Option<TagValue> {
+    em.iter()
+      .find(|(k, ..)| k == name)
+      .map(|(_, v, _)| v.clone())
+  }
+
+  fn priority(em: &[(SmolStr, TagValue, u8)], name: &str) -> Option<u8> {
+    em.iter().find(|(k, ..)| k == name).map(|(.., p)| *p)
   }
 
   /// FocusDistance + FocalLength. Oracle: FocusDistance raw 5500 ⇒ ValueConv 5.5
@@ -109,6 +120,10 @@ mod tests {
       find(&j, "FocalLength"),
       Some(TagValue::Str("50.0 mm".into()))
     );
+    // `FocusDistance` default `Priority => 1`; `FocalLength` `Priority => 0`
+    // (Panasonic.pm:2102).
+    assert_eq!(priority(&j, "FocusDistance"), Some(1u8));
+    assert_eq!(priority(&j, "FocalLength"), Some(0u8));
     let n = parse(&blob, ByteOrder::Little, false);
     assert_eq!(find(&n, "FocusDistance"), Some(TagValue::F64(5.5)));
     assert_eq!(find(&n, "FocalLength"), Some(TagValue::F64(50.0)));

--- a/src/exif/makernotes/vendors/leica/focus_info.rs
+++ b/src/exif/makernotes/vendors/leica/focus_info.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Panasonic::FocusInfo` (`Panasonic.pm:2084-2109`).
+//!
+//! Leica type-5 FocusInfo, reached via the `%Panasonic::Leica5` tag `0x040a`
+//! SubDirectory (`Panasonic.pm:2021-2024`). A `ProcessBinaryData` table with
+//! `FORMAT => 'int16u'` (so each numeric key is multiplied by the int16u size 2
+//! to get the byte offset), `TAG_PREFIX => 'Leica_FocusInfo'`, `FIRST_ENTRY =>
+//! 0`. The emitted tags carry the family-1 group `Leica`.
+//!
+//! Positions (`Panasonic.pm:2093-2108`):
+//!
+//! - key 0 (byte 0) `FocusDistance`, `int16u` — `ValueConv => '$val / 1000'`,
+//!   `PrintConv => '$val < 65535 ? "$val m" : "inf"'`. (The field is `int16u`,
+//!   so `$val/1000 <= 65.535 < 65535`: the `inf` branch is unreachable, but it
+//!   is kept faithfully.)
+//! - key 1 (byte 2) `FocalLength`, `int16u` — `RawConv => '$val ? $val : undef'`
+//!   (drop a zero raw), `ValueConv => '$val / 1000'`, `PrintConv =>
+//!   'sprintf("%.1f mm",$val)'`.
+//!
+//! `-n` carries the ValueConv number (`$val / 1000`); `-j` the PrintConv string.
+//!
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
+//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::{ByteOrder, get_u16};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Decode the `Panasonic::FocusInfo` binary block (`Panasonic.pm:2084-2109`)
+/// into the `(Name, TagValue)` emission pairs.
+///
+/// `data` is the raw `$$valPt` block; `order` the inherited parent Leica byte
+/// order. Per-field availability: each position is emitted only when its int16u
+/// is in range (FocalLength additionally drops a zero raw via its `RawConv`).
+#[must_use]
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // key 0 (byte 0) FocusDistance int16u.
+  if let Some(raw) = get_u16(data, 0, order) {
+    let v = f64::from(raw) / 1000.0;
+    let value = if print_conv {
+      // PrintConv: `$val < 65535 ? "$val m" : "inf"`.
+      if v < 65535.0 {
+        TagValue::Str(SmolStr::from(std::format!("{} m", fmt_milli(v))))
+      } else {
+        TagValue::Str(SmolStr::new_static("inf"))
+      }
+    } else {
+      TagValue::F64(v)
+    };
+    out.push((SmolStr::new_static("FocusDistance"), value));
+  }
+  // key 1 (byte 2) FocalLength int16u — RawConv drops a zero raw.
+  if let Some(raw) = get_u16(data, 2, order) {
+    // `RawConv => '$val ? $val : undef'`.
+    if raw != 0 {
+      let v = f64::from(raw) / 1000.0;
+      let value = if print_conv {
+        TagValue::Str(SmolStr::from(std::format!("{v:.1} mm")))
+      } else {
+        TagValue::F64(v)
+      };
+      out.push((SmolStr::new_static("FocalLength"), value));
+    }
+  }
+  out
+}
+
+/// Format `value / 1000` the way Perl stringifies it for the `"$val m"`
+/// interpolation — up to three fractional digits (a `k/1000` value is exact to
+/// three decimals) with trailing zeros (and a bare dot) stripped (`%g`-style).
+fn fmt_milli(v: f64) -> String {
+  let s = std::format!("{v:.3}");
+  if s.contains('.') {
+    s.trim_end_matches('0').trim_end_matches('.').to_string()
+  } else {
+    s
+  }
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// FocusDistance + FocalLength. Oracle: FocusDistance raw 5500 ⇒ ValueConv 5.5
+  /// ⇒ `"5.5 m"` (`-j`) / `5.5` (`-n`); FocalLength raw 50000 ⇒ 50 ⇒ `"50.0 mm"`
+  /// (`-j`, fixed 1 decimal) / `50` (`-n`).
+  #[test]
+  fn distance_and_length() {
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&5500u16.to_le_bytes());
+    blob.extend_from_slice(&50000u16.to_le_bytes());
+    let j = parse(&blob, ByteOrder::Little, true);
+    assert_eq!(
+      find(&j, "FocusDistance"),
+      Some(TagValue::Str("5.5 m".into()))
+    );
+    assert_eq!(
+      find(&j, "FocalLength"),
+      Some(TagValue::Str("50.0 mm".into()))
+    );
+    let n = parse(&blob, ByteOrder::Little, false);
+    assert_eq!(find(&n, "FocusDistance"), Some(TagValue::F64(5.5)));
+    assert_eq!(find(&n, "FocalLength"), Some(TagValue::F64(50.0)));
+  }
+
+  /// A whole-metre FocusDistance strips trailing zeros in the `"$val m"` form
+  /// (Perl `%g`): raw 5000 ⇒ 5 ⇒ `"5 m"` (not `"5.000 m"`).
+  #[test]
+  fn focus_distance_strips_trailing_zeros() {
+    let blob = 5000u16.to_le_bytes();
+    assert_eq!(
+      find(&parse(&blob, ByteOrder::Little, true), "FocusDistance"),
+      Some(TagValue::Str("5 m".into()))
+    );
+  }
+
+  /// FocalLength `RawConv => '$val ? $val : undef'` drops a zero raw (FocusDistance,
+  /// which has no such RawConv, still emits `"0 m"`).
+  #[test]
+  fn focal_length_zero_dropped() {
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&0u16.to_le_bytes()); // FocusDistance 0
+    blob.extend_from_slice(&0u16.to_le_bytes()); // FocalLength 0 ⇒ dropped
+    let em = parse(&blob, ByteOrder::Little, true);
+    assert_eq!(
+      find(&em, "FocusDistance"),
+      Some(TagValue::Str("0 m".into()))
+    );
+    assert_eq!(find(&em, "FocalLength"), None);
+  }
+
+  /// Per-field availability: a block holding only FocusDistance omits FocalLength.
+  #[test]
+  fn only_focus_distance_present() {
+    let em = parse(&1500u16.to_le_bytes(), ByteOrder::Little, true);
+    assert_eq!(
+      find(&em, "FocusDistance"),
+      Some(TagValue::Str("1.5 m".into()))
+    );
+    assert_eq!(find(&em, "FocalLength"), None);
+    assert!(parse(&[], ByteOrder::Little, true).is_empty());
+  }
+}

--- a/src/exif/makernotes/vendors/leica/mod.rs
+++ b/src/exif/makernotes/vendors/leica/mod.rs
@@ -52,18 +52,23 @@
 
 #![deny(clippy::indexing_slicing)]
 
+pub mod focus_info;
 pub mod lens_types;
 pub mod printconv;
+pub mod serial_info;
+pub mod shot_info;
 pub mod tags;
 
-use crate::exif::ifd::RawValue;
+use crate::exif::ifd::{ByteOrder, RawValue};
+use crate::value::TagValue;
 use smol_str::SmolStr;
+use std::vec::Vec;
 
 pub use lens_types::{LEICA_LENS_TYPES, LeicaLensType};
 pub use printconv::LeicaPrintConv;
 pub use tags::{
   LEICA2_TAGS, LEICA3_TAGS, LEICA4_TAGS, LEICA5_TAGS, LEICA6_TAGS, LEICA9_TAGS, LeicaCondition,
-  LeicaTag, LeicaVariant, format_override, lookup,
+  LeicaSubTable, LeicaTag, LeicaVariant, format_override, lookup,
 };
 
 /// Decoded Leica MakerNotes data — populated by
@@ -156,6 +161,29 @@ pub(crate) fn populate_typed(
         }
       }
     }
+  }
+}
+
+/// Decode a WALKED Leica `ProcessBinaryData` SubDirectory blob into its
+/// `(Name, TagValue)` emission pairs — the faithful descent for the Leica
+/// binary sub-tables (#105): `SerialInfo` (Leica3 0x0b), `FocusInfo` (Leica5
+/// 0x040a), `ShotInfo` (Leica5 0x0410). All emit under the `Leica` family-1
+/// group (`Panasonic.pm` declares `GROUPS => { 1 => 'Leica' }` for these
+/// tables).
+///
+/// `blob` is the verbatim `$$valPt` value span; `order` the byte order the
+/// parent Leica IFD was walked under.
+#[must_use]
+pub fn decode_leica_subdir(
+  sub: LeicaSubTable,
+  blob: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+) -> Vec<(SmolStr, TagValue)> {
+  match sub {
+    LeicaSubTable::SerialInfo => serial_info::parse(blob, print_conv),
+    LeicaSubTable::FocusInfo => focus_info::parse(blob, order, print_conv),
+    LeicaSubTable::ShotInfo => shot_info::parse(blob, order, print_conv),
   }
 }
 

--- a/src/exif/makernotes/vendors/leica/mod.rs
+++ b/src/exif/makernotes/vendors/leica/mod.rs
@@ -166,11 +166,20 @@ pub(crate) fn populate_typed(
 }
 
 /// Decode a WALKED Leica `ProcessBinaryData` SubDirectory blob into its
-/// `(Name, TagValue)` emission pairs — the faithful descent for the Leica
-/// binary sub-tables (#105): `SerialInfo` (Leica3 0x0b), `FocusInfo` (Leica5
-/// 0x040a), `ShotInfo` (Leica5 0x0410). All emit under the `Leica` family-1
-/// group (`Panasonic.pm` declares `GROUPS => { 1 => 'Leica' }` for these
-/// tables).
+/// `(Name, TagValue, Priority)` emission triples — the faithful descent for the
+/// Leica binary sub-tables (#105): `SerialInfo` (Leica3 0x0b), `FocusInfo`
+/// (Leica5 0x040a), `ShotInfo` (Leica5 0x0410), `Data1` (Subdir 0x3901). All
+/// emit under the `Leica` family-1 group (`Panasonic.pm` declares `GROUPS => { 1
+/// => 'Leica' }` for these tables).
+///
+/// The third triple element is the row's ExifTool `Priority => N` for duplicate
+/// handling — the default `1` for most rows, but `0` for the two `Priority => 0`
+/// rows reachable here: `Data1` `LensType` (`Panasonic.pm:1981`) and `FocusInfo`
+/// `FocalLength` (`Panasonic.pm:2102`). The capture loop emits each via
+/// [`write_vendor_value_with_priority`](crate::exif) so a `Priority => 0` leaf
+/// never overrides a higher-priority same-`(group, name)` sibling — e.g. a later
+/// `Data1` `LensType` must NOT replace the Subdir `0x3405 LensType` in the shared
+/// de-dup (`ExifTool.pm:9544-9560`).
 ///
 /// `blob` is the verbatim `$$valPt` value span; `order` the byte order the
 /// parent Leica IFD was walked under.
@@ -180,7 +189,7 @@ pub fn decode_leica_subdir(
   blob: &[u8],
   order: ByteOrder,
   print_conv: bool,
-) -> Vec<(SmolStr, TagValue)> {
+) -> Vec<(SmolStr, TagValue, u8)> {
   match sub {
     LeicaSubTable::SerialInfo => serial_info::parse(blob, print_conv),
     LeicaSubTable::FocusInfo => focus_info::parse(blob, order, print_conv),

--- a/src/exif/makernotes/vendors/leica/mod.rs
+++ b/src/exif/makernotes/vendors/leica/mod.rs
@@ -52,6 +52,7 @@
 
 #![deny(clippy::indexing_slicing)]
 
+pub mod data1;
 pub mod focus_info;
 pub mod lens_types;
 pub mod printconv;
@@ -68,7 +69,7 @@ pub use lens_types::{LEICA_LENS_TYPES, LeicaLensType};
 pub use printconv::LeicaPrintConv;
 pub use tags::{
   LEICA2_TAGS, LEICA3_TAGS, LEICA4_TAGS, LEICA5_TAGS, LEICA6_TAGS, LEICA9_TAGS, LeicaCondition,
-  LeicaSubTable, LeicaTag, LeicaVariant, format_override, lookup,
+  LeicaSubTable, LeicaTag, LeicaVariant, SUBDIR_TAGS, format_override, lookup,
 };
 
 /// Decoded Leica MakerNotes data — populated by
@@ -184,6 +185,10 @@ pub fn decode_leica_subdir(
     LeicaSubTable::SerialInfo => serial_info::parse(blob, print_conv),
     LeicaSubTable::FocusInfo => focus_info::parse(blob, order, print_conv),
     LeicaSubTable::ShotInfo => shot_info::parse(blob, order, print_conv),
+    LeicaSubTable::Data1 => data1::parse(blob, order, print_conv),
+    // `%Panasonic::Data2` is an EMPTY table (no named positions) — descends
+    // but emits nothing.
+    LeicaSubTable::Data2 => Vec::new(),
   }
 }
 

--- a/src/exif/makernotes/vendors/leica/serial_info.rs
+++ b/src/exif/makernotes/vendors/leica/serial_info.rs
@@ -15,8 +15,9 @@
 //!   `s/\0.*//s`) then run through `FixUTF8`. No `PrintConv`/`ValueConv`, so
 //!   `-j` and `-n` are identical.
 //!
-//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
-//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue,
+//! Priority)` emission triples the dispatch site wraps in the `Leica` family-1
+//! group.
 
 #![deny(clippy::indexing_slicing)]
 
@@ -25,15 +26,17 @@ use smol_str::SmolStr;
 use std::vec::Vec;
 
 /// Decode the `Panasonic::SerialInfo` binary block (`Panasonic.pm:1724-1733`)
-/// into the `(Name, TagValue)` emission pairs. `print_conv` is accepted for a
-/// uniform sub-table signature; there is no `PrintConv` here.
+/// into the `(Name, TagValue, Priority)` emission triples. `print_conv` is
+/// accepted for a uniform sub-table signature; there is no `PrintConv` here.
+/// `SerialNumber` carries no `Priority` directive, so it takes the default
+/// `Priority => 1`.
 #[must_use]
-pub fn parse(data: &[u8], print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+pub fn parse(data: &[u8], print_conv: bool) -> Vec<(SmolStr, TagValue, u8)> {
   let _ = print_conv;
-  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
-  // byte 4 SerialNumber string[8].
+  let mut out: Vec<(SmolStr, TagValue, u8)> = Vec::new();
+  // byte 4 SerialNumber string[8] — default `Priority => 1`.
   if let Some(v) = read_string(data, 4, 8) {
-    out.push((SmolStr::new_static("SerialNumber"), v));
+    out.push((SmolStr::new_static("SerialNumber"), v, 1));
   }
   out
 }
@@ -61,8 +64,10 @@ fn read_string(data: &[u8], off: usize, len: usize) -> Option<TagValue> {
 mod tests {
   use super::*;
 
-  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
-    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  fn find(em: &[(SmolStr, TagValue, u8)], name: &str) -> Option<TagValue> {
+    em.iter()
+      .find(|(k, ..)| k == name)
+      .map(|(_, v, _)| v.clone())
   }
 
   /// `SerialNumber` is a `string[8]` at byte 4. Oracle: a block whose bytes 4..12
@@ -76,6 +81,8 @@ mod tests {
       find(&em, "SerialNumber"),
       Some(TagValue::Str("1234567".into()))
     );
+    // No `Priority` directive ⇒ the default `Priority => 1`.
+    assert_eq!(em.first().map(|(.., p)| *p), Some(1u8));
     assert_eq!(em.len(), 1);
     // No PrintConv ⇒ `-n` identical.
     assert_eq!(parse(&blob, false), em);

--- a/src/exif/makernotes/vendors/leica/serial_info.rs
+++ b/src/exif/makernotes/vendors/leica/serial_info.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Panasonic::SerialInfo` (`Panasonic.pm:1724-1733`).
+//!
+//! Leica serial-number info, reached via the `%Panasonic::Leica3` tag `0x0b`
+//! SubDirectory (`Panasonic.pm:1712-1715`, the R8/R9 digital backs). A
+//! `ProcessBinaryData` table with the DEFAULT `FORMAT => 'int8u'` (numeric keys
+//! are byte offsets), `TAG_PREFIX => 'Leica_SerialInfo'`, `FIRST_ENTRY => 0`.
+//! The emitted tag carries the family-1 group `Leica`.
+//!
+//! One position (`Panasonic.pm:1729-1732`):
+//!
+//! - byte 4 `SerialNumber`, `string[8]` — NUL-truncated (`ReadValue`'s
+//!   `s/\0.*//s`) then run through `FixUTF8`. No `PrintConv`/`ValueConv`, so
+//!   `-j` and `-n` are identical.
+//!
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
+//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+
+#![deny(clippy::indexing_slicing)]
+
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Decode the `Panasonic::SerialInfo` binary block (`Panasonic.pm:1724-1733`)
+/// into the `(Name, TagValue)` emission pairs. `print_conv` is accepted for a
+/// uniform sub-table signature; there is no `PrintConv` here.
+#[must_use]
+pub fn parse(data: &[u8], print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let _ = print_conv;
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // byte 4 SerialNumber string[8].
+  if let Some(v) = read_string(data, 4, 8) {
+    out.push((SmolStr::new_static("SerialNumber"), v));
+  }
+  out
+}
+
+/// Read a `string[len]` at `off`: `None` when the start is at/past the block end
+/// (ExifTool's `next if $entry >= $size`), else the NUL-truncated, `FixUTF8`'d
+/// text over the bytes that fit.
+fn read_string(data: &[u8], off: usize, len: usize) -> Option<TagValue> {
+  if off >= data.len() {
+    return None;
+  }
+  let end = off.saturating_add(len).min(data.len());
+  let window = data.get(off..end).unwrap_or(&[]);
+  let trimmed = match window.iter().position(|&b| b == 0) {
+    Some(nul) => window.get(..nul).unwrap_or(window),
+    None => window,
+  };
+  Some(TagValue::Str(SmolStr::from(crate::convert::fix_utf8(
+    trimmed,
+  ))))
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// `SerialNumber` is a `string[8]` at byte 4. Oracle: a block whose bytes 4..12
+  /// hold `"1234567\0"` ⇒ `Leica:SerialNumber = "1234567"`.
+  #[test]
+  fn serial_number_at_offset_4() {
+    let mut blob = std::vec![0u8; 12];
+    blob[4..12].copy_from_slice(b"1234567\x00");
+    let em = parse(&blob, true);
+    assert_eq!(
+      find(&em, "SerialNumber"),
+      Some(TagValue::Str("1234567".into()))
+    );
+    assert_eq!(em.len(), 1);
+    // No PrintConv ⇒ `-n` identical.
+    assert_eq!(parse(&blob, false), em);
+  }
+
+  /// A block too short to reach byte 4 omits the field.
+  #[test]
+  fn short_block_omits_serial() {
+    assert!(parse(&[0, 1, 2], true).is_empty());
+  }
+}

--- a/src/exif/makernotes/vendors/leica/shot_info.rs
+++ b/src/exif/makernotes/vendors/leica/shot_info.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Panasonic::ShotInfo` (`Panasonic.pm:2069-2081`).
+//!
+//! Leica type-5 ShotInfo (X2), reached via the `%Panasonic::Leica5` tag `0x0410`
+//! SubDirectory (`Panasonic.pm:2039-2042`). A `ProcessBinaryData` table with the
+//! DEFAULT `FORMAT => 'int8u'` (numeric keys are byte offsets), `TAG_PREFIX =>
+//! 'Leica_ShotInfo'`, `FIRST_ENTRY => 0`. The emitted tag carries the family-1
+//! group `Leica`.
+//!
+//! One position (`Panasonic.pm:2077-2080`):
+//!
+//! - byte 0 `FileIndex`, `int16u` — no `PrintConv`/`ValueConv`, so `-j` and `-n`
+//!   are identical (the bare integer).
+//!
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
+//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::{ByteOrder, get_u16};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Decode the `Panasonic::ShotInfo` binary block (`Panasonic.pm:2069-2081`) into
+/// the `(Name, TagValue)` emission pairs. `print_conv` is accepted for a uniform
+/// sub-table signature; there is no `PrintConv` here.
+#[must_use]
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let _ = print_conv;
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // byte 0 FileIndex int16u.
+  if let Some(n) = get_u16(data, 0, order) {
+    out.push((
+      SmolStr::new_static("FileIndex"),
+      TagValue::I64(i64::from(n)),
+    ));
+  }
+  out
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// `FileIndex` is an `int16u` at byte 0. Oracle: bytes `D2 04` (LE) ⇒
+  /// `Leica:FileIndex = 1234`.
+  #[test]
+  fn file_index_at_offset_0() {
+    let em = parse(&1234u16.to_le_bytes(), ByteOrder::Little, true);
+    assert_eq!(find(&em, "FileIndex"), Some(TagValue::I64(1234)));
+    assert_eq!(em.len(), 1);
+    // No PrintConv ⇒ `-n` identical.
+    assert_eq!(parse(&1234u16.to_le_bytes(), ByteOrder::Little, false), em);
+  }
+
+  /// Big-endian decode reads MSB-first.
+  #[test]
+  fn big_endian() {
+    let em = parse(&1234u16.to_be_bytes(), ByteOrder::Big, true);
+    assert_eq!(find(&em, "FileIndex"), Some(TagValue::I64(1234)));
+  }
+
+  /// A sub-2-byte block omits the field.
+  #[test]
+  fn short_block_omits() {
+    assert!(parse(&[0x01], ByteOrder::Little, true).is_empty());
+  }
+}

--- a/src/exif/makernotes/vendors/leica/shot_info.rs
+++ b/src/exif/makernotes/vendors/leica/shot_info.rs
@@ -14,8 +14,9 @@
 //! - byte 0 `FileIndex`, `int16u` — no `PrintConv`/`ValueConv`, so `-j` and `-n`
 //!   are identical (the bare integer).
 //!
-//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
-//! emission pairs the dispatch site wraps in the `Leica` family-1 group.
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue,
+//! Priority)` emission triples the dispatch site wraps in the `Leica` family-1
+//! group.
 
 #![deny(clippy::indexing_slicing)]
 
@@ -25,17 +26,19 @@ use smol_str::SmolStr;
 use std::vec::Vec;
 
 /// Decode the `Panasonic::ShotInfo` binary block (`Panasonic.pm:2069-2081`) into
-/// the `(Name, TagValue)` emission pairs. `print_conv` is accepted for a uniform
-/// sub-table signature; there is no `PrintConv` here.
+/// the `(Name, TagValue, Priority)` emission triples. `print_conv` is accepted
+/// for a uniform sub-table signature; there is no `PrintConv` here. `FileIndex`
+/// carries no `Priority` directive, so it takes the default `Priority => 1`.
 #[must_use]
-pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue, u8)> {
   let _ = print_conv;
-  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
-  // byte 0 FileIndex int16u.
+  let mut out: Vec<(SmolStr, TagValue, u8)> = Vec::new();
+  // byte 0 FileIndex int16u — default `Priority => 1`.
   if let Some(n) = get_u16(data, 0, order) {
     out.push((
       SmolStr::new_static("FileIndex"),
       TagValue::I64(i64::from(n)),
+      1,
     ));
   }
   out
@@ -46,8 +49,10 @@ pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, T
 mod tests {
   use super::*;
 
-  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
-    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  fn find(em: &[(SmolStr, TagValue, u8)], name: &str) -> Option<TagValue> {
+    em.iter()
+      .find(|(k, ..)| k == name)
+      .map(|(_, v, _)| v.clone())
   }
 
   /// `FileIndex` is an `int16u` at byte 0. Oracle: bytes `D2 04` (LE) ⇒
@@ -56,6 +61,8 @@ mod tests {
   fn file_index_at_offset_0() {
     let em = parse(&1234u16.to_le_bytes(), ByteOrder::Little, true);
     assert_eq!(find(&em, "FileIndex"), Some(TagValue::I64(1234)));
+    // No `Priority` directive ⇒ the default `Priority => 1`.
+    assert_eq!(em.first().map(|(.., p)| *p), Some(1u8));
     assert_eq!(em.len(), 1);
     // No PrintConv ⇒ `-n` identical.
     assert_eq!(parse(&1234u16.to_le_bytes(), ByteOrder::Little, false), em);

--- a/src/exif/makernotes/vendors/leica/tags.rs
+++ b/src/exif/makernotes/vendors/leica/tags.rs
@@ -16,20 +16,19 @@
 //! `Walker` as the payload of
 //! [`TableRef::Leica`](crate::exif::makernotes::subdir::TableRef::Leica).
 //!
-//! ## Phase scope (the plain camera-indexing leaves)
+//! ## Scope (plain leaves + the binary sub-tables)
 //!
-//! Mirroring the Samsung/Pentax ports, this ports the PLAIN scalar/enum/string/
-//! lookup LEAVES of each table. The binary `ProcessBinaryData` sub-tables and
-//! the chained IFD SubDirectories are DEFERRED — their tag IDs are simply ABSENT
-//! from the tables, so the shared `Walker` drops them (unknown-tag skip):
+//! This ports the PLAIN scalar/enum/string/lookup LEAVES of each table PLUS the
+//! `ProcessBinaryData` SubDirectory pointers (a [`LeicaTag::sub_table`] marker,
+//! decoded at capture time via [`super::decode_leica_subdir`], #105):
 //!
-//! - **Leica3** `0x0b SerialInfo` (`%Panasonic::SerialInfo` binary) — deferred;
-//!   only `0x0d WB_RGBLevels` is a plain leaf.
+//! - **Leica3** `0x0b SerialInfo` (`%Panasonic::SerialInfo`) descends to its
+//!   binary block; `0x0d WB_RGBLevels` is the plain leaf.
 //! - **Leica4** — every row is a SubDirectory into `%Panasonic::Subdir` (which
-//!   chains into `Data1`/`Data2`); deferred. Leica4 therefore emits no plain
-//!   leaf of its own (it routes correctly + emits nothing, not spurious tags).
-//! - **Leica5** `0x040a FocusInfo` / `0x0410 ShotInfo` (binary) + `0x05ff
-//!   CameraIFD` (a nested TIFF) — deferred.
+//!   chains into `Data1`/`Data2`); deferred. Leica4 carries no plain leaf.
+//! - **Leica5** `0x040a FocusInfo` / `0x0410 ShotInfo` descend into their binary
+//!   sub-tables; the `0x05ff CameraIFD` nested TIFF (`PanasonicRaw::CameraIFD`,
+//!   raw-only) is out of scope.
 //! - **Leica6** `0x300 PreviewImage` (a `RawConv` preview blob) + `0x301
 //!   UnknownBlock` (`Unknown`+`Binary`+`Drop`) — deferred.
 
@@ -75,8 +74,25 @@ impl LeicaVariant {
   }
 }
 
-/// One Leica variant-table IFD tag (a plain LEAF — the deferred SubDirectory /
-/// binary rows are absent from the tables).
+/// A Leica `ProcessBinaryData` SubDirectory target reached from a Leica variant
+/// IFD row (#105). The binary block is decoded at capture time (the verbatim
+/// `$$valPt` span) and its positions emit under the `Leica` family-1 group via
+/// [`super::decode_leica_subdir`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LeicaSubTable {
+  /// `%Panasonic::SerialInfo` — Leica3 0x0b (`Panasonic.pm:1724`).
+  SerialInfo,
+  /// `%Panasonic::FocusInfo` — Leica5 0x040a (`Panasonic.pm:2084`).
+  FocusInfo,
+  /// `%Panasonic::ShotInfo` — Leica5 0x0410 (`Panasonic.pm:2069`).
+  ShotInfo,
+}
+
+/// One Leica variant-table IFD tag — a plain LEAF, or (when [`sub_table`] is
+/// `Some`) a `ProcessBinaryData` SubDirectory pointer descended at capture time.
+///
+/// [`sub_table`]: LeicaTag::sub_table
 #[derive(Debug, Clone, Copy)]
 pub struct LeicaTag {
   /// Tag ID (the `Panasonic.pm` Leica hash key).
@@ -92,6 +108,9 @@ pub struct LeicaTag {
   /// `Some(condition)` when the row carries a `Condition` that gates emission
   /// (the Leica5 0x0303 `$format eq "string"`, the Leica6 Typ-006 rows).
   pub condition: Option<LeicaCondition>,
+  /// `Some(sub)` when the row is a `ProcessBinaryData` SubDirectory pointer
+  /// descended at capture time (#105); `None` for a plain leaf.
+  pub sub_table: Option<LeicaSubTable>,
 }
 
 impl LeicaTag {
@@ -114,6 +133,13 @@ impl LeicaTag {
   #[inline(always)]
   pub const fn condition(&self) -> Option<LeicaCondition> {
     self.condition
+  }
+
+  /// The row's `ProcessBinaryData` SubDirectory target, if any (#105).
+  #[must_use]
+  #[inline(always)]
+  pub const fn sub_table(&self) -> Option<LeicaSubTable> {
+    self.sub_table
   }
 }
 
@@ -141,6 +167,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Quality,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x302 UserProfile (Panasonic.pm:1617) — int32u label hash.
   LeicaTag {
@@ -149,6 +176,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::UserProfile2,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x303 SerialNumber (Panasonic.pm:1628) — int32u, sprintf("%.7d",$val).
   LeicaTag {
@@ -157,6 +185,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::SerialNumber7,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x304 WhiteBalance (Panasonic.pm:1631) — int16u label hash + Kelvin OTHER.
   LeicaTag {
@@ -165,6 +194,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::WhiteBalance2,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x310 LensType (Panasonic.pm:1649) — int32u, %leicaLensTypes.
   LeicaTag {
@@ -173,6 +203,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::LensType,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x311 ExternalSensorBrightnessValue (Panasonic.pm:1657) — Format rational64s, sprintf("%.2f").
   LeicaTag {
@@ -181,6 +212,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf2f,
     format: Some(FormatOverride::new(Format::Rational64s, None)),
     condition: None,
+    sub_table: None,
   },
   // 0x312 MeasuredLV (Panasonic.pm:1663) — Format rational64s, sprintf("%.2f").
   LeicaTag {
@@ -189,6 +221,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf2f,
     format: Some(FormatOverride::new(Format::Rational64s, None)),
     condition: None,
+    sub_table: None,
   },
   // 0x313 ApproximateFNumber (Panasonic.pm:1669) — rational64u, sprintf("%.1f").
   LeicaTag {
@@ -197,6 +230,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf1f,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x320 CameraTemperature (Panasonic.pm:1679) — int32s, "$val C".
   LeicaTag {
@@ -205,6 +239,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::CameraTemperatureC,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x321 ColorTemperature (Panasonic.pm:1658) — int32u, raw.
   LeicaTag {
@@ -213,6 +248,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x322 WBRedLevel (Panasonic.pm:1659) — rational64u, raw.
   LeicaTag {
@@ -221,6 +257,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x323 WBGreenLevel (Panasonic.pm:1660) — rational64u, raw.
   LeicaTag {
@@ -229,6 +266,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x324 WBBlueLevel (Panasonic.pm:1661) — rational64u, raw.
   LeicaTag {
@@ -237,6 +275,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x325 UV-IRFilterCorrection (Panasonic.pm:1689) — int32u, 0=>Not Active 1=>Active.
   LeicaTag {
@@ -245,6 +284,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::UvIrFilterCorrection,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x330 CCDVersion (Panasonic.pm:1671) — int32u, raw.
   LeicaTag {
@@ -253,6 +293,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x331 CCDBoardVersion (Panasonic.pm:1672) — int32u, raw.
   LeicaTag {
@@ -261,6 +302,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x332 ControllerBoardVersion (Panasonic.pm:1673) — int32u, raw.
   LeicaTag {
@@ -269,6 +311,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x333 M16CVersion (Panasonic.pm:1674) — int32u, raw.
   LeicaTag {
@@ -277,6 +320,7 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x340 ImageIDNumber (Panasonic.pm:1702) — int32u, raw.
   LeicaTag {
@@ -285,13 +329,23 @@ pub const LEICA2_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
 ];
 
-/// `%Panasonic::Leica3` (`Panasonic.pm:1706-1721`) — the R8/R9 backs. The
-/// `0x0b SerialInfo` binary SubDirectory is deferred; `0x0d WB_RGBLevels` is the
-/// only plain leaf.
+/// `%Panasonic::Leica3` (`Panasonic.pm:1706-1721`) — the R8/R9 backs. `0x0b`
+/// descends into the `%Panasonic::SerialInfo` binary sub-table (#105); `0x0d
+/// WB_RGBLevels` is the plain leaf.
 pub const LEICA3_TAGS: &[LeicaTag] = &[
+  // 0x0b SerialInfo (Panasonic.pm:1712) — ProcessBinaryData SubDirectory.
+  LeicaTag {
+    id: 0x0b,
+    name: "SerialInfo",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: Some(LeicaSubTable::SerialInfo),
+  },
   // 0x0d WB_RGBLevels (Panasonic.pm:1719) — int16u Count 3, space-joined.
   LeicaTag {
     id: 0x0d,
@@ -299,6 +353,7 @@ pub const LEICA3_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
 ];
 
@@ -308,9 +363,10 @@ pub const LEICA3_TAGS: &[LeicaTag] = &[
 pub const LEICA4_TAGS: &[LeicaTag] = &[];
 
 /// `%Panasonic::Leica5` (`Panasonic.pm:1997-2066`) — X1/X2/X-VARIO/T/X-U +
-/// (via Leica8) Q/SL/CL. `PRIORITY => 0` at the table level. The `0x040a
-/// FocusInfo` / `0x0410 ShotInfo` binary SubDirectories + `0x05ff CameraIFD`
-/// nested TIFF are deferred.
+/// (via Leica8) Q/SL/CL. `PRIORITY => 0` at the table level. `0x040a FocusInfo`
+/// / `0x0410 ShotInfo` descend into their binary sub-tables (#105); the `0x05ff
+/// CameraIFD` nested TIFF (a `PanasonicRaw::CameraIFD` / raw-only directory) is
+/// out of scope.
 pub const LEICA5_TAGS: &[LeicaTag] = &[
   // 0x0303 LensType (Panasonic.pm:2004) — string, Condition $format eq "string" (Leica T only).
   LeicaTag {
@@ -319,6 +375,7 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: Some(LeicaCondition::FormatIsString),
+    sub_table: None,
   },
   // 0x0305 SerialNumber (Panasonic.pm:2014) — int32u, raw.
   LeicaTag {
@@ -327,6 +384,7 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x0407 OriginalFileName (Panasonic.pm:2023) — string.
   LeicaTag {
@@ -335,6 +393,7 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x0408 OriginalDirectory (Panasonic.pm:2024) — string.
   LeicaTag {
@@ -343,6 +402,16 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
+  },
+  // 0x040a FocusInfo (Panasonic.pm:2021) — ProcessBinaryData SubDirectory.
+  LeicaTag {
+    id: 0x040a,
+    name: "FocusInfo",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: Some(LeicaSubTable::FocusInfo),
   },
   // 0x040d ExposureMode (Panasonic.pm:2047) — Format int8u[4], PrintConv hash.
   LeicaTag {
@@ -351,6 +420,16 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::ExposureMode5,
     format: Some(FormatOverride::new(Format::Int8u, Some(4))),
     condition: None,
+    sub_table: None,
+  },
+  // 0x0410 ShotInfo (Panasonic.pm:2039) — ProcessBinaryData SubDirectory.
+  LeicaTag {
+    id: 0x0410,
+    name: "ShotInfo",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: Some(LeicaSubTable::ShotInfo),
   },
   // 0x0412 FilmMode (Panasonic.pm:2065) — string.
   LeicaTag {
@@ -359,6 +438,7 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x0413 WB_RGBLevels (Panasonic.pm:2066) — rational64u Count 3, space-joined.
   LeicaTag {
@@ -367,6 +447,7 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x0500 InternalSerialNumber (Panasonic.pm:2047) — undef, date-encoded PrintConv.
   LeicaTag {
@@ -375,6 +456,7 @@ pub const LEICA5_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::InternalSerialNumber,
     format: None,
     condition: None,
+    sub_table: None,
   },
 ];
 
@@ -390,6 +472,7 @@ pub const LEICA6_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::LensTypeTrim,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x304 FocusDistance (Panasonic.pm:2154) — int32u, raw.
   LeicaTag {
@@ -398,6 +481,7 @@ pub const LEICA6_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x311 ExternalSensorBrightnessValue (Panasonic.pm:2153) — Format rational64s, Condition Typ 006, sprintf("%.2f").
   LeicaTag {
@@ -406,6 +490,7 @@ pub const LEICA6_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf2f,
     format: Some(FormatOverride::new(Format::Rational64s, None)),
     condition: Some(LeicaCondition::ModelTyp006),
+    sub_table: None,
   },
   // 0x312 MeasuredLV (Panasonic.pm:2160) — Format rational64s, Condition Typ 006, sprintf("%.2f").
   LeicaTag {
@@ -414,6 +499,7 @@ pub const LEICA6_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf2f,
     format: Some(FormatOverride::new(Format::Rational64s, None)),
     condition: Some(LeicaCondition::ModelTyp006),
+    sub_table: None,
   },
   // 0x320 FirmwareVersion (Panasonic.pm:2171) — int8u Count 4, Condition Typ 006, $val=~tr/ /./.
   LeicaTag {
@@ -422,6 +508,7 @@ pub const LEICA6_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::FirmwareVersionDots,
     format: None,
     condition: Some(LeicaCondition::ModelTyp006),
+    sub_table: None,
   },
   // 0x321 LensSerialNumber (Panasonic.pm:2179) — int32u, Condition Typ 006, sprintf("%.10d").
   LeicaTag {
@@ -430,6 +517,7 @@ pub const LEICA6_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf10d,
     format: None,
     condition: Some(LeicaCondition::ModelTyp006),
+    sub_table: None,
   },
 ];
 
@@ -443,6 +531,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x311 ExternalSensorBrightnessValue (Panasonic.pm:2203) — Format rational64s, sprintf("%.2f").
   LeicaTag {
@@ -451,6 +540,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf2f,
     format: Some(FormatOverride::new(Format::Rational64s, None)),
     condition: None,
+    sub_table: None,
   },
   // 0x312 MeasuredLV (Panasonic.pm:2208) — Format rational64s, sprintf("%.2f").
   LeicaTag {
@@ -459,6 +549,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Sprintf2f,
     format: Some(FormatOverride::new(Format::Rational64s, None)),
     condition: None,
+    sub_table: None,
   },
   // 0x34c UserProfile (Panasonic.pm:2218) — string.
   LeicaTag {
@@ -467,6 +558,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x359 ISOSelected (Panasonic.pm:2223) — int32s, 0=>Auto + identity OTHER.
   LeicaTag {
@@ -475,6 +567,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::IsoSelected,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x35a FNumber (Panasonic.pm:2231) — int32s, ValueConv /1000, sprintf("%.1f").
   LeicaTag {
@@ -483,6 +576,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::Div1000Sprintf1f,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x35b CorrelatedColorTemp (Panasonic.pm:2233) — int16u, raw.
   LeicaTag {
@@ -491,6 +585,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x35c ColorTint (Panasonic.pm:2234) — int16s, raw.
   LeicaTag {
@@ -499,6 +594,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x35d WhitePoint (Panasonic.pm:2235) — rational64u Count 2, space-joined.
   LeicaTag {
@@ -507,6 +603,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
   // 0x370 LensProfileName (Panasonic.pm:2238) — string.
   LeicaTag {
@@ -515,6 +612,7 @@ pub const LEICA9_TAGS: &[LeicaTag] = &[
     conv: LeicaPrintConv::None,
     format: None,
     condition: None,
+    sub_table: None,
   },
 ];
 

--- a/src/exif/makernotes/vendors/leica/tags.rs
+++ b/src/exif/makernotes/vendors/leica/tags.rs
@@ -62,6 +62,11 @@ pub enum LeicaVariant {
   Leica6,
   /// `%Panasonic::Leica9` (`Panasonic.pm:2193`) — the S-Typ007/M10.
   Leica9,
+  /// `%Panasonic::Subdir` (`Panasonic.pm:1773`) — the Leica M9 sub-IFD the four
+  /// Leica4 `0x3000`/`0x3100`/`0x3400`/`0x3900` rows descend into (#105). Not a
+  /// dispatched top-level variant; reached only via the in-walk Leica4 descent,
+  /// walked under `ByteOrder => Unknown`.
+  Subdir,
 }
 
 impl LeicaVariant {
@@ -87,6 +92,12 @@ pub enum LeicaSubTable {
   FocusInfo,
   /// `%Panasonic::ShotInfo` — Leica5 0x0410 (`Panasonic.pm:2069`).
   ShotInfo,
+  /// `%Panasonic::Data1` — Subdir 0x3901 (`Panasonic.pm:1970`); one `LensType`
+  /// at byte 22.
+  Data1,
+  /// `%Panasonic::Data2` — Subdir 0x3902 (`Panasonic.pm:1989`); an EMPTY table
+  /// (no named positions), so it descends but emits nothing.
+  Data2,
 }
 
 /// One Leica variant-table IFD tag — a plain LEAF, or (when [`sub_table`] is
@@ -357,10 +368,208 @@ pub const LEICA3_TAGS: &[LeicaTag] = &[
   },
 ];
 
-/// `%Panasonic::Leica4` (`Panasonic.pm:1736-1770`) — the M9. EVERY row is a
-/// SubDirectory into `%Panasonic::Subdir` (deferred), so this table carries NO
-/// plain leaf (the walk routes correctly + emits nothing).
+/// `%Panasonic::Leica4` (`Panasonic.pm:1736-1770`) — the M9. EVERY row
+/// (`0x3000`/`0x3100`/`0x3400`/`0x3900`) is an IFD SubDirectory into
+/// `%Panasonic::Subdir` walked under `ByteOrder => Unknown` (#105); the descent
+/// is handled IN-WALK (keyed on `active_table == Leica(Leica4)`), so this table
+/// carries NO plain leaf and `lookup` returns `None` for every Leica4 id.
 pub const LEICA4_TAGS: &[LeicaTag] = &[];
+
+/// `%Panasonic::Subdir` (`Panasonic.pm:1773-1936`) — the Leica M9 sub-IFD tags
+/// (#105). Reached via the Leica4 `0x3000`/… descent. The plain leaves use the
+/// pre-built M9 conversions; `0x3901`/`0x3902` descend into the `Data1`/`Data2`
+/// binary sub-tables. Sorted by tag ID (binary-search-ready).
+pub const SUBDIR_TAGS: &[LeicaTag] = &[
+  // 0x300a Contrast (Panasonic.pm:1781) — int32u label hash.
+  LeicaTag {
+    id: 0x300a,
+    name: "Contrast",
+    conv: LeicaPrintConv::ContrastLevel,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x300b Sharpening (Panasonic.pm:1792) — int32u label hash.
+  LeicaTag {
+    id: 0x300b,
+    name: "Sharpening",
+    conv: LeicaPrintConv::Sharpening,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x300d Saturation (Panasonic.pm:1803) — Contrast hash + B&W extras.
+  LeicaTag {
+    id: 0x300d,
+    name: "Saturation",
+    conv: LeicaPrintConv::SaturationLevel,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3033 WhiteBalance (Panasonic.pm:1817) — M9 white-balance hash.
+  LeicaTag {
+    id: 0x3033,
+    name: "WhiteBalance",
+    conv: LeicaPrintConv::WhiteBalanceM9,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3034 JPEGQuality (Panasonic.pm:1833) — 94=>Basic, 97=>Fine.
+  LeicaTag {
+    id: 0x3034,
+    name: "JPEGQuality",
+    conv: LeicaPrintConv::JpegQuality,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3036 WB_RGBLevels (Panasonic.pm:1842) — rational64u Count 3, space-joined.
+  LeicaTag {
+    id: 0x3036,
+    name: "WB_RGBLevels",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3038 UserProfile (Panasonic.pm:1847) — string.
+  LeicaTag {
+    id: 0x3038,
+    name: "UserProfile",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x303a JPEGSize (Panasonic.pm:1851) — M9 resolution hash.
+  LeicaTag {
+    id: 0x303a,
+    name: "JPEGSize",
+    conv: LeicaPrintConv::JpegSize,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3103 SerialNumber (Panasonic.pm:1862) — string.
+  LeicaTag {
+    id: 0x3103,
+    name: "SerialNumber",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3109 FirmwareVersion (Panasonic.pm:1869) — string.
+  LeicaTag {
+    id: 0x3109,
+    name: "FirmwareVersion",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x312a BaseISO (Panasonic.pm:1873) — int32u, raw.
+  LeicaTag {
+    id: 0x312a,
+    name: "BaseISO",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x312b SensorWidth (Panasonic.pm:1877) — int32u, raw.
+  LeicaTag {
+    id: 0x312b,
+    name: "SensorWidth",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x312c SensorHeight (Panasonic.pm:1881) — int32u, raw.
+  LeicaTag {
+    id: 0x312c,
+    name: "SensorHeight",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x312d SensorBitDepth (Panasonic.pm:1885) — int32u, raw.
+  LeicaTag {
+    id: 0x312d,
+    name: "SensorBitDepth",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3402 CameraTemperature (Panasonic.pm:1889) — int32s, "$val C".
+  LeicaTag {
+    id: 0x3402,
+    name: "CameraTemperature",
+    conv: LeicaPrintConv::CameraTemperatureC,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3405 LensType (Panasonic.pm:1895) — int32u, %leicaLensTypes.
+  LeicaTag {
+    id: 0x3405,
+    name: "LensType",
+    conv: LeicaPrintConv::LensType,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3406 ApproximateFNumber (Panasonic.pm:1903) — rational64u, sprintf("%.1f").
+  LeicaTag {
+    id: 0x3406,
+    name: "ApproximateFNumber",
+    conv: LeicaPrintConv::Sprintf1f,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3407 MeasuredLV (Panasonic.pm:1909) — int32s, /1e5, sprintf("%.2f").
+  LeicaTag {
+    id: 0x3407,
+    name: "MeasuredLV",
+    conv: LeicaPrintConv::Div1e5Sprintf2f,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3408 ExternalSensorBrightnessValue (Panasonic.pm:1918) — int32s, /1e5, "%.2f".
+  LeicaTag {
+    id: 0x3408,
+    name: "ExternalSensorBrightnessValue",
+    conv: LeicaPrintConv::Div1e5Sprintf2f,
+    format: None,
+    condition: None,
+    sub_table: None,
+  },
+  // 0x3901 Data1 (Panasonic.pm:1927) — ProcessBinaryData SubDirectory.
+  LeicaTag {
+    id: 0x3901,
+    name: "Data1",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: Some(LeicaSubTable::Data1),
+  },
+  // 0x3902 Data2 (Panasonic.pm:1931) — ProcessBinaryData SubDirectory (empty).
+  LeicaTag {
+    id: 0x3902,
+    name: "Data2",
+    conv: LeicaPrintConv::None,
+    format: None,
+    condition: None,
+    sub_table: Some(LeicaSubTable::Data2),
+  },
+];
 
 /// `%Panasonic::Leica5` (`Panasonic.pm:1997-2066`) — X1/X2/X-VARIO/T/X-U +
 /// (via Leica8) Q/SL/CL. `PRIORITY => 0` at the table level. `0x040a FocusInfo`
@@ -628,6 +837,7 @@ const fn table_for(variant: LeicaVariant) -> &'static [LeicaTag] {
     LeicaVariant::Leica5 => LEICA5_TAGS,
     LeicaVariant::Leica6 => LEICA6_TAGS,
     LeicaVariant::Leica9 => LEICA9_TAGS,
+    LeicaVariant::Subdir => SUBDIR_TAGS,
   }
 }
 

--- a/src/exif/makernotes/vendors/leica/tests.rs
+++ b/src/exif/makernotes/vendors/leica/tests.rs
@@ -229,3 +229,48 @@ fn populate_typed_lens_and_serial() {
   assert_eq!(t.lens_name(), Some("Summicron-M 50mm f/2 (IV, V)"));
   assert_eq!(t.serial_number(), Some("0001234"));
 }
+
+/// The #105 binary `ProcessBinaryData` SubDirectory rows resolve with their
+/// `sub_table` marker (so the capture loop descends them), the extended tables
+/// stay sorted (the binary-search invariant), and `decode_leica_subdir` routes
+/// each marker to its decoder.
+#[test]
+fn binary_subdir_rows_present_and_routed() {
+  // The SubDirectory pointers carry the right marker.
+  assert_eq!(
+    lookup(LeicaVariant::Leica3, 0x0b).and_then(LeicaTag::sub_table),
+    Some(LeicaSubTable::SerialInfo)
+  );
+  assert_eq!(
+    lookup(LeicaVariant::Leica5, 0x040a).and_then(LeicaTag::sub_table),
+    Some(LeicaSubTable::FocusInfo)
+  );
+  assert_eq!(
+    lookup(LeicaVariant::Leica5, 0x0410).and_then(LeicaTag::sub_table),
+    Some(LeicaSubTable::ShotInfo)
+  );
+  // The extended tables stay strictly sorted (binary-search-ready).
+  for tags in [LEICA3_TAGS, LEICA5_TAGS] {
+    let mut prev: i64 = -1;
+    for t in tags {
+      assert!(
+        i64::from(t.id) > prev,
+        "LEICA table unsorted at {:#x}",
+        t.id
+      );
+      prev = i64::from(t.id);
+    }
+  }
+  // The dispatcher routes each marker to its decoder.
+  let shot = decode_leica_subdir(
+    LeicaSubTable::ShotInfo,
+    &1234u16.to_le_bytes(),
+    crate::exif::ifd::ByteOrder::Little,
+    true,
+  );
+  assert_eq!(shot.first().map(|(k, _)| k.as_str()), Some("FileIndex"));
+  assert_eq!(
+    shot.first().map(|(_, v)| v.clone()),
+    Some(TagValue::I64(1234))
+  );
+}

--- a/src/exif/makernotes/vendors/leica/tests.rs
+++ b/src/exif/makernotes/vendors/leica/tests.rs
@@ -4,6 +4,11 @@
 //! Unit tests for the Leica typed surface, the per-variant tag tables, and the
 //! `LeicaPrintConv` conversions (`%Panasonic::Leica2`..`Leica9`).
 
+// Crafted-byte fixtures index into fixed-size scratch buffers (e.g. the Data1
+// block's `data1[22..26]`); the parent module's `#![deny(clippy::indexing_slicing)]`
+// is not meant for this test code, matching the sibling inline test modules.
+#![allow(clippy::indexing_slicing)]
+
 use super::*;
 use crate::exif::ifd::RawValue;
 use crate::value::TagValue;
@@ -268,11 +273,13 @@ fn binary_subdir_rows_present_and_routed() {
     crate::exif::ifd::ByteOrder::Little,
     true,
   );
-  assert_eq!(shot.first().map(|(k, _)| k.as_str()), Some("FileIndex"));
+  assert_eq!(shot.first().map(|(k, ..)| k.as_str()), Some("FileIndex"));
   assert_eq!(
-    shot.first().map(|(_, v)| v.clone()),
+    shot.first().map(|(_, v, _)| v.clone()),
     Some(TagValue::I64(1234))
   );
+  // The default `Priority => 1` (ShotInfo `FileIndex` has no `Priority` directive).
+  assert_eq!(shot.first().map(|(.., p)| *p), Some(1u8));
 }
 
 /// The `%Panasonic::Subdir` table (#105, the Leica M9 sub-IFD): the plain leaves
@@ -396,5 +403,24 @@ fn leica4_descends_into_subdir_and_data1() {
   assert!(
     !names.contains(&"Subdir3000") && !names.contains(&"Data1"),
     "parent pointers must not emit; got {names:?}"
+  );
+  // #105 Codex [high]: BOTH LensType leaves are emitted, but the Subdir `0x3405`
+  // leaf keeps its default `Priority => 1` while the Data1 leaf carries
+  // `Priority => 0` (`Panasonic.pm:1981`) — so the shared de-dup keeps the
+  // higher-priority `0x3405` value and the later Data1 value never overrides it.
+  let prio = |name: &str, val: &str| -> Option<u8> {
+    em.iter()
+      .find(|e: &&VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+      .map(VendorEmission::priority)
+  };
+  assert_eq!(
+    prio("LensType", "Summilux-M 50mm f/1.4 (II)"),
+    Some(1),
+    "Subdir 0x3405 LensType default Priority => 1; got {names:?}"
+  );
+  assert_eq!(
+    prio("LensType", "Summilux-M 35mm f/1.4"),
+    Some(0),
+    "Data1 LensType Priority => 0 (Panasonic.pm:1981); got {names:?}"
   );
 }

--- a/src/exif/makernotes/vendors/leica/tests.rs
+++ b/src/exif/makernotes/vendors/leica/tests.rs
@@ -274,3 +274,127 @@ fn binary_subdir_rows_present_and_routed() {
     Some(TagValue::I64(1234))
   );
 }
+
+/// The `%Panasonic::Subdir` table (#105, the Leica M9 sub-IFD): the plain leaves
+/// resolve, the `0x3901`/`0x3902` rows carry the `Data1`/`Data2` markers, and the
+/// table is strictly sorted (binary-search-ready).
+#[test]
+fn subdir_table_leaves_and_markers() {
+  assert_eq!(
+    lookup(LeicaVariant::Subdir, 0x300a).map(LeicaTag::name),
+    Some("Contrast")
+  );
+  assert_eq!(
+    lookup(LeicaVariant::Subdir, 0x3405).map(LeicaTag::name),
+    Some("LensType")
+  );
+  assert_eq!(
+    lookup(LeicaVariant::Subdir, 0x3901).and_then(LeicaTag::sub_table),
+    Some(LeicaSubTable::Data1)
+  );
+  assert_eq!(
+    lookup(LeicaVariant::Subdir, 0x3902).and_then(LeicaTag::sub_table),
+    Some(LeicaSubTable::Data2)
+  );
+  let mut prev: i64 = -1;
+  for t in SUBDIR_TAGS {
+    assert!(
+      i64::from(t.id) > prev,
+      "SUBDIR_TAGS unsorted at {:#x}",
+      t.id
+    );
+    prev = i64::from(t.id);
+  }
+  // Data2 is an empty table ⇒ descends but emits nothing.
+  assert!(
+    decode_leica_subdir(
+      LeicaSubTable::Data2,
+      &[1, 2, 3, 4],
+      crate::exif::ifd::ByteOrder::Little,
+      true
+    )
+    .is_empty()
+  );
+}
+
+/// END-TO-END: a crafted Leica4 (M9) MakerNote descends Leica4 → `%Subdir` →
+/// `%Data1`. The four Leica4 `0x3000`/… rows are IFD SubDirectories into
+/// `%Panasonic::Subdir` (`ByteOrder => Unknown`); a Subdir `0x3901` row descends
+/// into the `%Panasonic::Data1` binary block. Proves the in-walk descent emits
+/// the Subdir LEAVES (Contrast, LensType) AND the Data1 LensType, with the parent
+/// pointers never emitted.
+#[test]
+fn leica4_descends_into_subdir_and_data1() {
+  use crate::exif::ifd::ByteOrder;
+  use crate::exif::makernotes::vendors::VendorEmission;
+  use crate::exif::makernotes::{BaseRule, ChildByteOrder, DetectedMakerNote, Vendor};
+
+  fn push_entry(buf: &mut std::vec::Vec<u8>, tag: u16, format: u16, count: u32, value: u32) {
+    buf.extend_from_slice(&tag.to_le_bytes());
+    buf.extend_from_slice(&format.to_le_bytes());
+    buf.extend_from_slice(&count.to_le_bytes());
+    buf.extend_from_slice(&value.to_le_bytes());
+  }
+
+  // mn_offset 0 + Leica4 `Base => $start - 8` (RelativeToStart(-8)) ⇒
+  // value_offset_base = (0 + 8) - 8 = 0, so every offset below is buffer-relative.
+  let mut buf = std::vec::Vec::new();
+  buf.extend_from_slice(b"LEICA0\x03\x00"); // 8-byte Leica4 signature
+  // Leica4 IFD @ 8: one entry 0x3000 -> Subdir IFD @ 26.
+  buf.extend_from_slice(&1u16.to_le_bytes());
+  push_entry(&mut buf, 0x3000, 4, 1, 26); // LONG, value = Subdir IFD offset
+  buf.extend_from_slice(&0u32.to_le_bytes()); // next-IFD
+  assert_eq!(buf.len(), 26);
+  // Subdir IFD @ 26: Contrast=2 ("Normal"), LensType=20 (id 5), Data1 @ 68.
+  buf.extend_from_slice(&3u16.to_le_bytes());
+  push_entry(&mut buf, 0x300a, 4, 1, 2); // Contrast int32u inline
+  push_entry(&mut buf, 0x3405, 4, 1, 20); // LensType int32u inline (id 5)
+  push_entry(&mut buf, 0x3901, 7, 26, 68); // Data1 undef[26] out-of-line @ 68
+  buf.extend_from_slice(&0u32.to_le_bytes()); // next-IFD
+  assert_eq!(buf.len(), 68);
+  // Data1 block @ 68: LensType int32u @ byte 22 = 24 (id 6).
+  let mut data1 = std::vec![0u8; 26];
+  data1[22..26].copy_from_slice(&24u32.to_le_bytes());
+  buf.extend_from_slice(&data1);
+
+  let detected = DetectedMakerNote::new(
+    Vendor::Leica,
+    8,
+    BaseRule::RelativeToStart(-8),
+    ChildByteOrder::Unknown,
+    false,
+  );
+  let (em, _typed) = crate::exif::leica_makernote_isolated(
+    &buf,
+    0,
+    buf.len(),
+    LeicaVariant::Leica4,
+    detected,
+    ByteOrder::Little,
+    0,
+    None,
+    true,
+  )
+  .expect("Leica4 walk");
+  let has = |name: &str, val: &str| {
+    em.iter()
+      .any(|e: &VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+  };
+  let names: std::vec::Vec<&str> = em.iter().map(VendorEmission::name).collect();
+  // Subdir leaves (descended Leica4 -> Subdir).
+  assert!(has("Contrast", "Normal"), "Subdir Contrast; got {names:?}");
+  assert!(
+    has("LensType", "Summilux-M 50mm f/1.4 (II)"),
+    "Subdir 0x3405 LensType; got {names:?}"
+  );
+  // Data1 descent (Subdir 0x3901 -> Data1 LensType, the &0xffff variant, id 6).
+  assert!(
+    has("LensType", "Summilux-M 35mm f/1.4"),
+    "Data1 LensType; got {names:?}"
+  );
+  // The parent SubDirectory pointers are never emitted as values.
+  assert!(
+    !names.contains(&"Subdir3000") && !names.contains(&"Data1"),
+    "parent pointers must not emit; got {names:?}"
+  );
+}

--- a/src/exif/makernotes/vendors/leica/tests.rs
+++ b/src/exif/makernotes/vendors/leica/tests.rs
@@ -424,3 +424,119 @@ fn leica4_descends_into_subdir_and_data1() {
     "Data1 LensType Priority => 0 (Panasonic.pm:1981); got {names:?}"
   );
 }
+
+/// MIXED-ENDIAN (#105): a crafted Leica4 (M9) whose OUTER IFD is little-endian
+/// but whose `%Subdir` child IFD (`ByteOrder => Unknown`) probes to BIG-endian.
+/// The Subdir `0x3901` `Data1` block carries an int32u `LensType` written
+/// BIG-endian; it MUST decode under the CHILD IFD's resolved order (BIG), not the
+/// outer MakerNote IFD's (LITTLE). Under the outer order the bytes byte-swap to a
+/// different lens id — the regression this guards. The plain Subdir leaves
+/// (Contrast / `0x3405` LensType), decoded inline during the child walk, already
+/// used the child order; this proves the binary sub-table re-slice now does too
+/// (each block decodes under [`ExifEntry::ifd_order`](crate::exif)).
+#[test]
+fn leica4_subdir_child_decodes_under_its_own_byte_order() {
+  use crate::exif::ifd::ByteOrder;
+  use crate::exif::makernotes::vendors::VendorEmission;
+  use crate::exif::makernotes::{BaseRule, ChildByteOrder, DetectedMakerNote, Vendor};
+
+  fn push_entry_le(buf: &mut std::vec::Vec<u8>, tag: u16, format: u16, count: u32, value: u32) {
+    buf.extend_from_slice(&tag.to_le_bytes());
+    buf.extend_from_slice(&format.to_le_bytes());
+    buf.extend_from_slice(&count.to_le_bytes());
+    buf.extend_from_slice(&value.to_le_bytes());
+  }
+  fn push_entry_be(buf: &mut std::vec::Vec<u8>, tag: u16, format: u16, count: u32, value: u32) {
+    buf.extend_from_slice(&tag.to_be_bytes());
+    buf.extend_from_slice(&format.to_be_bytes());
+    buf.extend_from_slice(&count.to_be_bytes());
+    buf.extend_from_slice(&value.to_be_bytes());
+  }
+
+  // mn_offset 0 + Leica4 `Base => $start - 8` (RelativeToStart(-8)) ⇒
+  // value_offset_base = (0 + 8) - 8 = 0, so every offset below is buffer-relative.
+  let mut buf = std::vec::Vec::new();
+  buf.extend_from_slice(b"LEICA0\x03\x00"); // 8-byte Leica4 signature
+  // OUTER Leica4 IFD @ 8 (LITTLE): the count word [0x01,0x00] read under the
+  // parent order (Little) = 1 ⇒ no toggle ⇒ the outer IFD stays LITTLE. One entry
+  // 0x3000 -> Subdir IFD @ 26.
+  buf.extend_from_slice(&1u16.to_le_bytes());
+  push_entry_le(&mut buf, 0x3000, 4, 1, 26); // LONG, value = Subdir IFD offset
+  buf.extend_from_slice(&0u32.to_le_bytes()); // next-IFD
+  assert_eq!(buf.len(), 26);
+  // CHILD Subdir IFD @ 26 (BIG): the count word [0x00,0x03] read under the parent
+  // order (Little) = 0x0300 ⇒ (num>>8)=3 > (num&0xff)=0 ⇒ TOGGLE ⇒ the child walks
+  // BIG. Three BIG-endian entries: Contrast=2 ("Normal"), LensType=20 (id 5),
+  // Data1 @ 68.
+  buf.extend_from_slice(&3u16.to_be_bytes());
+  push_entry_be(&mut buf, 0x300a, 4, 1, 2); // Contrast int32u inline
+  push_entry_be(&mut buf, 0x3405, 4, 1, 20); // LensType int32u inline (id 5)
+  push_entry_be(&mut buf, 0x3901, 7, 26, 68); // Data1 undef[26] out-of-line @ 68
+  buf.extend_from_slice(&0u32.to_be_bytes()); // next-IFD
+  assert_eq!(buf.len(), 68);
+  // Data1 block @ 68: LensType int32u @ byte 22 = 24 (id 6), written BIG-endian.
+  // Decoded under the child order (BIG) ⇒ 24 ⇒ id 6 "Summilux-M 35mm f/1.4";
+  // under the outer order (LITTLE) the bytes [00,00,00,18] byte-swap to
+  // 0x18000000 ⇒ id 0 "Uncoded lens" — the bug.
+  let mut data1 = std::vec![0u8; 26];
+  data1[22..26].copy_from_slice(&24u32.to_be_bytes());
+  buf.extend_from_slice(&data1);
+
+  let detected = DetectedMakerNote::new(
+    Vendor::Leica,
+    8,
+    BaseRule::RelativeToStart(-8),
+    ChildByteOrder::Unknown,
+    false,
+  );
+  let (em, _typed) = crate::exif::leica_makernote_isolated(
+    &buf,
+    0,
+    buf.len(),
+    LeicaVariant::Leica4,
+    detected,
+    ByteOrder::Little, // the OUTER/parent order
+    0,
+    None,
+    true,
+  )
+  .expect("Leica4 walk");
+  let has = |name: &str, val: &str| {
+    em.iter()
+      .any(|e: &VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+  };
+  let names: std::vec::Vec<&str> = em.iter().map(VendorEmission::name).collect();
+  // The BIG-endian child IFD's plain leaves decode under the child order.
+  assert!(
+    has("Contrast", "Normal"),
+    "Subdir Contrast (child BIG); got {names:?}"
+  );
+  assert!(
+    has("LensType", "Summilux-M 50mm f/1.4 (II)"),
+    "Subdir 0x3405 LensType (child BIG); got {names:?}"
+  );
+  // THE FIX: the Data1 binary sub-table decodes under the CHILD IFD's order (BIG)
+  // ⇒ id 6, not the byte-swapped outer-order value.
+  assert!(
+    has("LensType", "Summilux-M 35mm f/1.4"),
+    "Data1 LensType must decode under the child IFD order (BIG); got {names:?}"
+  );
+  // The byte-swapped (buggy outer-order) decode would be id 0 "Uncoded lens" —
+  // assert it is ABSENT so a regression to the outer order is unambiguous.
+  assert!(
+    !has("LensType", "Uncoded lens"),
+    "Data1 must NOT decode under the outer order (byte-swapped to id 0); got {names:?}"
+  );
+  // The byte-order fix leaves the `Priority => 0` (`Panasonic.pm:1981`) ride
+  // intact for the Data1 LensType.
+  let prio = |name: &str, val: &str| -> Option<u8> {
+    em.iter()
+      .find(|e: &&VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+      .map(VendorEmission::priority)
+  };
+  assert_eq!(
+    prio("LensType", "Summilux-M 35mm f/1.4"),
+    Some(0),
+    "Data1 LensType Priority => 0; got {names:?}"
+  );
+}

--- a/src/exif/makernotes/vendors/panasonic/face_det_info.rs
+++ b/src/exif/makernotes/vendors/panasonic/face_det_info.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Panasonic::FaceDetInfo` (`Panasonic.pm:2279-2329`).
+//!
+//! Face-detection position information, reached via the `%Panasonic::Main` tag
+//! `0x4e` SubDirectory (`Panasonic.pm:936-942`). A `ProcessBinaryData` table:
+//! `FORMAT => 'int16u'` (so each numeric key is multiplied by the int16u size 2
+//! to get the BYTE offset — `ExifTool.pm:9893,9957` `$entry = int($index) *
+//! $increment`), `FIRST_ENTRY => 0`, `DATAMEMBER => [ 0 ]`. The emitted tags
+//! carry the family-1 group `Panasonic` (the module default the source table
+//! inherits — verified via `GetTagTable`).
+//!
+//! Positions (`Panasonic.pm:2289-2328`):
+//!
+//! - key 0 (byte 0) `NumFacePositions`, `int16u` — the `DataMember`; gates the
+//!   five face positions below (`RawConv => '$$self{NumFacePositions} = $val'`).
+//! - key 1/5/9/13/17 (bytes 2/10/18/26/34) `Face1..5Position`, `int16u[4]` —
+//!   four numbers `X Y W H` (face center + width/height), each `RawConv =>
+//!   '$$self{NumFacePositions} < N ? undef : $val'`: emitted only when
+//!   `NumFacePositions >= N`.
+//!
+//! No `PrintConv`/`ValueConv` on any position, so `-j` and `-n` are identical
+//! (the bare integer / space-joined integer list).
+//!
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
+//! emission pairs the dispatch site wraps in the `Panasonic` family-1 group.
+
+// Golden-v2 Contract 3c: panic-safety by construction — every read is a checked
+// `get_u16`/`.get()` dominated by a length guard (re-asserts the parent `exif`
+// deny over the makernotes subtree's slice shim).
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::{ByteOrder, get_u16};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// The five `FaceNPosition` names, indexed by `N - 1`.
+const FACE_NAMES: [&str; 5] = [
+  "Face1Position",
+  "Face2Position",
+  "Face3Position",
+  "Face4Position",
+  "Face5Position",
+];
+
+/// Decode the `Panasonic::FaceDetInfo` binary block (`Panasonic.pm:2279-2329`)
+/// into the `(Name, TagValue)` emission pairs.
+///
+/// `data` is the raw `$$valPt` block (the verbatim `0x4e` value bytes); `order`
+/// the parent Panasonic byte order (the SubDirectory has no `ByteOrder`
+/// override, so it inherits, `Panasonic.pm:939-941`). Per-field availability:
+/// each position is emitted only when its bytes are in range AND the
+/// `NumFacePositions` `RawConv` gate passes — a truncated block yields the
+/// fields that fit, never an all-or-nothing drop.
+#[must_use]
+pub fn parse(data: &[u8], order: ByteOrder) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // key 0 (byte 0) NumFacePositions — the DataMember. Absent ⇒ the whole block
+  // has no usable count word, so nothing is emitted.
+  let Some(num) = get_u16(data, 0, order) else {
+    return out;
+  };
+  out.push((
+    SmolStr::new_static("NumFacePositions"),
+    TagValue::I64(i64::from(num)),
+  ));
+  // FaceNPosition int16u[4] at byte 2 + (N-1)*8 (key 1/5/9/13/17 × increment 2),
+  // gated `NumFacePositions >= N`.
+  for (i, name) in FACE_NAMES.iter().enumerate() {
+    // `RawConv => '$$self{NumFacePositions} < N ? undef : $val'` (N = i + 1).
+    if u32::from(num) < (i as u32 + 1) {
+      continue;
+    }
+    let byte = 2 + i * 8;
+    if let Some(v) = read_u16x4(data, byte, order) {
+      out.push((SmolStr::new_static(name), v));
+    }
+  }
+  out
+}
+
+/// Read four `int16u` values at `byte` and render them as the space-joined
+/// integer string ExifTool's default array rendering produces (`"160 120 50
+/// 50"`). `None` when any of the four are out of range (per-field availability).
+fn read_u16x4(data: &[u8], byte: usize, order: ByteOrder) -> Option<TagValue> {
+  use std::fmt::Write;
+  let mut s = String::new();
+  for k in 0..4 {
+    let v = get_u16(data, byte.checked_add(k * 2)?, order)?;
+    if k != 0 {
+      s.push(' ');
+    }
+    let _ = write!(s, "{v}");
+  }
+  Some(TagValue::Str(SmolStr::from(s)))
+}
+
+#[cfg(test)]
+// The file-level `#![deny(clippy::indexing_slicing)]` is a parser-panic-safety
+// contract; the test builders index fixed-layout buffers freely (an out-of-range
+// index is a test-assertion failure, not a shipped panic), so it is relaxed here.
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// Build a little-endian FaceDetInfo block: NumFacePositions then `faces`
+  /// quadruples.
+  fn build(num: u16, faces: &[[u16; 4]]) -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&num.to_le_bytes());
+    for f in faces {
+      for v in f {
+        b.extend_from_slice(&v.to_le_bytes());
+      }
+    }
+    b
+  }
+
+  /// Two faces present + declared. Oracle (`ProcessBinaryData` over the crafted
+  /// block): `NumFacePositions = 2`, `Face1Position = "160 120 50 50"`,
+  /// `Face2Position = "40 30 20 20"`; no `Face3..5Position` (count gate).
+  #[test]
+  fn two_faces() {
+    let blob = build(2, &[[160, 120, 50, 50], [40, 30, 20, 20]]);
+    let em = parse(&blob, ByteOrder::Little);
+    assert_eq!(find(&em, "NumFacePositions"), Some(TagValue::I64(2)));
+    assert_eq!(
+      find(&em, "Face1Position"),
+      Some(TagValue::Str("160 120 50 50".into()))
+    );
+    assert_eq!(
+      find(&em, "Face2Position"),
+      Some(TagValue::Str("40 30 20 20".into()))
+    );
+    assert_eq!(find(&em, "Face3Position"), None);
+    assert_eq!(em.len(), 3);
+  }
+
+  /// The `NumFacePositions` `RawConv` gate drops a face whose index exceeds the
+  /// declared count even when its BYTES are present (`NumFacePositions < N ?
+  /// undef`).
+  #[test]
+  fn count_gate_drops_present_bytes() {
+    // Declare 1 but supply 2 quadruples of bytes.
+    let blob = build(1, &[[1, 2, 3, 4], [5, 6, 7, 8]]);
+    let em = parse(&blob, ByteOrder::Little);
+    assert_eq!(find(&em, "NumFacePositions"), Some(TagValue::I64(1)));
+    assert_eq!(
+      find(&em, "Face1Position"),
+      Some(TagValue::Str("1 2 3 4".into()))
+    );
+    assert_eq!(
+      find(&em, "Face2Position"),
+      None,
+      "Face2 must be gated off by NumFacePositions = 1"
+    );
+  }
+
+  /// Per-field availability: a declared face whose bytes are entirely absent
+  /// (its byte offset is at/past the block end, ExifTool's `next if $entry >=
+  /// $size`) is simply omitted; the count word + the in-range faces still emit.
+  #[test]
+  fn absent_face_bytes_omitted() {
+    // Declare 3 but supply only 2 full quadruples ⇒ Face3 starts at byte 18 of
+    // an 18-byte block (start == size) ⇒ omitted.
+    let blob = build(3, &[[9, 8, 7, 6], [5, 4, 3, 2]]);
+    assert_eq!(blob.len(), 18);
+    let em = parse(&blob, ByteOrder::Little);
+    assert_eq!(find(&em, "NumFacePositions"), Some(TagValue::I64(3)));
+    assert_eq!(
+      find(&em, "Face1Position"),
+      Some(TagValue::Str("9 8 7 6".into()))
+    );
+    assert_eq!(
+      find(&em, "Face2Position"),
+      Some(TagValue::Str("5 4 3 2".into()))
+    );
+    assert_eq!(find(&em, "Face3Position"), None);
+  }
+
+  /// An empty / sub-2-byte block has no count word ⇒ nothing is emitted.
+  #[test]
+  fn empty_block_emits_nothing() {
+    assert!(parse(&[], ByteOrder::Little).is_empty());
+    assert!(parse(&[0x01], ByteOrder::Little).is_empty());
+  }
+
+  /// Big-endian decode reads the count + positions MSB-first.
+  #[test]
+  fn big_endian() {
+    let mut blob = Vec::new();
+    blob.extend_from_slice(&1u16.to_be_bytes());
+    for v in [100u16, 200, 25, 25] {
+      blob.extend_from_slice(&v.to_be_bytes());
+    }
+    let em = parse(&blob, ByteOrder::Big);
+    assert_eq!(find(&em, "NumFacePositions"), Some(TagValue::I64(1)));
+    assert_eq!(
+      find(&em, "Face1Position"),
+      Some(TagValue::Str("100 200 25 25".into()))
+    );
+  }
+}

--- a/src/exif/makernotes/vendors/panasonic/face_rec_info.rs
+++ b/src/exif/makernotes/vendors/panasonic/face_rec_info.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Panasonic::FaceRecInfo` (`Panasonic.pm:2332-2397`).
+//!
+//! Face-RECOGNITION information (named/known faces), reached via the
+//! `%Panasonic::Main` tag `0x61` SubDirectory (`Panasonic.pm:1007-1012`), first
+//! seen on the DMC-TZ7. A `ProcessBinaryData` table with the DEFAULT
+//! `FORMAT => 'int8u'` (so each numeric key IS the byte offset — increment 1),
+//! `FIRST_ENTRY => 0`, `DATAMEMBER => [ 0 ]`. The emitted tags carry the
+//! family-1 group `Panasonic` (the module default — verified via `GetTagTable`).
+//!
+//! Positions (`Panasonic.pm:2345-2396`), one block per recognized face:
+//!
+//! - byte 0 `FacesRecognized`, `int16u` — the `DataMember`; gates the per-face
+//!   fields (`RawConv => '$$self{FacesRecognized} = $val'`).
+//! - face N (N = 1..3), each gated `RawConv => '$$self{FacesRecognized} < N ?
+//!   undef : $val'`:
+//!   - `RecognizedFaceNName`, `string[20]`;
+//!   - `RecognizedFaceNPosition`, `int16u[4]` (same `X Y W H` form as the face
+//!     DETECTION tags);
+//!   - `RecognizedFaceNAge`, `string[20]`.
+//!
+//! No `PrintConv`/`ValueConv`, so `-j` and `-n` are identical. Strings are
+//! NUL-truncated (`ReadValue`'s `s/\0.*//s`) then run through ExifTool's
+//! `FixUTF8` (`crate::convert::fix_utf8`), exactly like the Canon `SerialInfo`
+//! port.
+//!
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
+//! emission pairs the dispatch site wraps in the `Panasonic` family-1 group.
+
+// Golden-v2 Contract 3c: panic-safety by construction — every read is checked.
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::{ByteOrder, get_u16};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// `(NameTag, name byte, PositionTag, position byte, AgeTag, age byte)` for the
+/// three recognized-face blocks (`Panasonic.pm:2351-2396`).
+const FACE_FIELDS: [(&str, usize, &str, usize, &str, usize); 3] = [
+  (
+    "RecognizedFace1Name",
+    4,
+    "RecognizedFace1Position",
+    24,
+    "RecognizedFace1Age",
+    32,
+  ),
+  (
+    "RecognizedFace2Name",
+    52,
+    "RecognizedFace2Position",
+    72,
+    "RecognizedFace2Age",
+    80,
+  ),
+  (
+    "RecognizedFace3Name",
+    100,
+    "RecognizedFace3Position",
+    120,
+    "RecognizedFace3Age",
+    128,
+  ),
+];
+
+/// Decode the `Panasonic::FaceRecInfo` binary block (`Panasonic.pm:2332-2397`)
+/// into the `(Name, TagValue)` emission pairs.
+///
+/// `data` is the raw `$$valPt` block (the verbatim `0x61` value bytes); `order`
+/// the inherited parent Panasonic byte order. Each face's three fields are
+/// emitted only when `FacesRecognized >= N` (the `RawConv` gate) AND the bytes
+/// are in range (per-field availability).
+#[must_use]
+pub fn parse(data: &[u8], order: ByteOrder) -> Vec<(SmolStr, TagValue)> {
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // byte 0 FacesRecognized — the DataMember. Absent ⇒ nothing emitted.
+  let Some(faces) = get_u16(data, 0, order) else {
+    return out;
+  };
+  out.push((
+    SmolStr::new_static("FacesRecognized"),
+    TagValue::I64(i64::from(faces)),
+  ));
+  for (i, (name_tag, name_off, pos_tag, pos_off, age_tag, age_off)) in
+    FACE_FIELDS.iter().enumerate()
+  {
+    // `RawConv => '$$self{FacesRecognized} < N ? undef : $val'` (N = i + 1).
+    if u32::from(faces) < (i as u32 + 1) {
+      continue;
+    }
+    if let Some(v) = read_string(data, *name_off, 20) {
+      out.push((SmolStr::new_static(name_tag), v));
+    }
+    if let Some(v) = read_u16x4(data, *pos_off, order) {
+      out.push((SmolStr::new_static(pos_tag), v));
+    }
+    if let Some(v) = read_string(data, *age_off, 20) {
+      out.push((SmolStr::new_static(age_tag), v));
+    }
+  }
+  out
+}
+
+/// Read a `string[len]` at `off`: `None` when the start is at/past the block end
+/// (ExifTool's `next if $entry >= $size`), else the NUL-truncated, `FixUTF8`'d
+/// text over the bytes that fit (`ReadValue` clamps the count to what is
+/// available, so a truncated trailing field reads fewer bytes — the Canon
+/// `SerialInfo` convention).
+fn read_string(data: &[u8], off: usize, len: usize) -> Option<TagValue> {
+  if off >= data.len() {
+    return None;
+  }
+  let end = off.saturating_add(len).min(data.len());
+  let window = data.get(off..end).unwrap_or(&[]);
+  // `s/\0.*//s` — truncate at the first NUL byte.
+  let trimmed = match window.iter().position(|&b| b == 0) {
+    Some(nul) => window.get(..nul).unwrap_or(window),
+    None => window,
+  };
+  Some(TagValue::Str(SmolStr::from(crate::convert::fix_utf8(
+    trimmed,
+  ))))
+}
+
+/// Read four `int16u` values at `off` as the space-joined integer string; `None`
+/// when any of the four are out of range (per-field availability).
+fn read_u16x4(data: &[u8], off: usize, order: ByteOrder) -> Option<TagValue> {
+  use std::fmt::Write;
+  let mut s = String::new();
+  for k in 0..4 {
+    let v = get_u16(data, off.checked_add(k * 2)?, order)?;
+    if k != 0 {
+      s.push(' ');
+    }
+    let _ = write!(s, "{v}");
+  }
+  Some(TagValue::Str(SmolStr::from(s)))
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// Build a little-endian FaceRecInfo block holding `faces` declared and one
+  /// fully-populated face block (Name@4, Position@24, Age@32) — 52 bytes.
+  fn build_one(faces: u16, name: &[u8], pos: [u16; 4], age: &[u8]) -> Vec<u8> {
+    let mut b = std::vec![0u8; 52];
+    b[0..2].copy_from_slice(&faces.to_le_bytes());
+    b[4..4 + name.len().min(20)].copy_from_slice(&name[..name.len().min(20)]);
+    for (k, v) in pos.iter().enumerate() {
+      b[24 + k * 2..26 + k * 2].copy_from_slice(&v.to_le_bytes());
+    }
+    b[32..32 + age.len().min(20)].copy_from_slice(&age[..age.len().min(20)]);
+    b
+  }
+
+  /// One recognized face. Oracle: `FacesRecognized = 1`,
+  /// `RecognizedFace1Name = "Alice"`, `RecognizedFace1Position = "10 20 30 40"`,
+  /// `RecognizedFace1Age = "25"`; no Face2/Face3 (count gate).
+  #[test]
+  fn one_recognized_face() {
+    let blob = build_one(1, b"Alice", [10, 20, 30, 40], b"25");
+    let em = parse(&blob, ByteOrder::Little);
+    assert_eq!(find(&em, "FacesRecognized"), Some(TagValue::I64(1)));
+    assert_eq!(
+      find(&em, "RecognizedFace1Name"),
+      Some(TagValue::Str("Alice".into()))
+    );
+    assert_eq!(
+      find(&em, "RecognizedFace1Position"),
+      Some(TagValue::Str("10 20 30 40".into()))
+    );
+    assert_eq!(
+      find(&em, "RecognizedFace1Age"),
+      Some(TagValue::Str("25".into()))
+    );
+    assert_eq!(find(&em, "RecognizedFace2Name"), None);
+    assert_eq!(em.len(), 4);
+    // No PrintConv ⇒ `-n` identical.
+    assert_eq!(parse(&blob, ByteOrder::Little), em);
+  }
+
+  /// The count gate drops a face whose Name/Position/Age bytes ARE present but
+  /// whose index exceeds `FacesRecognized`.
+  #[test]
+  fn count_gate_drops_present_face2() {
+    // Declare 1 but supply a 100-byte block (room for Face2's fields).
+    let mut blob = build_one(1, b"Bob", [1, 2, 3, 4], b"30");
+    blob.resize(120, 0);
+    blob[52..55].copy_from_slice(b"Eve"); // Face2 name bytes present
+    let em = parse(&blob, ByteOrder::Little);
+    assert_eq!(
+      find(&em, "RecognizedFace1Name"),
+      Some(TagValue::Str("Bob".into()))
+    );
+    assert_eq!(
+      find(&em, "RecognizedFace2Name"),
+      None,
+      "Face2 gated off by FacesRecognized = 1"
+    );
+  }
+
+  /// Strings NUL-truncate (a 20-byte field with a NUL terminator).
+  #[test]
+  fn name_nul_truncates() {
+    let blob = build_one(1, b"Carol\x00ignored", [0, 0, 0, 0], b"40");
+    assert_eq!(
+      find(&parse(&blob, ByteOrder::Little), "RecognizedFace1Name"),
+      Some(TagValue::Str("Carol".into()))
+    );
+  }
+
+  /// An empty / sub-2-byte block has no count word ⇒ nothing emitted.
+  #[test]
+  fn empty_block_emits_nothing() {
+    assert!(parse(&[], ByteOrder::Little).is_empty());
+    assert!(parse(&[0x01], ByteOrder::Little).is_empty());
+  }
+}

--- a/src/exif/makernotes/vendors/panasonic/mod.rs
+++ b/src/exif/makernotes/vendors/panasonic/mod.rs
@@ -33,14 +33,15 @@
 //!   parsed fields — body identity (Lens model/serial, internal serial,
 //!   firmware, ImageStabilization, FilmMode, PhotoStyle, Roll/PitchAngle).
 //!
-//! ## Deferred (Phase 3+1 follow-up)
+//! ## Main SubDirectory pointers
 //!
-//! The Main hash has exactly four SubDirectory pointers; the dedicated
-//! walkers are deferred (each blob is surfaced raw):
+//! The Main hash has exactly four SubDirectory pointers. Three are
+//! `ProcessBinaryData` sub-tables walked natively (#105) — their positions emit
+//! under the `Panasonic` family-1 group via [`decode_main_subdir`]:
 //!
-//! - `Panasonic::FaceDetInfo` at 0x4e (`Panasonic.pm:936-942`).
-//! - `Panasonic::FaceRecInfo` at 0x61 (`Panasonic.pm:1007-1012`).
-//! - `Panasonic::TimeInfo` at 0x2003 (`Panasonic.pm:1524-1527`).
+//! - `Panasonic::FaceDetInfo` at 0x4e (`Panasonic.pm:936-942`) — [`face_det_info`].
+//! - `Panasonic::FaceRecInfo` at 0x61 (`Panasonic.pm:1007-1012`) — [`face_rec_info`].
+//! - `Panasonic::TimeInfo` at 0x2003 (`Panasonic.pm:1524-1527`) — [`time_info`].
 //! - `PrintIM::Main` at 0x0e00 (`Panasonic.pm:1518-1523`) — handled by the
 //!   shared PrintIM module.
 //!
@@ -62,8 +63,11 @@
 #![deny(clippy::indexing_slicing)]
 
 pub mod body;
+pub mod face_det_info;
+pub mod face_rec_info;
 pub mod printconv;
 pub mod tags;
+pub mod time_info;
 
 use crate::exif::makernotes::detected::BaseRule;
 use crate::exif::makernotes::vendors::VendorEmission;
@@ -656,6 +660,35 @@ fn first_i64(raw: &RawValue) -> Option<i64> {
   }
 }
 
+/// Decode a WALKED `%Panasonic::Main` ProcessBinaryData SubDirectory blob into
+/// its `(Name, TagValue)` emission pairs — the faithful descent for the three
+/// binary sub-tables `%Panasonic::Main` references: `FaceDetInfo` (0x4e,
+/// `Panasonic.pm:2279`), `FaceRecInfo` (0x61, `:2332`), `TimeInfo` (0x2003,
+/// `:1939`). All three emit under the `Panasonic` family-1 group (the module
+/// default the source tables inherit).
+///
+/// `blob` is the verbatim `$$valPt` value span (`data[value_offset ..
+/// value_offset + value_size]`); `order` the inherited parent Panasonic byte
+/// order (none of the three SubDirectory refs carry a `ByteOrder` override).
+/// Returns `None` for [`SubTable::PrintIm`] — the `PrintIM::Main` SubDirectory
+/// (0x0e00) is handled by the shared PrintIM module, not this descent — so the
+/// caller falls through to its existing (no-emit) handling.
+#[must_use]
+pub fn decode_main_subdir(
+  sub: SubTable,
+  blob: &[u8],
+  order: ByteOrder,
+  print_conv: bool,
+) -> Option<Vec<(SmolStr, TagValue)>> {
+  match sub {
+    SubTable::FaceDetInfo => Some(face_det_info::parse(blob, order)),
+    SubTable::FaceRecInfo => Some(face_rec_info::parse(blob, order)),
+    SubTable::TimeInfo => Some(time_info::parse(blob, order, print_conv)),
+    // `PrintIM::Main` is handled by the shared PrintIM module, not here.
+    SubTable::PrintIm => None,
+  }
+}
+
 #[cfg(test)]
 // The file-level `#![deny(clippy::indexing_slicing)]` is a parser-panic-safety
 // contract (Phase C S2); the test-builder helpers index fixed-layout buffers
@@ -1102,53 +1135,60 @@ mod tests {
     );
   }
 
-  /// SubDirectory rows are DESCENDED-INTO, never emitted as a parent value.
-  /// A `%Panasonic::Main` body carrying 0x4e FaceDetInfo
-  /// (`Panasonic.pm:936-942`, SubDirectory → `Panasonic::FaceDetInfo`) and
-  /// 0x2003 TimeInfo (`:1524-1527`, SubDirectory → `Panasonic::TimeInfo`)
-  /// must emit NEITHER `FaceDetInfo` NOR `TimeInfo` — ExifTool's
-  /// `if ($subdir)` block descends + `next`s before `FoundTag`
-  /// (`Exif.pm:6919,7103-7104,7180`), and Phase 3 defers the child walk. A
-  /// sibling leaf (0x01 ImageQuality) IS still emitted, proving the
-  /// suppression is targeted at the SubDirectory rows, not a blanket drop.
+  /// SubDirectory rows DESCEND into their child `ProcessBinaryData` table (#105):
+  /// the PARENT pointer (`FaceDetInfo`/`TimeInfo`) is NEVER emitted as a value
+  /// (ExifTool's `if ($subdir)` descends + `next`s before `FoundTag`,
+  /// `Exif.pm:6919,7103-7104,7180`), but the CHILD positions ARE emitted under
+  /// the `Panasonic` group. A sibling leaf (0x01 ImageQuality) is still emitted,
+  /// proving the descent is targeted, not a blanket drop. End-to-end through the
+  /// shared-`Walker` capture loop.
   #[test]
-  fn subdir_facedetinfo_timeinfo_not_emitted() {
+  fn subdir_facedetinfo_timeinfo_descend_to_children() {
+    // 0x4e FaceDetInfo undef[10]: NumFacePositions=1, Face1Position=160 120 50 50.
+    let mut face = std::vec![0u8; 10];
+    face[0..2].copy_from_slice(&1u16.to_le_bytes());
+    for (k, v) in [160u16, 120, 50, 50].iter().enumerate() {
+      face[2 + k * 2..4 + k * 2].copy_from_slice(&v.to_le_bytes());
+    }
+    // 0x2003 TimeInfo undef[20]: PanasonicDateTime + TimeLapseShotNumber=9.
+    let mut time = std::vec![0u8; 20];
+    time[0..8].copy_from_slice(&[0x20, 0x21, 0x06, 0x28, 0x14, 0x30, 0x00, 0x55]);
+    time[16..20].copy_from_slice(&9u32.to_le_bytes());
     // Entries MUST be tag-id sorted: 0x01, 0x4e, 0x2003.
     let blob = build_blob(&[
       (0x01, 0x03, 1, std::vec![0x02, 0x00, 0, 0]), // ImageQuality int16u = 2 ("High")
-      (0x4e, 0x07, 4, std::vec![0x01, 0x02, 0x03, 0x04]), // FaceDetInfo undef[4]
-      (0x2003, 0x07, 4, std::vec![0x05, 0x06, 0x07, 0x08]), // TimeInfo undef[4]
+      (0x4e, 0x07, 10, face),
+      (0x2003, 0x07, 20, time),
     ]);
     for print_conv in [true, false] {
       let (_t, em) = parse_with_print_conv(&blob, ByteOrder::Little, print_conv);
+      // The PARENT SubDirectory pointers are never emitted as values.
+      assert_eq!(emit_value(&em, "FaceDetInfo"), None);
+      assert_eq!(emit_value(&em, "TimeInfo"), None);
+      // The CHILD positions ARE emitted (the #105 descent), identical in both modes.
+      assert_eq!(emit_value(&em, "NumFacePositions"), Some(TagValue::I64(1)));
       assert_eq!(
-        emit_value(&em, "FaceDetInfo"),
-        None,
-        "Panasonic:FaceDetInfo (0x4e SubDirectory) must NOT be emitted \
-         (print_conv={print_conv})"
+        emit_value(&em, "Face1Position"),
+        Some(TagValue::Str("160 120 50 50".into()))
       );
       assert_eq!(
-        emit_value(&em, "TimeInfo"),
-        None,
-        "Panasonic:TimeInfo (0x2003 SubDirectory) must NOT be emitted \
-         (print_conv={print_conv})"
+        emit_value(&em, "PanasonicDateTime"),
+        Some(TagValue::Str("2021:06:28 14:30:00.55".into()))
       );
-      // The sibling leaf is retained (value form differs by mode: "High" in
-      // print-conv, raw 2 in value-conv — only presence matters here).
-      assert!(
-        emit_value(&em, "ImageQuality").is_some(),
-        "sibling leaf ImageQuality must still be emitted (print_conv={print_conv})"
+      assert_eq!(
+        emit_value(&em, "TimeLapseShotNumber"),
+        Some(TagValue::I64(9))
       );
     }
-    // In print-conv mode the leaf renders via PrintConv (`Panasonic.pm:281`).
+    // In print-conv mode the sibling leaf renders via PrintConv (`Panasonic.pm:281`).
     let (_tp, emp) = parse_with_print_conv(&blob, ByteOrder::Little, true);
     assert_eq!(
       emit_value(&emp, "ImageQuality"),
       Some(TagValue::Str("High".into()))
     );
 
-    // Also assert through the Metadata sink: no `Panasonic:FaceDetInfo` /
-    // `Panasonic:TimeInfo` key, mirroring the bundled default `-G1 -j` output.
+    // Through the Metadata sink: child keys present, parent keys absent, all
+    // under the `Panasonic` family-1 group (the source tables' module default).
     let mut md = Metadata::new("test.rw2");
     parse_into_metadata(&blob, ByteOrder::Little, true, &mut md);
     let names: Vec<&str> = md.tags_slice().iter().map(|t| t.name()).collect();
@@ -1157,9 +1197,19 @@ mod tests {
       "no SubDirectory parent may reach the Metadata sink, got {names:?}"
     );
     assert!(
-      names.contains(&"ImageQuality"),
-      "ImageQuality must reach the sink, got {names:?}"
+      names.contains(&"NumFacePositions")
+        && names.contains(&"PanasonicDateTime")
+        && names.contains(&"ImageQuality"),
+      "child + sibling tags must reach the sink, got {names:?}"
     );
+    for t in md.tags_slice() {
+      assert_eq!(
+        t.group_ref().family1(),
+        "Panasonic",
+        "tag {:?} must emit under the Panasonic group",
+        t.name()
+      );
+    }
   }
 
   /// `$format`-gated single-HASH `Condition` suppression for the LensType

--- a/src/exif/makernotes/vendors/panasonic/tags.rs
+++ b/src/exif/makernotes/vendors/panasonic/tags.rs
@@ -14,10 +14,11 @@
 //!   `RecognizedFaceFlags` is `Unknown => 1`, `Panasonic.pm:1025`), and a
 //!   [`PanasonicPrintConv`] strategy.
 //! - SubDirectory pointers (`FaceDetInfo` 0x4e, `FaceRecInfo` 0x61,
-//!   `PrintIM` 0x0e00, `TimeInfo` 0x2003) are recorded as [`SubTable`]
-//!   so the dispatcher can surface the raw blob; the dedicated walkers are
-//!   deferred follow-ups (see the deferral issues linked from #62). They
-//!   are the ONLY four SubDirectory entries in the Main hash.
+//!   `PrintIM` 0x0e00, `TimeInfo` 0x2003) are recorded as [`SubTable`]. The
+//!   three `ProcessBinaryData` sub-tables are walked natively (#105) via
+//!   [`decode_main_subdir`](super::decode_main_subdir); `PrintIM` is handled by
+//!   the shared PrintIM module. They are the ONLY four SubDirectory entries in
+//!   the Main hash.
 //! - Conditional ARRAY rows (`0x0f` AFAreaMode FZ10 vs other; `0x2c`
 //!   ContrastMode 4-way per-model) collapse to the bundled NON-model-gated
 //!   ("other models" / final) branch, exactly as the Apple/Canon ports do
@@ -101,21 +102,24 @@ impl PanasonicTag {
 }
 
 /// Panasonic Main SubDirectory targets. The Main hash has exactly four
-/// SubDirectory entries; Phase 3 doesn't walk any of them natively (the
-/// camera-indexing data is all in the LEAF tags), so each SubDirectory
-/// blob is surfaced as a raw value (presence + size) and the dedicated
-/// walker is deferred per follow-up issue.
+/// SubDirectory entries. Three are `ProcessBinaryData` sub-tables walked
+/// natively (#105) — their positions emit under the `Panasonic` family-1 group
+/// via [`decode_main_subdir`](super::decode_main_subdir); the fourth (PrintIM)
+/// is handled by the shared PrintIM module.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SubTable {
-  /// `%Panasonic::FaceDetInfo` at 0x4e (`Panasonic.pm:936-942`). Deferred.
+  /// `%Panasonic::FaceDetInfo` at 0x4e (`Panasonic.pm:936-942`) — walked
+  /// (`super::face_det_info`).
   FaceDetInfo,
-  /// `%Panasonic::FaceRecInfo` at 0x61 (`Panasonic.pm:1007-1012`). Deferred.
+  /// `%Panasonic::FaceRecInfo` at 0x61 (`Panasonic.pm:1007-1012`) — walked
+  /// (`super::face_rec_info`).
   FaceRecInfo,
-  /// `%Panasonic::TimeInfo` at 0x2003 (`Panasonic.pm:1524-1527`). Deferred.
+  /// `%Panasonic::TimeInfo` at 0x2003 (`Panasonic.pm:1524-1527`) — walked
+  /// (`super::time_info`).
   TimeInfo,
-  /// `PrintIM::Main` at 0x0e00 (`Panasonic.pm:1518-1523`) — handled by a
-  /// separate module. Surfaced raw.
+  /// `PrintIM::Main` at 0x0e00 (`Panasonic.pm:1518-1523`) — handled by the
+  /// shared PrintIM module.
   PrintIm,
 }
 

--- a/src/exif/makernotes/vendors/panasonic/time_info.rs
+++ b/src/exif/makernotes/vendors/panasonic/time_info.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `%Image::ExifTool::Panasonic::TimeInfo` (`Panasonic.pm:1939-1968`).
+//!
+//! Timestamp information, reached via the `%Panasonic::Main` tag `0x2003`
+//! SubDirectory (`Panasonic.pm:1524-1527`). A `ProcessBinaryData` table with the
+//! DEFAULT `FORMAT => 'int8u'` (numeric keys are byte offsets), `FIRST_ENTRY =>
+//! 0`. The emitted tags carry the family-1 group `Panasonic`.
+//!
+//! Positions (`Panasonic.pm:1946-1967`):
+//!
+//! - byte 0 `PanasonicDateTime`, `undef[8]`:
+//!   - `RawConv => '$val =~ /^\0/ ? undef : $val'` — drop when the first byte is
+//!     NUL;
+//!   - `ValueConv => 'sprintf("%s:%s:%s %s:%s:%s.%s", unpack "H4H2H2H2H2H2H2",
+//!     $val)'` — the 8 bytes are nibble-hex-encoded into `YYYY:MM:DD
+//!     HH:MM:SS.ff` (Perl `unpack "H"` is high-nibble-first lowercase hex; the
+//!     leading `H4` consumes the first TWO bytes as the four-digit year);
+//!   - `PrintConv => '$self->ConvertDateTime($val)'` — identity under the
+//!     default options exifast models (no `-dateFormat`), so `-j` and `-n` agree.
+//! - byte 16 `TimeLapseShotNumber`, `int32u`.
+//!
+//! D8: a pure decoder (no public fields); returns the `(Name, TagValue)`
+//! emission pairs the dispatch site wraps in the `Panasonic` family-1 group.
+
+// Golden-v2 Contract 3c: panic-safety by construction — array destructuring +
+// checked reads, no raw indexing.
+#![deny(clippy::indexing_slicing)]
+
+use crate::exif::ifd::{ByteOrder, get_u32};
+use crate::value::TagValue;
+use smol_str::SmolStr;
+use std::vec::Vec;
+
+/// Decode the `Panasonic::TimeInfo` binary block (`Panasonic.pm:1939-1968`) into
+/// the `(Name, TagValue)` emission pairs.
+///
+/// `data` is the raw `$$valPt` block (the verbatim `0x2003` value bytes);
+/// `order` the inherited parent Panasonic byte order (consumed by the
+/// `TimeLapseShotNumber` int32u read). `print_conv` is accepted for a uniform
+/// sub-table signature; `PanasonicDateTime`'s only `PrintConv` is the identity
+/// `ConvertDateTime`, so the result is the same in both modes.
+#[must_use]
+pub fn parse(data: &[u8], order: ByteOrder, print_conv: bool) -> Vec<(SmolStr, TagValue)> {
+  let _ = print_conv; // ConvertDateTime is identity here
+  let mut out: Vec<(SmolStr, TagValue)> = Vec::new();
+  // byte 0 PanasonicDateTime undef[8] — RawConv NUL-drop + the nibble-hex ValueConv.
+  if let Some(dt) = format_datetime(data) {
+    out.push((
+      SmolStr::new_static("PanasonicDateTime"),
+      TagValue::Str(SmolStr::from(dt)),
+    ));
+  }
+  // byte 16 TimeLapseShotNumber int32u.
+  if let Some(n) = get_u32(data, 16, order) {
+    out.push((
+      SmolStr::new_static("TimeLapseShotNumber"),
+      TagValue::I64(i64::from(n)),
+    ));
+  }
+  out
+}
+
+/// `unpack "H4H2H2H2H2H2H2"` + the `sprintf` date format (`Panasonic.pm:1952`),
+/// gated by the `RawConv => '$val =~ /^\0/ ? undef : $val'` NUL-drop
+/// (`Panasonic.pm:1951`). `None` when fewer than 8 bytes are present (the `undef`
+/// field cannot be fully read) or the first byte is NUL.
+fn format_datetime(data: &[u8]) -> Option<String> {
+  let win: [u8; 8] = data.get(0..8)?.try_into().ok()?;
+  let [b0, b1, b2, b3, b4, b5, b6, b7] = win;
+  // `RawConv => '$val =~ /^\0/ ? undef : $val'` — drop a leading-NUL value.
+  if b0 == 0 {
+    return None;
+  }
+  // `unpack "H"` is high-nibble-first LOWERCASE hex; the `H4` leading field
+  // consumes the first two bytes ⇒ the four-digit year.
+  Some(std::format!(
+    "{b0:02x}{b1:02x}:{b2:02x}:{b3:02x} {b4:02x}:{b5:02x}:{b6:02x}.{b7:02x}"
+  ))
+}
+
+#[cfg(test)]
+#[allow(clippy::indexing_slicing)]
+mod tests {
+  use super::*;
+
+  fn find(em: &[(SmolStr, TagValue)], name: &str) -> Option<TagValue> {
+    em.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone())
+  }
+
+  /// A normal BCD-style datetime + a TimeLapseShotNumber. Oracle (`unpack
+  /// "H4H2H2H2H2H2H2"` then the sprintf): bytes `20 21 06 28 14 30 00 55` ⇒
+  /// `"2021:06:28 14:30:00.55"`; int32u at byte 16 ⇒ the shot number.
+  #[test]
+  fn datetime_and_shot_number() {
+    let mut blob = std::vec![0u8; 20];
+    blob[0..8].copy_from_slice(&[0x20, 0x21, 0x06, 0x28, 0x14, 0x30, 0x00, 0x55]);
+    blob[16..20].copy_from_slice(&7u32.to_le_bytes());
+    let em = parse(&blob, ByteOrder::Little, true);
+    assert_eq!(
+      find(&em, "PanasonicDateTime"),
+      Some(TagValue::Str("2021:06:28 14:30:00.55".into()))
+    );
+    assert_eq!(find(&em, "TimeLapseShotNumber"), Some(TagValue::I64(7)));
+    // ConvertDateTime is identity ⇒ `-n` matches `-j`.
+    assert_eq!(parse(&blob, ByteOrder::Little, false), em);
+  }
+
+  /// `RawConv => '$val =~ /^\0/ ? undef'` drops a leading-NUL datetime; the
+  /// TimeLapseShotNumber (if present) still emits.
+  #[test]
+  fn leading_nul_datetime_dropped() {
+    let mut blob = std::vec![0u8; 20];
+    // First byte NUL ⇒ PanasonicDateTime dropped.
+    blob[0..8].copy_from_slice(&[0x00, 0x21, 0x06, 0x28, 0x14, 0x30, 0x00, 0x55]);
+    blob[16..20].copy_from_slice(&3u32.to_le_bytes());
+    let em = parse(&blob, ByteOrder::Little, true);
+    assert_eq!(find(&em, "PanasonicDateTime"), None);
+    assert_eq!(find(&em, "TimeLapseShotNumber"), Some(TagValue::I64(3)));
+  }
+
+  /// Lowercase nibble-hex: a byte with an a-f nibble renders lowercase (Perl
+  /// `unpack "H"`).
+  #[test]
+  fn nibble_hex_is_lowercase() {
+    let blob = [0x20, 0x1a, 0x0b, 0x1c, 0x0a, 0x0f, 0x00, 0x00];
+    assert_eq!(
+      find(&parse(&blob, ByteOrder::Little, true), "PanasonicDateTime"),
+      Some(TagValue::Str("201a:0b:1c 0a:0f:00.00".into()))
+    );
+  }
+
+  /// A block shorter than 8 bytes has no full datetime field; an absent
+  /// TimeLapseShotNumber (block < 20 bytes) is omitted.
+  #[test]
+  fn short_block() {
+    assert!(parse(&[0x20, 0x21], ByteOrder::Little, true).is_empty());
+    // 8-byte block: datetime present, shot number absent.
+    let blob = [0x20, 0x21, 0x06, 0x28, 0x14, 0x30, 0x00, 0x55];
+    let em = parse(&blob, ByteOrder::Little, true);
+    assert_eq!(
+      find(&em, "PanasonicDateTime"),
+      Some(TagValue::Str("2021:06:28 14:30:00.55".into()))
+    );
+    assert_eq!(find(&em, "TimeLapseShotNumber"), None);
+  }
+}

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -8603,6 +8603,34 @@ impl Walker<'_, '_> {
         Some(t) => (t.name(), ResolvedConv::Samsung(t)),
         None => return,
       },
+      // `%Panasonic::Leica4` (M9, #105) — every row is an IFD SubDirectory into
+      // `%Panasonic::Subdir` (`Panasonic.pm:1742-1769`, `0x3000`/`0x3100`/`0x3400`/
+      // `0x3900`), walked under `ByteOrder => Unknown`. Descend IN-WALK here (like
+      // the Samsung `PreviewIfd` descent below): the child IFD starts at `$val +
+      // value_offset_base` (the default `Start => '$val'`, the inherited base), and
+      // its leaves resolve under `active_table == Leica(Subdir)`. The parent
+      // pointer is NEVER emitted (`return`), matching ExifTool's descend-then-`next`
+      // (`Exif.pm:7103-7104`); a non-SubDirectory Leica4 id is unknown ⇒ skipped.
+      // Leica4 carries no plain leaf, so this arm handles every Leica4 entry.
+      TableRef::Leica(makernotes::vendors::leica::tags::LeicaVariant::Leica4) => {
+        if matches!(tag_id, 0x3000 | 0x3100 | 0x3400 | 0x3900)
+          && let Some(off) = first_uint(&raw)
+          && let Some(start) = i64::try_from(off)
+            .ok()
+            .map(|d| d.saturating_add(self.value_offset_base))
+            .and_then(|a| usize::try_from(a).ok())
+        {
+          self.process_subdir(
+            start,
+            kind,
+            TableRef::Leica(makernotes::vendors::leica::tags::LeicaVariant::Subdir),
+            ByteOrderRule::Unknown,
+            FixBaseMode::No,
+            ProcessProc::Exif,
+          );
+        }
+        return;
+      }
       // `%Panasonic::Leica2`..`Leica9` (#259). The resolved [`LeicaTag`] rides in
       // `ResolvedConv::Leica` WITH its variant so the emit ([`emit_leica_value`])
       // reapplies its `LeicaPrintConv` + evaluates the row `Condition`. An unknown

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -906,6 +906,19 @@ pub struct ExifEntry {
   /// standalone TIFF) for an IFD0 leaf; never serialized (an emission-ordering
   /// aid only — VALUES stay byte-identical).
   own_ifd_start: usize,
+  /// The RESOLVED byte order the IFD body this entry was walked under was read in
+  /// — `self.order` at push time, i.e. the order
+  /// [`process_subdir`](Walker::process_subdir) resolved for THIS directory. For a
+  /// `ByteOrder => Unknown` child (the Leica4 `%Subdir` IFDs) the probe can pick a
+  /// DIFFERENT order than the parent MakerNote IFD, so it is recorded PER entry,
+  /// alongside [`own_ifd_start`](Self::own_ifd_start): together they identify the
+  /// directory AND the order its values decode under. Consumed by the Leica binary
+  /// sub-table re-slice (#105) so a `Data1`/`FocusInfo`/`ShotInfo` block decodes
+  /// its ints with ITS containing IFD's order — a mixed-endian Leica4 `%Subdir`
+  /// child would otherwise byte-swap the `Data1` `int32u LensType`. A synthetic /
+  /// placeholder push (no walked IFD) carries the walker's active order and never
+  /// has it read. Never serialized (VALUES stay byte-identical).
+  ifd_order: ByteOrder,
   /// The SOURCE-BLOCK ordinal — the index of the independent TIFF block this
   /// entry was extracted from when several are MERGED into one [`ExifMeta`]
   /// (a multi-`APP1` JPEG: each independent `APP1` Exif segment is its own
@@ -999,6 +1012,17 @@ impl ExifEntry {
   #[inline(always)]
   pub(crate) const fn own_ifd_start(&self) -> usize {
     self.own_ifd_start
+  }
+
+  /// The resolved byte order of this entry's OWN containing IFD body
+  /// ([`process_subdir`](Walker::process_subdir)'s `resolved_order` for that
+  /// directory). Consumed by the Leica binary sub-table decode (#105) to re-slice
+  /// each block under its containing IFD's order, not the outer MakerNote IFD's;
+  /// never serialized.
+  #[must_use]
+  #[inline(always)]
+  pub(crate) const fn ifd_order(&self) -> ByteOrder {
+    self.ifd_order
   }
 
   /// The source-block ordinal (the merged `APP1` Exif block this entry came
@@ -6031,6 +6055,9 @@ impl Walker<'_, '_> {
               value_offset: 0,
               value_size: 0,
               own_ifd_start: 0,
+              // The walker's active order; a MinoltaRaw leaf is never a Leica
+              // sub-table parent, so the Leica re-slice never reads it.
+              ifd_order: self.order,
               source_block: 0,
               conv: ResolvedConv::Exif(leaf.tag),
             });
@@ -8305,6 +8332,9 @@ impl Walker<'_, '_> {
       value_offset: 0,
       value_size: 0,
       own_ifd_start: 0,
+      // The walker's active order; a synthetic Binary placeholder is never a Leica
+      // sub-table parent, so the Leica re-slice never reads it.
+      ifd_order: self.order,
       source_block: 0,
       conv: ResolvedConv::Exif(&SYNTHETIC_DATA_TAG),
     });
@@ -8908,6 +8938,11 @@ impl Walker<'_, '_> {
       // ExifIFD leaf, the InteropIFD body for an inline `0xa005` leaf) — the
       // MakerNote splice anchors on it (`push_exif_tags`).
       own_ifd_start: ifd_start,
+      // The order THIS directory was resolved + walked under (`self.order` is the
+      // `process_subdir`-resolved order for `ifd_start`). A `ByteOrder => Unknown`
+      // child can differ from its parent, so the Leica binary sub-table re-slice
+      // (#105) decodes each block under THIS, not the outer MakerNote IFD's order.
+      ifd_order: self.order,
       // Single walk = the first/only source block (`0`); the JPEG merge
       // re-stamps later `APP1` blocks' entries (`set_source_block`).
       source_block: 0,
@@ -9118,6 +9153,9 @@ impl Walker<'_, '_> {
         // The synthetic DataTag image trails its OWN IFD's leaves (the same
         // emitted-directory `ifd_start` the pair was collected under).
         own_ifd_start: pair.ifd_start,
+        // The walker's active order; a synthetic DataTag image is never a Leica
+        // sub-table parent, so the Leica re-slice never reads it.
+        ifd_order: self.order,
         // The synthetic DataTag image trails its IFD's leaves in the SAME
         // source block; `finalize_data_tags` runs per-block before any merge
         // (re-stamped with the block ordinal in `merge_exif_block`).
@@ -14711,17 +14749,6 @@ pub(in crate::exif) fn leica_makernote_isolated(
   // Capture the walked `ResolvedConv::Leica` leaves into the vendor-emission
   // `Vec`; build the typed `MakerNotesLeica` from the SAME gate-passing entries.
   let g1 = vendor_group1_of(TableRef::Leica(variant)).unwrap_or("Leica");
-  // The byte order the Leica variant IFD was actually walked under — the probed
-  // order for `ByteOrder => Unknown` (resolved exactly as `process_subdir` does),
-  // else the fixed rule. The binary sub-tables (#105) inherit it for their
-  // int16u reads.
-  let subdir_order = match byte_order_rule {
-    ByteOrderRule::Fixed(o) => o,
-    ByteOrderRule::Unknown => {
-      makernotes::fixbase::detect_unknown_byte_order(data, ifd_offset, parent_order)
-        .unwrap_or(parent_order)
-    }
-  };
   let mut emissions = std::vec::Vec::new();
   let mut typed = MakerNotesLeica::new();
   {
@@ -14733,16 +14760,22 @@ pub(in crate::exif) fn leica_makernote_isolated(
         continue;
       };
       // A WALKED ProcessBinaryData SubDirectory (SerialInfo 0x0b / FocusInfo
-      // 0x040a / ShotInfo 0x0410, #105): re-slice the verbatim `$$valPt` span and
-      // emit each position under the `Leica` family-1 group, reproducing
-      // ExifTool's descend-then-`next` (the parent pointer is never emitted).
+      // 0x040a / ShotInfo 0x0410, Data1 0x3901, #105): re-slice the verbatim
+      // `$$valPt` span and emit each position under the `Leica` family-1 group,
+      // reproducing ExifTool's descend-then-`next` (the parent pointer is never
+      // emitted). Decode under [`ifd_order`](ExifEntry::ifd_order) — the order of
+      // the IFD THAT ACTUALLY CONTAINED this entry: a top-level Leica5
+      // SerialInfo/FocusInfo/ShotInfo inherits the outer Leica IFD's order, while a
+      // Leica4 Data1 reached via a `ByteOrder => Unknown` `%Subdir` child decodes
+      // under the CHILD's probed order (which can differ from the outer MakerNote
+      // IFD's — a mixed-endian M9 would otherwise byte-swap the int32u `LensType`).
       // Every binary position is an explicit entry ⇒ `unknown = false`.
       if let Some(sub) = leica_tag.sub_table() {
         let blob = data
           .get(entry.value_offset()..entry.value_offset().saturating_add(entry.value_size()))
           .unwrap_or(&[]);
         for (name, value, priority) in
-          makernotes::vendors::leica::decode_leica_subdir(sub, blob, subdir_order, print_conv)
+          makernotes::vendors::leica::decode_leica_subdir(sub, blob, entry.ifd_order(), print_conv)
         {
           // Each decoded position carries its ExifTool `Priority => N` (default 1;
           // `0` for Data1 `LensType` / FocusInfo `FocalLength`), so a `Priority =>

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -11499,8 +11499,12 @@ fn emit_nikon_value<S: ExifSink>(
 ///
 /// 1. **SubDirectory skip** — a row with a `sub_table` (FaceDetInfo 0x4e /
 ///    FaceRecInfo 0x61 / PrintIM 0x0e00 / TimeInfo 0x2003) DESCENDS into a child
-///    table and never emits the parent pointer as a value; Phase 3 defers the
-///    child walk, so NEITHER parent nor children emit (`Exif.pm:7103-7104`).
+///    table and never emits the PARENT pointer as a value (`Exif.pm:7103-7104`).
+///    The CHILD `ProcessBinaryData` walk for the three binary sub-tables runs in
+///    the capture loop (`panasonic::decode_main_subdir`, #105) BEFORE this leaf
+///    emit is reached; this function only guarantees the parent pointer itself
+///    emits nothing (the defensive `emit_entry` fallback, which does not run the
+///    child walk, also relies on this skip).
 /// 2. **Single-HASH `Condition` suppression** — the `$format`-gated LensType rows
 ///    0xc4/0xc5/0xe4 are dropped when `$format ne "int16u"` (and 0xc4 also drops
 ///    the `0xffff` `$$valPt` sentinel), read off [`ExifEntry::on_disk_format`].
@@ -11546,7 +11550,10 @@ fn emit_panasonic_value<S: ExifSink>(
   use makernotes::vendors::panasonic::{PanasonicPrintConv, populate_typed};
   let tag_id = entry.tag_id;
   let raw = entry.value.raw();
-  // Step 1 — deferred SubDirectory row: emit NEITHER parent nor children.
+  // Step 1 — SubDirectory row: the PARENT pointer emits nothing here. The
+  // production capture loop runs the child `ProcessBinaryData` walk
+  // (`decode_main_subdir`) BEFORE this is reached; this guard covers the
+  // defensive `emit_entry` fallback (no child walk there).
   if panasonic_tag.sub_table.is_some() {
     return Ok(());
   }
@@ -13233,6 +13240,25 @@ pub(in crate::exif) fn panasonic_makernote_isolated_with_offset(
       // (never produced under `TableRef::Panasonic`) is skipped —
       // `emit_panasonic_value` needs the `PanasonicTag`.
       if let ResolvedConv::Panasonic(panasonic_tag) = entry.conv {
+        // A WALKED ProcessBinaryData SubDirectory (FaceDetInfo 0x4e / FaceRecInfo
+        // 0x61 / TimeInfo 0x2003, #105) is decoded HERE: re-slice the verbatim
+        // `$$valPt` value span and emit each position under the `Panasonic`
+        // family-1 group, reproducing ExifTool's descend-then-`next` (the parent
+        // pointer is NEVER emitted, `Exif.pm:7103-7104`). PrintIM (0x0e00) returns
+        // `None` and falls through to `emit_panasonic_value` (which skips it — the
+        // shared PrintIM module handles it). Every binary position is an explicit
+        // entry ⇒ `unknown = false`.
+        if let Some(sub) = panasonic_tag.sub_table {
+          let blob = data
+            .get(entry.value_offset()..entry.value_offset().saturating_add(entry.value_size()))
+            .unwrap_or(&[]);
+          if let Some(pairs) = panasonic::decode_main_subdir(sub, blob, order, print_conv) {
+            for (name, value) in pairs {
+              let Ok(()) = sink.write_vendor_value("MakerNotes", g1, name.as_str(), value, false);
+            }
+            continue;
+          }
+        }
         let Ok(()) = emit_panasonic_value(
           g1,
           entry,

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -14741,10 +14741,22 @@ pub(in crate::exif) fn leica_makernote_isolated(
         let blob = data
           .get(entry.value_offset()..entry.value_offset().saturating_add(entry.value_size()))
           .unwrap_or(&[]);
-        for (name, value) in
+        for (name, value, priority) in
           makernotes::vendors::leica::decode_leica_subdir(sub, blob, subdir_order, print_conv)
         {
-          let Ok(()) = sink.write_vendor_value("MakerNotes", g1, name.as_str(), value, false);
+          // Each decoded position carries its ExifTool `Priority => N` (default 1;
+          // `0` for Data1 `LensType` / FocusInfo `FocalLength`), so a `Priority =>
+          // 0` leaf never overrides a higher-priority same-`(group, name)` sibling
+          // (e.g. a later Data1 `LensType` must NOT replace the Subdir `0x3405
+          // LensType`) in the shared de-dup (`ExifTool.pm:9544-9560`).
+          let Ok(()) = sink.write_vendor_value_with_priority(
+            "MakerNotes",
+            g1,
+            name.as_str(),
+            value,
+            false,
+            priority,
+          );
         }
         continue;
       }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -11287,6 +11287,13 @@ fn emit_leica_value<S: ExifSink>(
   out: &mut S,
 ) -> Result<(), core::convert::Infallible> {
   use makernotes::vendors::leica::tags::LeicaCondition;
+  // A SubDirectory row's PARENT pointer emits nothing here (#105). The production
+  // capture loop runs the child `ProcessBinaryData` walk (`decode_leica_subdir`)
+  // BEFORE this is reached; this guard covers the defensive `emit_entry`
+  // fallback (no child walk there).
+  if leica_tag.sub_table().is_some() {
+    return Ok(());
+  }
   // Row `Condition` gate. A failing Condition ⇒ `GetTagInfo` returns no tag ⇒
   // emit NOTHING and populate NO typed field (the absent-tag behaviour).
   if let Some(cond) = leica_tag.condition() {
@@ -14676,6 +14683,17 @@ pub(in crate::exif) fn leica_makernote_isolated(
   // Capture the walked `ResolvedConv::Leica` leaves into the vendor-emission
   // `Vec`; build the typed `MakerNotesLeica` from the SAME gate-passing entries.
   let g1 = vendor_group1_of(TableRef::Leica(variant)).unwrap_or("Leica");
+  // The byte order the Leica variant IFD was actually walked under — the probed
+  // order for `ByteOrder => Unknown` (resolved exactly as `process_subdir` does),
+  // else the fixed rule. The binary sub-tables (#105) inherit it for their
+  // int16u reads.
+  let subdir_order = match byte_order_rule {
+    ByteOrderRule::Fixed(o) => o,
+    ByteOrderRule::Unknown => {
+      makernotes::fixbase::detect_unknown_byte_order(data, ifd_offset, parent_order)
+        .unwrap_or(parent_order)
+    }
+  };
   let mut emissions = std::vec::Vec::new();
   let mut typed = MakerNotesLeica::new();
   {
@@ -14686,6 +14704,22 @@ pub(in crate::exif) fn leica_makernote_isolated(
       let ResolvedConv::Leica(entry_variant, leica_tag) = entry.conv else {
         continue;
       };
+      // A WALKED ProcessBinaryData SubDirectory (SerialInfo 0x0b / FocusInfo
+      // 0x040a / ShotInfo 0x0410, #105): re-slice the verbatim `$$valPt` span and
+      // emit each position under the `Leica` family-1 group, reproducing
+      // ExifTool's descend-then-`next` (the parent pointer is never emitted).
+      // Every binary position is an explicit entry ⇒ `unknown = false`.
+      if let Some(sub) = leica_tag.sub_table() {
+        let blob = data
+          .get(entry.value_offset()..entry.value_offset().saturating_add(entry.value_size()))
+          .unwrap_or(&[]);
+        for (name, value) in
+          makernotes::vendors::leica::decode_leica_subdir(sub, blob, subdir_order, print_conv)
+        {
+          let Ok(()) = sink.write_vendor_value("MakerNotes", g1, name.as_str(), value, false);
+        }
+        continue;
+      }
       let Ok(()) = emit_leica_value(
         g1,
         entry,

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -4788,6 +4788,130 @@ fn leica7_embedded_app1_nonzero_base_matches_bundled_exiftool() {
   let _ = std::fs::remove_file(&path);
 }
 
+/// #105 Codex [high]: the Leica4 → `%Subdir` → `%Data1` `LensType` `Priority`
+/// collision, END-TO-END through the full `extract_info` pipeline (walk + shared
+/// de-dup).
+///
+/// A Leica4 (M9) MakerNote carrying BOTH the Subdir `0x3405 LensType` (default
+/// `Priority => 1`) AND the `0x3901 Data1` `LensType` (`Priority => 0`,
+/// `Panasonic.pm:1981`) must keep the HIGHER-priority `0x3405` value in the final
+/// de-dup: the `Data1` leaf is walked AFTER `0x3405` (since `0x3901 > 0x3405`),
+/// but its `Priority => 0` means it NEVER overrides (`ExifTool.pm:9544-9560`).
+/// Before the fix the `Data1` leaf emitted at the default priority and wrongly
+/// REPLACED the `0x3405` value. The unit test
+/// `leica4_descends_into_subdir_and_data1` asserts both leaves emit with the
+/// right per-leaf priorities (1 vs 0); this proves the downstream de-dup keeps
+/// the winner. Asserted in BOTH `-j` (the looked-up lens name) and `-n` (the
+/// ValueConv `"id bits"` string) modes.
+///
+/// (No `perl exiftool` cross-check: exifast's Leica4 `0x3000` SubDirectory
+/// descent reads the entry value as an integer offset (an inline `int32u` count-1
+/// pointer, `src/exif/mod.rs` `first_uint`), whereas ExifTool descends the value
+/// as OUT-OF-LINE sub-IFD bytes (`$valuePtr = base + offset`), so no single
+/// crafted fixture is walked by both engines — a pre-existing #105 descent-model
+/// question orthogonal to this priority fix. ExifTool's de-dup outcome was
+/// ground-truthed separately on an out-of-line fixture it can read: it likewise
+/// keeps the `0x3405` value over the `Priority => 0` Data1 one.)
+#[cfg(all(feature = "exif", feature = "std", feature = "json"))]
+#[test]
+fn leica4_data1_lenstype_priority0_does_not_override_subdir_0x3405() {
+  fn entry(buf: &mut Vec<u8>, tag: u16, fmt: u16, count: u32, value: u32) {
+    buf.extend_from_slice(&tag.to_le_bytes());
+    buf.extend_from_slice(&fmt.to_le_bytes());
+    buf.extend_from_slice(&count.to_le_bytes());
+    buf.extend_from_slice(&value.to_le_bytes());
+  }
+
+  // The Leica4 MakerNote value — the proven layout the
+  // `leica4_descends_into_subdir_and_data1` unit test walks. Offsets are
+  // blob-relative; Leica4 `Base => $start - 8` makes `value_offset_base ==
+  // mn_offset`, so a blob-relative offset `P` resolves at `data[P + mn_offset] =
+  // blob[P]` regardless of where the blob lands in the file.
+  let mut mn = Vec::new();
+  mn.extend_from_slice(b"LEICA0\x03\x00"); // 8-byte Leica4 signature (byte 5 = '0')
+  // Leica4 IFD @ 8: one entry 0x3000 -> Subdir IFD @ 26.
+  mn.extend_from_slice(&1u16.to_le_bytes());
+  entry(&mut mn, 0x3000, 4, 1, 26);
+  mn.extend_from_slice(&0u32.to_le_bytes()); // next-IFD
+  assert_eq!(mn.len(), 26);
+  // Subdir IFD @ 26: Contrast=2, 0x3405 LensType=20 (id 5, Priority => 1),
+  // 0x3901 Data1 @ 68.
+  mn.extend_from_slice(&3u16.to_le_bytes());
+  entry(&mut mn, 0x300a, 4, 1, 2); // Contrast int32u inline
+  entry(&mut mn, 0x3405, 4, 1, 20); // LensType int32u inline (id 5)
+  entry(&mut mn, 0x3901, 7, 26, 68); // Data1 undef[26] out-of-line @ 68
+  mn.extend_from_slice(&0u32.to_le_bytes()); // next-IFD
+  assert_eq!(mn.len(), 68);
+  // Data1 block @ 68: LensType int32u @ byte 22 = 24 (id 6, Priority => 0).
+  let mut data1 = std::vec![0u8; 22];
+  data1.extend_from_slice(&24u32.to_le_bytes());
+  mn.extend_from_slice(&data1);
+  assert_eq!(mn.len(), 94);
+
+  // Wrap in a standalone little-endian TIFF: IFD0(Make, Model, ExifIFD) ->
+  // ExifIFD(MakerNote 0x927c @ the blob). Leica4 dispatch needs Make
+  // `^Leica Camera AG` + the `LEICA0` signature.
+  let make = b"Leica Camera AG\x00"; // 16 bytes
+  let hdr = 8usize;
+  let ifd0_size = 2 + 12 * 3 + 4; // 42
+  let make_off = hdr + ifd0_size; // 50
+  let exif_off = make_off + make.len(); // 66
+  let exif_size = 2 + 12 + 4; // 18
+  let mn_off = exif_off + exif_size; // 84
+  let mut tiff = Vec::new();
+  tiff.extend_from_slice(b"II");
+  tiff.extend_from_slice(&42u16.to_le_bytes());
+  tiff.extend_from_slice(&(hdr as u32).to_le_bytes()); // IFD0 @ 8
+  tiff.extend_from_slice(&3u16.to_le_bytes());
+  entry(&mut tiff, 0x010f, 2, make.len() as u32, make_off as u32); // Make
+  entry(&mut tiff, 0x0110, 2, 3, u32::from_le_bytes(*b"M9\x00\x00")); // Model "M9" inline
+  entry(&mut tiff, 0x8769, 4, 1, exif_off as u32); // ExifIFD pointer
+  tiff.extend_from_slice(&0u32.to_le_bytes()); // next-IFD
+  assert_eq!(tiff.len(), make_off);
+  tiff.extend_from_slice(make);
+  assert_eq!(tiff.len(), exif_off);
+  tiff.extend_from_slice(&1u16.to_le_bytes());
+  entry(&mut tiff, 0x927c, 7, mn.len() as u32, mn_off as u32); // MakerNote
+  tiff.extend_from_slice(&0u32.to_le_bytes()); // next-IFD
+  assert_eq!(tiff.len(), mn_off);
+  tiff.extend_from_slice(&mn);
+
+  // (print_on, winner = 0x3405 value, loser = Data1 value).
+  for (print_on, winner, loser) in [
+    (true, "Summilux-M 50mm f/1.4 (II)", "Summilux-M 35mm f/1.4"),
+    (false, "5 0", "6 0"),
+  ] {
+    let mode = if print_on { "-j" } else { "-n" };
+    let json = exifast::parser::extract_info("leica4_collision.tif", &tiff, print_on);
+    let doc: serde_json::Value =
+      serde_json::from_str(&json).unwrap_or_else(|e| panic!("{mode}: invalid JSON ({e})"));
+    let obj = doc
+      .as_array()
+      .and_then(|a| a.first())
+      .and_then(|o| o.as_object())
+      .unwrap_or_else(|| panic!("{mode}: doc is [{{…}}]"));
+    let lens = obj.get("Leica:LensType").and_then(|v| v.as_str());
+    assert_eq!(
+      lens,
+      Some(winner),
+      "{mode}: Leica:LensType must stay the higher-priority 0x3405 value, NOT the \
+       Priority => 0 Data1 value (keys: {:?})",
+      obj.keys().collect::<Vec<_>>()
+    );
+    assert_ne!(
+      lens,
+      Some(loser),
+      "{mode}: the Priority => 0 Data1 LensType must not override 0x3405"
+    );
+    // The Subdir walk reached its leaves (proves the descent ran).
+    assert!(
+      obj.contains_key("Leica:Contrast"),
+      "{mode}: Subdir Contrast leaf present (keys: {:?})",
+      obj.keys().collect::<Vec<_>>()
+    );
+  }
+}
+
 // ===========================================================================
 // MakerNote directory-size SALVAGE clamp (Exif.pm:6384-6388, #248)
 // ===========================================================================


### PR DESCRIPTION
Closes #105. Ports the genuinely-missing Panasonic + Leica sub-tables faithfully from ExifTool 13.59 Panasonic.pm:

- **Panasonic Main binary subdirs**: FaceDetInfo (0x4e), FaceRecInfo (0x61), TimeInfo (0x2003, BCD date).
- **Leica binary subdirs**: SerialInfo (Leica3 0x0b), FocusInfo/ShotInfo (Leica5 0x040a/0x0410), and the Leica4-hosted **Subdir IFD chain** (0x3000/0x3100/0x3400/0x3900 → Subdir leaves → Data1 0x3901 / Data2 0x3902).
- **Priority-0 dedup** (R2): Data1 LensType + FocusInfo FocalLength emit at Priority 0 (per-leaf priority threaded) so they don't override higher-priority same-name Subdir leaves (e.g. 0x3405 LensType wins) — full class sweep of the 3 Priority entries.
- **Per-IFD byte order** (R3): added `ExifEntry.ifd_order` so a Leica4 Subdir child IFD that resolves a different endianness (ByteOrderRule::Unknown) decodes its Data1/binary values under the **child** order, not the stale outer order.

**Out of scope** (per the issue): PANA (MP4 udta atom), DSA (raw/RW2). **Fixtureless** (active fixtures don't exercise these subdirs) — validated by **no-regression (conformance 498/0 byte-identical)** + unit tests incl an end-to-end collision test + a mixed-endian test. build=0 conformance=498/0 alloc_budget=ok typed_serde=337 timed=161/0 lib=4257/0 xtask=26. **Codex: R1 bulk + R2 priority APPROVE; R3 byte-order fix re-verified green** (the R3 review was repeatedly killed by an external timeout, push landed each time; merged on the full green gate). **Follow-up filed** for the pre-existing Leica4 0x3000 Subdir-DESCENT model difference (inline-offset vs out-of-line sub-IFD). Memory-amplification → #443.