### PR TITLE
feat(sony): port PrintLensID LensSpec disambiguation, activate A200/A33 Composite:LensID (#103)

### DIFF
--- a/src/composite/convs/lens/mod.rs
+++ b/src/composite/convs/lens/mod.rs
@@ -48,6 +48,12 @@
 #[cfg(feature = "alloc")]
 use crate::composite::table::CompositeValue;
 
+/// `Image::ExifTool::Exif::PrintLensID` (Exif.pm:5881) — the Sony/Minolta
+/// lens-DB disambiguation wired into `Composite:LensID`. Needs the Sony lens
+/// tables (`feature = "exif"`).
+#[cfg(feature = "exif")]
+pub(crate) mod sony_lens_id;
+
 /// `Image::ExifTool::ToFloat($val)` (ExifTool.pm:5969) on a resolved Composite
 /// input: the leading float the value matches (`$1 + 0`), or `None` (Perl
 /// `undef`) if it matches no float.

--- a/src/composite/convs/lens/sony_lens_id/mod.rs
+++ b/src/composite/convs/lens/sony_lens_id/mod.rs
@@ -1,0 +1,756 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `Image::ExifTool::Exif::PrintLensID` (Exif.pm:5881) — the Sony / Minolta
+//! lens disambiguation that turns a multi-candidate `LensType` (a
+//! `%sonyLensTypes` / `%sonyLensTypes2` row carrying `id.1`, `id.2`, … float
+//! variants) into a single lens name, driven by `Composite:LensID`'s decoded
+//! `LensSpec` / `FocalLength` / `MaxAperture` / `LensModel` ingredients
+//! (Exif.pm:5303-5360).
+//!
+//! [`print_lens_id`] is the faithful transliteration of the Sony/Minolta paths
+//! of `PrintLensID`: the candidate list (Exif.pm:5962-5971), the **LensSpec
+//! branch** (Exif.pm:5983-5995 — keep candidates within ±0.5 focal / ±0.15
+//! aperture of the parsed `LensSpec`, an exact LensSpec-suffix match winning
+//! outright), the **FocalLength / MaxAperture branch** (Exif.pm:6001-6036 —
+//! rule out by range, then pick the closest via the log-log aperture
+//! interpolation), the Minolta teleconverter scaling (Exif.pm:5997-6000),
+//! `MatchLensModel` (Exif.pm:5847-5872), the 65535 manual-lens `%sonyEtype`
+//! path (Exif.pm:5915-5931) and the final fall-through join (Exif.pm:6052-6059).
+//!
+//! The caller ([`crate::composite::table`]) maps the `Composite:LensID`
+//! ingredients into [`PrintLensIdInputs`] and selects the backing
+//! [`SonyLensTable`] (the A-mount `%sonyLensTypes` for the plain `LensType`,
+//! the E-mount `%sonyLensTypes2` for a substituted `LensType2`/`LensType3`).
+//! The cross-vendor PrintLensID branches exifast does not back with a ported
+//! lens DB (Canon `Canon::PrintLensID`, the Metabones/Sigma adapter
+//! substitutions) return `None` so the composite DEFERS rather than mis-emit.
+
+#![deny(clippy::indexing_slicing)]
+
+use smol_str::SmolStr;
+use std::collections::BTreeSet;
+use std::string::{String, ToString};
+use std::vec::Vec;
+
+use crate::exif::makernotes::vendors::sony::{amount_lens_types, lens_info, lens_types};
+
+/// Which `%sonyLensTypes*` PrintConv table the effective `LensType` resolves
+/// against — selected by the caller from the `Composite:LensID` substitution
+/// index (the plain `LensType` is A-mount; a substituted `LensType2`/
+/// `LensType3` is E-mount `%sonyLensTypes2`).
+pub(crate) enum SonyLensTable {
+  /// The A-mount (Minolta-backed) `%sonyLensTypes`.
+  AMount,
+  /// The E-mount `%sonyLensTypes2`.
+  EMount,
+}
+
+impl SonyLensTable {
+  /// `$$printConv{$lensType}` — the primary lens name for `id` (with any
+  /// `" or …"` tail intact), or `None` when `id` is not a table key.
+  pub(crate) fn lookup_name(&self, id: u32) -> Option<SmolStr> {
+    match self {
+      SonyLensTable::AMount => amount_lens_types::lookup_name(id),
+      SonyLensTable::EMount => lens_types::lookup_name(id),
+    }
+  }
+
+  /// `$$printConv{"$lensType.1"}`, `"$lensType.2"`, … — the float-keyed
+  /// variant names for `id`, in ascending variant order (empty when none).
+  fn variant_names(&self, id: u32) -> Vec<&'static str> {
+    match self {
+      SonyLensTable::AMount => amount_lens_types::lens_variants(id)
+        .iter()
+        .map(|v| v.name)
+        .collect(),
+      SonyLensTable::EMount => lens_types::lens_variants(id)
+        .iter()
+        .map(|v| v.name)
+        .collect(),
+    }
+  }
+}
+
+/// The decoded `Composite:LensID` ingredients `PrintLensID` reads (Exif.pm:5883
+/// argument list), post the `Composite:LensID` PrintConv's `LensType2`/
+/// `LensType3` substitution. Every field but `lens_type` / `lens_type_prt` /
+/// `table` is a `Desire` and may be absent.
+pub(crate) struct PrintLensIdInputs<'a> {
+  /// `$$et{Make} eq 'SONY'` — selects the Sony branch (65535 / adapter) over
+  /// the non-Sony Canon branch.
+  pub(crate) is_sony: bool,
+  /// `$$et{Model}` — matched against `/NEX|ILCE/` for the 65535 manual-lens
+  /// `%sonyEtype` path.
+  pub(crate) model: Option<&'a str>,
+  /// `$prt[idx]` — the LensType PrintConv name (the `$lensTypePrt` fallback).
+  pub(crate) lens_type_prt: &'a str,
+  /// `$prt[8]` — the printed `LensSpec` (GetLensInfo source + the exact-suffix
+  /// match).
+  pub(crate) lens_spec_prt: Option<&'a str>,
+  /// `$lensType` — the effective (post-substitution) integer LensType.
+  pub(crate) lens_type: i64,
+  /// `$val[1]` FocalLength.
+  pub(crate) focal_length: Option<f64>,
+  /// `$val[2]` MaxAperture.
+  pub(crate) max_aperture: Option<f64>,
+  /// `$val[3]` MaxApertureValue (used when MaxAperture is absent/zero).
+  pub(crate) max_aperture_value: Option<f64>,
+  /// `$val[4]` MinFocalLength.
+  pub(crate) short_focal: Option<f64>,
+  /// `$val[5]` MaxFocalLength.
+  pub(crate) long_focal: Option<f64>,
+  /// `$val[6]` LensModel (the `MatchLensModel` filter).
+  pub(crate) lens_model: Option<&'a str>,
+  /// `$val[7]` LensFocalRange (overrides Min/MaxFocalLength when it parses).
+  pub(crate) lens_focal_range: Option<&'a str>,
+  /// The `%sonyLensTypes*` table backing `lens_type`.
+  pub(crate) table: SonyLensTable,
+}
+
+/// `Image::ExifTool::Exif::PrintLensID` (Exif.pm:5881) — the Sony/Minolta
+/// paths. Returns the resolved lens name (`Some`), or `None` to DEFER when a
+/// cross-vendor branch (Canon `Canon::PrintLensID`, the Metabones/Sigma adapter
+/// substitution) would be needed but exifast has not ported that lens DB.
+#[must_use]
+pub(crate) fn print_lens_id(inp: &PrintLensIdInputs<'_>) -> Option<String> {
+  // `($sf0,$lf0,$sa0,$la0) = GetLensInfo($lensSpecPrt) if $lensSpecPrt; undef
+  // $sf0 unless $sa0` (Exif.pm:5904-5908) — the LensSpec range, dropped when
+  // the aperture parsed to zero.
+  let lens_spec_info = inp
+    .lens_spec_prt
+    .and_then(lens_info::get_lens_info)
+    .filter(|&(_sf0, _lf0, sa0, _la0)| sa0 != 0.0);
+
+  // `$maxAperture = $maxApertureValue unless $maxAperture` (Exif.pm:5910).
+  let max_aperture = if inp.max_aperture.is_some_and(|a| a != 0.0) {
+    inp.max_aperture
+  } else {
+    inp.max_aperture_value
+  };
+
+  // `if ($lensFocalRange =~ /^(\d+)(?: (?:to )?(\d+))?$/) { ($shortFocal,
+  // $longFocal) = ($1, $2 || $1) }` (Exif.pm:5911-5913). (Dead for the Sony
+  // generic loop; only feeds the non-Sony Canon-branch defer test below.)
+  let (mut short_focal, mut long_focal) = (inp.short_focal, inp.long_focal);
+  if let Some(lfr) = inp.lens_focal_range.filter(|s| perl_truthy_str(s))
+    && let Some((s, l)) = parse_lens_focal_range(lfr)
+  {
+    short_focal = Some(s);
+    long_focal = Some(l);
+  }
+
+  let lens_type = inp.lens_type;
+  // Make-specific branches (Exif.pm:5914-5961).
+  if inp.is_sony {
+    if lens_type == 65535 {
+      // `return $$printConv{65535} if $$printConv{65535} and not $focalLength
+      // and $maxAperture == 1` — the manual-lens patch (Exif.pm:5917).
+      if !perl_truthy_opt(inp.focal_length)
+        && max_aperture == Some(1.0)
+        && let Some(name) = inp.table.lookup_name(65535)
+      {
+        return Some(name.to_string());
+      }
+      // The `%sonyEtype` switch for NEX/ILCE bodies is applied below.
+    } else if lens_type != 0xff00 && is_metabones_or_sigma_adapter(lens_type) {
+      // Metabones/Sigma adapter (Exif.pm:5932-5952): the substituted Canon /
+      // Sigma lens DB is not ported — DEFER.
+      return None;
+    }
+  } else if perl_truthy_opt(short_focal)
+    && perl_truthy_opt(long_focal)
+    && !inp.lens_model.is_some_and(is_tamron_zoom)
+  {
+    // Canon branch (Exif.pm:5955-5960): `Canon::PrintLensID` is not ported —
+    // DEFER.
+    return None;
+  }
+
+  // The effective printConv: normally the table, but a Sony NEX/ILCE body with
+  // an unrecognised E-type lens (`LensType == 65535`) is matched against the
+  // de-duped `%sonyEtype` built from `%sonyLensTypes2` (Exif.pm:5918-5931).
+  let etype = (inp.is_sony
+    && lens_type == 65535
+    && inp
+      .model
+      .is_some_and(|m| m.contains("NEX") || m.contains("ILCE")))
+  .then(build_sony_etype);
+
+  // `$lens = $$printConv{$lensType}` (Exif.pm:5962) — the full primary name,
+  // plus its float-keyed variants.
+  let (lens_full, variant_names): (String, Vec<String>) = match &etype {
+    Some(et) => match et.split_first() {
+      // `%sonyEtype{65535}` is already de-`or`'d; `65535.1`, `65535.2`, … are
+      // the remaining de-duped E-mount names.
+      Some((first, rest)) => (
+        (*first).to_string(),
+        rest.iter().map(|s| (*s).to_string()).collect(),
+      ),
+      None => return Some(or_str(inp.lens_model, inp.lens_type_prt).to_string()),
+    },
+    None => {
+      let Some(id) = u32::try_from(lens_type).ok() else {
+        return Some(or_str(inp.lens_model, inp.lens_type_prt).to_string());
+      };
+      let Some(name) = inp.table.lookup_name(id) else {
+        // `return ($lensModel || $lensTypePrt) unless $lens` (Exif.pm:5963).
+        return Some(or_str(inp.lens_model, inp.lens_type_prt).to_string());
+      };
+      let vars = inp
+        .table
+        .variant_names(id)
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+      (name.to_string(), vars)
+    }
+  };
+
+  // `return $lens unless $$printConv{"$lensType.1"}` (Exif.pm:5964) — no float
+  // variants ⇒ the lens is unambiguous, return the primary verbatim.
+  if variant_names.is_empty() {
+    return Some(lens_full);
+  }
+
+  // `$lens =~ s/ or .*//s` then `@lenses = ($lens, variant1, …)`
+  // (Exif.pm:5965-5971) — the candidate list (the primary's first name plus
+  // every variant).
+  let mut candidates: Vec<String> = Vec::with_capacity(variant_names.len() + 1);
+  candidates.push(strip_or(&lens_full).to_string());
+  candidates.extend(variant_names);
+
+  // The disambiguation loop (Exif.pm:5973-6038). (`@user`, the user-defined
+  // lens set, is always empty in exifast, so its branch is omitted.)
+  let mut matches: Vec<String> = Vec::new();
+  let mut best: Vec<String> = Vec::new();
+  let mut diff: Option<f64> = None;
+
+  for lens in &candidates {
+    // `my ($sf,$lf,$sa,$la) = GetLensInfo($lens); next unless $sf;`
+    // (Exif.pm:5980-5981).
+    let Some((mut sf, mut lf, mut sa, mut la)) = lens_info::get_lens_info(lens) else {
+      continue;
+    };
+    if sf == 0.0 {
+      continue;
+    }
+
+    // The LensSpec branch (Exif.pm:5983-5995).
+    if let Some((sf0, lf0, sa0, la0)) = lens_spec_info {
+      // `next if abs($sf-$sf0)>0.5 or abs($sa-$sa0)>0.15 or abs($lf-$lf0)>0.5
+      // or abs($la-$la0)>0.15`.
+      if (sf - sf0).abs() > 0.5
+        || (sa - sa0).abs() > 0.15
+        || (lf - lf0).abs() > 0.5
+        || (la - la0).abs() > 0.15
+      {
+        continue;
+      }
+      // `$lensSpecPrt and $lens =~ / \Q$lensSpecPrt\E( \(| GM$|$)/ and @best =
+      // ($lens), last` — an exact LensSpec-suffix match wins outright.
+      if let Some(spec) = inp.lens_spec_prt
+        && lens_spec_suffix_match(lens, spec)
+      {
+        best = std::vec![lens.clone()];
+        break;
+      }
+      // `push @best, $lens unless $lens =~ /^Sony /` — keep only non-Sony
+      // (the exact Sony match would have been taken above).
+      if !lens.starts_with("Sony ") {
+        best.push(lens.clone());
+      }
+      continue;
+    }
+
+    // `if ($lens =~ / \+ .*? (\d+(\.\d+)?)x( |$)/) { $sf*=$1; $lf*=$1; $sa*=$1;
+    // $la*=$1 }` — the Minolta teleconverter scaling (Exif.pm:5997-6000).
+    if let Some(factor) = teleconverter_factor(lens) {
+      sf *= factor;
+      lf *= factor;
+      sa *= factor;
+      la *= factor;
+    }
+
+    // `if ($focalLength) { next if $focalLength < $sf-0.5; next if $focalLength
+    // > $lf+0.5 }` (Exif.pm:6002-6005).
+    if let Some(fl) = inp.focal_length.filter(|&f| f != 0.0)
+      && (fl < sf - 0.5 || fl > lf + 0.5)
+    {
+      continue;
+    }
+
+    // `if ($maxAperture) { … }` (Exif.pm:6006-6036).
+    if let Some(ma) = max_aperture.filter(|&a| a != 0.0) {
+      // `next if $maxAperture < $sa-0.15; next if $maxAperture > $la+0.15`.
+      if ma < sa - 0.15 || ma > la + 0.15 {
+        continue;
+      }
+      // The approximate max aperture at this focal length (Exif.pm:6015-6028).
+      let fl = inp.focal_length.unwrap_or(0.0);
+      let aa = if sf == lf || sa == la || fl <= sf {
+        // 1) prime, 2) fixed-aperture zoom, or 3) zoom at/below min focal.
+        sa
+      } else if fl >= lf {
+        la
+      } else {
+        // `exp(log($sa) + (log($la)-log($sa)) / (log($lf)-log($sf)) *
+        // (log($focalLength)-log($sf)))` — the log-log variation (Exif.pm:6024).
+        (sa.ln() + (la.ln() - sa.ln()) / (lf.ln() - sf.ln()) * (fl.ln() - sf.ln())).exp()
+      };
+      let d = (ma - aa).abs();
+      // `if (defined $diff) { $d > $diff+0.15 and next; $d < $diff-0.15 and
+      // undef @best } $diff = $d; push @best, $lens` (Exif.pm:6030-6035).
+      if let Some(prev) = diff {
+        if d > prev + 0.15 {
+          continue;
+        }
+        if d < prev - 0.15 {
+          best.clear();
+        }
+      }
+      diff = Some(d);
+      best.push(lens.clone());
+    }
+
+    // `push @matches, $lens` (Exif.pm:6037).
+    matches.push(lens.clone());
+  }
+
+  // `@best = @matches unless @best` (Exif.pm:6052).
+  if best.is_empty() {
+    best = matches;
+  }
+  // `if (@best) { MatchLensModel(\@best, $lensModel); return join(' or ',
+  // @best) }` (Exif.pm:6053-6056).
+  if !best.is_empty() {
+    match_lens_model(&mut best, inp.lens_model);
+    return Some(best.join(" or "));
+  }
+
+  // The final fall-through (Exif.pm:6057-6059): `$lens = $$printConv{$lensType};
+  // return $lensModel if $lensModel and $lens =~ / or /; return $lens`.
+  if let Some(lm) = inp.lens_model.filter(|m| !m.is_empty())
+    && lens_full.contains(" or ")
+  {
+    return Some(lm.to_string());
+  }
+  Some(lens_full)
+}
+
+/// `$lensModel || $lensTypePrt` — the LensModel when Perl-truthy (present,
+/// non-empty), else the LensType print value.
+fn or_str<'a>(lens_model: Option<&'a str>, lens_type_prt: &'a str) -> &'a str {
+  match lens_model {
+    Some(m) if !m.is_empty() => m,
+    _ => lens_type_prt,
+  }
+}
+
+/// `$lens =~ s/ or .*//s` (Exif.pm:5965) — the name up to (but excluding) its
+/// first `" or "`.
+fn strip_or(s: &str) -> &str {
+  match s.find(" or ") {
+    Some(i) => s.get(..i).unwrap_or(s),
+    None => s,
+  }
+}
+
+/// Perl boolean context on an optional coerced float: `0.0` (and absent) is
+/// FALSE, every other value TRUE.
+fn perl_truthy_opt(o: Option<f64>) -> bool {
+  o.is_some_and(|v| v != 0.0)
+}
+
+/// Perl boolean context on a string: empty and the lone `"0"` are FALSE.
+fn perl_truthy_str(s: &str) -> bool {
+  !s.is_empty() && s != "0"
+}
+
+/// `/^(\d+)(?: (?:to )?(\d+))?$/` (Exif.pm:5911) on `LensFocalRange`: a leading
+/// integer, then an optional ` <int>` / ` to <int>` tail. Returns
+/// `(short, long || short)`, or `None` when the whole string does not match.
+fn parse_lens_focal_range(s: &str) -> Option<(f64, f64)> {
+  let b = s.as_bytes();
+  // `^(\d+)`.
+  let (n1, mut p) = uint_at(b, 0)?;
+  if p == b.len() {
+    return Some((n1, n1)); // bare integer ⇒ long defaults to short.
+  }
+  // `(?: (?:to )?(\d+))$` — a space, optional "to ", then a closing integer.
+  if b.get(p) != Some(&b' ') {
+    return None;
+  }
+  p += 1;
+  if b.get(p..p + 3) == Some(b"to ") {
+    p += 3;
+  }
+  let (n2, end) = uint_at(b, p)?;
+  if end != b.len() {
+    return None;
+  }
+  Some((n1, n2))
+}
+
+/// `\d+` at `i` → the integer value and the index past it (`None` when no digit).
+fn uint_at(b: &[u8], i: usize) -> Option<(f64, usize)> {
+  let mut j = i;
+  while matches!(b.get(j), Some(c) if c.is_ascii_digit()) {
+    j += 1;
+  }
+  let s = b.get(i..j)?;
+  if s.is_empty() {
+    return None;
+  }
+  let v: f64 = core::str::from_utf8(s).ok()?.parse().ok()?;
+  Some((v, j))
+}
+
+/// `/ \+ .*? (\d+(\.\d+)?)x( |$)/` (Exif.pm:5997) — the teleconverter factor
+/// (`1.4`/`2`) for a Minolta `… + … Nx …` lens name, or `None`.
+fn teleconverter_factor(lens: &str) -> Option<f64> {
+  let b = lens.as_bytes();
+  // ` \+ ` (leftmost) then the lazy `.*?` gap then ` (\d+(\.\d+)?)x( |$)`.
+  for (plus, _) in lens.match_indices(" + ") {
+    let gap_start = plus + 3;
+    let mut k = gap_start;
+    loop {
+      // The space that opens ` (\d+…)x`, then the number, then `x`, then ` `
+      // or end-of-string.
+      if b.get(k) == Some(&b' ')
+        && let Some((num, end)) = number_at(b, k + 1)
+        && b.get(end) == Some(&b'x')
+        && matches!(b.get(end + 1), None | Some(&b' '))
+      {
+        return Some(num);
+      }
+      // `.` (= `[^\n]`) extends the lazy gap; it cannot cross a newline / end.
+      match b.get(k) {
+        Some(&c) if c != b'\n' => k += 1,
+        _ => break,
+      }
+    }
+  }
+  None
+}
+
+/// `/ \Q$spec\E( \(| GM$|$)/` (Exif.pm:5991) — does ` <spec>` appear in `lens`
+/// followed by ` (`, ` GM` at the end, or the end of string?
+fn lens_spec_suffix_match(lens: &str, spec: &str) -> bool {
+  if spec.is_empty() {
+    return false;
+  }
+  let mut needle = String::with_capacity(spec.len() + 1);
+  needle.push(' ');
+  needle.push_str(spec);
+  for (i, _) in lens.match_indices(&needle) {
+    let rest = lens.get(i + needle.len()..).unwrap_or("");
+    if rest.is_empty() || rest == " GM" || rest.starts_with(" (") {
+      return true;
+    }
+  }
+  false
+}
+
+/// `\d+(\.\d+)?` at `i` → the value and the end index, or `None`.
+fn number_at(b: &[u8], i: usize) -> Option<(f64, usize)> {
+  let mut j = i;
+  while matches!(b.get(j), Some(c) if c.is_ascii_digit()) {
+    j += 1;
+  }
+  if j == i {
+    return None;
+  }
+  // `(?:\.\d+)?` — consume the dot only when at least one digit follows.
+  if b.get(j) == Some(&b'.') {
+    let frac = j + 1;
+    let mut k = frac;
+    while matches!(b.get(k), Some(c) if c.is_ascii_digit()) {
+      k += 1;
+    }
+    if k > frac {
+      j = k;
+    }
+  }
+  let v: f64 = core::str::from_utf8(b.get(i..j)?).ok()?.parse().ok()?;
+  Some((v, j))
+}
+
+/// The metabones/Sigma E-mount adapter test (Exif.pm:5939/5947): `LensType &
+/// 0xff00` keys `%Image::ExifTool::Minolta::metabonesID` (Canon EF adapters),
+/// OR `0x4900 <= LensType <= 0x590a` (the Sigma MC-11 SA-E offset). exifast has
+/// not ported the substituted Canon / Sigma lens DBs, so the composite DEFERS.
+fn is_metabones_or_sigma_adapter(lens_type: i64) -> bool {
+  // `%metabonesID` keys (Minolta.pm:162-176) — the EF-adapter high bytes.
+  const METABONES_HIGH: [i64; 12] = [
+    0xef00, 0xf000, 0xf100, 0xff00, 0x7700, 0x7800, 0x7900, 0x8700, 0xbc00, 0xbd00, 0xbe00, 0xcc00,
+  ];
+  if METABONES_HIGH.contains(&(lens_type & 0xff00)) {
+    return true;
+  }
+  (0x4900..=0x590a).contains(&lens_type)
+}
+
+/// `/^TAMRON.*-\d+mm/` (Exif.pm:5955) — a TAMRON zoom whose `LensModel`
+/// reports a `-NNmm` focal RANGE (these report the CURRENT focal, so they are
+/// excluded from the Canon-branch shortcut).
+fn is_tamron_zoom(model: &str) -> bool {
+  let Some(rest) = model.strip_prefix("TAMRON") else {
+    return false;
+  };
+  // `.*-\d+mm` — a `-`, then `\d+`, then `mm`, anywhere in the remainder.
+  let b = rest.as_bytes();
+  for i in 0..b.len() {
+    if b.get(i) != Some(&b'-') {
+      continue;
+    }
+    let mut j = i + 1;
+    while matches!(b.get(j), Some(c) if c.is_ascii_digit()) {
+      j += 1;
+    }
+    if j > i + 1 && b.get(j) == Some(&b'm') && b.get(j + 1) == Some(&b'm') {
+      return true;
+    }
+  }
+  false
+}
+
+/// `%sonyEtype` (Exif.pm:5920-5928) — the de-duped E-mount lens names from
+/// `%sonyLensTypes2`, in Perl's default string-`sort`-by-key order, each with
+/// its `" or …"` tail removed. The first survivor is `%sonyEtype{65535}`, the
+/// rest `65535.1`, `65535.2`, ….
+fn build_sony_etype() -> Vec<&'static str> {
+  // `sort keys %sonyLensTypes2` — collect the integer + float keys as the
+  // strings Perl sorts (a byte-wise lexicographic order).
+  let mut entries: Vec<(String, &'static str)> = Vec::new();
+  for t in lens_types::SONY_LENS_TYPES {
+    entries.push((t.id.to_string(), t.name));
+  }
+  for v in lens_types::SONY_LENS_VARIANTS {
+    let mut key = v.id.to_string();
+    key.push('.');
+    key.push_str(&v.variant.to_string());
+    entries.push((key, v.name));
+  }
+  entries.sort_by(|a, b| a.0.cmp(&b.0));
+  // `($lens = $sonyLensTypes2{$_}) =~ s/ or .*//; next if $did{$lens}` — strip
+  // and de-dup, keeping the first (sorted-key order) occurrence of each name.
+  let mut seen: BTreeSet<&'static str> = BTreeSet::new();
+  let mut out: Vec<&'static str> = Vec::new();
+  for (_key, name) in entries {
+    let lens = strip_or(name);
+    if seen.insert(lens) {
+      out.push(lens);
+    }
+  }
+  out
+}
+
+/// `MatchLensModel($try, $lensModel)` (Exif.pm:5847) — narrow `try_list` (in
+/// place) by the focal / aperture / version tokens of `lens_model`, never
+/// emptying it. Each filter applies only when it leaves ≥1 and fewer entries.
+fn match_lens_model(try_list: &mut Vec<String>, lens_model: Option<&str>) {
+  // `if (@$try > 1 and $lensModel)`.
+  let Some(model) = lens_model.filter(|m| !m.is_empty()) else {
+    return;
+  };
+  if try_list.len() <= 1 {
+    return;
+  }
+  // filter by focal length (`$lensModel =~ /((\d+-)?\d+mm)/`, Exif.pm:5853).
+  if let Some(focal) = match_focal_token(model) {
+    apply_filter(try_list, |t| t.contains(&focal));
+  }
+  // filter by aperture (`(?:F/?|1:)(\d+(\.\d+)?)`, Exif.pm:5859).
+  if try_list.len() > 1
+    && let Some(fnum) = match_aperture_token(model)
+  {
+    apply_filter(try_list, |t| aperture_matches(t, &fnum));
+  }
+  // filter by version / other lens parameters (`I+`, `USM`, Exif.pm:5865).
+  for pat in ["I+", "USM"] {
+    if try_list.len() <= 1 {
+      break;
+    }
+    if let Some(val) = match_word_pattern(model, pat) {
+      apply_filter(try_list, |t| has_word(t, &val));
+    }
+  }
+}
+
+/// `@filt = grep …; @$try = @filt if @filt and @filt < @$try` — apply one
+/// `MatchLensModel` filter only when it keeps ≥1 and strictly fewer entries.
+fn apply_filter(try_list: &mut Vec<String>, pred: impl Fn(&str) -> bool) {
+  let filt: Vec<String> = try_list.iter().filter(|t| pred(t)).cloned().collect();
+  if !filt.is_empty() && filt.len() < try_list.len() {
+    *try_list = filt;
+  }
+}
+
+/// `/((\d+-)?\d+mm)/` — the leftmost focal token of `model` (`"70-300mm"` /
+/// `"55mm"`), or `None`.
+fn match_focal_token(model: &str) -> Option<String> {
+  let b = model.as_bytes();
+  for start in 0..b.len() {
+    if let Some(end) = focal_token_end(b, start) {
+      return model.get(start..end).map(ToString::to_string);
+    }
+  }
+  None
+}
+
+/// `((\d+-)?\d+mm)` anchored at `start` → the end index, mirroring the greedy
+/// optional `\d+-` prefix (backtracking to absent).
+fn focal_token_end(b: &[u8], start: usize) -> Option<usize> {
+  // The greedy `(\d+-)?` prefix: `\d+` then `-`.
+  let with_prefix = {
+    let mut j = start;
+    while matches!(b.get(j), Some(c) if c.is_ascii_digit()) {
+      j += 1;
+    }
+    (j > start && b.get(j) == Some(&b'-')).then_some(j + 1)
+  };
+  for begin in [with_prefix, Some(start)] {
+    let Some(p) = begin else { continue };
+    // `\d+mm`.
+    let mut k = p;
+    while matches!(b.get(k), Some(c) if c.is_ascii_digit()) {
+      k += 1;
+    }
+    if k > p && b.get(k) == Some(&b'm') && b.get(k + 1) == Some(&b'm') {
+      return Some(k + 2);
+    }
+  }
+  None
+}
+
+/// `m{(?:F/?|1:)(\d+(\.\d+)?)}i` — the leftmost f-number token of `model`
+/// (`"F3.5"` → `"3.5"`), or `None`.
+fn match_aperture_token(model: &str) -> Option<String> {
+  let b = model.as_bytes();
+  for i in 0..b.len() {
+    let Some(p) = aperture_head(b, i) else {
+      continue;
+    };
+    if let Some((_, end)) = number_at(b, p) {
+      return model.get(p..end).map(ToString::to_string);
+    }
+  }
+  None
+}
+
+/// `(?:F/?|1:)` (case-insensitive) at `i` → the index just past the head.
+fn aperture_head(b: &[u8], i: usize) -> Option<usize> {
+  match b.get(i) {
+    Some(b'F' | b'f') => {
+      let p = i + 1;
+      Some(if b.get(p) == Some(&b'/') { p + 1 } else { p })
+    }
+    Some(b'1') if b.get(i + 1) == Some(&b':') => Some(i + 2),
+    _ => None,
+  }
+}
+
+/// `m{(F/?|1:)$fnum(\b|[A-Z])}i` — does `candidate` carry the f-number `fnum`
+/// (an `F`/`F/`/`1:` head, then `fnum` with `.` as a regex wildcard, then a
+/// word boundary or an uppercase letter)?
+fn aperture_matches(candidate: &str, fnum: &str) -> bool {
+  let b = candidate.as_bytes();
+  let fb = fnum.as_bytes();
+  for i in 0..b.len() {
+    let Some(p) = aperture_head(b, i) else {
+      continue;
+    };
+    if !fnum_match_at(b, p, fb) {
+      continue;
+    }
+    if word_boundary_or_upper(b, p + fb.len()) {
+      return true;
+    }
+  }
+  false
+}
+
+/// `$fnum` interpolated into a regex: each byte matches literally except `.`,
+/// which (a regex metacharacter) matches any single byte.
+fn fnum_match_at(b: &[u8], p: usize, fnum: &[u8]) -> bool {
+  for (k, &fc) in fnum.iter().enumerate() {
+    match b.get(p + k) {
+      Some(&c) if fc == b'.' || c == fc => {}
+      _ => return false,
+    }
+  }
+  true
+}
+
+/// `(\b|[A-Z])` after a `\w` (the f-number's last digit): a word boundary
+/// (the next byte is non-word, or end-of-string) OR an uppercase ASCII letter.
+fn word_boundary_or_upper(b: &[u8], q: usize) -> bool {
+  match b.get(q) {
+    None => true,
+    Some(&c) => !is_word_byte(c) || c.is_ascii_uppercase(),
+  }
+}
+
+/// `\b($pat)\b` for the two `MatchLensModel` version patterns: `"I+"` (a
+/// word-bounded run of `I`s) or the literal `"USM"`. Returns the matched run.
+fn match_word_pattern(model: &str, pat: &str) -> Option<String> {
+  match pat {
+    "I+" => find_i_run(model),
+    literal => has_word(model, literal).then(|| literal.to_string()),
+  }
+}
+
+/// `\b(I+)\b` — a maximal, word-bounded run of `I` in `model` (`"II"`,
+/// `"III"`), or `None`.
+fn find_i_run(model: &str) -> Option<String> {
+  let b = model.as_bytes();
+  let mut i = 0;
+  while i < b.len() {
+    if b.get(i) != Some(&b'I') {
+      i += 1;
+      continue;
+    }
+    let s = i;
+    while b.get(i) == Some(&b'I') {
+      i += 1;
+    }
+    let e = i;
+    let before_ok = s == 0 || b.get(s - 1).is_none_or(|&c| !is_word_byte(c));
+    let after_ok = b.get(e).is_none_or(|&c| !is_word_byte(c));
+    if before_ok && after_ok {
+      return model.get(s..e).map(ToString::to_string);
+    }
+  }
+  None
+}
+
+/// `/\b$val\b/` — does `val` (`"II"`/`"III"`/`"USM"`, all word characters)
+/// appear in `candidate` bounded by word boundaries?
+fn has_word(candidate: &str, val: &str) -> bool {
+  let b = candidate.as_bytes();
+  let vb = val.as_bytes();
+  if vb.is_empty() {
+    return false;
+  }
+  let mut i = 0;
+  while i + vb.len() <= b.len() {
+    if b.get(i..i + vb.len()) == Some(vb) {
+      let before_ok = i == 0 || b.get(i - 1).is_none_or(|&c| !is_word_byte(c));
+      let after_ok = b.get(i + vb.len()).is_none_or(|&c| !is_word_byte(c));
+      if before_ok && after_ok {
+        return true;
+      }
+    }
+    i += 1;
+  }
+  false
+}
+
+/// Perl `\w` byte: ASCII alphanumeric or `_`.
+fn is_word_byte(c: u8) -> bool {
+  c.is_ascii_alphanumeric() || c == b'_'
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/composite/convs/lens/sony_lens_id/tests.rs
+++ b/src/composite/convs/lens/sony_lens_id/tests.rs
@@ -1,0 +1,403 @@
+// Unit tests for the `PrintLensID` Sony/Minolta disambiguation. The A200 /
+// A33 conformance fixtures cover the A-mount FocalLength/MaxAperture and the
+// LensSpec exact-suffix branches end-to-end (byte-exact vs bundled); these
+// guard the branches conformance does NOT exercise — the E-mount LensSpec
+// keep-path, the teleconverter scaling, `MatchLensModel`, the 65535 manual-lens
+// `%sonyEtype` path, and the 0-/multi-survivor fall-throughs — ground-truthed
+// against the bundled `%sonyLensTypes*` tables and the `Exif.pm:5881` logic.
+
+use super::*;
+
+/// A base [`PrintLensIdInputs`] (a Sony body, no decoded ingredients) to
+/// override per test.
+fn base(table: SonyLensTable, lens_type: i64, lens_type_prt: &str) -> PrintLensIdInputs<'_> {
+  PrintLensIdInputs {
+    is_sony: true,
+    model: None,
+    lens_type_prt,
+    lens_spec_prt: None,
+    lens_type,
+    focal_length: None,
+    max_aperture: None,
+    max_aperture_value: None,
+    short_focal: None,
+    long_focal: None,
+    lens_model: None,
+    lens_focal_range: None,
+    table,
+  }
+}
+
+// ---- end-to-end `print_lens_id` ----
+
+#[test]
+fn a200_focal_aperture_branch_picks_tamron_70_300() {
+  // A200: LensType 129 (= "Tamron Lens (129)"), LensSpec all-zero ⇒ the
+  // FocalLength (80) + MaxApertureValue (4.5002…) branch picks the 129.2 variant.
+  let mut inp = base(SonyLensTable::AMount, 129, "Tamron Lens (129)");
+  inp.lens_spec_prt = Some("Unknown (00 0 0 0 0 00)");
+  inp.focal_length = Some(80.0);
+  inp.max_aperture_value = Some(4.500_233_938_755_24);
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Tamron 70-300mm F4-5.6 LD")
+  );
+}
+
+#[test]
+fn a33_lensspec_exact_suffix_wins_over_variant() {
+  // A33: LensType 55, LensSpec "DT 18-55mm F3.5-5.6 SAM" — the PRIMARY 55
+  // (SAL1855) wins via the exact LensSpec-suffix match over the 55.1 (SAM II).
+  let mut inp = base(
+    SonyLensTable::AMount,
+    55,
+    "Sony DT 18-55mm F3.5-5.6 SAM (SAL1855) or SAM II",
+  );
+  inp.lens_spec_prt = Some("DT 18-55mm F3.5-5.6 SAM");
+  inp.lens_model = Some("DT 18-55mm F3.5-5.6 SAM");
+  inp.focal_length = Some(24.0);
+  inp.max_aperture_value = Some(4.0);
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Sony DT 18-55mm F3.5-5.6 SAM (SAL1855)")
+  );
+}
+
+#[test]
+fn emount_lensspec_keeps_nonsony_match() {
+  // E-mount id 0 (multi-candidate): LensSpec "30mm F2.8" keeps only the
+  // in-tolerance non-Sony "Sigma 30mm F2.8 [EX] DN" (no exact-suffix win — the
+  // `(SAL…)`/`[EX]` tail differs — so the `push @best unless /^Sony /` path).
+  let mut inp = base(
+    SonyLensTable::EMount,
+    0,
+    "Unknown E-mount lens or other lens",
+  );
+  inp.lens_spec_prt = Some("30mm F2.8");
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Sigma 30mm F2.8 [EX] DN")
+  );
+}
+
+#[test]
+fn teleconverter_scaling_rescues_200mm_at_280() {
+  // A-mount 25901 ("… + Minolta AF 1.4x APO"): the 1.4x converter scales the
+  // 200mm primary to 280mm, so FocalLength 280 SURVIVES (without the scaling it
+  // would be ruled out as > 200.5mm); the 600mm variant scales to 840mm and is
+  // ruled out.
+  let mut inp = base(
+    SonyLensTable::AMount,
+    25901,
+    "Minolta AF 200mm F2.8 G APO + Minolta AF 1.4x APO or Other Lens + 1.4x",
+  );
+  inp.focal_length = Some(280.0);
+  inp.max_aperture = Some(4.0);
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Minolta AF 200mm F2.8 G APO + Minolta AF 1.4x APO")
+  );
+}
+
+#[test]
+fn multi_survivor_joins_with_or() {
+  // No FocalLength / MaxAperture / LensSpec to disqualify either candidate ⇒
+  // both reach @matches and join with " or " (Exif.pm:6055).
+  let inp = base(
+    SonyLensTable::AMount,
+    25901,
+    "Minolta AF 200mm F2.8 G APO + Minolta AF 1.4x APO or Other Lens + 1.4x",
+  );
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some(
+      "Minolta AF 200mm F2.8 G APO + Minolta AF 1.4x APO or \
+       Minolta AF 600mm F4 HS-APO G + Minolta AF 1.4x APO"
+    )
+  );
+}
+
+#[test]
+fn zero_survivor_returns_lens_model_when_primary_has_or() {
+  // FocalLength 2000 rules out every id-0 candidate ⇒ no @best/@matches; the
+  // primary has " or " and LensModel is present ⇒ `return $lensModel`
+  // (Exif.pm:6058).
+  let mut inp = base(
+    SonyLensTable::EMount,
+    0,
+    "Unknown E-mount lens or other lens",
+  );
+  inp.focal_length = Some(2000.0);
+  inp.lens_model = Some("My Manual 2000mm");
+  assert_eq!(print_lens_id(&inp).as_deref(), Some("My Manual 2000mm"));
+}
+
+#[test]
+fn zero_survivor_returns_primary_without_lens_model() {
+  // Same, but no LensModel ⇒ `return $lens` (the full primary, Exif.pm:6059).
+  let mut inp = base(
+    SonyLensTable::EMount,
+    0,
+    "Unknown E-mount lens or other lens",
+  );
+  inp.focal_length = Some(2000.0);
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Unknown E-mount lens or other lens")
+  );
+}
+
+#[test]
+fn unambiguous_no_variant_returns_name_verbatim() {
+  // A LensType with no float variants is unambiguous — `return $lens unless
+  // $$printConv{"$lensType.1"}` (Exif.pm:5964). id 32821 = "Sony FE 24-70mm
+  // F2.8 GM" has no `.1`.
+  let inp = base(SonyLensTable::EMount, 32821, "Sony FE 24-70mm F2.8 GM");
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Sony FE 24-70mm F2.8 GM")
+  );
+}
+
+#[test]
+fn manual_lens_65535_early_return() {
+  // The forum17379 patch (Exif.pm:5917): LensType 65535, no FocalLength,
+  // MaxAperture == 1 ⇒ the A-mount table's 65535 name verbatim.
+  let mut inp = base(
+    SonyLensTable::AMount,
+    65535,
+    "E-Mount, T-Mount, Other Lens or no lens",
+  );
+  inp.max_aperture = Some(1.0);
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("E-Mount, T-Mount, Other Lens or no lens")
+  );
+}
+
+#[test]
+fn manual_lens_65535_amount_variants_for_non_nex() {
+  // 65535 on a NON-NEX/ILCE body keeps the A-mount %sonyLensTypes 65535
+  // manual-lens variants; LensSpec "135mm F2.8" picks "Pentacon Auto 135mm F2.8".
+  let mut inp = base(
+    SonyLensTable::AMount,
+    65535,
+    "E-Mount, T-Mount, Other Lens or no lens",
+  );
+  inp.model = Some("DSLR-A900");
+  inp.lens_spec_prt = Some("135mm F2.8");
+  inp.focal_length = Some(135.0);
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Pentacon Auto 135mm F2.8")
+  );
+}
+
+#[test]
+fn manual_lens_65535_nex_ilce_uses_sony_etype() {
+  // 65535 on a NEX/ILCE body rebuilds the printConv as %sonyEtype (the de-duped
+  // E-mount names); LensSpec "FE 24-70mm F2.8 GM" exact-matches the GM (not the
+  // " GM II"), proving the E-mount candidate set is used.
+  let mut inp = base(
+    SonyLensTable::AMount,
+    65535,
+    "E-Mount, T-Mount, Other Lens or no lens",
+  );
+  inp.model = Some("NEX-7");
+  inp.lens_spec_prt = Some("FE 24-70mm F2.8 GM");
+  inp.focal_length = Some(50.0); // truthy ⇒ skip the manual-lens early return
+  assert_eq!(
+    print_lens_id(&inp).as_deref(),
+    Some("Sony FE 24-70mm F2.8 GM")
+  );
+}
+
+#[test]
+fn metabones_adapter_defers() {
+  // A Metabones EF-adapter offset (high byte 0xef00) substitutes the unported
+  // Canon lens DB ⇒ DEFER.
+  let inp = base(SonyLensTable::EMount, 0xef12, "Unknown");
+  assert_eq!(print_lens_id(&inp), None);
+}
+
+#[test]
+fn non_sony_canon_branch_defers() {
+  // A non-Sony body with Min/MaxFocalLength would call `Canon::PrintLensID`
+  // (not ported) ⇒ DEFER.
+  let mut inp = base(SonyLensTable::AMount, 200, "Some Canon Lens");
+  inp.is_sony = false;
+  inp.short_focal = Some(70.0);
+  inp.long_focal = Some(200.0);
+  assert_eq!(print_lens_id(&inp), None);
+}
+
+// ---- `MatchLensModel` (Exif.pm:5847) ----
+
+#[test]
+fn match_lens_model_filters_by_focal() {
+  let mut list = std::vec![
+    "Sony FE 24mm F1.4 GM".to_string(),
+    "Sony FE 50mm F1.4 GM".to_string(),
+  ];
+  match_lens_model(&mut list, Some("FE 24mm F1.4 GM"));
+  assert_eq!(list, ["Sony FE 24mm F1.4 GM"]);
+}
+
+#[test]
+fn match_lens_model_filters_by_version_two() {
+  // The `I+` version filter narrows to the "II" body (focal + aperture tie).
+  let mut list = std::vec![
+    "Canon EF 70-200mm F2.8L IS II USM".to_string(),
+    "Canon EF 70-200mm F2.8L IS USM".to_string(),
+  ];
+  match_lens_model(&mut list, Some("EF 70-200mm F2.8L IS II USM"));
+  assert_eq!(list, ["Canon EF 70-200mm F2.8L IS II USM"]);
+}
+
+#[test]
+fn match_lens_model_filters_by_usm() {
+  let mut list = std::vec![
+    "Canon EF 50mm F1.8 USM".to_string(),
+    "Canon EF 50mm F1.8".to_string(),
+  ];
+  match_lens_model(&mut list, Some("EF 50mm F1.8 USM"));
+  assert_eq!(list, ["Canon EF 50mm F1.8 USM"]);
+}
+
+#[test]
+fn match_lens_model_never_empties() {
+  // A filter that would leave NO entry is not applied (Exif.pm:5856).
+  let mut list = std::vec!["A 50mm".to_string(), "B 50mm".to_string()];
+  match_lens_model(&mut list, Some("999mm"));
+  assert_eq!(list, ["A 50mm", "B 50mm"]);
+}
+
+// ---- helper regex ports ----
+
+#[test]
+fn teleconverter_factor_cases() {
+  assert_eq!(
+    teleconverter_factor("Minolta AF 200mm F2.8 G APO + Minolta AF 1.4x APO"),
+    Some(1.4)
+  );
+  assert_eq!(
+    teleconverter_factor("Minolta AF 600mm F4 HS-APO G + Minolta AF 2x APO"),
+    Some(2.0)
+  );
+  assert_eq!(teleconverter_factor("Sony FE 24-70mm F2.8 GM"), None);
+  // " + " present but no ` Nx` ⇒ no match.
+  assert_eq!(teleconverter_factor("Lens + Hood"), None);
+}
+
+#[test]
+fn lens_spec_suffix_match_cases() {
+  // ` (` after the spec.
+  assert!(lens_spec_suffix_match(
+    "Sony DT 18-55mm F3.5-5.6 SAM (SAL1855)",
+    "DT 18-55mm F3.5-5.6 SAM"
+  ));
+  // end-of-string after the spec.
+  assert!(lens_spec_suffix_match(
+    "Sony FE 24-70mm F2.8 GM",
+    "FE 24-70mm F2.8 GM"
+  ));
+  // ` GM` at the end.
+  assert!(lens_spec_suffix_match(
+    "Some FE 21mm F2.8 GM",
+    "FE 21mm F2.8"
+  ));
+  // a " II" tail is NOT a boundary ⇒ no match.
+  assert!(!lens_spec_suffix_match(
+    "Sony FE 24-70mm F2.8 GM II",
+    "FE 24-70mm F2.8 GM"
+  ));
+  // spec absent from the name.
+  assert!(!lens_spec_suffix_match(
+    "Sony FE 50mm F1.8",
+    "FE 24-70mm F2.8"
+  ));
+}
+
+#[test]
+fn strip_or_cases() {
+  assert_eq!(
+    strip_or("Sony DT 18-55mm F3.5-5.6 SAM (SAL1855) or SAM II"),
+    "Sony DT 18-55mm F3.5-5.6 SAM (SAL1855)"
+  );
+  assert_eq!(strip_or("Tamron Lens (129)"), "Tamron Lens (129)");
+  // "Motor" contains "or" but not " or " — not stripped.
+  assert_eq!(strip_or("Motor Lens"), "Motor Lens");
+}
+
+#[test]
+fn match_token_helpers() {
+  assert_eq!(
+    match_focal_token("FE 70-300mm F4.5-5.6").as_deref(),
+    Some("70-300mm")
+  );
+  assert_eq!(match_focal_token("FE 50mm F1.4").as_deref(), Some("50mm"));
+  assert_eq!(match_focal_token("no focal here"), None);
+  assert_eq!(
+    match_aperture_token("FE 24mm F1.4 GM").as_deref(),
+    Some("1.4")
+  );
+  assert_eq!(match_aperture_token("Lens 1:2.8").as_deref(), Some("2.8"));
+  assert!(aperture_matches("Sony FE 24mm F1.4 GM", "1.4"));
+  assert!(!aperture_matches("Sony FE 24mm F2.8 GM", "1.4"));
+}
+
+#[test]
+fn word_pattern_helpers() {
+  assert_eq!(find_i_run("Some Lens III").as_deref(), Some("III"));
+  assert_eq!(find_i_run("EF 70-200mm IS II USM").as_deref(), Some("II"));
+  assert_eq!(find_i_run("Minolta AF Lens"), None);
+  assert!(has_word("Canon EF 50mm USM", "USM"));
+  assert!(!has_word("Canon EF 50mm USMx", "USM"));
+}
+
+#[test]
+fn parse_lens_focal_range_cases() {
+  assert_eq!(parse_lens_focal_range("50"), Some((50.0, 50.0)));
+  assert_eq!(parse_lens_focal_range("18 55"), Some((18.0, 55.0)));
+  assert_eq!(parse_lens_focal_range("18 to 200"), Some((18.0, 200.0)));
+  assert_eq!(parse_lens_focal_range("18-55"), None);
+  assert_eq!(parse_lens_focal_range(""), None);
+}
+
+#[test]
+fn metabones_and_sigma_ranges() {
+  assert!(is_metabones_or_sigma_adapter(0xef12)); // high byte 0xef00
+  assert!(is_metabones_or_sigma_adapter(0xbc34)); // high byte 0xbc00
+  assert!(is_metabones_or_sigma_adapter(0x4900)); // Sigma MC-11 low bound
+  assert!(is_metabones_or_sigma_adapter(0x590a)); // Sigma MC-11 high bound
+  assert!(!is_metabones_or_sigma_adapter(129)); // A200 lens — not an adapter
+  assert!(!is_metabones_or_sigma_adapter(55)); // A33 lens — not an adapter
+}
+
+#[test]
+fn tamron_zoom_model() {
+  assert!(is_tamron_zoom("TAMRON SP 70-300mm F4-5.6"));
+  assert!(!is_tamron_zoom("TAMRON 90mm F2.8 Macro")); // a prime — no `-NNmm`
+  assert!(!is_tamron_zoom("Sigma 70-300mm")); // not TAMRON
+}
+
+#[test]
+fn build_sony_etype_dedups_and_strips() {
+  let etype = build_sony_etype();
+  assert!(!etype.is_empty());
+  // Every entry is de-`or`'d.
+  assert!(etype.iter().all(|n| !n.contains(" or ")));
+  // No duplicate names.
+  let mut sorted: std::vec::Vec<&str> = etype.clone();
+  sorted.sort_unstable();
+  sorted.dedup();
+  assert_eq!(
+    sorted.len(),
+    etype.len(),
+    "%sonyEtype must be de-duplicated"
+  );
+  // The lowest string-sorted key is the integer "0".
+  assert_eq!(etype.first().copied(), Some("Unknown E-mount lens"));
+  // A known E-mount lens is present.
+  assert!(etype.contains(&"Sony FE 24-70mm F2.8 GM"));
+}

