### PR TITLE
feat(composite): priority-aware bare-name resolver, activate Sony A200 ImageSize (#436)

### DIFF
--- a/src/composite/mod.rs
+++ b/src/composite/mod.rs
@@ -185,17 +185,30 @@ impl CompositeSink for crate::tagmap::TagMap {
     // Within a single document, a GROUP-SCOPED input (`groups` non-empty) takes
     // the LAST match within that group set — the duplicate-override precedence
     // (`APE_dup_override`: a later `APE:SampleRate=48000` overrides an earlier
-    // `MAC:SampleRate=44100`). A BARE-NAME input (empty `groups`) takes the FIRST
-    // match across ALL groups — ExifTool's bare-name lookup returns the
-    // PRIORITY-directory value (the main EXIF IFD), which exifast emits BEFORE
-    // the lower-priority MakerNote duplicate; so `Composite:FocalLength35efl`'s
-    // bare `FocalLength` resolves to `ExifIFD:FocalLength` (50.0), NOT a later
-    // `Nikon:FocalLength` (50.4). (Entries are in first-occurrence emission
-    // order: EXIF IFDs precede MakerNote sub-tables, mirroring ExifTool's
-    // `$$self{PRIORITY}` directory.)
+    // `MAC:SampleRate=44100`). A BARE-NAME input (empty `groups`) resolves the
+    // un-suffixed key the way ExifTool's `FoundTag` settles it (ExifTool.pm:9544-
+    // 9560): the HIGHEST effective priority wins. So `Composite:FocalLength35efl`'s
+    // bare `FocalLength` resolves to `ExifIFD:FocalLength` (`Priority => 1`, 50.0)
+    // over a MakerNote `Nikon:FocalLength` (its table `PRIORITY => 0`, 50.4); the
+    // A200's bare `ImageWidth` resolves to `MinoltaRaw:ImageWidth` (`Priority => 1`,
+    // 3872) over the earlier-emitted `SubIFD:ImageWidth` (the `%Exif::Main`
+    // `Priority => 0` tag, 3880); a Pentax `File:ImageWidth` (`Priority => 1`)
+    // beats an `XMP-tiff:ImageWidth` (`%XMP::tiff PRIORITY => 0`). Among EQUAL max
+    // priority we keep the FIRST-emitted (today's tiebreak) — the equal-priority
+    // true file-walk-order recency tiebreak (ExifTool's `$priority >= $oldPriority`
+    // last-wins) is deferred to #474, because exifast's emission order is NOT file
+    // order, so a last-match flip would regress the 6 Pentax composites.
     let find_in = |d: u32| {
       if groups.is_empty() {
-        self.entries().iter().find(pred_in(d))
+        // MAX effective priority, FIRST-emitted among equals (`>` is strict, so a
+        // later equal-priority entry never displaces the first match).
+        self
+          .entries()
+          .iter()
+          .filter(pred_in(d))
+          .map(|e| (e, crate::tagmap::effective_priority(e.3.as_str(), e.4)))
+          .reduce(|best, cur| if cur.1 > best.1 { cur } else { best })
+          .map(|(e, _)| e)
       } else {
         self.entries().iter().rev().find(pred_in(d))
       }
@@ -243,10 +256,15 @@ impl CompositeSink for crate::tagmap::TagMap {
 }
 
 /// The [`iter_tags`](crate::format_parser::AnyMeta::iter_tags) sink — the
-/// deduped [`Tag`](crate::value::Tag) `Vec`. Appended composites carry the full
-/// `Composite`/`Composite` group (family-0 = family-1), matching the JSON path.
+/// deduped [`Tag`](crate::value::Tag) `Vec`, each tag PAIRED with its surviving
+/// entry's EFFECTIVE priority so the bare-name resolver can prefer the
+/// highest-priority ingredient (exactly as the `TagMap` sink reads entry.4). The
+/// priority is stripped at the [`iter_tags`](crate::format_parser::AnyMeta::iter_tags)
+/// boundary, so the public tag iterator is unchanged. Appended composites carry
+/// the full `Composite`/`Composite` group (family-0 = family-1) and ExifTool's
+/// `Priority`, matching the JSON path.
 #[cfg(feature = "alloc")]
-impl CompositeSink for std::vec::Vec<crate::value::Tag> {
+impl CompositeSink for std::vec::Vec<(crate::value::Tag, u8)> {
   fn resolve(
     &self,
     groups: &[&str],
@@ -262,14 +280,26 @@ impl CompositeSink for std::vec::Vec<crate::value::Tag> {
         && group0.is_none_or(|g0| t.group_ref().family0() == g0)
     };
     let pred_in = |d: u32| {
-      move |t: &&crate::value::Tag| t.group_ref().doc() == d && t.name() == name && group_ok(t)
+      move |item: &&(crate::value::Tag, u8)| {
+        item.0.group_ref().doc() == d && item.0.name() == name && group_ok(&item.0)
+      }
     };
-    // Bare-name (empty `groups`) ⇒ FIRST match (the priority-directory EXIF tag,
-    // emitted before its MakerNote duplicate); group-scoped ⇒ LAST match (the
-    // duplicate-override). See the `TagMap` impl's note.
+    // Bare-name (empty `groups`) ⇒ the HIGHEST effective priority wins, FIRST-
+    // emitted among equals; group-scoped ⇒ LAST match (the duplicate-override).
+    // See the `TagMap` impl's note (equal-priority recency is #474).
     let find_in = |d: u32| {
       if groups.is_empty() {
-        self.iter().find(pred_in(d))
+        self
+          .iter()
+          .filter(pred_in(d))
+          .map(|item| {
+            (
+              item,
+              crate::tagmap::effective_priority(item.0.name(), item.1),
+            )
+          })
+          .reduce(|best, cur| if cur.1 > best.1 { cur } else { best })
+          .map(|(item, _)| item)
       } else {
         self.iter().rev().find(pred_in(d))
       }
@@ -277,26 +307,30 @@ impl CompositeSink for std::vec::Vec<crate::value::Tag> {
     let found = match doc {
       DocScope::Exact(d) => find_in(d),
       DocScope::Main => find_in(0).or_else(|| {
-        let cross =
-          |t: &&crate::value::Tag| t.group_ref().doc() != 0 && t.name() == name && group_ok(t);
+        let cross = |item: &&(crate::value::Tag, u8)| {
+          item.0.group_ref().doc() != 0 && item.0.name() == name && group_ok(&item.0)
+        };
         self.iter().find(cross)
       }),
     };
     match found {
-      Some(tag) => CompositeValue::Present(t_value(tag).clone()),
+      Some(item) => CompositeValue::Present(t_value(&item.0).clone()),
       None => CompositeValue::Missing,
     }
   }
   fn has_composite(&self, name: &str, doc: u32) -> bool {
-    self.iter().any(|t| {
+    self.iter().any(|(t, _p)| {
       t.group_ref().doc() == doc && t.group_ref().family1() == "Composite" && t.name() == name
     })
   }
-  fn append(&mut self, name: &'static str, _priority: u8, value: TagValue, doc: u32) {
-    self.push(crate::value::Tag::new(
-      crate::value::Group::with_doc("Composite", "Composite", doc),
-      name,
-      value,
+  fn append(&mut self, name: &'static str, priority: u8, value: TagValue, doc: u32) {
+    self.push((
+      crate::value::Tag::new(
+        crate::value::Group::with_doc("Composite", "Composite", doc),
+        name,
+        value,
+      ),
+      priority,
     ));
   }
 }
@@ -419,8 +453,8 @@ pub(crate) fn build_composites(
 /// derivations exactly as for the JSON path.
 #[cfg(feature = "alloc")]
 pub(crate) fn build_composites_into_tags(
-  tags: &mut std::vec::Vec<crate::value::Tag>,
-  other_view: Option<&mut std::vec::Vec<crate::value::Tag>>,
+  tags: &mut std::vec::Vec<(crate::value::Tag, u8)>,
+  other_view: Option<&mut std::vec::Vec<(crate::value::Tag, u8)>>,
   mode: crate::emit::ConvMode,
   doc_count: u32,
   ctx: &table::CompositeContext,

--- a/src/composite/tests.rs
+++ b/src/composite/tests.rs
@@ -2527,12 +2527,12 @@ mod subdoc {
   /// `>=` the stored one; a `Priority => 0` duplicate never overrides). This is
   /// the SAME predicate the `TagMap` sink uses, so feeding the SAME stream into
   /// both lets us assert the two sinks agree across every priority case. The
-  /// post-dedup `Vec` is what the `CompositeSink for Vec<Tag>` impl resolves
-  /// over.
+  /// post-dedup `Vec` is what the `CompositeSink for Vec<(Tag, u8)>` impl
+  /// resolves over — each tag PAIRED with its surviving effective priority.
   #[cfg(feature = "quicktime")]
   fn vec_deduped_g0(
     entries: &[(u32, &str, &str, &str, u8, TagValue)],
-  ) -> std::vec::Vec<crate::value::Tag> {
+  ) -> std::vec::Vec<(crate::value::Tag, u8)> {
     let mut out: std::vec::Vec<(crate::value::Tag, u8)> = std::vec::Vec::new();
     for (doc, g0, g1, n, p, v) in entries {
       let tag =
@@ -2551,7 +2551,7 @@ mod subdoc {
         out.push((tag, effective));
       }
     }
-    out.into_iter().map(|(t, _p)| t).collect()
+    out
   }
 
   /// TWO-SINK PARITY (the #133 finding): a MIXED-family-0 duplicate — same

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -10325,6 +10325,15 @@ trait ExifSink {
     unknown: bool,
     priority: u8,
   ) -> Result<(), core::convert::Infallible>;
+
+  /// Set the ExifTool `Priority => N` for the NEXT scalar leaf written through
+  /// the `write_*` scalars — [`emit_entry`] threads the `%Exif::Main`
+  /// `Priority => 0` for `ImageWidth`/`ImageHeight` (Exif.pm:493/501) so the
+  /// bare-name Composite resolver prefers a higher-priority producer. The default
+  /// is a NO-OP: only the value-storing [`EmittedTagSink`] tracks it (every other
+  /// sink either discards scalar writes or has no priority axis).
+  #[inline(always)]
+  fn set_leaf_priority(&mut self, _priority: u8) {}
 }
 
 /// Test-only sink: each writer delegates to the matching inherent
@@ -10440,6 +10449,14 @@ struct EmittedTagSink<'v> {
   /// IFD entries via this sink, and the MakerNote vendor tags), eliminating the
   /// per-call temp `Vec` the EXIF-entry pass used to allocate + move (P2).
   tags: &'v mut std::vec::Vec<crate::emit::EmittedTag>,
+  /// ExifTool `Priority => N` for the NEXT scalar leaf pushed ([`emit_entry`]
+  /// sets it per entry via [`ExifSink::set_leaf_priority`]). Defaults to `1` (the
+  /// `FoundTag` default); `0` for the `%Exif::Main` `ImageWidth`/`ImageHeight`
+  /// (Exif.pm:493/501, `Priority => 0`) so the bare-name Composite resolver
+  /// prefers a higher-priority producer (the A200's `MinoltaRaw:ImageWidth`).
+  /// [`push`](Self::push) consumes it and resets to `1`, so any writer that does
+  /// not set it gets the default.
+  leaf_priority: u8,
 }
 
 #[cfg(feature = "alloc")]
@@ -10447,24 +10464,35 @@ impl<'v> EmittedTagSink<'v> {
   /// Wrap a destination buffer.
   #[inline(always)]
   fn new(tags: &'v mut std::vec::Vec<crate::emit::EmittedTag>) -> Self {
-    Self { tags }
+    Self {
+      tags,
+      leaf_priority: 1,
+    }
   }
 
   /// Push one rendered [`EmittedTag`] — `Group{family0:"EXIF", family1:group}`,
-  /// `unknown:false` (EXIF tables have no `Unknown=>1`).
+  /// `unknown:false` (EXIF tables have no `Unknown=>1`), at the pending
+  /// [`leaf_priority`](Self::leaf_priority) (then reset to the `1` default).
   #[inline(always)]
   fn push(&mut self, group: &str, name: &str, value: crate::value::TagValue) {
-    self.tags.push(crate::emit::EmittedTag::new(
+    self.tags.push(crate::emit::EmittedTag::new_with_priority(
       crate::value::Group::new("EXIF", group),
       smol_str::SmolStr::new(name),
       value,
       false,
+      self.leaf_priority,
     ));
+    self.leaf_priority = 1;
   }
 }
 
 #[cfg(feature = "alloc")]
 impl ExifSink for EmittedTagSink<'_> {
+  /// Stash the per-entry priority for the next [`push`](EmittedTagSink::push).
+  #[inline(always)]
+  fn set_leaf_priority(&mut self, priority: u8) {
+    self.leaf_priority = priority;
+  }
   #[inline(always)]
   fn write_str(
     &mut self,
@@ -10855,6 +10883,30 @@ impl ExifSink for PreviewIfdSink<'_> {
 // DataMembers, and the sink). Bundling them into a context struct would obscure
 // the 1:1 mapping to `parse_in_tiff`'s collection-time render, not clarify it —
 // the sibling `emit_canon_subtable` carries the same allow for the same reason.
+/// ExifTool's `Priority => N` for an EXIF leaf's BARE-NAME Composite resolution
+/// (`ExifTool.pm:9469`, the tag-table `Priority`). `%Exif::Main`'s `ImageWidth`
+/// (0x0100) and `ImageHeight` (0x0101) carry `Priority => 0` (Exif.pm:493/501,
+/// "so PRIORITY_DIR takes precedence"); every other EXIF/GPS row defaults to `1`.
+///
+/// This threads the tag-table priority ONLY: ExifTool's priority-directory boost
+/// (ExifTool.pm:9554) fires solely for a same-name DUPLICATE in the priority
+/// directory and never promotes the FIRST-stored `ImageWidth`, so the bare key
+/// stays effective-`0` — ground-truthed on the A200, where `$$et{PRIORITY}` for
+/// the `SubIFD` `ImageWidth` is `undef` while the later `MinoltaRaw:ImageWidth`
+/// (`%MinoltaRaw::PRD` has no `Priority` ⇒ `1`) wins. Because that MinoltaRaw
+/// producer emits as a `0x000e` leaf (NOT `0x0100`), this guard leaves it at `1`
+/// and only the `SubIFD:ImageWidth` (`0x0100`) drops to `0`, so the bare
+/// `Composite:ImageSize` resolves to the MinoltaRaw `3872x2592`. A non-Exif
+/// `conv` (a Canon vendor leaf) keeps `1` — its own `Priority` rides its
+/// `VendorEmission`.
+#[cfg(feature = "alloc")]
+fn exif_leaf_priority(entry: &ExifEntry) -> u8 {
+  match entry.conv {
+    ResolvedConv::Exif(tag) if matches!(tag.id(), 0x0100 | 0x0101) => 0,
+    _ => 1,
+  }
+}
+
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "alloc")]
 fn emit_entry<S: ExifSink>(
@@ -10911,6 +10963,12 @@ fn emit_entry<S: ExifSink>(
   // / byte shape, which the golden `convert::apply` runtime — written for the
   // already-rendered `TagValue` — cannot reproduce byte-identically for a
   // multi-element value or preserve in TagValue shape; #243 Codex R1/R2.)
+  //
+  // Thread this leaf's ExifTool `Priority` into the sink (the `EmittedTag` rides
+  // it; the sink resets to `1` after the push) so the bare-name Composite
+  // resolver prefers a higher-priority producer — the A200's `SubIFD:ImageWidth`
+  // (0x0100, `Priority => 0`) loses to `MinoltaRaw:ImageWidth`.
+  out.set_leaf_priority(exif_leaf_priority(entry));
   match entry.conv {
     ResolvedConv::Exif(tag) => {
       emit_exif_value(group, name, raw, tag.conv(), order, print_conv, out)

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -714,7 +714,10 @@ impl AnyMeta<'_> {
   /// first-wins; an ordinary `Priority => 1` tag last-wins (`1 >= 1`).
   /// First-occurrence POSITION is always preserved.
   #[cfg(feature = "alloc")]
-  fn collect_deduped_tags(&self, mode: crate::emit::ConvMode) -> std::vec::Vec<crate::value::Tag> {
+  fn collect_deduped_tags(
+    &self,
+    mode: crate::emit::ConvMode,
+  ) -> std::vec::Vec<(crate::value::Tag, u8)> {
     let opts = crate::emit::EmitOptions::g1(mode, false);
     // Each slot carries its surviving entry's EFFECTIVE priority alongside the
     // `Tag`, exactly as [`crate::tagmap::TagMap`] stores it, so a later
@@ -751,7 +754,12 @@ impl AnyMeta<'_> {
         out.push((tag, effective));
       }
     }
-    out.into_iter().map(|(t, _p)| t).collect()
+    // Carry the effective priority OUT (not just for the in-loop dedup): the
+    // bare-name Composite resolver prefers the highest-priority ingredient, so it
+    // needs each surviving tag's priority — the `Vec<(Tag, u8)>` `CompositeSink`
+    // reads it, mirroring the `TagMap` sink's entry.4. Stripped back to plain
+    // `Tag` at the `iter_tags` boundary, so the public API is unchanged.
+    out
   }
 
   /// The format tag stream as [`value::Tag`](crate::value::Tag)s
@@ -787,17 +795,22 @@ impl AnyMeta<'_> {
     // we re-collect the SAME stream in the OPPOSITE mode for the other view.
     let mut other_view = self.collect_deduped_tags(mode.flipped());
     if self.runs_composites() {
-      let doc_count = out.iter().map(|t| t.group_ref().doc()).max().unwrap_or(0);
+      let doc_count = out
+        .iter()
+        .map(|(t, _p)| t.group_ref().doc())
+        .max()
+        .unwrap_or(0);
       let mdat_total = self.composite_media_data_total();
-      // The ValueConv view supplies `CalcRotation`'s raw `vide` HandlerType.
-      let value_view: &std::vec::Vec<crate::value::Tag> = match mode {
+      // The ValueConv view supplies `CalcRotation`'s raw `vide` HandlerType. Each
+      // entry is `(Tag, priority)`; rotation reads only the tag.
+      let value_view: &std::vec::Vec<(crate::value::Tag, u8)> = match mode {
         crate::emit::ConvMode::ValueConv => &out,
         crate::emit::ConvMode::PrintConv => &other_view,
       };
       let rotation = crate::composite::calc_rotation_from(
         value_view
           .iter()
-          .map(|t| (t.group_ref().family1(), t.name(), t.value_ref())),
+          .map(|(t, _p)| (t.group_ref().family1(), t.name(), t.value_ref())),
       );
       let ctx = crate::composite::CompositeContext::new(mdat_total, rotation)
         .with_file_size(self.composite_file_size());
@@ -809,7 +822,8 @@ impl AnyMeta<'_> {
         &ctx,
       );
     }
-    out.into_iter()
+    // Strip the per-tag priority — the public iterator yields plain `Tag`s.
+    out.into_iter().map(|(t, _p)| t)
   }
 
   /// Does this `AnyMeta` RUN the Composite post-pass?

--- a/src/formats/xmp.rs
+++ b/src/formats/xmp.rs
@@ -345,17 +345,21 @@ impl XmpMeta<'_> {
   /// `XMP::ProcessXMP` running once PER packet and `FoundTag` ACCUMULATING (a
   /// duplicate tag is never dropped — ExifTool.pm:9514-9596), this appends
   /// `other`'s tags AFTER this packet's in file-walk order; the downstream
-  /// last-wins `TagMap`/`iter_tags` dedup then resolves a duplicate same-name
-  /// XMP tag to the later (file-order) packet's value — matching ExifTool's
-  /// equal-priority "later atom owns the bare tag key" resolution.
+  /// `TagMap`/`iter_tags` dedup then resolves a duplicate same-`(family1, name)`
+  /// XMP tag by ExifTool's priority-aware `FoundTag` rule (ExifTool.pm:9544-
+  /// 9564): a default-priority namespace resolves to the LATER (file-order)
+  /// packet's value (last-wins — "later atom owns the bare tag key"), while a
+  /// `PRIORITY => 0` namespace (`tiff`/`exif`/`exifEX`, XMP.pm:1900/1992/2462)
+  /// keeps the EARLIER packet's value (first-wins — the priority-0 duplicate can
+  /// never override an established tag; Codex #436 R1). See `XmpMeta::tags`.
   ///
   /// `Warning` stays FIRST-wins (`FoundTag('Warning')`, Extra.pm Priority 0 ⇒
   /// the earliest-extracted warning is the public one), so an existing warning
   /// is kept; the Nikon-NX-D `OverrideFileType` latch is OR-ed (any packet that
   /// fires it sets it). `LIST_TAGS` does NOT span packets (ExifTool resets it
   /// per `ProcessDirectory`, ExifTool.pm:9076), so cross-packet duplicates go
-  /// through the new-key/last-wins path, never an in-place list append — which
-  /// is exactly what concatenation + last-wins dedup reproduces.
+  /// through the new-key/priority-aware-dedup path, never an in-place list
+  /// append — which is exactly what concatenation + that dedup reproduces.
   ///
   /// Returns `true` when THIS call adopted `other`'s warning — i.e. there was no
   /// earlier warning and `other` carried one. The caller uses that to record the
@@ -4924,11 +4928,35 @@ impl crate::emit::Taggable for XmpMeta<'_> {
     let mode = opts.mode;
     let print_conv = matches!(mode, crate::emit::ConvMode::PrintConv);
     self.tags.iter().map(move |tag| {
-      crate::emit::EmittedTag::new(
+      // ExifTool marks the `tiff`/`exif`/`exifEX` XMP namespaces `PRIORITY => 0`
+      // ("not as reliable as actual TIFF/EXIF tags", XMP.pm:1900/1992/2462), so a
+      // bare-name Composite ingredient prefers the real EXIF/File producer over
+      // the XMP one (a Pentax `File:ImageWidth` `Priority => 1` beats an
+      // `XMP-tiff:ImageWidth`). The SAME `PRIORITY => 0` ALSO makes the
+      // EMISSION-layer same-`(family1, name)` dedup priority-aware (Codex #436
+      // R1): when two of these tags reach the `TagMap`/`collect_deduped_tags`
+      // sink, the later one's `new != 0 && new >= stored` is false ⇒ it cannot
+      // override ⇒ FIRST-wins, faithful to ExifTool's `FoundTag` priority-0 rule
+      // (ExifTool.pm:9544-9564 — the same rule that has bundled emit 111 for two
+      // `tiff:ImageWidth` 111/222). A default-priority namespace (e.g. `dc`)
+      // stays LAST-wins (`1 >= 1` replaces). SCOPE: two same-`(family1, name)`
+      // XMP tags reach the sink only as SEPARATE `XmpTag`s — across packets
+      // (`absorb_additional_packet`) or as the Composite resolver's File-vs-XMP
+      // pair; a single packet already collapses same-path duplicates earlier, in
+      // `restore_struct`/`build_value` (last-wins), so the priority is NOT
+      // observable in a one-packet `.xmp` (exifast stays last-wins there — a
+      // separate `restore_struct` matter, NOT changed by this priority).
+      // Locked by the `priority0_xmp_namespaces_emission_dedup_first_wins` test.
+      let priority = u8::from(!matches!(
+        tag.group.as_str(),
+        "XMP-tiff" | "XMP-exif" | "XMP-exifEX"
+      ));
+      crate::emit::EmittedTag::new_with_priority(
         crate::value::Group::new("XMP", tag.group.as_str()),
         tag.name.clone(),
         tag.value.to_tag_value(print_conv),
         false,
+        priority,
       )
     })
   }
@@ -6374,5 +6402,146 @@ mod tests {
     let clean_b = super::parse_borrowed(&f).expect("clean parses");
     assert!(!clean_a.absorb_additional_packet(clean_b));
     assert_eq!(clean_a.warning(), None);
+  }
+
+  /// Codex #436 R1: the `PRIORITY => 0` `tiff`/`exif`/`exifEX` XMP namespaces
+  /// dedup FIRST-wins at the emission layer, while a default-priority namespace
+  /// (`dc`) stays LAST-wins — the priority-aware `FoundTag` rule
+  /// (`ExifTool.pm:9544-9564`) that [`XmpMeta::tags`] now threads via its per-tag
+  /// `Priority => N` (`0` for `tiff`/`exif`/`exifEX`, `1` otherwise).
+  ///
+  /// Two same-`(family1, name)` XMP tags reach the `TagMap` sink only as
+  /// SEPARATE `XmpTag`s, i.e. ACROSS packets (`absorb_additional_packet`): a
+  /// SINGLE packet collapses same-path duplicates EARLIER, in
+  /// `restore_struct`/`build_value` (last-wins), so this dedup is exercised via
+  /// the cross-packet path here rather than a standalone-`.xmp` conformance
+  /// fixture (which would only ever see the already-collapsed single value).
+  /// Oracle values: bundled ExifTool 13.59 keeps the FIRST of two priority-0
+  /// dups (`tiff:ImageWidth` 111/222 ⇒ 111, `exif:SpectralSensitivity` ⇒
+  /// `exifFIRST`, `exifEX:LensModel` ⇒ `lensFIRST`) and the LAST of two
+  /// default-priority `dc:format` (aaa/bbb ⇒ bbb).
+  #[test]
+  #[cfg(feature = "alloc")]
+  fn priority0_xmp_namespaces_emission_dedup_first_wins() {
+    use crate::emit::{ConvMode, EmitOptions, Taggable as _};
+    use crate::value::TagValue;
+
+    // A minimal single-property XMP packet in an arbitrary namespace (modelled
+    // on `one_tag_packet`, which is hard-coded to `foo`).
+    let packet = |prefix: &str, uri: &str, name: &str, value: &str| -> std::vec::Vec<u8> {
+      format!(
+        r#"<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="" xmlns:{prefix}="{uri}">
+   <{prefix}:{name}>{value}</{prefix}:{name}>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="r"?>"#
+      )
+      .into_bytes()
+    };
+
+    let opts = EmitOptions::g1(ConvMode::ValueConv, false);
+    // The value surviving the priority-aware `TagMap` dedup (the JSON/golden
+    // sink) for `(family1, name)`.
+    let survivor = |merged: &super::XmpMeta<'_>, g: &str, n: &str| -> Option<TagValue> {
+      let mut tm = crate::tagmap::TagMap::new();
+      crate::emit::run_emission(merged, opts, &mut tm);
+      tm.entries()
+        .iter()
+        .find(|e| e.2.as_str() == g && e.3.as_str() == n)
+        .map(|e| e.5.clone())
+    };
+
+    // PRIORITY => 0 `tiff`: the priority-0 duplicate cannot override ⇒ the FIRST
+    // packet's value survives (matches bundled's 111).
+    let tiff_uri = "http://ns.adobe.com/tiff/1.0/";
+    let (tiff1_bytes, tiff2_bytes) = (
+      packet("tiff", tiff_uri, "ImageWidth", "111"),
+      packet("tiff", tiff_uri, "ImageWidth", "222"),
+    );
+    let mut tiff = super::parse_borrowed(&tiff1_bytes).expect("tiff 1 parses");
+    let tiff2 = super::parse_borrowed(&tiff2_bytes).expect("tiff 2 parses");
+    tiff.absorb_additional_packet(tiff2);
+    // Both reached the sink as separate tags (the accumulation prerequisite)...
+    assert_eq!(tiff.tags_slice().len(), 2);
+    // ...and `XmpMeta::tags` stamps the priority-0 namespace as `Priority => 0`.
+    assert!(
+      tiff
+        .tags(opts)
+        .all(|e| e.tag().group_ref().family1() == "XMP-tiff" && e.priority() == 0)
+    );
+    // FIRST-wins through the emission dedup.
+    assert_eq!(
+      survivor(&tiff, "XMP-tiff", "ImageWidth"),
+      Some(TagValue::Str("111".into())),
+    );
+
+    // PRIORITY => 0 `exif` (URI `http://ns.adobe.com/exif/1.0/`): the same
+    // first-wins rule via the `SpectralSensitivity` text property — locks the
+    // `XMP-exif` group-string path production hard-codes next to `XMP-tiff`
+    // (matches bundled's `exifFIRST`).
+    let exif_uri = "http://ns.adobe.com/exif/1.0/";
+    let (exif1_bytes, exif2_bytes) = (
+      packet("exif", exif_uri, "SpectralSensitivity", "exifFIRST"),
+      packet("exif", exif_uri, "SpectralSensitivity", "exifSECOND"),
+    );
+    let mut exif = super::parse_borrowed(&exif1_bytes).expect("exif 1 parses");
+    let exif2 = super::parse_borrowed(&exif2_bytes).expect("exif 2 parses");
+    exif.absorb_additional_packet(exif2);
+    assert_eq!(exif.tags_slice().len(), 2);
+    assert!(
+      exif
+        .tags(opts)
+        .all(|e| e.tag().group_ref().family1() == "XMP-exif" && e.priority() == 0)
+    );
+    assert_eq!(
+      survivor(&exif, "XMP-exif", "SpectralSensitivity"),
+      Some(TagValue::Str("exifFIRST".into())),
+    );
+
+    // PRIORITY => 0 `exifEX` (URI `http://cipa.jp/exif/1.0/`): same first-wins
+    // via the `LensModel` text property — locks the `XMP-exifEX` group-string
+    // path production hard-codes (matches bundled's `lensFIRST`).
+    let exifex_uri = "http://cipa.jp/exif/1.0/";
+    let (exifex1_bytes, exifex2_bytes) = (
+      packet("exifEX", exifex_uri, "LensModel", "lensFIRST"),
+      packet("exifEX", exifex_uri, "LensModel", "lensSECOND"),
+    );
+    let mut exifex = super::parse_borrowed(&exifex1_bytes).expect("exifEX 1 parses");
+    let exifex2 = super::parse_borrowed(&exifex2_bytes).expect("exifEX 2 parses");
+    exifex.absorb_additional_packet(exifex2);
+    assert_eq!(exifex.tags_slice().len(), 2);
+    assert!(
+      exifex
+        .tags(opts)
+        .all(|e| e.tag().group_ref().family1() == "XMP-exifEX" && e.priority() == 0)
+    );
+    assert_eq!(
+      survivor(&exifex, "XMP-exifEX", "LensModel"),
+      Some(TagValue::Str("lensFIRST".into())),
+    );
+
+    // Default-priority `dc`: a duplicate overrides (`1 >= 1`) ⇒ the LAST packet's
+    // value survives (matches bundled's bbb).
+    let dc_uri = "http://purl.org/dc/elements/1.1/";
+    let (dc1_bytes, dc2_bytes) = (
+      packet("dc", dc_uri, "format", "aaa"),
+      packet("dc", dc_uri, "format", "bbb"),
+    );
+    let mut dc = super::parse_borrowed(&dc1_bytes).expect("dc 1 parses");
+    let dc2 = super::parse_borrowed(&dc2_bytes).expect("dc 2 parses");
+    dc.absorb_additional_packet(dc2);
+    assert!(
+      dc.tags(opts)
+        .all(|e| e.tag().group_ref().family1() == "XMP-dc" && e.priority() == 1)
+    );
+    // LAST-wins through the emission dedup.
+    assert_eq!(
+      survivor(&dc, "XMP-dc", "Format"),
+      Some(TagValue::Str("bbb".into())),
+    );
   }
 }

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -10320,27 +10320,23 @@ fn sony_arw_real_sr2_and_subifd_conformance() {
   const A33_DEFERRED: &[&str] = &[];
   // A200 (2008 Minolta-derived body): the OLDER `%Sony::Main` sub-table tower —
   // `CameraInfo2` (0x0010, LittleEndian), `FocusInfo` (0x0020), `CameraSettings`
-  // (0x0114, BigEndian `int16u`) — is now FULLY PORTED on top of chunk 1's
+  // (0x0114, BigEndian `int16u`) — is FULLY PORTED on top of chunk 1's
   // `MinoltaRaw` subsystem, so every `Sony:*` AF/exposure/flash/WB/battery leaf
   // emits byte-exact, and the dependent `Composite:FocusDistance` (= `inf`, via
-  // the new `Sony:FocusPosition`) computes. The residuals are three composites:
-  const A200_DEFERRED: &[&str] = &[
-    // `Composite:ImageSize`/`Megapixels` (#436): bundled resolves the bare-name
-    // `Composite:ImageSize` from the `MinoltaRaw:ImageWidth`/`ImageHeight`
-    // (`Priority => 1`, the SR2-corrected 3872x2592) over the `SubIFD:ImageWidth`
-    // (`Priority => 0`, the padded 3880x2600). exifast's bare-name Composite
-    // resolver is emission-order-FIRST (it does NOT yet prefer a higher-priority
-    // ingredient), so it picks the earlier `SubIFD` dims (3880x2600 → 10.1 MP).
-    // The priority-aware bare-name resolution is tracked in #436 (owner-deferred,
-    // low priority); changing the shared `composite/mod.rs` resolver is out of
-    // scope here. Both diverging composites are dropped from BOTH sides.
-    "Composite:ImageSize",
-    "Composite:Megapixels",
-    // `Composite:LensID` (= `Tamron 70-300mm F4-5.6 LD`) is now ACTIVE (#103
-    // part 3): the A200's AMBIGUOUS `Sony:LensType` 129 (`Tamron Lens (129)`)
-    // resolves byte-exact to the 129.2 variant via the `Exif::PrintLensID`
-    // FocalLength (80) + MaxApertureValue (4.5002…) branch (`Exif.pm:6001`).
-  ];
+  // the new `Sony:FocusPosition`) computes. NO residuals — the body is fully
+  // byte-exact:
+  // * `Composite:ImageSize` (`3872x2592`) / `Megapixels` (`10.0`) now resolve
+  //   byte-exact (#436 part 1): the bare-name Composite resolver is PRIORITY-AWARE
+  //   (`composite/mod.rs` — MAX effective priority, first-emission among equals),
+  //   so it prefers the `MinoltaRaw:ImageWidth`/`ImageHeight` (`Priority => 1`,
+  //   the SR2-corrected `3872x2592`) over the earlier-emitted `SubIFD:ImageWidth`
+  //   (the `%Exif::Main` `0x0100` `Priority => 0` leaf, the padded `3880x2600`),
+  //   matching bundled.
+  // * `Composite:LensID` (= `Tamron 70-300mm F4-5.6 LD`) is ACTIVE (#103 part 3):
+  //   the AMBIGUOUS `Sony:LensType` 129 (`Tamron Lens (129)`) resolves byte-exact
+  //   to the 129.2 variant via the `Exif::PrintLensID` FocalLength (80) +
+  //   MaxApertureValue (4.5002…) branch (`Exif.pm:6001`).
+  const A200_DEFERRED: &[&str] = &[];
   check_excluding(
     "Sony_ILME-FX3_real.ARW",
     "Sony_ILME-FX3_real.ARW.json",

--- a/tests/typed_serde_parity.rs
+++ b/tests/typed_serde_parity.rs
@@ -526,21 +526,17 @@ const FIXTURE_EXCLUDED_KEYS: &[(&str, &[&str])] = &[
   // `ProcessBinaryData` tower is ported AND `Composite:LensID` now resolves the
   // ambiguous `Sony:LensType` 55 via `Exif::PrintLensID` (#103 part 3), so the
   // fixture no longer needs an exclusion entry.
-  // The `Sony_DSLR-A200_real.ARW` raw is now active (its OLDER `%Sony::Main`
-  // sub-table tower — `CameraInfo2`/`FocusInfo`/`CameraSettings` — is fully
-  // ported, see the `NOT_ACTIVE` note). The residuals are `Composite:ImageSize`/
-  // `Megapixels` (#436 — bundled resolves the bare-name `Composite:ImageSize`
-  // from `MinoltaRaw:ImageWidth` `Priority => 1` over `SubIFD:ImageWidth`
-  // `Priority => 0`; exifast's bare-name Composite resolver is emission-order-
-  // first, picking the padded `SubIFD` 3880x2600 → 10.1 MP, not the SR2-corrected
-  // 3872x2592 → 10.0 MP — a shared-resolver change tracked in owner-deferred
-  // #436). `Composite:LensID` (= `Tamron 70-300mm F4-5.6 LD`) is now ACTIVE via
-  // the `Exif::PrintLensID` FocalLength/MaxAperture branch (#103 part 3). Mirrors
+  // `Sony_DSLR-A200_real.ARW` is fully byte-exact (no excluded keys): its OLDER
+  // `%Sony::Main` sub-table tower (`CameraInfo2`/`FocusInfo`/`CameraSettings`) is
+  // ported, and `Composite:ImageSize` (`3872x2592`) / `Megapixels` (`10.0`) now
+  // resolve byte-exact (#436 part 1) — the bare-name Composite resolver is
+  // PRIORITY-AWARE, preferring `MinoltaRaw:ImageWidth`/`ImageHeight`
+  // (`Priority => 1`, SR2-corrected) over the earlier `SubIFD:ImageWidth`
+  // (`%Exif::Main` `0x0100` `Priority => 0`, the padded 3880x2600). With
+  // `Composite:LensID` (= `Tamron 70-300mm F4-5.6 LD`) also ACTIVE via
+  // `Exif::PrintLensID` (#103 part 3), the fixture no longer needs an exclusion
+  // entry. Mirrors
   // `conformance.rs::sony_arw_real_sr2_and_subifd_conformance`'s `A200_DEFERRED`.
-  (
-    "Sony_DSLR-A200_real.ARW",
-    &["Composite:ImageSize", "Composite:Megapixels"],
-  ),
   // `Canon_EOS-5D_real.CR2` — the deep Canon MakerNote sub-table activation
   // (#84/#85/#87). The newly-ported ColorData3 (0x4001 count 796) / CameraInfo5D
   // (0x0d) / Processing (0xa0) / MeasuredColor (0xaa) / CustomFunctions5D (0x0f →


### PR DESCRIPTION
Makes the bare-name Composite resolver PRIORITY-AWARE (max effective priority, then first-emission among equals), faithful to ExifTool's FoundTag rule (ExifTool.pm:9544-9564). Threads the true producer priorities: Exif ImageWidth/ImageHeight (0x0100/0x0101) at Priority 0 (Exif.pm:493/501), XMP tiff/exif/exifEX namespaces at Priority 0 (PRIORITY=>0). Activates Sony A200 Composite:ImageSize=3872x2592 / Megapixels=10.0 byte-exact (MinoltaRaw P1 beats SubIFD P0; previously #436-excluded).

A side effect — also faithful — is that priority-0 XMP-namespace duplicates now dedup FIRST-wins (matching bundled: XMP-tiff:ImageWidth=111 first, XMP-dc:Format=bbb last); locked by a cross-packet unit test over tiff/exif/exifEX (first-wins) + dc (last-wins).

Deferred (filed): #474 (crafted-MNG equal-priority true-recency needs a file-walk-order signal); #477 (restore_struct same-packet XMP first-wins — pre-existing, orthogonal).

Verify: conformance 508/0 (A200 activated, 6 Pentax byte-identical, all else unchanged) lib=4330/0 typed_serde=652 alloc=0 timed_metadata=162/0 xtask=26/0. Codex review R1-R3: R1 [high] XMP dedup coupling ground-truthed FAITHFUL (bundled first-wins for PRIORITY=>0); R2 [medium]+R3 locked all 3 priority-0 namespaces with oracle-backed cross-packet tests.