### PR TITLE
feat(sony): port CameraSettings3 A4xx-only + NEX-only conditional leaves (#103 part 1)

### DIFF
--- a/src/exif/makernotes/vendors/sony/camerasettings3.rs
+++ b/src/exif/makernotes/vendors/sony/camerasettings3.rs
@@ -19,8 +19,8 @@ use smol_str::SmolStr;
 
 use super::subtables::{
   SubEmission, drive_mode, exposure_comp_value, exposure_program2, hash_hex_value,
-  model_is_a4xx_exact, model_is_a4xx_prefix, model_is_nex, read_u32, signed_setting_value,
-  white_balance_setting,
+  model_is_a4xx_exact, model_is_a4xx_prefix, model_is_nex, read_u16, read_u32,
+  signed_setting_value, white_balance_setting,
 };
 
 /// Render a plain (non-hex) hash-PrintConv leaf (`-j` label/`Unknown (N)`, `-n`
@@ -184,10 +184,12 @@ fn face_detection(v: u8) -> Option<&'static str> {
 /// Walk the `CameraSettings3` block and emit the settings leaves for the model.
 ///
 /// `buf` is the verbatim (un-enciphered) `0x0114` block; `model` is
-/// `$$self{Model}`; `print_conv` selects `-j` vs `-n`. The 9-point DSLR-A4xx
-/// bodies use a different masked-tag layout (0x283.. / 0x30c..) — this port
-/// targets the "other models" (SLT / A560 / A580 / NEX) branches the A33 needs
-/// plus the shared leaves; the A4xx-only conditional leaves stay deferred.
+/// `$$self{Model}`; `print_conv` selects `-j` vs `-n`. The model-conditional
+/// leaves fall into families: the shared leaves; the "other models" (SLT / A560
+/// / A580 / NEX) branches; the A4xx-only branch (`=~ /^DSLR-(A450|A500|A550)$/`),
+/// whose 12 leaves sit at the `+0x200`-shifted masked layout (0x283.. / 0x30c.. /
+/// 0x400..); and the NEX-only branch (`=~ /^NEX-/`), the 0x3f0/0x3f3/0x3f7
+/// `LensE-mountVersion`/`LensFirmwareVersion`/`LensType2` lens leaves.
 #[must_use]
 pub fn parse_camera_settings3(
   buf: &[u8],
@@ -445,10 +447,7 @@ pub fn parse_camera_settings3(
     );
   }
   // 0x36 LiveViewAFSetting — `!~ /^(NEX-|DSLR-(A450|A500|A550)$)/` (NEX prefix +
-  // A4xx $-exact, Sony.pm:5506). 0x38 PanoramaSize3D is `!~
-  // /^DSLR-(A450|A500|A550)$/` ($-exact only, Sony.pm:5519); its `!nex` gate is a
-  // pre-existing over-exclusion outside this A4xx-anchor fix, kept so real NEX
-  // bodies stay byte-identical.
+  // A4xx $-exact, Sony.pm:5505).
   if !a4xx_exact && !nex {
     push_hash(
       buf,
@@ -458,6 +457,10 @@ pub fn parse_camera_settings3(
       print_conv,
       &mut out,
     );
+  }
+  // 0x38 PanoramaSize3D — `!~ /^DSLR-(A450|A500|A550)$/` (A4xx $-exact ONLY; its
+  // Condition does NOT exclude NEX, Sony.pm:5519).
+  if !a4xx_exact {
     push_hash(
       buf,
       0x38,
@@ -568,6 +571,137 @@ pub fn parse_camera_settings3(
       name: "ShotNumberSincePowerUp2",
       value: TagValue::I64(i64::from(v)),
     });
+  }
+
+  // --- A4xx-only family (`=~ /^DSLR-(A450|A500|A550)$/`, $-anchored EXACT,
+  // Sony.pm:5668-5802) — the 12 leaves the A4xx bodies place at the +0x200-shifted
+  // masked layout in place of the SLT/"other models" 0x83.. / 0x10c.. block.
+  if a4xx_exact {
+    push_hash(
+      buf,
+      0x283,
+      "AFButtonPressed",
+      af_button_pressed,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x284,
+      "LiveViewMetering",
+      live_view_metering,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x285,
+      "ViewingMode2",
+      viewing_mode2,
+      print_conv,
+      &mut out,
+    );
+    push_hash(buf, 0x286, "AELock", ae_lock, print_conv, &mut out);
+    push_hash(
+      buf,
+      0x287,
+      "FlashStatusBuilt-in",
+      flash_status_builtin,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x288,
+      "FlashStatusExternal",
+      flash_status_external,
+      print_conv,
+      &mut out,
+    );
+    push_hash(
+      buf,
+      0x28b,
+      "LiveViewFocusMode",
+      live_view_focus_mode,
+      print_conv,
+      &mut out,
+    );
+    // 0x30c SequenceNumber — int8u, {0=>Single,255=>n/a,OTHER passthrough}
+    // (Sony.pm:5733-5743).
+    if let Some(&raw) = buf.get(0x30c) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "SequenceNumber",
+        value: sequence_number_value(raw, print_conv),
+      });
+    }
+    // 0x314 ImageNumber — int16u, Mask 0x3fff, `sprintf("%.4d")` (Sony.pm:5744).
+    if let Some(v) = read_u16(buf, 0x314) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "ImageNumber",
+        value: masked_count_value(u32::from(v & 0x3fff), 4, print_conv),
+      });
+    }
+    // 0x316 FolderNumber — int16u, Mask 0x03ff, `sprintf("%.3d")` (Sony.pm:5753).
+    if let Some(v) = read_u16(buf, 0x316) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "FolderNumber",
+        value: masked_count_value(u32::from(v & 0x03ff), 3, print_conv),
+      });
+    }
+    // 0x400 ImageNumber — int16u, Mask 0x3fff, `sprintf("%.4d")` (Sony.pm:5785).
+    if let Some(v) = read_u16(buf, 0x400) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "ImageNumber",
+        value: masked_count_value(u32::from(v & 0x3fff), 4, print_conv),
+      });
+    }
+    // 0x402 FolderNumber — int16u, Mask 0x03ff, `sprintf("%.3d")` (Sony.pm:5794).
+    if let Some(v) = read_u16(buf, 0x402) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "FolderNumber",
+        value: masked_count_value(u32::from(v & 0x03ff), 3, print_conv),
+      });
+    }
+  }
+
+  // --- NEX-only family (`=~ /^NEX-/`, Sony.pm:5762-5784) — the E-mount lens
+  // leaves. 0x3f7 `LensType2` also gates on the 0x99 `LensMount` DataMember
+  // (`$$self{LensMount} != 1`); the raw int8u at 0x99 is the latched member.
+  if nex {
+    // 0x3f0 LensE-mountVersion — int16u, `sprintf("%x.%.2x",$val>>8,$val&0xff)`.
+    if let Some(v) = read_u16(buf, 0x3f0) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "LensE-mountVersion",
+        value: lens_e_mount_version(v, print_conv),
+      });
+    }
+    // 0x3f3 LensFirmwareVersion — int16u,
+    // `sprintf("Ver.%.2x.%.3d",$val>>8,$val&0xff)`.
+    if let Some(v) = read_u16(buf, 0x3f3) {
+      out.push(SubEmission {
+        priority: 1,
+        name: "LensFirmwareVersion",
+        value: lens_firmware_version(v, print_conv),
+      });
+    }
+    // 0x3f7 LensType2 — int16u, %sonyLensTypes2 (E-mount), gated on the latched
+    // 0x99 LensMount `!= 1`. Perl's `$$self{LensMount} != 1` numifies an unset
+    // member to 0 (`!= 1` true), matching `None != Some(1)`.
+    if buf.get(0x99).copied() != Some(1)
+      && let Some(v) = read_u16(buf, 0x3f7)
+    {
+      out.push(SubEmission {
+        priority: 1,
+        name: "LensType2",
+        value: lens_type2_value(v, print_conv),
+      });
+    }
   }
 
   // `%CameraSettings3` is `PRIORITY => 0` (Sony.pm:5139): every leaf here is a
