### PR TITLE
docs(dji): correct stale comment — FrameNumber 3-1-1 IS emitted (#476)

### DIFF
--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -13995,9 +13995,11 @@ fn emit_parrot(
 ///
 /// `SerialNumber2` (`2-2-3-1`, AVATA2 / DJI Neo) is a NAMED, default-extracted
 /// tag (DJI.pm:399/:553) and IS emitted (verbatim string, after `SerialNumber`).
-/// `FrameNumber` (`3-1-1`) and the Accelerometer / model-code / version fields
-/// are intentionally dropped (camera-indexing scope; see the `dji_protobuf`
-/// module docs) — the typed surface never stored them.
+/// `FrameNumber` (`3-1-1`) is likewise a NAMED, default-extracted tag
+/// (DJI.pm:279… `#forum17996`) and IS emitted per `djmd` sample (below). The
+/// Accelerometer / model-code / version fields are intentionally dropped
+/// (`Unknown => 1` non-default extractions; see the `dji_protobuf` module
+/// docs) — the typed surface never stored them.
 ///
 /// AccelerometerX/Y/Z: the typed [`crate::metadata::DjiTelemetrySample`] drops
 /// them (NOT camera/GPS metadata), so they are not emitted here.


### PR DESCRIPTION
#476 reported DJI protobuf FrameNumber (3-1-1) as walked-but-discarded, citing the quicktime.rs comment. Investigation: FrameNumber emission ALREADY shipped in PR #375 (#359) for all 16 protocols — the walker sets it (dji_protobuf.rs:1706), dji_push_sample_tags emits it (quicktime.rs:14238, the -ee path), and it is unit-tested (field_lookup_frame_number_all_protocols + djmd_frame_number_decodes_per_sample, both passing). The issue was filed off a stale comment that #375 forgot to update (it contradicted the correct dji_protobuf_tables.rs comment). This corrects that one stale comment. Doc-only; conformance 508/0 byte-identical. Closes #476.