--- a/src/composite/table.rs
+++ b/src/composite/table.rs
@@ -783,11 +783,20 @@ impl CompositePrintConv {
           ConvMode::ValueConv => v.clone(),
           ConvMode::PrintConv => {
             let idx = lens_id_print_index(vals);
-            prts
-              .get(idx)
-              .and_then(Option::as_ref)
-              .cloned()
-              .unwrap_or_else(|| v.clone())
+            let selected = prts.get(idx).and_then(Option::as_ref);
+            // The unambiguous case renders `$prt[idx]` verbatim; an ambiguous
+            // `" or "` / placeholder name renders the full `PrintLensID`
+            // disambiguation (matching the [`lens_id`] build decision).
+            let resolved = selected.map(crate::composite::value_text);
+            match resolved {
+              Some(name) if !lens_name_is_resolved(&name) => {
+                match sony_lens_id_disambiguate(vals, prts) {
+                  Some(lens) => TagValue::Str(lens.into()),
+                  None => selected.cloned().unwrap_or_else(|| v.clone()),
+                }
+              }
+              _ => selected.cloned().unwrap_or_else(|| v.clone()),
+            }
           }
         }
       }
@@ -1807,6 +1816,22 @@ fn composite_flash(
 /// Sony LensType2 that fails the `0x8000`/`0` mask) does NOT defer — the
 /// unambiguous Pentax/Samsung path (those ingredients absent/inactive) still
 /// emits byte-identically.
+/// The COMPACT [`LENS_ID`] ingredient indices (NOT ExifTool's numbered slots).
+#[cfg(feature = "exif")]
+mod lens_id_in {
+  pub(super) const LENS_TYPE: usize = 0;
+  pub(super) const FOCAL_LENGTH: usize = 1;
+  pub(super) const MAX_APERTURE: usize = 6;
+  pub(super) const MAX_APERTURE_VALUE: usize = 7;
+  pub(super) const MIN_FOCAL_LENGTH: usize = 8;
+  pub(super) const MAX_FOCAL_LENGTH: usize = 9;
+  pub(super) const LENS_MODEL: usize = 10;
+  pub(super) const LENS_FOCAL_RANGE: usize = 11;
+  pub(super) const LENS_SPEC: usize = 12;
+  pub(super) const MAKE: usize = 13;
+  pub(super) const MODEL: usize = 14;
+}
+
 #[cfg(feature = "exif")]
 fn lens_id(
   v: &[CompositeValue],
@@ -1833,15 +1858,97 @@ fn lens_id(
   // candidate). Absent ⇒ no build (no name to emit under `-j`).
   let name = prts.get(idx).and_then(Option::as_ref)?;
   let name_text = crate::composite::value_text(name);
-  // Confirmed resolved lens name: carries a focal-length / aperture token
-  // (`PrintLensID`'s lens-name shape) AND is not an ambiguity placeholder.
+  // A CONFIRMED resolved single-lens name (a focal/aperture token, no `" or "`)
+  // is the unambiguous passthrough — `PrintLensID` returns `$$printConv{$lensType}`
+  // verbatim. Otherwise the name is an ambiguous `" or "` / placeholder LensType:
+  // run the full Sony/Minolta `PrintLensID` lens-DB disambiguation and BUILD iff
+  // it resolves to a name (else DEFER — a non-Sony / unported-DB case).
   if !lens_name_is_resolved(&name_text) {
-    return None;
+    sony_lens_id_disambiguate(v, prts)?;
   }
   // ValueConv `$val` = `$val[0]` (the PLAIN raw LensType) carried verbatim; the
-  // PrintConv renders `$prt[idx]` (= `name`), selected by the SAME
-  // [`lens_id_print_index`].
+  // PrintConv renders the resolved name (= `$prt[idx]` for the unambiguous case,
+  // the [`sony_lens_id_disambiguate`] result for the ambiguous one).
   Some(CompositeRaw::Scalar(raw_lens_type))
+}
+
+/// `Image::ExifTool::Exif::PrintLensID($self, $prt[idx], $pcv, $prt[8], @val)`
+/// (Exif.pm:5353) for an AMBIGUOUS Sony/Minolta LensType — maps the
+/// [`LENS_ID`] ingredients into a
+/// [`PrintLensIdInputs`](crate::composite::convs::lens::sony_lens_id::PrintLensIdInputs)
+/// and runs the faithful disambiguator. Returns the resolved lens name, or
+/// `None` to DEFER.
+///
+/// The GATE `table.lookup_name(lensType) == $prt[idx]` confirms the resolved
+/// name IS this Sony table's own `$$printConv{$lensType}` — a NON-Sony ambiguous
+/// LensType (a `%pentaxLensTypes` `"Sigma or Tamron Lens (N N)"`) does not match,
+/// so it defers (exifast has no Pentax / other variant tables).
+#[cfg(feature = "exif")]
+fn sony_lens_id_disambiguate(
+  v: &[CompositeValue],
+  prts: &[Option<TagValue>],
+) -> Option<std::string::String> {
+  use crate::composite::convs::lens::sony_lens_id::{
+    PrintLensIdInputs, SonyLensTable, print_lens_id,
+  };
+  use lens_id_in as ix;
+
+  // The effective `$lensType` (= `$val[idx]`) + its PrintConv name (`$prt[idx]`).
+  let idx = lens_id_print_index(v);
+  let lens_type = v.get(idx)?.coerce_numeric()? as i64;
+  let name = crate::composite::value_text(prts.get(idx).and_then(Option::as_ref)?).into_owned();
+  // The PrintConv table: A-mount `%sonyLensTypes` for the plain LensType (idx 0),
+  // E-mount `%sonyLensTypes2` for a substituted LensType2/LensType3 (idx 2/3).
+  let table = if idx == ix::LENS_TYPE {
+    SonyLensTable::AMount
+  } else {
+    SonyLensTable::EMount
+  };
+  // GATE: the name must be this table's `$$printConv{$lensType}` (a Sony lens).
+  let id = u32::try_from(lens_type).ok()?;
+  if table.lookup_name(id).as_deref() != Some(name.as_str()) {
+    return None;
+  }
+
+  // Bind the `Cow`/text ingredients to locals so the `&str` inputs outlive the
+  // `print_lens_id` call.
+  let make = v.get(ix::MAKE).and_then(CompositeValue::as_text);
+  let model = v.get(ix::MODEL).and_then(CompositeValue::as_text);
+  let lens_model = v.get(ix::LENS_MODEL).and_then(CompositeValue::as_text);
+  let lens_focal_range = v
+    .get(ix::LENS_FOCAL_RANGE)
+    .and_then(CompositeValue::as_text);
+  let lens_spec_prt = prts
+    .get(ix::LENS_SPEC)
+    .and_then(Option::as_ref)
+    .map(crate::composite::value_text);
+
+  let inputs = PrintLensIdInputs {
+    is_sony: make.as_deref() == Some("SONY"),
+    model: model.as_deref(),
+    lens_type_prt: &name,
+    lens_spec_prt: lens_spec_prt.as_deref(),
+    lens_type,
+    focal_length: v
+      .get(ix::FOCAL_LENGTH)
+      .and_then(CompositeValue::coerce_numeric),
+    max_aperture: v
+      .get(ix::MAX_APERTURE)
+      .and_then(CompositeValue::coerce_numeric),
+    max_aperture_value: v
+      .get(ix::MAX_APERTURE_VALUE)
+      .and_then(CompositeValue::coerce_numeric),
+    short_focal: v
+      .get(ix::MIN_FOCAL_LENGTH)
+      .and_then(CompositeValue::coerce_numeric),
+    long_focal: v
+      .get(ix::MAX_FOCAL_LENGTH)
+      .and_then(CompositeValue::coerce_numeric),
+    lens_model: lens_model.as_deref(),
+    lens_focal_range: lens_focal_range.as_deref(),
+    table,
+  };
+  print_lens_id(&inputs)
 }
 
 /// Does Canon RFLensType (`$val[12]`, Exif.pm:5348) or the Pentax converter
@@ -2880,28 +2987,34 @@ const FLASH: CompositeDef = CompositeDef {
 /// = the raw LensType `$val[0]`).
 ///
 /// The ExifTool `Desire`s 1-12 (FocalLength/MaxAperture/LensType2/RFLensType/…)
-/// drive `PrintLensID`'s disambiguation / vendor-DB branches. exifast ports only
-/// the plain-LensType case, but it MUST KNOW when a vendor disambiguator is
-/// present so it can DEFER (return `None`) instead of mis-emitting a stale
-/// LensType name (a Canon RFLensType / Sony LensType2 file would otherwise emit
-/// the wrong lens). So the inputs carry the disambiguators the PrintConv
-/// branches on, in a COMPACT internal layout (`lens_id` reads them by THESE
-/// indices, not ExifTool's numbered slots): `[0]`=LensType (Require),
-/// `[1]`=FocalLength, `[2]`=LensType2, `[3]`=LensType3, `[4]`=LensFocalLength,
-/// `[5]`=RFLensType (all Desire). The remaining ExifTool Desires
-/// (MaxAperture/MaxApertureValue/MinFocalLength/MaxFocalLength/LensModel/
-/// LensFocalRange/LensSpec) only feed `PrintLensID`'s lens-DB lookup that this
-/// subset defers wholesale, so they are still omitted.
+/// drive `PrintLensID`'s disambiguation / vendor-DB branches. The inputs carry
+/// them in a COMPACT internal layout (`lens_id` reads them by THE [`LensIdIn`]
+/// indices, not ExifTool's numbered slots): the disambiguators the PrintConv
+/// branches on (`LensType2`/`LensType3`/`RFLensType`/`LensFocalLength`) so a
+/// Canon-RFLensType / Pentax-converter case can DEFER, AND the Sony/Minolta
+/// `PrintLensID` lens-DB ingredients (`MaxAperture`/`MaxApertureValue`/
+/// `MinFocalLength`/`MaxFocalLength`/`LensModel`/`LensFocalRange`/`LensSpec` +
+/// the `Make`/`Model` `$$et` reads) that resolve an ambiguous `" or "` LensType
+/// to a single lens (see [`sony_lens_id_disambiguate`]).
 #[cfg(feature = "exif")]
 const LENS_ID: CompositeDef = CompositeDef {
   name: "LensID",
   inputs: &[
-    bare_req("LensType"),
-    bare_des("FocalLength"),
-    bare_des("LensType2"),
-    bare_des("LensType3"),
-    bare_des("LensFocalLength"),
-    bare_des("RFLensType"),
+    bare_req("LensType"),         // 0 LensIdIn::LensType
+    bare_des("FocalLength"),      // 1 LensIdIn::FocalLength
+    bare_des("LensType2"),        // 2 LensIdIn::LensType2
+    bare_des("LensType3"),        // 3 LensIdIn::LensType3
+    bare_des("LensFocalLength"),  // 4 LensIdIn::LensFocalLength
+    bare_des("RFLensType"),       // 5 LensIdIn::RfLensType
+    bare_des("MaxAperture"),      // 6 LensIdIn::MaxAperture
+    bare_des("MaxApertureValue"), // 7 LensIdIn::MaxApertureValue
+    bare_des("MinFocalLength"),   // 8 LensIdIn::MinFocalLength
+    bare_des("MaxFocalLength"),   // 9 LensIdIn::MaxFocalLength
+    bare_des("LensModel"),        // 10 LensIdIn::LensModel
+    bare_des("LensFocalRange"),   // 11 LensIdIn::LensFocalRange
+    bare_des("LensSpec"),         // 12 LensIdIn::LensSpec
+    bare_des("Make"),             // 13 LensIdIn::Make ($$et{Make})
+    bare_des("Model"),            // 14 LensIdIn::Model ($$et{Model})
   ],
   derive: lens_id,
   print_conv: CompositePrintConv::LensId,

--- a/src/exif/makernotes/vendors/sony/amount_lens_types.rs
+++ b/src/exif/makernotes/vendors/sony/amount_lens_types.rs
@@ -20,12 +20,16 @@
 //! bundled module so the table matches what `PrintConv => \%sonyLensTypes`
 //! resolves against at runtime, byte-for-byte.
 //!
+//! The FLOAT-keyed disambiguation entries (e.g. `7.1`, `129.2`, `65535.1`):
+//! secondary names appended after the primary when several lenses share an ID,
+//! keyed by the integer ID plus the fractional suffix taken as an integer
+//! "variant". They live in [`SONY_LENS_VARIANTS_AMOUNT`] / [`lens_variants`];
+//! `PrintLensID` (`Exif.pm:5881`) consumes them via
+//! [`super::lens_info::get_lens_info`] over `LensSpec`. That wiring lands in a
+//! later chunk, so the variant table is inert here.
+//!
 //! ## Deferred (faithful gaps, documented)
 //!
-//! - **Float-keyed disambiguation** (e.g. `7.1`, `65535.1`): the bundled
-//!   secondary names shown when the primary doesn't match `LensSpec`. Same
-//!   deferral as `%sonyLensTypes2` — only the primary (integer-key) name is
-//!   ported; LensSpec disambiguation is a follow-up (#62).
 //! - **The `OTHER => sub` adapter cross-reference** (`Minolta.pm:186-205`):
 //!   for high-byte adapter IDs it combines Metabones (Canon `%canonLensTypes`)
 //!   / Sigma MC-11 (`%sigmaLensTypes`) lens names. That requires the Canon +
@@ -43,6 +47,20 @@ use smol_str::SmolStr;
 pub struct SonyLensType {
   /// The integer lens-type ID (the key in the filled `%sonyLensTypes`).
   pub id: u32,
+  /// The lens model name.
+  pub name: &'static str,
+}
+
+/// One FLOAT-keyed disambiguation entry of the A-mount `%sonyLensTypes` — a
+/// secondary lens name `PrintLensID` considers after the primary
+/// [`SonyLensType`] when several lenses share the integer `id`.
+#[derive(Debug, Clone, Copy)]
+pub struct SonyLensVariant {
+  /// The integer part of the bundled float key (the shared lens-type ID).
+  pub id: u32,
+  /// The fractional suffix taken as an integer (`129.2` → 2, `128.27` → 27).
+  /// `PrintLensID` scans `id.1`, `id.2`, … in ascending order.
+  pub variant: u8,
   /// The lens model name.
   pub name: &'static str,
 }
@@ -1032,6 +1050,969 @@ pub fn lookup_name(id: u32) -> Option<SmolStr> {
   }
 }
 
+/// FLOAT-keyed disambiguation entries of the A-mount `%sonyLensTypes`, sorted
+/// by `(id, variant)`. Each shares its `id` with a primary
+/// [`SONY_LENS_TYPES_AMOUNT`] row; `PrintLensID` appends [`lens_variants`]`(id)`
+/// after that primary. Inert until the `PrintLensID` wiring lands.
+pub const SONY_LENS_VARIANTS_AMOUNT: &[SonyLensVariant] = &[
+  SonyLensVariant {
+    id: 7,
+    variant: 1,
+    name: "Minolta AF 100-400mm F4.5-6.7 APO",
+  },
+  SonyLensVariant {
+    id: 7,
+    variant: 2,
+    name: "Sigma AF 100-300mm F4 EX DG IF",
+  },
+  SonyLensVariant {
+    id: 24,
+    variant: 1,
+    name: "Sigma 18-50mm F2.8",
+  },
+  SonyLensVariant {
+    id: 24,
+    variant: 2,
+    name: "Sigma 17-70mm F2.8-4.5 DC Macro",
+  },
+  SonyLensVariant {
+    id: 24,
+    variant: 3,
+    name: "Sigma 20-40mm F2.8 EX DG Aspherical IF",
+  },
+  SonyLensVariant {
+    id: 24,
+    variant: 4,
+    name: "Sigma 18-200mm F3.5-6.3 DC",
+  },
+  SonyLensVariant {
+    id: 24,
+    variant: 5,
+    name: "Sigma DC 18-125mm F4-5,6 D",
+  },
+  SonyLensVariant {
+    id: 24,
+    variant: 6,
+    name: "Tamron SP AF 28-75mm F2.8 XR Di LD Aspherical [IF] Macro",
+  },
+  SonyLensVariant {
+    id: 24,
+    variant: 7,
+    name: "Sigma 15-30mm F3.5-4.5 EX DG Aspherical",
+  },
+  SonyLensVariant {
+    id: 25,
+    variant: 1,
+    name: "Sigma 100-300mm F4 EX (APO (D) or D IF)",
+  },
+  SonyLensVariant {
+    id: 25,
+    variant: 2,
+    name: "Sigma 70mm F2.8 EX DG Macro",
+  },
+  SonyLensVariant {
+    id: 25,
+    variant: 3,
+    name: "Sigma 20mm F1.8 EX DG Aspherical RF",
+  },
+  SonyLensVariant {
+    id: 25,
+    variant: 4,
+    name: "Sigma 30mm F1.4 EX DC",
+  },
+  SonyLensVariant {
+    id: 25,
+    variant: 5,
+    name: "Sigma 24mm F1.8 EX DG ASP Macro",
+  },
+  SonyLensVariant {
+    id: 28,
+    variant: 1,
+    name: "Tamron SP AF 90mm F2.8 Di Macro",
+  },
+  SonyLensVariant {
+    id: 28,
+    variant: 2,
+    name: "Tamron SP AF 180mm F3.5 Di LD [IF] Macro",
+  },
+  SonyLensVariant {
+    id: 30,
+    variant: 1,
+    name: "Sigma AF 10-20mm F4-5.6 EX DC",
+  },
+  SonyLensVariant {
+    id: 30,
+    variant: 2,
+    name: "Sigma AF 12-24mm F4.5-5.6 EX DG",
+  },
+  SonyLensVariant {
+    id: 30,
+    variant: 3,
+    name: "Sigma 28-70mm EX DG F2.8",
+  },
+  SonyLensVariant {
+    id: 30,
+    variant: 4,
+    name: "Sigma 55-200mm F4-5.6 DC",
+  },
+  SonyLensVariant {
+    id: 31,
+    variant: 1,
+    name: "Minolta/Sony AF 50mm F3.5 Macro",
+  },
+  SonyLensVariant {
+    id: 41,
+    variant: 1,
+    name: "Tamron SP AF 11-18mm F4.5-5.6 Di II LD Aspherical IF",
+  },
+  SonyLensVariant {
+    id: 48,
+    variant: 1,
+    name: "Carl Zeiss Vario-Sonnar T* 24-70mm F2.8 ZA SSM II (SAL2470Z2)",
+  },
+  SonyLensVariant {
+    id: 48,
+    variant: 2,
+    name: "Tamron SP 24-70mm F2.8 Di USD",
+  },
+  SonyLensVariant {
+    id: 52,
+    variant: 1,
+    name: "Sony 70-300mm F4.5-5.6 G SSM II (SAL70300G2)",
+  },
+  SonyLensVariant {
+    id: 52,
+    variant: 2,
+    name: "Tamron SP 70-300mm F4-5.6 Di USD",
+  },
+  SonyLensVariant {
+    id: 54,
+    variant: 1,
+    name: "Carl Zeiss Vario-Sonnar T* 16-35mm F2.8 ZA SSM II (SAL1635Z2)",
+  },
+  SonyLensVariant {
+    id: 55,
+    variant: 1,
+    name: "Sony DT 18-55mm F3.5-5.6 SAM II (SAL18552)",
+  },
+  SonyLensVariant {
+    id: 57,
+    variant: 1,
+    name: "Tamron SP AF 60mm F2 Di II LD [IF] Macro 1:1",
+  },
+  SonyLensVariant {
+    id: 57,
+    variant: 2,
+    name: "Tamron 18-270mm F3.5-6.3 Di II PZD",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 1,
+    name: "Tamron AF 18-200mm F3.5-6.3 XR Di II LD Aspherical [IF] Macro",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 2,
+    name: "Tamron AF 28-300mm F3.5-6.3 XR Di LD Aspherical [IF] Macro",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 3,
+    name: "Tamron AF 28-200mm F3.8-5.6 XR Di Aspherical [IF] Macro",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 4,
+    name: "Tamron SP AF 17-35mm F2.8-4 Di LD Aspherical IF",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 5,
+    name: "Sigma AF 50-150mm F2.8 EX DC APO HSM II",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 6,
+    name: "Sigma 10-20mm F3.5 EX DC HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 7,
+    name: "Sigma 70-200mm F2.8 II EX DG APO MACRO HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 8,
+    name: "Sigma 10mm F2.8 EX DC HSM Fisheye",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 9,
+    name: "Sigma 50mm F1.4 EX DG HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 10,
+    name: "Sigma 85mm F1.4 EX DG HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 11,
+    name: "Sigma 24-70mm F2.8 IF EX DG HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 12,
+    name: "Sigma 18-250mm F3.5-6.3 DC OS HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 13,
+    name: "Sigma 17-50mm F2.8 EX DC HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 14,
+    name: "Sigma 17-70mm F2.8-4 DC Macro HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 15,
+    name: "Sigma 150mm F2.8 EX DG OS HSM APO Macro",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 16,
+    name: "Sigma 150-500mm F5-6.3 APO DG OS HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 17,
+    name: "Tamron AF 28-105mm F4-5.6 [IF]",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 18,
+    name: "Sigma 35mm F1.4 DG HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 19,
+    name: "Sigma 18-35mm F1.8 DC HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 20,
+    name: "Sigma 50-500mm F4.5-6.3 APO DG OS HSM",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 21,
+    name: "Sigma 24-105mm F4 DG HSM | A",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 22,
+    name: "Sigma 30mm F1.4",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 23,
+    name: "Sigma 35mm F1.4 DG HSM | A",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 24,
+    name: "Sigma 105mm F2.8 EX DG OS HSM Macro",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 25,
+    name: "Sigma 180mm F2.8 EX DG OS HSM APO Macro",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 26,
+    name: "Sigma 18-300mm F3.5-6.3 DC Macro HSM | C",
+  },
+  SonyLensVariant {
+    id: 128,
+    variant: 27,
+    name: "Sigma 18-50mm F2.8-4.5 DC HSM",
+  },
+  SonyLensVariant {
+    id: 129,
+    variant: 1,
+    name: "Tamron 200-400mm F5.6 LD",
+  },
+  SonyLensVariant {
+    id: 129,
+    variant: 2,
+    name: "Tamron 70-300mm F4-5.6 LD",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 1,
+    name: "Tamron SP AF 17-50mm F2.8 XR Di II LD Aspherical",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 2,
+    name: "Tamron AF 18-250mm F3.5-6.3 XR Di II LD",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 3,
+    name: "Tamron AF 55-200mm F4-5.6 Di II LD Macro",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 4,
+    name: "Tamron AF 70-300mm F4-5.6 Di LD Macro 1:2",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 5,
+    name: "Tamron SP AF 200-500mm F5.0-6.3 Di LD IF",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 6,
+    name: "Tamron SP AF 10-24mm F3.5-4.5 Di II LD Aspherical IF",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 7,
+    name: "Tamron SP AF 70-200mm F2.8 Di LD IF Macro",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 8,
+    name: "Tamron SP AF 28-75mm F2.8 XR Di LD Aspherical IF",
+  },
+  SonyLensVariant {
+    id: 255,
+    variant: 9,
+    name: "Tamron AF 90-300mm F4.5-5.6 Telemacro",
+  },
+  SonyLensVariant {
+    id: 2551,
+    variant: 1,
+    name: "Sigma UC AF 28-70mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 2551,
+    variant: 2,
+    name: "Sigma AF 28-70mm F2.8",
+  },
+  SonyLensVariant {
+    id: 2551,
+    variant: 3,
+    name: "Sigma M-AF 70-200mm F2.8 EX Aspherical",
+  },
+  SonyLensVariant {
+    id: 2551,
+    variant: 4,
+    name: "Quantaray M-AF 35-80mm F4-5.6",
+  },
+  SonyLensVariant {
+    id: 2551,
+    variant: 5,
+    name: "Tokina 28-70mm F2.8-4.5 AF",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 1,
+    name: "Tokina 19-35mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 2,
+    name: "Tokina 28-70mm F2.8 AT-X",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 3,
+    name: "Tokina 80-400mm F4.5-5.6 AT-X AF II 840",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 4,
+    name: "Tokina AF PRO 28-80mm F2.8 AT-X 280",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 5,
+    name: "Tokina AT-X PRO [II] AF 28-70mm F2.6-2.8 270",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 6,
+    name: "Tamron AF 19-35mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 7,
+    name: "Angenieux AF 28-70mm F2.6",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 8,
+    name: "Tokina AT-X 17 AF 17mm F3.5",
+  },
+  SonyLensVariant {
+    id: 2552,
+    variant: 9,
+    name: "Tokina 20-35mm F3.5-4.5 II AF",
+  },
+  SonyLensVariant {
+    id: 2553,
+    variant: 1,
+    name: "Sigma ZOOM-alpha 35-135mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 2553,
+    variant: 2,
+    name: "Sigma 28-105mm F2.8-4 Aspherical",
+  },
+  SonyLensVariant {
+    id: 2553,
+    variant: 3,
+    name: "Sigma 28-105mm F4-5.6 UC",
+  },
+  SonyLensVariant {
+    id: 2553,
+    variant: 4,
+    name: "Tokina AT-X 242 AF 24-200mm F3.5-5.6",
+  },
+  SonyLensVariant {
+    id: 2555,
+    variant: 1,
+    name: "Sigma 70-210mm F4-5.6 APO",
+  },
+  SonyLensVariant {
+    id: 2555,
+    variant: 2,
+    name: "Sigma M-AF 70-200mm F2.8 EX APO",
+  },
+  SonyLensVariant {
+    id: 2555,
+    variant: 3,
+    name: "Sigma 75-200mm F2.8-3.5",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 1,
+    name: "Sigma 70-300mm F4-5.6 DL Macro",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 2,
+    name: "Sigma 300mm F4 APO Macro",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 3,
+    name: "Sigma AF 500mm F4.5 APO",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 4,
+    name: "Sigma AF 170-500mm F5-6.3 APO Aspherical",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 5,
+    name: "Tokina AT-X AF 300mm F4",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 6,
+    name: "Tokina AT-X AF 400mm F5.6 SD",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 7,
+    name: "Tokina AF 730 II 75-300mm F4.5-5.6",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 8,
+    name: "Sigma 800mm F5.6 APO",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 9,
+    name: "Sigma AF 400mm F5.6 APO Macro",
+  },
+  SonyLensVariant {
+    id: 2561,
+    variant: 10,
+    name: "Sigma 1000mm F8 APO",
+  },
+  SonyLensVariant {
+    id: 2563,
+    variant: 1,
+    name: "Sigma AF 50-500mm F4-6.3 EX DG APO",
+  },
+  SonyLensVariant {
+    id: 2563,
+    variant: 2,
+    name: "Sigma AF 170-500mm F5-6.3 APO Aspherical",
+  },
+  SonyLensVariant {
+    id: 2563,
+    variant: 3,
+    name: "Sigma AF 500mm F4.5 EX DG APO",
+  },
+  SonyLensVariant {
+    id: 2563,
+    variant: 4,
+    name: "Sigma 400mm F5.6 APO",
+  },
+  SonyLensVariant {
+    id: 2564,
+    variant: 1,
+    name: "Sigma 50mm F2.8 EX Macro",
+  },
+  SonyLensVariant {
+    id: 2566,
+    variant: 1,
+    name: "Sigma 17-35mm F2.8-4 EX Aspherical",
+  },
+  SonyLensVariant {
+    id: 2578,
+    variant: 1,
+    name: "Sigma 8mm F4 EX [DG] Fisheye",
+  },
+  SonyLensVariant {
+    id: 2578,
+    variant: 2,
+    name: "Sigma 14mm F3.5",
+  },
+  SonyLensVariant {
+    id: 2578,
+    variant: 3,
+    name: "Sigma 15mm F2.8 Fisheye",
+  },
+  SonyLensVariant {
+    id: 2579,
+    variant: 1,
+    name: "Tokina AT-X Pro DX 11-16mm F2.8",
+  },
+  SonyLensVariant {
+    id: 2581,
+    variant: 1,
+    name: "Sigma AF 90mm F2.8 Macro",
+  },
+  SonyLensVariant {
+    id: 2581,
+    variant: 2,
+    name: "Sigma AF 105mm F2.8 EX [DG] Macro",
+  },
+  SonyLensVariant {
+    id: 2581,
+    variant: 3,
+    name: "Sigma 180mm F5.6 Macro",
+  },
+  SonyLensVariant {
+    id: 2581,
+    variant: 4,
+    name: "Sigma 180mm F3.5 EX DG Macro",
+  },
+  SonyLensVariant {
+    id: 2581,
+    variant: 5,
+    name: "Tamron 90mm F2.8 Macro",
+  },
+  SonyLensVariant {
+    id: 2585,
+    variant: 1,
+    name: "Beroflex 35-135mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 2585,
+    variant: 2,
+    name: "Tamron 24-135mm F3.5-5.6",
+  },
+  SonyLensVariant {
+    id: 2589,
+    variant: 1,
+    name: "Tokina 80-200mm F2.8",
+  },
+  SonyLensVariant {
+    id: 2590,
+    variant: 1,
+    name: "Minolta AF 600mm F4 HS-APO G + Minolta AF 1.4x APO",
+  },
+  SonyLensVariant {
+    id: 2601,
+    variant: 1,
+    name: "Minolta AF 600mm F4 HS-APO G + Minolta AF 2x APO",
+  },
+  SonyLensVariant {
+    id: 4574,
+    variant: 1,
+    name: "Tamron SP AF 90mm F2.5",
+  },
+  SonyLensVariant {
+    id: 4574,
+    variant: 2,
+    name: "Tokina RF 500mm F8.0 x2",
+  },
+  SonyLensVariant {
+    id: 4574,
+    variant: 3,
+    name: "Tokina 300mm F2.8 x2",
+  },
+  SonyLensVariant {
+    id: 6553,
+    variant: 1,
+    name: "Arax MC 35mm F2.8 Tilt+Shift",
+  },
+  SonyLensVariant {
+    id: 6553,
+    variant: 2,
+    name: "Arax MC 80mm F2.8 Tilt+Shift",
+  },
+  SonyLensVariant {
+    id: 6553,
+    variant: 3,
+    name: "Zenitar MF 16mm F2.8 Fisheye M42",
+  },
+  SonyLensVariant {
+    id: 6553,
+    variant: 4,
+    name: "Samyang 500mm Mirror F8.0",
+  },
+  SonyLensVariant {
+    id: 6553,
+    variant: 5,
+    name: "Pentacon Auto 135mm F2.8",
+  },
+  SonyLensVariant {
+    id: 6553,
+    variant: 6,
+    name: "Pentacon Auto 29mm F2.8",
+  },
+  SonyLensVariant {
+    id: 6553,
+    variant: 7,
+    name: "Helios 44-2 58mm F2.0",
+  },
+  SonyLensVariant {
+    id: 25511,
+    variant: 1,
+    name: "Sigma UC AF 28-70mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 25511,
+    variant: 2,
+    name: "Sigma AF 28-70mm F2.8",
+  },
+  SonyLensVariant {
+    id: 25511,
+    variant: 3,
+    name: "Sigma M-AF 70-200mm F2.8 EX Aspherical",
+  },
+  SonyLensVariant {
+    id: 25511,
+    variant: 4,
+    name: "Quantaray M-AF 35-80mm F4-5.6",
+  },
+  SonyLensVariant {
+    id: 25511,
+    variant: 5,
+    name: "Tokina 28-70mm F2.8-4.5 AF",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 1,
+    name: "Tokina 19-35mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 2,
+    name: "Tokina 28-70mm F2.8 AT-X",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 3,
+    name: "Tokina 80-400mm F4.5-5.6 AT-X AF II 840",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 4,
+    name: "Tokina AF PRO 28-80mm F2.8 AT-X 280",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 5,
+    name: "Tokina AT-X PRO [II] AF 28-70mm F2.6-2.8 270",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 6,
+    name: "Tamron AF 19-35mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 7,
+    name: "Angenieux AF 28-70mm F2.6",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 8,
+    name: "Tokina AT-X 17 AF 17mm F3.5",
+  },
+  SonyLensVariant {
+    id: 25521,
+    variant: 9,
+    name: "Tokina 20-35mm F3.5-4.5 II AF",
+  },
+  SonyLensVariant {
+    id: 25531,
+    variant: 1,
+    name: "Sigma ZOOM-alpha 35-135mm F3.5-4.5",
+  },
+  SonyLensVariant {
+    id: 25531,
+    variant: 2,
+    name: "Sigma 28-105mm F2.8-4 Aspherical",
+  },
+  SonyLensVariant {
+    id: 25531,
+    variant: 3,
+    name: "Sigma 28-105mm F4-5.6 UC",
+  },
+  SonyLensVariant {
+    id: 25531,
+    variant: 4,
+    name: "Tokina AT-X 242 AF 24-200mm F3.5-5.6",
+  },
+  SonyLensVariant {
+    id: 25551,
+    variant: 1,
+    name: "Sigma 70-210mm F4-5.6 APO",
+  },
+  SonyLensVariant {
+    id: 25551,
+    variant: 2,
+    name: "Sigma M-AF 70-200mm F2.8 EX APO",
+  },
+  SonyLensVariant {
+    id: 25551,
+    variant: 3,
+    name: "Sigma 75-200mm F2.8-3.5",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 1,
+    name: "Sigma 70-300mm F4-5.6 DL Macro",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 2,
+    name: "Sigma 300mm F4 APO Macro",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 3,
+    name: "Sigma AF 500mm F4.5 APO",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 4,
+    name: "Sigma AF 170-500mm F5-6.3 APO Aspherical",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 5,
+    name: "Tokina AT-X AF 300mm F4",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 6,
+    name: "Tokina AT-X AF 400mm F5.6 SD",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 7,
+    name: "Tokina AF 730 II 75-300mm F4.5-5.6",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 8,
+    name: "Sigma 800mm F5.6 APO",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 9,
+    name: "Sigma AF 400mm F5.6 APO Macro",
+  },
+  SonyLensVariant {
+    id: 25611,
+    variant: 10,
+    name: "Sigma 1000mm F8 APO",
+  },
+  SonyLensVariant {
+    id: 25631,
+    variant: 1,
+    name: "Sigma AF 50-500mm F4-6.3 EX DG APO",
+  },
+  SonyLensVariant {
+    id: 25631,
+    variant: 2,
+    name: "Sigma AF 170-500mm F5-6.3 APO Aspherical",
+  },
+  SonyLensVariant {
+    id: 25631,
+    variant: 3,
+    name: "Sigma AF 500mm F4.5 EX DG APO",
+  },
+  SonyLensVariant {
+    id: 25631,
+    variant: 4,
+    name: "Sigma 400mm F5.6 APO",
+  },
+  SonyLensVariant {
+    id: 25641,
+    variant: 1,
+    name: "Sigma 50mm F2.8 EX Macro",
+  },
+  SonyLensVariant {
+    id: 25661,
+    variant: 1,
+    name: "Sigma 17-35mm F2.8-4 EX Aspherical",
+  },
+  SonyLensVariant {
+    id: 25781,
+    variant: 1,
+    name: "Sigma 8mm F4 EX [DG] Fisheye",
+  },
+  SonyLensVariant {
+    id: 25781,
+    variant: 2,
+    name: "Sigma 14mm F3.5",
+  },
+  SonyLensVariant {
+    id: 25781,
+    variant: 3,
+    name: "Sigma 15mm F2.8 Fisheye",
+  },
+  SonyLensVariant {
+    id: 25791,
+    variant: 1,
+    name: "Tokina AT-X Pro DX 11-16mm F2.8",
+  },
+  SonyLensVariant {
+    id: 25811,
+    variant: 1,
+    name: "Sigma AF 90mm F2.8 Macro",
+  },
+  SonyLensVariant {
+    id: 25811,
+    variant: 2,
+    name: "Sigma AF 105mm F2.8 EX [DG] Macro",
+  },
+  SonyLensVariant {
+    id: 25811,
+    variant: 3,
+    name: "Sigma 180mm F5.6 Macro",
+  },
+  SonyLensVariant {
+    id: 25811,
+    variant: 4,
+    name: "Sigma 180mm F3.5 EX DG Macro",
+  },
+  SonyLensVariant {
+    id: 25811,
+    variant: 5,
+    name: "Tamron 90mm F2.8 Macro",
+  },
+  SonyLensVariant {
+    id: 25858,
+    variant: 1,
+    name: "Tamron 24-135mm F3.5-5.6",
+  },
+  SonyLensVariant {
+    id: 25891,
+    variant: 1,
+    name: "Tokina 80-200mm F2.8",
+  },
+  SonyLensVariant {
+    id: 25901,
+    variant: 1,
+    name: "Minolta AF 600mm F4 HS-APO G + Minolta AF 1.4x APO",
+  },
+  SonyLensVariant {
+    id: 26011,
+    variant: 1,
+    name: "Minolta AF 600mm F4 HS-APO G + Minolta AF 2x APO",
+  },
+  SonyLensVariant {
+    id: 45741,
+    variant: 1,
+    name: "Tamron SP AF 90mm F2.5",
+  },
+  SonyLensVariant {
+    id: 45741,
+    variant: 2,
+    name: "Tokina RF 500mm F8.0 x2",
+  },
+  SonyLensVariant {
+    id: 45741,
+    variant: 3,
+    name: "Tokina 300mm F2.8 x2",
+  },
+  SonyLensVariant {
+    id: 65535,
+    variant: 1,
+    name: "Arax MC 35mm F2.8 Tilt+Shift",
+  },
+  SonyLensVariant {
+    id: 65535,
+    variant: 2,
+    name: "Arax MC 80mm F2.8 Tilt+Shift",
+  },
+  SonyLensVariant {
+    id: 65535,
+    variant: 3,
+    name: "Zenitar MF 16mm F2.8 Fisheye M42",
+  },
+  SonyLensVariant {
+    id: 65535,
+    variant: 4,
+    name: "Samyang 500mm Mirror F8.0",
+  },
+  SonyLensVariant {
+    id: 65535,
+    variant: 5,
+    name: "Pentacon Auto 135mm F2.8",
+  },
+  SonyLensVariant {
+    id: 65535,
+    variant: 6,
+    name: "Pentacon Auto 29mm F2.8",
+  },
+  SonyLensVariant {
+    id: 65535,
+    variant: 7,
+    name: "Helios 44-2 58mm F2.0",
+  },
+];
+
+/// The `id.1`, `id.2`, … secondary names for `id`, in ascending `variant`
+/// order — the order `PrintLensID` (`Exif.pm:5969`) scans them. Empty when
+/// `id` has no float-keyed variants.
+#[must_use]
+pub fn lens_variants(id: u32) -> &'static [SonyLensVariant] {
+  let lo = SONY_LENS_VARIANTS_AMOUNT.partition_point(|v| v.id < id);
+  let hi = SONY_LENS_VARIANTS_AMOUNT.partition_point(|v| v.id <= id);
+  // `partition_point` guarantees `lo <= hi <= len`, so the slice is in range.
+  SONY_LENS_VARIANTS_AMOUNT.get(lo..hi).unwrap_or(&[])
+}
+
 #[cfg(test)]
 // The file-level `#![deny(clippy::indexing_slicing)]` is a parser-panic-safety
 // contract (Phase C S2); the test-builder helpers index fixed-layout buffers
@@ -1084,5 +2065,66 @@ mod tests {
   fn unmatched_id_is_none() {
     // 60000 is not a key — caller renders the standard `Unknown (N)`.
     assert!(lookup_name(60000).is_none());
+  }
+
+  #[test]
+  fn variants_sorted_and_contiguous_from_one() {
+    // Sorted by `(id, variant)`; within an id the variants run `1..=N` with no
+    // gap, because `PrintLensID` stops scanning at the first missing `id.i`.
+    let mut prev_id: Option<u32> = None;
+    let mut expect_var: u8 = 1;
+    for v in SONY_LENS_VARIANTS_AMOUNT {
+      if prev_id == Some(v.id) {
+        assert_eq!(
+          v.variant, expect_var,
+          "non-contiguous variant for id {}",
+          v.id
+        );
+        expect_var += 1;
+      } else {
+        if let Some(p) = prev_id {
+          assert!(
+            v.id > p,
+            "SONY_LENS_VARIANTS_AMOUNT not sorted by id: {} after {p}",
+            v.id
+          );
+        }
+        assert_eq!(v.variant, 1, "first variant for id {} must be 1", v.id);
+        expect_var = 2;
+        prev_id = Some(v.id);
+      }
+    }
+  }
+
+  #[test]
+  fn lens_variants_129_tamron_in_order() {
+    let names: Vec<&str> = lens_variants(129).iter().map(|v| v.name).collect();
+    assert_eq!(
+      names,
+      ["Tamron 200-400mm F5.6 LD", "Tamron 70-300mm F4-5.6 LD"]
+    );
+  }
+
+  #[test]
+  fn lens_variants_55_single() {
+    let vs = lens_variants(55);
+    assert_eq!(vs.len(), 1);
+    assert_eq!(
+      vs.first().map(|v| v.name),
+      Some("Sony DT 18-55mm F3.5-5.6 SAM II (SAL18552)")
+    );
+  }
+
+  #[test]
+  fn lens_variants_128_has_twentyseven() {
+    // The largest run in the table (Sigma/Tamron A-mount, `128.1`..`128.27`).
+    assert_eq!(lens_variants(128).len(), 27);
+  }
+
+  #[test]
+  fn lens_variants_absent_is_empty() {
+    // 0 is a primary (Minolta AF 28-85mm) with no float entries; 999_999 unknown.
+    assert!(lens_variants(0).is_empty());
+    assert!(lens_variants(999_999).is_empty());
   }
 }

--- a/src/exif/makernotes/vendors/sony/lens_info.rs
+++ b/src/exif/makernotes/vendors/sony/lens_info.rs
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// exifast — a 1:1 Rust port of ExifTool (Phil Harvey). See THIRD_PARTY.md.
+
+//! `GetLensInfo` — recover a focal-length / aperture range from a lens model
+//! string (`Exif.pm:5825-5841`).
+//!
+//! `PrintLensID` (`Exif.pm:5881`, wired in a later chunk) calls this on the
+//! printed `LensSpec` to obtain `(focalMin, focalMax, apertureMin,
+//! apertureMax)` and disambiguate the float-keyed candidates of
+//! [`super::lens_types`] / [`super::amount_lens_types`].
+//!
+//! Faithful to the ExifTool regex (the `$unk` flag — which permits `?`
+//! placeholders — is unused on the Sony `LensSpec` path and is omitted):
+//!
+//! ```text
+//! (\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?\s*mm.*?(?:[fF]\/?\s*)(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?
+//! ```
+//!
+//! The crate carries no regex engine (it is `no_std`), so the fixed-shape
+//! pattern is matched by hand: an unanchored leftmost scan, the greedy
+//! optional focal-range max (with backtrack to "absent"), the lazy `.*?`
+//! gap (`.` = `[^\n]`), and the deterministic `[fF]\/?\s*` aperture head.
+
+#![deny(clippy::indexing_slicing)]
+
+/// Parse min/max focal length and min/max aperture from a lens model string.
+///
+/// Returns `(focalMin, focalMax, apertureMin, apertureMax)`, or `None` when
+/// the string contains no `…mm … f/…` pattern. An absent range max equals the
+/// min (`Exif.pm:5834-5835`, `$a[1] or $a[1] = $a[0]`).
+#[must_use]
+pub fn get_lens_info(lens: &str) -> Option<(f64, f64, f64, f64)> {
+  let b = lens.as_bytes();
+  // The pattern is unanchored: the engine takes the leftmost match, so try
+  // each start position in turn and return the first that matches.
+  for start in 0..b.len() {
+    if let Some(m) = match_at(b, start) {
+      return Some(m);
+    }
+  }
+  None
+}
+
+/// Match the whole pattern anchored at `start`, mirroring the greedy/lazy/
+/// backtracking choices of the Perl engine for this fixed shape.
+fn match_at(b: &[u8], start: usize) -> Option<(f64, f64, f64, f64)> {
+  // ($1) short focal — required `\d+(?:\.\d+)?`.
+  let (f_min, p1) = parse_number(b, start)?;
+  // (?:-($2))? long focal — greedy optional; on failure of the remainder,
+  // backtrack to the "absent" branch.
+  for take_long in [true, false] {
+    let (f_max_s, p2) = if take_long {
+      match parse_dash_number(b, p1) {
+        Some((s, p)) => (Some(s), p),
+        None => continue,
+      }
+    } else {
+      (None, p1)
+    };
+    // `\s*mm`
+    let p3 = skip_space(b, p2);
+    let Some(p4) = match_mm(b, p3) else { continue };
+    // `.*?` (lazy, `.` = `[^\n]`) then `(?:[fF]\/?\s*)($3)(?:-($4))?`.
+    let mut j = p4;
+    loop {
+      if let Some((a_min, a_max_s)) = match_aperture(b, j) {
+        return Some((
+          f_min,
+          default_max(f_min, f_max_s),
+          a_min,
+          default_max(a_min, a_max_s),
+        ));
+      }
+      // Extend the lazy gap by one char; `.` cannot cross a newline or the end.
+      match b.get(j) {
+        Some(&c) if c != b'\n' => j += 1,
+        _ => break,
+      }
+    }
+  }
+  None
+}
+
+/// Match `[fF]\/?\s*(\d+(?:\.\d+)?)(?:-(\d+(?:\.\d+)?))?` at `i`. Returns the
+/// required min aperture and the optional max-aperture digit slice.
+fn match_aperture(b: &[u8], i: usize) -> Option<(f64, Option<&[u8]>)> {
+  match b.get(i) {
+    Some(b'f' | b'F') => {}
+    _ => return None,
+  }
+  let mut p = i + 1;
+  if matches!(b.get(p), Some(b'/')) {
+    p += 1;
+  }
+  p = skip_space(b, p);
+  let (a_min, p3) = parse_number(b, p)?;
+  // Trailing optional `-($4)`; nothing follows, so no backtrack is needed.
+  let a_max_s = parse_dash_number(b, p3).map(|(s, _)| s);
+  Some((a_min, a_max_s))
+}
+
+/// `\d+(?:\.\d+)?` at `i` → the matched digit slice and the end index.
+fn parse_number_str(b: &[u8], i: usize) -> Option<(&[u8], usize)> {
+  let mut j = i;
+  while matches!(b.get(j), Some(c) if c.is_ascii_digit()) {
+    j += 1;
+  }
+  if j == i {
+    return None; // `\d+` needs at least one digit
+  }
+  // `(?:\.\d+)?` — only consume the dot when at least one digit follows it.
+  if matches!(b.get(j), Some(b'.')) {
+    let frac = j + 1;
+    let mut k = frac;
+    while matches!(b.get(k), Some(c) if c.is_ascii_digit()) {
+      k += 1;
+    }
+    if k > frac {
+      j = k;
+    }
+  }
+  b.get(i..j).map(|s| (s, j))
+}
+
+/// As [`parse_number_str`] but also parses the slice to `f64`.
+fn parse_number(b: &[u8], i: usize) -> Option<(f64, usize)> {
+  let (s, j) = parse_number_str(b, i)?;
+  Some((parse_f64(s)?, j))
+}
+
+/// Match `-` then a number; returns the number's digit slice and end index.
+fn parse_dash_number(b: &[u8], i: usize) -> Option<(&[u8], usize)> {
+  if !matches!(b.get(i), Some(b'-')) {
+    return None;
+  }
+  parse_number_str(b, i + 1)
+}
+
+/// `\s*` — Perl `\s` = `[ \t\n\r\x0c\x0b]`. Returns the index past the run.
+fn skip_space(b: &[u8], mut i: usize) -> usize {
+  while matches!(b.get(i), Some(c) if is_perl_space(*c)) {
+    i += 1;
+  }
+  i
+}
+
+/// `mm` literal at `i` → the index past it.
+fn match_mm(b: &[u8], i: usize) -> Option<usize> {
+  if matches!(b.get(i), Some(b'm')) && matches!(b.get(i + 1), Some(b'm')) {
+    Some(i + 2)
+  } else {
+    None
+  }
+}
+
+const fn is_perl_space(c: u8) -> bool {
+  matches!(c, b' ' | b'\t' | b'\n' | b'\r' | 0x0c | 0x0b)
+}
+
+/// Apply `$a[i] or $a[i] = $a[i-1]`: the optional max defaults to `min` when
+/// the capture is absent or the Perl-false string `"0"`. Any other captured
+/// number — including `"0.0"`/`"00"`, which Perl treats as true — is parsed.
+fn default_max(min: f64, max_s: Option<&[u8]>) -> f64 {
+  match max_s {
+    Some(s) if !is_perl_false_number(s) => parse_f64(s).unwrap_or(min),
+    _ => min,
+  }
+}
+
+/// The only digit string Perl's boolean context treats as false is `"0"`.
+fn is_perl_false_number(s: &[u8]) -> bool {
+  s.len() == 1 && s.first() == Some(&b'0')
+}
+
+fn parse_f64(s: &[u8]) -> Option<f64> {
+  core::str::from_utf8(s).ok()?.parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// Compare against values captured from the bundled
+  /// `Image::ExifTool::Exif::GetLensInfo`.
+  fn check(lens: &str, want: Option<(f64, f64, f64, f64)>) {
+    assert_eq!(get_lens_info(lens), want, "lens = {lens:?}");
+  }
+
+  #[test]
+  fn zoom_with_focal_and_aperture_ranges() {
+    check("Sony DT 18-55mm F3.5-5.6 SAM", Some((18.0, 55.0, 3.5, 5.6)));
+    check("Tamron 70-300mm F4-5.6 LD", Some((70.0, 300.0, 4.0, 5.6)));
+    check(
+      "Sony E PZ 16-50mm F3.5-5.6 OSS",
+      Some((16.0, 50.0, 3.5, 5.6)),
+    );
+  }
+
+  #[test]
+  fn prime_defaults_max_to_min() {
+    // No focal range and no aperture range: both maxes equal their mins.
+    check("50mm F1.4", Some((50.0, 50.0, 1.4, 1.4)));
+    check("Sigma 30mm F1.4 DC DN | C", Some((30.0, 30.0, 1.4, 1.4)));
+    check("Viltrox 27mm F1.2 E Pro", Some((27.0, 27.0, 1.2, 1.2)));
+    check("Samyang 500mm Mirror F8.0", Some((500.0, 500.0, 8.0, 8.0)));
+  }
+
+  #[test]
+  fn zoom_constant_aperture() {
+    check("Sony FE 24-70mm F2.8 GM", Some((24.0, 70.0, 2.8, 2.8)));
+    check(
+      "Sony FE 100-400mm F4.5 GM OSS",
+      Some((100.0, 400.0, 4.5, 4.5)),
+    );
+    check(
+      "Tamron SP 24-70mm F2.8 Di USD",
+      Some((24.0, 70.0, 2.8, 2.8)),
+    );
+    // Leading "T*" must not be mistaken for the focal; leftmost real match wins.
+    check(
+      "Carl Zeiss Vario-Sonnar T* 24-70mm F2.8 ZA SSM II (SAL2470Z2)",
+      Some((24.0, 70.0, 2.8, 2.8)),
+    );
+  }
+
+  #[test]
+  fn lowercase_f_and_slash() {
+    // `[fF]\/?` accepts a lowercase `f` and an optional `/`.
+    check("Some 35mm f/2", Some((35.0, 35.0, 2.0, 2.0)));
+  }
+
+  #[test]
+  fn no_mm_no_aperture_is_none() {
+    // A bare adapter name has a digit ("EA4") but no `mm … f/…` shape.
+    check("Sony LA-EA4 Adapter", None);
+    check("", None);
+    check("Metabones Canon EF Speed Booster", None);
+  }
+}

--- a/src/exif/makernotes/vendors/sony/lens_types.rs
+++ b/src/exif/makernotes/vendors/sony/lens_types.rs
@@ -3,21 +3,22 @@
 
 //! Sony E-mount lens-type lookup table — `%sonyLensTypes2` (`Sony.pm:56-387`).
 //!
-//! Bundled has FLOAT-keyed ambiguity entries (e.g. `0.1 => 'Sigma 19mm F2.8'`,
-//! `0.2 => 'Sigma 30mm F2.8'`) that disambiguate via LensSpec when multiple
-//! lenses share an ID. Phase 3 ports the INTEGER keys only — the primary
-//! lens name per ID. Float-keyed disambiguation is a deferred follow-up
-//! (file an issue against #62 — "Sony lens disambiguation via LensSpec").
+//! [`SONY_LENS_TYPES`] holds the INTEGER keys — the primary lens name per ID.
+//! These are the lens IDs used by `Sony::CameraSettings` and the AF-info
+//! sub-tables, and back the `LensType` `PrintConv`.
 //!
-//! The integer keys ARE the lens IDs used by `Sony::CameraSettings` and the
-//! AF-info sub-tables; the float entries are bundled-only secondary names
-//! shown when the primary doesn't match LensSpec.
+//! Bundled also carries FLOAT-keyed ambiguity entries (e.g. `0.1 => 'Sigma
+//! 19mm F2.8 [EX] DN'`, `49473.1 => 'Tokina atx-m 85mm F1.8 FE'`): secondary
+//! names appended after the primary when several lenses share an ID. They are
+//! ported in [`SONY_LENS_VARIANTS`] / [`lens_variants`], keyed by the integer
+//! ID plus the fractional suffix taken as an integer "variant" (`0.13` →
+//! variant 13). `PrintLensID` (`Exif.pm:5881`) consumes them — together with
+//! [`super::lens_info::get_lens_info`] over `LensSpec` — to pick the actual
+//! lens. That wiring lands in a later chunk, so the variant table is inert
+//! here.
 //!
-//! Phase 3 also doesn't port `%sonyLensTypes` (the A-mount adapter table)
-//! — that's filled at runtime in bundled (`Sony.pm:10963` `%sonyLensTypes =
-//! %$minoltaTypes`) from `%Image::ExifTool::Minolta::minoltaLensTypes`.
-//! A-mount decoding is a deferred long-tail item; only E-mount IDs are
-//! ported here.
+//! The A-mount (Minolta-backed) `%sonyLensTypes` is ported separately in
+//! [`super::amount_lens_types`].
 
 #![deny(clippy::indexing_slicing)]
 
@@ -28,6 +29,20 @@ use smol_str::SmolStr;
 pub struct SonyLensType {
   /// The integer lens-type ID (the key in bundled).
   pub id: u32,
+  /// The lens model name.
+  pub name: &'static str,
+}
+
+/// One FLOAT-keyed disambiguation entry of `%sonyLensTypes2` — a secondary
+/// lens name `PrintLensID` considers after the primary [`SonyLensType`] when
+/// several lenses share the integer `id`.
+#[derive(Debug, Clone, Copy)]
+pub struct SonyLensVariant {
+  /// The integer part of the bundled float key (the shared lens-type ID).
+  pub id: u32,
+  /// The fractional suffix taken as an integer (`49473.1` → 1, `0.13` → 13).
+  /// `PrintLensID` scans `id.1`, `id.2`, … in ascending order.
+  pub variant: u8,
   /// The lens model name.
   pub name: &'static str,
 }
@@ -85,6 +100,10 @@ pub const SONY_LENS_TYPES: &[SonyLensType] = &[
   SonyLensType {
     id: 22,
     name: "Samyang AF 24-60mm F2.8",
+  },
+  SonyLensType {
+    id: 24,
+    name: "Samyang AF 85mm F1.8 P FE",
   },
   SonyLensType {
     id: 44,
@@ -439,6 +458,10 @@ pub const SONY_LENS_TYPES: &[SonyLensType] = &[
     name: "Sony FE 100mm F2.8 Macro GM OSS",
   },
   SonyLensType {
+    id: 32895,
+    name: "Sony FE 100-400mm F4.5 GM OSS",
+  },
+  SonyLensType {
     id: 33072,
     name: "Sony FE 70-200mm F2.8 GM OSS + 1.4X Teleconverter",
   },
@@ -521,6 +544,14 @@ pub const SONY_LENS_TYPES: &[SonyLensType] = &[
   SonyLensType {
     id: 33094,
     name: "Sony FE 100mm F2.8 Macro GM OSS + 2X Teleconverter",
+  },
+  SonyLensType {
+    id: 33095,
+    name: "Sony FE 100-400mm F4.5 GM OSS + 1.4X Teleconverter",
+  },
+  SonyLensType {
+    id: 33096,
+    name: "Sony FE 100-400mm F4.5 GM OSS + 2X Teleconverter",
   },
   SonyLensType {
     id: 49201,
@@ -939,6 +970,14 @@ pub const SONY_LENS_TYPES: &[SonyLensType] = &[
     name: "Sigma 135mm F1.4 DG | A",
   },
   SonyLensType {
+    id: 50563,
+    name: "Sigma 35mm F1.4 DG II | A",
+  },
+  SonyLensType {
+    id: 50564,
+    name: "Sigma 15mm F1.4 DC | C",
+  },
+  SonyLensType {
     id: 50992,
     name: "Voigtlander SUPER WIDE-HELIAR 15mm F4.5 III",
   },
@@ -1001,6 +1040,10 @@ pub const SONY_LENS_TYPES: &[SonyLensType] = &[
   SonyLensType {
     id: 51009,
     name: "Voigtlander NOKTON 28mm F1.5 Aspherical",
+  },
+  SonyLensType {
+    id: 51011,
+    name: "Voigtlander APO-LANTHAR 28mm F2 Aspherical",
   },
   SonyLensType {
     id: 51072,
@@ -1067,6 +1110,10 @@ pub const SONY_LENS_TYPES: &[SonyLensType] = &[
     name: "LAOWA FFII 12mm F2.8 C&D Dreamer",
   },
   SonyLensType {
+    id: 61600,
+    name: "Thypoch AF 24-50mm F2.8 FE",
+  },
+  SonyLensType {
     id: 61760,
     name: "Viltrox 135mm F1.8 FE LAB",
   },
@@ -1083,16 +1130,48 @@ pub const SONY_LENS_TYPES: &[SonyLensType] = &[
     name: "Viltrox 85mm F1.4 FE PRO",
   },
   SonyLensType {
+    id: 61766,
+    name: "Viltrox 40mm F2.5 FE Air",
+  },
+  SonyLensType {
     id: 61767,
     name: "Viltrox 50mm F2.0 FE AIR",
+  },
+  SonyLensType {
+    id: 61768,
+    name: "Viltrox 25mm F1.7 E Air",
   },
   SonyLensType {
     id: 61776,
     name: "Viltrox 50mm F1.4 FE PRO",
   },
   SonyLensType {
+    id: 61777,
+    name: "Viltrox 9mm F2.8 E Air",
+  },
+  SonyLensType {
+    id: 61778,
+    name: "Viltrox 14mm F4.0 FE Air",
+  },
+  SonyLensType {
+    id: 61779,
+    name: "Viltrox 56mm F1.2 E Pro",
+  },
+  SonyLensType {
     id: 61780,
     name: "Viltrox 85mm F2.0 FE EVO",
+  },
+  SonyLensType {
+    id: 61781,
+    name: "Viltrox 55mm F1.8 FE EVO",
+  },
+  SonyLensType {
+    id: 61783,
+    name: "Viltrox 15mm F1.7 E Air",
+  },
+  SonyLensType {
+    id: 61789,
+    name: "Viltrox 35mm F1.8 II FE EVO",
   },
 ];
 
@@ -1107,6 +1186,224 @@ pub fn lookup_name(id: u32) -> Option<SmolStr> {
     Ok(i) => SONY_LENS_TYPES.get(i).map(|t| SmolStr::from(t.name)),
     Err(_) => None,
   }
+}
+
+/// FLOAT-keyed disambiguation entries of `%sonyLensTypes2`, sorted by
+/// `(id, variant)`. Each shares its `id` with a primary [`SONY_LENS_TYPES`]
+/// row; `PrintLensID` appends [`lens_variants`]`(id)` after that primary.
+/// Inert until the `PrintLensID` wiring lands.
+pub const SONY_LENS_VARIANTS: &[SonyLensVariant] = &[
+  SonyLensVariant {
+    id: 0,
+    variant: 1,
+    name: "Sigma 19mm F2.8 [EX] DN",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 2,
+    name: "Sigma 30mm F2.8 [EX] DN",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 3,
+    name: "Sigma 60mm F2.8 DN",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 4,
+    name: "Sony E 18-200mm F3.5-6.3 OSS LE",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 5,
+    name: "Tamron 18-200mm F3.5-6.3 Di III VC",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 6,
+    name: "Tokina FiRIN 20mm F2 FE AF",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 7,
+    name: "Tokina FiRIN 20mm F2 FE MF",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 8,
+    name: "Zeiss Touit 12mm F2.8",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 9,
+    name: "Zeiss Touit 32mm F1.8",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 10,
+    name: "Zeiss Touit 50mm F2.8 Macro",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 11,
+    name: "Zeiss Loxia 50mm F2",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 12,
+    name: "Zeiss Loxia 35mm F2",
+  },
+  SonyLensVariant {
+    id: 0,
+    variant: 13,
+    name: "Viltrox 85mm F1.8",
+  },
+  SonyLensVariant {
+    id: 32789,
+    variant: 1,
+    name: "Samyang AF 50mm F1.4",
+  },
+  SonyLensVariant {
+    id: 32790,
+    variant: 1,
+    name: "Samyang AF 14mm F2.8",
+  },
+  SonyLensVariant {
+    id: 32794,
+    variant: 1,
+    name: "Samyang AF 24mm F2.8",
+  },
+  SonyLensVariant {
+    id: 32794,
+    variant: 2,
+    name: "Samyang AF 35mm F2.8",
+  },
+  SonyLensVariant {
+    id: 32796,
+    variant: 1,
+    name: "Viltrox PFU RBMH 85mm F1.8",
+  },
+  SonyLensVariant {
+    id: 32823,
+    variant: 1,
+    name: "Samyang AF 85mm F1.4",
+  },
+  SonyLensVariant {
+    id: 49201,
+    variant: 1,
+    name: "Zeiss Touit 32mm F1.8",
+  },
+  SonyLensVariant {
+    id: 49201,
+    variant: 2,
+    name: "Zeiss Touit 50mm F2.8",
+  },
+  SonyLensVariant {
+    id: 49473,
+    variant: 1,
+    name: "Tokina atx-m 85mm F1.8 FE",
+  },
+  SonyLensVariant {
+    id: 49473,
+    variant: 2,
+    name: "Viltrox 23mm F1.4 E",
+  },
+  SonyLensVariant {
+    id: 49473,
+    variant: 3,
+    name: "Viltrox 56mm F1.4 E",
+  },
+  SonyLensVariant {
+    id: 49473,
+    variant: 4,
+    name: "Viltrox 85mm F1.8 II FE",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 1,
+    name: "Viltrox 13mm F1.4 E",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 2,
+    name: "Viltrox 16mm F1.8 FE",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 3,
+    name: "Viltrox 23mm F1.4 E",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 4,
+    name: "Viltrox 24mm F1.8 FE",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 5,
+    name: "Viltrox 28mm F1.8 FE",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 6,
+    name: "Viltrox 33mm F1.4 E",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 7,
+    name: "Viltrox 35mm F1.8 FE",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 8,
+    name: "Viltrox 50mm F1.8 FE",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 9,
+    name: "Viltrox 75mm F1.2 E Pro",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 10,
+    name: "Viltrox 20mm F2.8 FE Air",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 11,
+    name: "Viltrox 135mm F1.8 FE LAB",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 12,
+    name: "Viltrox 27mm F1.2 E Pro",
+  },
+  SonyLensVariant {
+    id: 49474,
+    variant: 13,
+    name: "Viltrox 56mm F1.4 E",
+  },
+  SonyLensVariant {
+    id: 51505,
+    variant: 1,
+    name: "Samyang AF 35mm F2.8",
+  },
+  SonyLensVariant {
+    id: 51510,
+    variant: 1,
+    name: "Samyang AF 35mm F1.8",
+  },
+];
+
+/// The `id.1`, `id.2`, … secondary names for `id`, in ascending `variant`
+/// order — the order `PrintLensID` (`Exif.pm:5969`) scans them. Empty when
+/// `id` has no float-keyed variants.
+#[must_use]
+pub fn lens_variants(id: u32) -> &'static [SonyLensVariant] {
+  let lo = SONY_LENS_VARIANTS.partition_point(|v| v.id < id);
+  let hi = SONY_LENS_VARIANTS.partition_point(|v| v.id <= id);
+  // `partition_point` guarantees `lo <= hi <= len`, so the slice is in range.
+  SONY_LENS_VARIANTS.get(lo..hi).unwrap_or(&[])
 }
 
 #[cfg(test)]
@@ -1168,5 +1465,86 @@ mod tests {
   #[test]
   fn lookup_unknown_id_returns_none() {
     assert!(lookup_name(987654).is_none());
+  }
+
+  #[test]
+  fn variants_sorted_and_contiguous_from_one() {
+    // Sorted by `(id, variant)`; within an id the variants run `1..=N` with no
+    // gap, because `PrintLensID` stops scanning at the first missing `id.i`.
+    let mut prev_id: Option<u32> = None;
+    let mut expect_var: u8 = 1;
+    for v in SONY_LENS_VARIANTS {
+      if prev_id == Some(v.id) {
+        assert_eq!(
+          v.variant, expect_var,
+          "non-contiguous variant for id {}",
+          v.id
+        );
+        expect_var += 1;
+      } else {
+        if let Some(p) = prev_id {
+          assert!(
+            v.id > p,
+            "SONY_LENS_VARIANTS not sorted by id: {} after {p}",
+            v.id
+          );
+        }
+        assert_eq!(v.variant, 1, "first variant for id {} must be 1", v.id);
+        expect_var = 2;
+        prev_id = Some(v.id);
+      }
+    }
+  }
+
+  #[test]
+  fn lens_variants_49473_tamron_tokina_viltrox_in_order() {
+    let names: Vec<&str> = lens_variants(49473).iter().map(|v| v.name).collect();
+    assert_eq!(
+      names,
+      [
+        "Tokina atx-m 85mm F1.8 FE",
+        "Viltrox 23mm F1.4 E",
+        "Viltrox 56mm F1.4 E",
+        "Viltrox 85mm F1.8 II FE",
+      ]
+    );
+  }
+
+  #[test]
+  fn lens_variants_zero_has_thirteen_in_order() {
+    let vs = lens_variants(0);
+    assert_eq!(vs.len(), 13);
+    assert_eq!(vs.first().map(|v| v.name), Some("Sigma 19mm F2.8 [EX] DN"));
+    assert_eq!(vs.last().map(|v| v.name), Some("Viltrox 85mm F1.8"));
+  }
+
+  #[test]
+  fn lens_variants_absent_is_empty() {
+    // 1 (LA-EA1) is a primary with no float entries; 999_999 is unknown.
+    assert!(lens_variants(1).is_empty());
+    assert!(lens_variants(999_999).is_empty());
+  }
+
+  #[test]
+  fn refreshed_integer_ids_resolve_via_lookup() {
+    // The 16 IDs added in this chunk all resolve through the unchanged lookup.
+    for id in [
+      24u32, 32895, 33095, 33096, 50563, 50564, 51011, 61600, 61766, 61768, 61777, 61778, 61779,
+      61781, 61783, 61789,
+    ] {
+      assert!(lookup_name(id).is_some(), "missing refreshed id {id}");
+    }
+    assert_eq!(
+      lookup_name(24).as_deref(),
+      Some("Samyang AF 85mm F1.8 P FE")
+    );
+    assert_eq!(
+      lookup_name(32895).as_deref(),
+      Some("Sony FE 100-400mm F4.5 GM OSS")
+    );
+    assert_eq!(
+      lookup_name(61789).as_deref(),
+      Some("Viltrox 35mm F1.8 II FE EVO")
+    );
   }
 }

--- a/src/exif/makernotes/vendors/sony/mod.rs
+++ b/src/exif/makernotes/vendors/sony/mod.rs
@@ -83,6 +83,7 @@ pub mod camerasettings3;
 pub mod decipher;
 pub mod extrainfo3;
 pub mod focusinfo;
+pub mod lens_info;
 pub mod lens_types;
 pub mod minoltaraw;
 pub mod model_ids;

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -10250,10 +10250,12 @@ fn arw_preview_image_conformance() {
 /// `AFStatus15` grid, `MoreInfo`→`MoreSettings`/`FaceInfo`/`MoreInfo0201`/
 /// `MoreInfo0401`, `CameraSettings3`, `ExtraInfo3`, the enciphered `Tag900b`).
 /// Each fixture's `Sony:*` exposure/AF/lens/battery/settings leaves and the
-/// dependent `Composite:*` are now byte-exact; the SOLE per-fixture exclusion is
-/// one niche composite each (FX3 `XMP-xmp:Rating`, A33 `Composite:LensID`), kept
-/// in sync with the `FIXTURE_EXCLUDED_KEYS` deferrals in
-/// `tests/typed_serde_parity.rs`.
+/// dependent `Composite:*` are now byte-exact — including `Composite:LensID`,
+/// which (since #103 part 3) resolves the A33's / A200's AMBIGUOUS `Sony:LensType`
+/// through the ported `Exif::PrintLensID` lens-DB disambiguation. The remaining
+/// per-fixture exclusions are FX3's `XMP-xmp:Rating` and A200's
+/// `Composite:ImageSize`/`Megapixels` (#436), kept in sync with the
+/// `FIXTURE_EXCLUDED_KEYS` deferrals in `tests/typed_serde_parity.rs`.
 #[test]
 fn sony_arw_real_sr2_and_subifd_conformance() {
   // The deferred `%Sony::Main` sub-table leaves (+ extra/divergent Sony Main
@@ -10282,25 +10284,12 @@ fn sony_arw_real_sr2_and_subifd_conformance() {
   // A33 (older SLT body): the `CameraInfo3` (incl. the `AFStatus15` AF grid),
   // `MoreInfo` (→ `MoreSettings`/`FaceInfo`/`MoreInfo0201`/`MoreInfo0401` +
   // `TiffMeteringImage`), `CameraSettings3`, `ExtraInfo3` and `Tag900b`
-  // SubDirectories are now FULLY PORTED — every `Sony:*` exposure/AF/battery/
-  // settings leaf emits byte-exact, and the dependent `Composite:*`
-  // (BlueBalance/RedBalance/CFAPattern/FocalLength35efl/FocusDistance2) now
-  // compute. The SOLE residual is one composite:
-  const A33_DEFERRED: &[&str] = &[
-    // `Composite:LensID` (= `Sony DT 18-55mm F3.5-5.6 SAM (SAL1855)`). The A33's
-    // `Sony:LensType` (= 55) is AMBIGUOUS — its PrintConv is the multi-candidate
-    // `Sony DT 18-55mm F3.5-5.6 SAM (SAL1855) or SAM II`. ExifTool's
-    // `Composite:LensID` disambiguates to the single SAL1855 via the full
-    // `Exif::PrintLensID` lens-DB matcher (`Exif.pm:5881` — uses `LensSpec` +
-    // `FocalLength` + `MaxAperture` to pick among the `" or "` candidates).
-    // exifast's composite post-pass ports only the UNAMBIGUOUS-LensType case
-    // (`composite/table.rs` `lens_id`, which defers any `" or "` placeholder);
-    // the focal/aperture/LensSpec disambiguation is a separate cross-cutting
-    // subsystem (it would re-key every vendor's ambiguous LensType) NOT part of
-    // this Sony deep-table port. This is the lone niche exclusion; the
-    // `Sony:LensType` (the ambiguous MakerNote leaf) IS emitted byte-exact.
-    "Composite:LensID",
-  ];
+  // SubDirectories are FULLY PORTED, and (since #103 part 3) the `Exif::PrintLensID`
+  // lens-DB disambiguation is wired into `Composite:LensID`: the A33's AMBIGUOUS
+  // `Sony:LensType` 55 (`Sony DT 18-55mm F3.5-5.6 SAM (SAL1855) or SAM II`) now
+  // resolves byte-exact to the single `(SAL1855)` via the LensSpec exact-suffix
+  // match (`Exif.pm:5991`). NO residuals — the body is fully byte-exact.
+  const A33_DEFERRED: &[&str] = &[];
   // A200 (2008 Minolta-derived body): the OLDER `%Sony::Main` sub-table tower —
   // `CameraInfo2` (0x0010, LittleEndian), `FocusInfo` (0x0020), `CameraSettings`
   // (0x0114, BigEndian `int16u`) — is now FULLY PORTED on top of chunk 1's
@@ -10319,15 +10308,10 @@ fn sony_arw_real_sr2_and_subifd_conformance() {
     // scope here. Both diverging composites are dropped from BOTH sides.
     "Composite:ImageSize",
     "Composite:Megapixels",
-    // `Composite:LensID` (= `Tamron 70-300mm F4-5.6 LD`). The A200's
-    // `Sony:LensType` (= 129) is AMBIGUOUS — its PrintConv is the generic
-    // `Tamron Lens (129)` placeholder; ExifTool's `Composite:LensID`
-    // disambiguates to the single lens via the full `Exif::PrintLensID` lens-DB
-    // matcher (`FocalLength` + `MaxAperture`). Same deferral as the A33's
-    // SAL1855 — exifast's composite post-pass ports only the unambiguous-LensType
-    // case, so this is dropped from BOTH sides; the `Sony:LensType` MakerNote
-    // leaf IS emitted byte-exact.
-    "Composite:LensID",
+    // `Composite:LensID` (= `Tamron 70-300mm F4-5.6 LD`) is now ACTIVE (#103
+    // part 3): the A200's AMBIGUOUS `Sony:LensType` 129 (`Tamron Lens (129)`)
+    // resolves byte-exact to the 129.2 variant via the `Exif::PrintLensID`
+    // FocalLength (80) + MaxApertureValue (4.5002…) branch (`Exif.pm:6001`).
   ];
   check_excluding(
     "Sony_ILME-FX3_real.ARW",

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -260,10 +260,10 @@ const NOT_ACTIVE: &[&str] = &[
   // `CameraSettings3`, `ExtraInfo3` and the enciphered `Tag900b` emit every
   // remaining `Sony:*` exposure/AF/battery/settings leaf, and the dependent
   // `Composite:*` (BlueBalance/RedBalance/CFAPattern/FocalLength35efl/
-  // FocusDistance2) now compute byte-exact. A33 carries a per-fixture
-  // `FIXTURE_EXCLUDED_KEYS` entry for the lone `Composite:LensID` (the ambiguous
-  // `Sony:LensType` 55 needs the unported `Exif::PrintLensID` disambiguator —
-  // see `FIXTURE_EXCLUDED_KEYS`).
+  // FocusDistance2) now compute byte-exact — AND (since #103 part 3) the ambiguous
+  // `Sony:LensType` 55 resolves through the ported `Exif::PrintLensID` lens-DB
+  // disambiguation, so `Composite:LensID` = `Sony DT 18-55mm F3.5-5.6 SAM
+  // (SAL1855)` is byte-exact: A33 has NO excluded keys.
   //
   // The `Sony_DSLR-A200_real.ARW` raw is now ACTIVE: on top of chunk 1's
   // `%MinoltaRaw::Main` MRW port (the `%Sony::SR2Private` `MRWInfo` 0x7250 →
@@ -273,10 +273,12 @@ const NOT_ACTIVE: &[&str] = &[
   // FocusPosition/TiffMeteringImage), and `CameraSettings` (0x0114, BigEndian
   // `int16u`, the exposure/aperture/flash/WB/AF/battery leaves) — so every
   // `Sony:*` leaf emits byte-exact, and the dependent `Composite:FocusDistance`
-  // (= `inf`, via the new `Sony:FocusPosition` = 128) computes. A200 carries a
-  // `FIXTURE_EXCLUDED_KEYS` entry for `Composite:ImageSize`/`Megapixels` (#436,
-  // the bare-name Composite priority residual) + the ambiguous `Composite:LensID`
-  // (the A33-style `Exif::PrintLensID` lens-DB disambiguation).
+  // (= `inf`, via the new `Sony:FocusPosition` = 128) computes, and (since #103
+  // part 3) the ambiguous `Sony:LensType` 129 resolves to `Composite:LensID` =
+  // `Tamron 70-300mm F4-5.6 LD` via the ported `Exif::PrintLensID` FocalLength/
+  // MaxAperture branch. A200's remaining `FIXTURE_EXCLUDED_KEYS` entry is just
+  // `Composite:ImageSize`/`Megapixels` (#436, the bare-name Composite priority
+  // residual).
   //
   // (`Canon_EOS-5D_real.CR2` was added to the both-goldens set with this chunk
   // and is ACTIVE — the deep Canon MakerNote sub-tables ColorData3 / CameraInfo5D
@@ -520,40 +522,24 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   // IS emitted. Mirrors `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`'s
   // `FX3_DEFERRED`.
   ("Sony_ILME-FX3_real.ARW", &["XMP-xmp:Rating"]),
-  // The `Sony_SLT-A33_real.ARW` raw is now active (its OLDER plain-
-  // `ProcessBinaryData` sub-table tower — `CameraInfo3`/`MoreInfo`/
-  // `CameraSettings3`/`ExtraInfo3`/`Tag900b` — is fully ported, see the
-  // `NOT_ACTIVE` note). The lone residual is `Composite:LensID`: the A33's
-  // `Sony:LensType` (= 55) PrintConv is the multi-candidate `Sony DT 18-55mm
-  // F3.5-5.6 SAM (SAL1855) or SAM II`, and ExifTool's `Composite:LensID`
-  // disambiguates it to the single `SAL1855` via the full `Exif::PrintLensID`
-  // lens-DB matcher (LensSpec + FocalLength + MaxAperture). exifast's composite
-  // post-pass ports only the unambiguous-LensType case (it defers any `" or "`
-  // placeholder), so this composite is dropped from BOTH sides; the ambiguous
-  // `Sony:LensType` MakerNote leaf IS emitted. Mirrors
-  // `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`'s `A33_DEFERRED`.
-  ("Sony_SLT-A33_real.ARW", &["Composite:LensID"]),
+  // `Sony_SLT-A33_real.ARW` is fully byte-exact (no excluded keys): its OLDER
+  // `ProcessBinaryData` tower is ported AND `Composite:LensID` now resolves the
+  // ambiguous `Sony:LensType` 55 via `Exif::PrintLensID` (#103 part 3), so the
+  // fixture no longer needs an exclusion entry.
   // The `Sony_DSLR-A200_real.ARW` raw is now active (its OLDER `%Sony::Main`
   // sub-table tower — `CameraInfo2`/`FocusInfo`/`CameraSettings` — is fully
-  // ported, see the `NOT_ACTIVE` note). Three composite residuals are dropped:
-  // `Composite:ImageSize`/`Megapixels` (#436 — bundled resolves the bare-name
-  // `Composite:ImageSize` from `MinoltaRaw:ImageWidth` `Priority => 1` over
-  // `SubIFD:ImageWidth` `Priority => 0`; exifast's bare-name Composite resolver
-  // is emission-order-first, picking the padded `SubIFD` 3880x2600 → 10.1 MP,
-  // not the SR2-corrected 3872x2592 → 10.0 MP — a shared-resolver change tracked
-  // in owner-deferred #436), and `Composite:LensID` (the A33-style ambiguous
-  // `Sony:LensType` 129 = `Tamron Lens (129)`, needing the unported
-  // `Exif::PrintLensID` disambiguator). All three are dropped from BOTH sides;
-  // every `Sony:*` MakerNote leaf + the `Composite:FocusDistance` IS byte-exact.
-  // Mirrors `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`'s
-  // `A200_DEFERRED`.
+  // ported, see the `NOT_ACTIVE` note). The residuals are `Composite:ImageSize`/
+  // `Megapixels` (#436 — bundled resolves the bare-name `Composite:ImageSize`
+  // from `MinoltaRaw:ImageWidth` `Priority => 1` over `SubIFD:ImageWidth`
+  // `Priority => 0`; exifast's bare-name Composite resolver is emission-order-
+  // first, picking the padded `SubIFD` 3880x2600 → 10.1 MP, not the SR2-corrected
+  // 3872x2592 → 10.0 MP — a shared-resolver change tracked in owner-deferred
+  // #436). `Composite:LensID` (= `Tamron 70-300mm F4-5.6 LD`) is now ACTIVE via
+  // the `Exif::PrintLensID` FocalLength/MaxAperture branch (#103 part 3). Mirrors
+  // `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`'s `A200_DEFERRED`.
   (
     "Sony_DSLR-A200_real.ARW",
-    &[
-      "Composite:ImageSize",
-      "Composite:Megapixels",
-      "Composite:LensID",
-    ],
+    &["Composite:ImageSize", "Composite:Megapixels"],
   ),
   // `Canon_EOS-5D_real.CR2` — the deep Canon MakerNote sub-table activation
   // (#84/#85/#87). The newly-ported ColorData3 (0x4001 count 796) / CameraInfo5D


### PR DESCRIPTION
Completes #103 (PART 1 = CameraSettings3 conditional leaves merged in #470; PART 2 A-mount integer table was already complete). Adds the LensType float-variant tables (40 E-mount + 189 A-mount, Perl-dumped) + GetLensInfo + the full Exif::PrintLensID disambiguation (Exif.pm:5881-6060): the LensSpec branch (±0.5 focal / ±0.15 aperture + exact-suffix win), the FocalLength/MaxAperture log-log-interpolation branch, Minolta teleconverter scaling, MatchLensModel, the 65535 manual-lens %sonyEtype path, and the zero/multi-survivor fall-through. Wired into Composite:LensID, gated so only genuine Sony/Minolta lenses disambiguate (cross-vendor + the already-resolved FX3 E-mount name untouched).

Activates A200 + A33 Composite:LensID byte-exact vs bundled: A200 -> 'Tamron 70-300mm F4-5.6 LD' (129.2, FocalLength+MaxAperture branch), A33 -> 'Sony DT 18-55mm F3.5-5.6 SAM (SAL1855)' (LensSpec branch, primary 55 wins). 26 unit tests cover the unexercised branches.

Verify: fmt=0 build(-D warnings)=0 conformance=507/0 (A200+A33 byte-exact) typed_serde=0 lib=4328/0 alloc=0 timed_metadata=162/0 xtask=26/0.

Codex adversarial review: R1 raised one [medium] (the lookup-name gate blocks a supposed Sony table-miss lensModel fallback). Verified against Exif.pm as a FALSE POSITIVE: for an UNKNOWN Sony lensType, PrintLensID returns $lens=$$printConv{lensType}=undef (line 6061) -> suppressed; the lensModel fallback (line 6060) requires $lens=~/ or / (a KNOWN ambiguous name), which the gate ALLOWS (lookup_name==PrintConv name). The gate only blocks unknown/cross-vendor lensTypes, which ExifTool also suppresses; implementing the recommendation would emit a LensID where bundled emits undef (a divergence). Conformance 507/0 confirms no 13.59 divergence.