@@ -961,6 +1095,47 @@ fn sequence_number_value(raw: u8, print_conv: bool) -> TagValue {
     0 => TagValue::Str("Single".into()),
     255 => TagValue::Str("n/a".into()),
     n => TagValue::I64(i64::from(n)),
+  }
+}
+
+/// `LensE-mountVersion` value (`Sony.pm:5762-5768`): PrintConv
+/// `sprintf("%x.%.2x", $val>>8, $val&0xff)`; the raw `int16u` in `-n`.
+fn lens_e_mount_version(raw: u16, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(raw));
+  }
+  TagValue::Str(SmolStr::new(std::format!(
+    "{:x}.{:02x}",
+    raw >> 8,
+    raw & 0xff
+  )))
+}
+
+/// `LensFirmwareVersion` value (`Sony.pm:5771-5776`): PrintConv
+/// `sprintf("Ver.%.2x.%.3d", $val>>8, $val&0xff)`; the raw `int16u` in `-n`.
+fn lens_firmware_version(raw: u16, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(raw));
+  }
+  TagValue::Str(SmolStr::new(std::format!(
+    "Ver.{:02x}.{:03}",
+    raw >> 8,
+    raw & 0xff
+  )))
+}
+
+/// `LensType2` (E-mount `%sonyLensTypes2`) value (`Sony.pm:5777-5784`): the hash
+/// label (`-j`), or `Unknown ($val)` on a miss (the shared
+/// [`lens_types::lookup_name`](super::lens_types::lookup_name) renderer Tag9405a
+/// 0x0605 uses); the raw `int16u` in `-n`. `PrintInt => 1` is a
+/// `BuildTagLookup`-only doc flag, not a runtime directive.
+fn lens_type2_value(raw: u16, print_conv: bool) -> TagValue {
+  if !print_conv {
+    return TagValue::I64(i64::from(raw));
+  }
+  match super::lens_types::lookup_name(u32::from(raw)) {
+    Some(label) => TagValue::Str(label),
+    None => TagValue::Str(SmolStr::from(std::format!("Unknown ({raw})"))),
   }
 }
 

--- a/src/exif/makernotes/vendors/sony/camerasettings3_tests.rs
+++ b/src/exif/makernotes/vendors/sony/camerasettings3_tests.rs
@@ -16,6 +16,22 @@ fn has(model: &str, buf: &[u8], name: &str) -> bool {
     .any(|e| e.name == name)
 }
 
+/// The PrintConv (`-j`) value of the FIRST `name` leaf the model emits.
+fn value_of(model: &str, buf: &[u8], name: &str) -> Option<TagValue> {
+  parse_camera_settings3(buf, Some(model), true)
+    .into_iter()
+    .find(|e| e.name == name)
+    .map(|e| e.value)
+}
+
+/// How many leaves named `name` the model emits.
+fn count(model: &str, buf: &[u8], name: &str) -> usize {
+  parse_camera_settings3(buf, Some(model), true)
+    .iter()
+    .filter(|e| e.name == name)
+    .count()
+}
+
 #[test]
 fn a4xx_anchors_split_exact_vs_prefix() {
   let mut buf = vec![0u8; 0x210];
@@ -49,4 +65,169 @@ fn a4xx_anchors_split_exact_vs_prefix() {
       "{m} 0x87 must be excluded (prefix)"
     );
   }
+}
+
+/// FAMILY 4 (A4xx-only, `=~ /^DSLR-(A450|A500|A550)$/`): the +0x200-shifted masked
+/// layout (0x283.. / 0x30c.. / 0x400..) fires, and the lower-offset "other models"
+/// leaves at 0x83 / 0x99 / 0x32 / the int32u 0x0114 path do NOT.
+#[test]
+fn a4xx_family_emits_shifted_layout_not_other_models() {
+  let mut buf = vec![0u8; 0x600];
+  buf[0x283] = 16; // AFButtonPressed = Yes (0x283, A4xx)
+  buf[0x286] = 2; // AELock = Off
+  buf[0x287] = 1; // FlashStatusBuilt-in = Off (the A4xx 0x287, not 0x87)
+  buf[0x28b] = 16; // LiveViewFocusMode = Manual
+  buf[0x30c] = 2; // SequenceNumber = 2 (OTHER passthrough)
+  // 0x314 ImageNumber int16u LE 0xC539, Mask 0x3fff -> 0x0539 = 1337 -> "1337".
+  buf[0x314] = 0x39;
+  buf[0x315] = 0xC5;
+  // 0x316 FolderNumber int16u LE 0xFC2A, Mask 0x03ff -> 0x002A = 42 -> "042".
+  buf[0x316] = 0x2A;
+  buf[0x317] = 0xFC;
+  // 0x400 ImageNumber / 0x402 FolderNumber (the second A4xx source).
+  buf[0x400] = 0x01; // -> 1 -> "0001"
+  buf[0x402] = 0x05; // -> 5 -> "005"
+  // The "other models" lower-offset leaves (present in the buffer, must stay
+  // silent for an A4xx body):
+  buf[0x83] = 1; // would be AFButtonPressed = No
+  buf[0x99] = 16; // would be LensMount = A-mount
+  buf[0x32] = 1; // would be SweepPanoramaSize = Standard
+
+  // The +0x200 leaves emit with their A4xx values.
+  assert_eq!(
+    value_of("DSLR-A500", &buf, "AFButtonPressed"),
+    Some(TagValue::Str("Yes".into())),
+    "0x283 wins over the 0x83 No"
+  );
+  assert_eq!(
+    value_of("DSLR-A500", &buf, "AELock"),
+    Some(TagValue::Str("Off".into()))
+  );
+  assert_eq!(
+    value_of("DSLR-A500", &buf, "FlashStatusBuilt-in"),
+    Some(TagValue::Str("Off".into()))
+  );
+  assert_eq!(
+    value_of("DSLR-A500", &buf, "LiveViewFocusMode"),
+    Some(TagValue::Str("Manual".into()))
+  );
+  assert_eq!(
+    value_of("DSLR-A500", &buf, "SequenceNumber"),
+    Some(TagValue::I64(2))
+  );
+  // Mask + sprintf("%.4d") / sprintf("%.3d") — the FIRST ImageNumber/FolderNumber
+  // are the 0x314/0x316 masked reads.
+  assert_eq!(
+    value_of("DSLR-A500", &buf, "ImageNumber"),
+    Some(TagValue::Str("1337".into())),
+    "0x314 masked int16u + %.4d"
+  );
+  assert_eq!(
+    value_of("DSLR-A500", &buf, "FolderNumber"),
+    Some(TagValue::Str("042".into())),
+    "0x316 masked int16u + %.3d"
+  );
+  // BOTH the 0x314/0x316 and 0x400/0x402 sources fire (== 2), and the int32u
+  // 0x0114 path is A4xx-excluded (would have made it 3).
+  assert_eq!(count("DSLR-A500", &buf, "ImageNumber"), 2);
+  assert_eq!(count("DSLR-A500", &buf, "FolderNumber"), 2);
+
+  // The "other models"-only leaves are excluded for an A4xx body.
+  assert!(!has("DSLR-A500", &buf, "LensMount"), "0x99 A4xx-excluded");
+  assert!(
+    !has("DSLR-A500", &buf, "SweepPanoramaSize"),
+    "0x32 A4xx-excluded"
+  );
+
+  // A non-A4xx body reads the lower-offset 0x83 (= No) and 0x99 instead.
+  assert_eq!(
+    value_of("SLT-A33", &buf, "AFButtonPressed"),
+    Some(TagValue::Str("No".into()))
+  );
+  assert!(has("SLT-A33", &buf, "LensMount"));
+}
+
+/// FAMILY 5 (NEX-only, `=~ /^NEX-/`): the 0x3f0/0x3f3/0x3f7 lens leaves fire,
+/// 0x3f7 `LensType2` resolves via the E-mount table and honours the 0x99
+/// `LensMount != 1` gate, and the STEP-3 fix lets 0x38 `PanoramaSize3D` emit.
+#[test]
+fn nex_family_lens_leaves_and_0x38_fix() {
+  let mut buf = vec![0u8; 0x600];
+  // 0x3f0 LensE-mountVersion int16u LE 0x0102 -> sprintf("%x.%.2x",1,2) = "1.02".
+  buf[0x3f0] = 0x02;
+  buf[0x3f1] = 0x01;
+  // 0x3f3 LensFirmwareVersion int16u LE 0x010f -> "Ver.01.015".
+  buf[0x3f3] = 0x0F;
+  buf[0x3f4] = 0x01;
+  buf[0x99] = 17; // LensMount = E-mount (!= 1) -> 0x3f7 fires
+  // 0x3f7 LensType2 int16u LE 2 -> %sonyLensTypes2[2] = "Sony LA-EA2 Adapter".
+  buf[0x3f7] = 0x02;
+  buf[0x38] = 1; // PanoramaSize3D = Standard (the fix: NEX NOT excluded)
+
+  assert_eq!(
+    value_of("NEX-5", &buf, "LensE-mountVersion"),
+    Some(TagValue::Str("1.02".into()))
+  );
+  assert_eq!(
+    value_of("NEX-5", &buf, "LensFirmwareVersion"),
+    Some(TagValue::Str("Ver.01.015".into()))
+  );
+  assert_eq!(
+    value_of("NEX-5", &buf, "LensType2"),
+    Some(TagValue::Str("Sony LA-EA2 Adapter".into())),
+    "0x3f7 resolves via the E-mount %sonyLensTypes2 table"
+  );
+  // STEP 3 fix: 0x38 Condition excludes ONLY A4xx, not NEX (was over-gated `!nex`).
+  assert_eq!(
+    value_of("NEX-5", &buf, "PanoramaSize3D"),
+    Some(TagValue::Str("Standard".into())),
+    "0x38 must emit for a NEX body"
+  );
+
+  // The LensMount DataMember gate: LensMount == 1 suppresses 0x3f7.
+  let mut mount1 = buf.clone();
+  mount1[0x99] = 1;
+  assert!(
+    !has("NEX-5", &mount1, "LensType2"),
+    "LensMount==1 excludes 0x3f7 LensType2"
+  );
+  // The NEX lens leaves never fire for an A4xx body.
+  assert!(!has("DSLR-A500", &buf, "LensE-mountVersion"));
+  assert!(!has("DSLR-A500", &buf, "LensType2"));
+}
+
+/// REGRESSION: a non-A4xx, non-NEX body (A560) still walks the unchanged "other
+/// models" branch — the A4xx-shifted and NEX-only families never fire, and the
+/// 0x38 fix leaves it emitting `PanoramaSize3D` exactly as before.
+#[test]
+fn a560_other_models_unchanged() {
+  let mut buf = vec![0u8; 0x600];
+  buf[0x83] = 1; // AFButtonPressed = No (other-models layout)
+  buf[0x99] = 16; // LensMount = A-mount
+  buf[0x38] = 2; // PanoramaSize3D = Wide
+  buf[0x36] = 1; // LiveViewAFSetting = Phase-detect AF
+  // A4xx-shifted + NEX leaves present in the buffer but must stay silent.
+  buf[0x283] = 16; // would be the A4xx AFButtonPressed = Yes
+  buf[0x3f0] = 0x02;
+  buf[0x3f1] = 0x01;
+
+  assert_eq!(
+    value_of("DSLR-A560", &buf, "AFButtonPressed"),
+    Some(TagValue::Str("No".into())),
+    "A560 reads 0x83, never the A4xx 0x283"
+  );
+  assert_eq!(
+    value_of("DSLR-A560", &buf, "LensMount"),
+    Some(TagValue::Str("A-mount".into()))
+  );
+  assert_eq!(
+    value_of("DSLR-A560", &buf, "PanoramaSize3D"),
+    Some(TagValue::Str("Wide".into()))
+  );
+  assert_eq!(
+    value_of("DSLR-A560", &buf, "LiveViewAFSetting"),
+    Some(TagValue::Str("Phase-detect AF".into()))
+  );
+  assert!(!has("DSLR-A560", &buf, "LensE-mountVersion"));
+  assert!(!has("DSLR-A560", &buf, "LensFirmwareVersion"));
 }


### PR DESCRIPTION
Completes the model-conditional %Sony::CameraSettings3 coverage (the framework + families 1/2/3 already existed). Adds the 12 A4xx-only leaves (DSLR-A450/A500/A550, +0x200 shifted offsets 0x283-0x402: AFButtonPressed/LiveViewMetering/ViewingMode2/AELock/FlashStatus*/LiveViewFocusMode/SequenceNumber/ImageNumber+FolderNumber masked) and the 3 NEX-only leaves (0x3f0 LensE-mountVersion, 0x3f3 LensFirmwareVersion, 0x3f7 LensType2 via the E-mount table + LensMount!=1 gate), each verified against Sony.pm. Also fixes a 0x38 PanoramaSize3D over-exclusion (ExifTool's 0x38 condition excludes only the A4xx-exact models, not NEX). Part 1 of 3 for #103.

Fixtureless (no A4xx/NEX fixture) → validated by 3 new camerasettings3 unit tests (A4xx body, NEX body, other-model regression guard) + no-regression. Verify: fmt=0 build(-D warnings)=0 conformance=507/0 (A33 byte-identical) lib=4287/0 alloc=0 typed_serde=0 timed_metadata=162/0 xtask=26/0. Codex adversarial review: APPROVE (no material findings — all 15 leaves match Sony.pm, bounds-checked reads).