### PR TITLE
perf(exif): confine suppressed-Unknown vendor emissions to a borrowed EmissionValue<'a> — bound the Sony 0x94xx memory amplification (#443)

### DIFF
--- a/src/exif/makernotes/vendors/apple/mod.rs
+++ b/src/exif/makernotes/vendors/apple/mod.rs
@@ -315,20 +315,20 @@ mod tests {
   // through the surviving path. The isolated helper installs the typed slot only
   // for `-j` (`print_conv.then(...)`); the `-n` tests below ignore the typed
   // surface, so an empty fallback there is never observed.
-  fn parse(
+  fn parse<'e>(
     blob: &[u8],
     order: ByteOrder,
     make: Option<&str>,
-  ) -> (MakerNotesApple, Vec<VendorEmission>) {
+  ) -> (MakerNotesApple, Vec<VendorEmission<'e>>) {
     parse_with_print_conv(blob, order, true, make)
   }
 
-  fn parse_with_print_conv(
+  fn parse_with_print_conv<'e>(
     blob: &[u8],
     order: ByteOrder,
     print_conv: bool,
     make: Option<&str>,
-  ) -> (MakerNotesApple, Vec<VendorEmission>) {
+  ) -> (MakerNotesApple, Vec<VendorEmission<'e>>) {
     let (emissions, typed) = crate::exif::apple_makernote_isolated(blob, order, print_conv, make);
     (typed.unwrap_or_else(MakerNotesApple::new), emissions)
   }
@@ -354,7 +354,7 @@ mod tests {
     assert_eq!(typed.maker_note_version(), Some(4));
     assert_eq!(emissions.len(), 1);
     assert_eq!(emissions[0].name(), "MakerNoteVersion");
-    assert_eq!(emissions[0].value(), &TagValue::I64(4));
+    assert_eq!(emissions[0].value().as_ref(), &TagValue::I64(4));
   }
 
   #[test]
@@ -363,7 +363,10 @@ mod tests {
     let (typed, emissions) = parse(&blob, ByteOrder::Big, Some("Apple"));
     assert_eq!(typed.hdr_image_type(), Some(3));
     assert_eq!(emissions.len(), 1);
-    assert_eq!(emissions[0].value(), &TagValue::Str("HDR Image".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("HDR Image".into())
+    );
   }
 
   #[test]
@@ -373,7 +376,7 @@ mod tests {
     assert_eq!(typed.camera_type(), Some(0));
     assert_eq!(typed.camera_type_label(), Some("Back Wide Angle"));
     assert_eq!(
-      emissions[0].value(),
+      emissions[0].value().as_ref(),
       &TagValue::Str("Back Wide Angle".into())
     );
   }
@@ -383,14 +386,17 @@ mod tests {
     let blob = one_entry_blob(0x0014, 0x0009, 1, [0x00, 0x00, 0x00, 0x05]); // 5 = unknown
     let (typed, emissions) = parse(&blob, ByteOrder::Big, Some("Apple"));
     assert_eq!(typed.image_capture_type(), Some(5));
-    assert_eq!(emissions[0].value(), &TagValue::Str("Unknown (5)".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("Unknown (5)".into())
+    );
   }
 
   #[test]
   fn parse_with_print_conv_off_emits_raw_int() {
     let blob = one_entry_blob(0x000a, 0x0009, 1, [0x00, 0x00, 0x00, 0x03]);
     let (_typed, emissions) = parse_with_print_conv(&blob, ByteOrder::Big, false, Some("Apple"));
-    assert_eq!(emissions[0].value(), &TagValue::I64(3));
+    assert_eq!(emissions[0].value().as_ref(), &TagValue::I64(3));
   }
 
   #[test]

--- a/src/exif/makernotes/vendors/canon/mod.rs
+++ b/src/exif/makernotes/vendors/canon/mod.rs
@@ -372,12 +372,12 @@ impl MakerNotesCanon {
 /// ShutterCount row (`$$self{FileType} eq "CR3"`, `Canon.pm:4885`) while leaving
 /// the ShotInfo position-22 CRW clause off (no CR3/CRM/MP4 container is "CRW").
 #[must_use]
-pub fn redispatch_ctmd_makernote(
+pub fn redispatch_ctmd_makernote<'e>(
   tiff_block: &[u8],
   print_conv: bool,
   model: Option<&str>,
   file_type: Option<&str>,
-) -> Vec<VendorEmission> {
+) -> Vec<VendorEmission<'e>> {
   // TIFF header: `[II/MM][0x2a][ifd0_offset:u32]` (8 bytes). Bail on a short /
   // unrecognized header (ExifTool's `ProcessTIFF` would `return 0`).
   let Some(order) = tiff_block
@@ -1065,11 +1065,11 @@ mod tests {
   // dispatch through the surviving path. The isolated helper installs the typed
   // slot only for `-j` (`print_conv.then(...)`); every `typed`-asserting test
   // below runs `-j`, so the empty `-n` fallback is never observed.
-  fn parse(blob: &[u8], order: ByteOrder) -> (MakerNotesCanon, Vec<VendorEmission>) {
+  fn parse<'e>(blob: &[u8], order: ByteOrder) -> (MakerNotesCanon, Vec<VendorEmission<'e>>) {
     parse_in_tiff(blob, 0, blob.len(), order, true, None, None)
   }
 
-  fn parse_in_tiff(
+  fn parse_in_tiff<'e>(
     tiff_data: &[u8],
     mn_offset: usize,
     mn_len: usize,
@@ -1077,7 +1077,7 @@ mod tests {
     print_conv: bool,
     model: Option<&str>,
     file_type: Option<&str>,
-  ) -> (MakerNotesCanon, Vec<VendorEmission>) {
+  ) -> (MakerNotesCanon, Vec<VendorEmission<'e>>) {
     let (emissions, typed) = crate::exif::canon_makernote_isolated(
       tiff_data, mn_offset, mn_len, order, model, file_type, print_conv,
     );
@@ -1135,7 +1135,7 @@ mod tests {
     let v = emissions
       .iter()
       .find(|e| e.name() == "CanonModelID")
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
       .unwrap();
     assert_eq!(v, TagValue::Str("EOS D30".into()));
   }
@@ -1157,7 +1157,7 @@ mod tests {
     let v = emissions
       .iter()
       .find(|e| e.name() == "SerialNumber")
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
       .unwrap();
     assert_eq!(v, TagValue::Str("0560018150".into()));
   }
@@ -1180,7 +1180,7 @@ mod tests {
     let v = emissions
       .iter()
       .find(|e| e.name() == "SerialNumber")
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
       .unwrap();
     assert_eq!(v, TagValue::Str("500292".into()));
   }
@@ -1193,7 +1193,7 @@ mod tests {
     let v = emissions
       .iter()
       .find(|e| e.name() == "FileNumber")
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
       .unwrap();
     assert_eq!(v, TagValue::Str("118-1861".into()));
   }
@@ -1210,7 +1210,7 @@ mod tests {
     let v = emissions
       .iter()
       .find(|e| e.name() == "InternalSerialNumber")
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
       .unwrap();
     assert_eq!(v, TagValue::Str("ABC123".into()));
   }
@@ -1258,12 +1258,12 @@ mod tests {
     let isn2 = emissions
       .iter()
       .find(|e| e.name() == "InternalSerialNumber2")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(isn2, Some(TagValue::Str("ABC123XYZ".into())));
     let isn = emissions
       .iter()
       .find(|e| e.name() == "InternalSerialNumber")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(isn, Some(TagValue::Str("DEF456".into())));
     // The typed `internal_serial_number` tracks only the model-agnostic
     // SECOND-arm leaf, which an EOS-5D never takes — it stays unset.
@@ -1296,7 +1296,7 @@ mod tests {
     let isn = emissions
       .iter()
       .find(|e| e.name() == "InternalSerialNumber")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(isn, Some(TagValue::Str("DEF456".into())));
   }
 
@@ -1321,7 +1321,7 @@ mod tests {
     let isn2 = emissions
       .iter()
       .find(|e| e.name() == "InternalSerialNumber2")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(isn2, Some(TagValue::Str("WXYZ12ABC".into())));
     // The typed `internal_serial_number` (SECOND-arm) stays unset.
     assert_eq!(typed.internal_serial_number(), None);
@@ -1347,7 +1347,7 @@ mod tests {
     let v = emissions
       .iter()
       .find(|e| e.name() == "InternalSerialNumber")
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
       .unwrap();
     assert_eq!(v, TagValue::Str("ABC123".into()));
   }
@@ -1388,7 +1388,7 @@ mod tests {
     assert_eq!(
       em.iter()
         .find(|e| e.name() == "BatteryType")
-        .map(|e| e.value().clone()),
+        .map(|e| e.value().into_owned()),
       Some(TagValue::Str("LP-E6N".into())),
       "a valid undef[76] BatteryType emits its run"
     );

--- a/src/exif/makernotes/vendors/dji/dji_info.rs
+++ b/src/exif/makernotes/vendors/dji/dji_info.rs
@@ -359,8 +359,8 @@ fn split_first_colon(inner: &[u8]) -> (&[u8], Option<&[u8]>) {
 /// `%DJI::Info` carries no Conv, so the result is independent of `print_conv`
 /// (the parameter is accepted for call-site symmetry with the IFD path).
 #[must_use]
-pub fn parse_dji_info(blob: &[u8]) -> Vec<VendorEmission> {
-  let mut emissions: Vec<VendorEmission> = Vec::new();
+pub fn parse_dji_info<'e>(blob: &[u8]) -> Vec<VendorEmission<'e>> {
+  let mut emissions: Vec<VendorEmission<'e>> = Vec::new();
   // `/\G.../g`: the first capture must begin at offset 0 (the dispatch
   // guarantees `[ae_dbg_info:`); each subsequent `\G` anchor is the index
   // just past the previous `]`. A failed match terminates the loop.
@@ -402,7 +402,7 @@ mod tests {
   use super::*;
   use crate::value::TagValue;
 
-  fn names(emis: &[VendorEmission]) -> Vec<&str> {
+  fn names<'s>(emis: &'s [VendorEmission<'_>]) -> Vec<&'s str> {
     emis.iter().map(VendorEmission::name).collect()
   }
 
@@ -436,9 +436,18 @@ mod tests {
         "SensorID",
       ]
     );
-    assert_eq!(emis[0].value(), &TagValue::Str("Ver=1.0,exp=auto".into()));
-    assert_eq!(emis[1].value(), &TagValue::Str("0 1 2 3 4 5".into()));
-    assert_eq!(emis[3].value(), &TagValue::Str("-12.3,4.5,0.0".into()));
+    assert_eq!(
+      emis[0].value().as_ref(),
+      &TagValue::Str("Ver=1.0,exp=auto".into())
+    );
+    assert_eq!(
+      emis[1].value().as_ref(),
+      &TagValue::Str("0 1 2 3 4 5".into())
+    );
+    assert_eq!(
+      emis[3].value().as_ref(),
+      &TagValue::Str("-12.3,4.5,0.0".into())
+    );
   }
 
   #[test]
@@ -446,7 +455,10 @@ mod tests {
     // Bundled: `[some_unknown_tag:hello world]` ⇒ DJI:Some_Unknown_Tag.
     let emis = parse_dji_info(b"[ae_dbg_info:x][some_unknown_tag:hello world]");
     assert_eq!(names(&emis), std::vec!["AEDebugInfo", "Some_Unknown_Tag"]);
-    assert_eq!(emis[1].value(), &TagValue::Str("hello world".into()));
+    assert_eq!(
+      emis[1].value().as_ref(),
+      &TagValue::Str("hello world".into())
+    );
   }
 
   #[test]
@@ -454,7 +466,7 @@ mod tests {
     // `split /:/, $1, 2` ⇒ value = "a:b:c=1". Bundled: DJI:AEDebugInfo "a:b:c=1".
     let emis = parse_dji_info(b"[ae_dbg_info:a:b:c=1]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Str("a:b:c=1".into()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Str("a:b:c=1".into()));
   }
 
   #[test]
@@ -471,7 +483,7 @@ mod tests {
     // DJI:Tag "emptykey".
     let emis = parse_dji_info(b"[ae_dbg_info:x][:emptykey]");
     assert_eq!(names(&emis), std::vec!["AEDebugInfo", "Tag"]);
-    assert_eq!(emis[1].value(), &TagValue::Str("emptykey".into()));
+    assert_eq!(emis[1].value().as_ref(), &TagValue::Str("emptykey".into()));
   }
 
   #[test]
@@ -480,7 +492,7 @@ mod tests {
     // Bundled: "(Binary data 0 bytes, use -b option to extract)".
     let emis = parse_dji_info(b"[ae_dbg_info:]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Bytes(std::vec![]));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Bytes(std::vec![]));
   }
 
   #[test]
@@ -488,7 +500,7 @@ mod tests {
     // `hello\0\0\0` ⇒ printable prefix "hello", trailing NULs stripped.
     let emis = parse_dji_info(b"[ae_dbg_info:hello\x00\x00\x00]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Str("hello".into()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Str("hello".into()));
   }
 
   #[test]
@@ -497,7 +509,10 @@ mod tests {
     // Bundled: "(Binary data 5 bytes, …)".
     let emis = parse_dji_info(b"[ae_dbg_info:ab\x00cd]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Bytes(b"ab\x00cd".to_vec()));
+    assert_eq!(
+      emis[0].value().as_ref(),
+      &TagValue::Bytes(b"ab\x00cd".to_vec())
+    );
   }
 
   #[test]
@@ -506,7 +521,7 @@ mod tests {
     let emis = parse_dji_info(b"[ae_dbg_info:\x01\x02\x03\xff\xfe]");
     assert_eq!(emis.len(), 1);
     assert_eq!(
-      emis[0].value(),
+      emis[0].value().as_ref(),
       &TagValue::Bytes(b"\x01\x02\x03\xff\xfe".to_vec())
     );
   }
@@ -528,7 +543,7 @@ mod tests {
     let emis = parse_dji_info(b"[ae_dbg_info:ok]x[awb_dbg_info:y]");
     assert_eq!(names(&emis), std::vec!["AEDebugInfo"]);
     assert_eq!(
-      emis[0].value(),
+      emis[0].value().as_ref(),
       &TagValue::Str("ok]x[awb_dbg_info:y".into())
     );
   }
@@ -556,7 +571,7 @@ mod tests {
     // is captured. Bundled 13.59: DJI:AEDebugInfo "ok".
     let emis = parse_dji_info(b"[ae_dbg_info:ok]\n");
     assert_eq!(names(&emis), std::vec!["AEDebugInfo"]);
-    assert_eq!(emis[0].value(), &TagValue::Str("ok".into()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Str("ok".into()));
   }
 
   #[test]
@@ -566,8 +581,8 @@ mod tests {
     // MakeTagInfo "Tagb". Bundled 13.59: DJI:AEDebugInfo "a:1", DJI:Tagb 2.
     let emis = parse_dji_info(b"[ae_dbg_info:a:1][b:2]\n");
     assert_eq!(names(&emis), std::vec!["AEDebugInfo", "Tagb"]);
-    assert_eq!(emis[0].value(), &TagValue::Str("a:1".into()));
-    assert_eq!(emis[1].value(), &TagValue::Str("2".into()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Str("a:1".into()));
+    assert_eq!(emis[1].value().as_ref(), &TagValue::Str("2".into()));
   }
 
   #[test]
@@ -591,7 +606,7 @@ mod tests {
     let emis = parse_dji_info(b"[ae_dbg_info:ok]\n[awb_dbg_info:y]");
     assert_eq!(names(&emis), std::vec!["AEDebugInfo"]);
     assert_eq!(
-      emis[0].value(),
+      emis[0].value().as_ref(),
       &TagValue::Bytes(b"ok]\n[awb_dbg_info:y".to_vec())
     );
   }
@@ -603,7 +618,7 @@ mod tests {
     // the anchor). Bundled 13.59: DJI:AEDebugInfo "ok".
     let emis = parse_dji_info(b"[ae_dbg_info:ok\n]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Str("ok".into()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Str("ok".into()));
   }
 
   #[test]
@@ -614,7 +629,10 @@ mod tests {
     // Bundled 13.59: DJI:AEDebugInfo "(Binary data 4 bytes, …)".
     let emis = parse_dji_info(b"[ae_dbg_info:ok\n\n]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Bytes(b"ok\n\n".to_vec()));
+    assert_eq!(
+      emis[0].value().as_ref(),
+      &TagValue::Bytes(b"ok\n\n".to_vec())
+    );
   }
 
   #[test]
@@ -624,7 +642,7 @@ mod tests {
     // (the NULs are stripped). Bundled 13.59: DJI:AEDebugInfo "ok".
     let emis = parse_dji_info(b"[ae_dbg_info:ok\x00\n]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Str("ok".into()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Str("ok".into()));
   }
 
   #[test]
@@ -635,7 +653,10 @@ mod tests {
     // DJI:AEDebugInfo "(Binary data 4 bytes, …)".
     let emis = parse_dji_info(b"[ae_dbg_info:ok\n\x00]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Bytes(b"ok\n\x00".to_vec()));
+    assert_eq!(
+      emis[0].value().as_ref(),
+      &TagValue::Bytes(b"ok\n\x00".to_vec())
+    );
   }
 
   #[test]
@@ -645,7 +666,7 @@ mod tests {
     // binary (the full 1-byte value). Bundled 13.59: "(Binary data 1 bytes,…)".
     let emis = parse_dji_info(b"[ae_dbg_info:\n]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Bytes(b"\n".to_vec()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Bytes(b"\n".to_vec()));
   }
 
   #[test]
@@ -655,7 +676,7 @@ mod tests {
     // DJI:AEDebugInfo "hello".
     let emis = parse_dji_info(b"[ae_dbg_info:hello\x00\x00\n]");
     assert_eq!(emis.len(), 1);
-    assert_eq!(emis[0].value(), &TagValue::Str("hello".into()));
+    assert_eq!(emis[0].value().as_ref(), &TagValue::Str("hello".into()));
   }
 
   // ---- MakeTagInfo name-derivation unit coverage (ExifTool.pm:9312-9317) ----

--- a/src/exif/makernotes/vendors/dji/mod.rs
+++ b/src/exif/makernotes/vendors/dji/mod.rs
@@ -276,17 +276,17 @@ impl MakerNotesDji {
 /// `blob` is the raw 0x927C value (DJI's body has no header — `Start =>
 /// '$valuePtr'`); `parent_order` is the parent IFD walk's byte order.
 #[must_use]
-pub fn parse(blob: &[u8], parent_order: ByteOrder) -> (MakerNotesDji, Vec<VendorEmission>) {
+pub fn parse<'e>(blob: &[u8], parent_order: ByteOrder) -> (MakerNotesDji, Vec<VendorEmission<'e>>) {
   parse_with_print_conv(blob, parent_order, true)
 }
 
 /// Like [`parse`] but lets the caller toggle PrintConv.
 #[must_use]
-pub fn parse_with_print_conv(
+pub fn parse_with_print_conv<'e>(
   blob: &[u8],
   parent_order: ByteOrder,
   print_conv: bool,
-) -> (MakerNotesDji, Vec<VendorEmission>) {
+) -> (MakerNotesDji, Vec<VendorEmission<'e>>) {
   parse_in_tiff(blob, 0, blob.len(), parent_order, print_conv)
 }
 
@@ -308,15 +308,15 @@ pub fn parse_with_print_conv(
 /// `MakerNotesDji` fields (it carries debug blobs, not the camera-pose / speed
 /// data the struct models), so the typed slot stays empty there.
 #[must_use]
-pub fn parse_in_tiff(
+pub fn parse_in_tiff<'e>(
   tiff_data: &[u8],
   mn_offset: usize,
   mn_len: usize,
   parent_order: ByteOrder,
   print_conv: bool,
-) -> (MakerNotesDji, Vec<VendorEmission>) {
+) -> (MakerNotesDji, Vec<VendorEmission<'e>>) {
   let mut typed = MakerNotesDji::new();
-  let mut emissions: Vec<VendorEmission> = Vec::new();
+  let mut emissions: Vec<VendorEmission<'e>> = Vec::new();
   // DJIInfo (`MakerNoteDJIInfo`, `NotIFD => 1`): the whole 0x927C value is the
   // bracketed-string body (`DirStart = 0`). `%DJI::Info` has no Conv, so the
   // emissions are `print_conv`-independent.
@@ -359,7 +359,7 @@ pub fn parse_into_metadata(
     if e.unknown() {
       continue;
     }
-    into.push(group.clone(), e.name(), e.value().clone());
+    into.push(group.clone(), e.name(), e.value().into_owned());
   }
 }
 
@@ -454,7 +454,10 @@ mod tests {
     let (typed, emissions) = parse(&blob, ByteOrder::Little);
     assert_eq!(emissions.len(), 1);
     assert_eq!(emissions[0].name(), "Pitch");
-    assert_eq!(emissions[0].value(), &TagValue::Str("+12.50".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("+12.50".into())
+    );
     assert!((typed.flight_pitch().unwrap() - 12.5).abs() < 1e-6);
   }
 
@@ -516,7 +519,7 @@ mod tests {
     let (typed, emissions) = parse(&blob, ByteOrder::Little);
     assert_eq!(emissions.len(), 1);
     assert_eq!(emissions[0].name(), "Make");
-    assert_eq!(emissions[0].value(), &TagValue::Str("DJI".into()));
+    assert_eq!(emissions[0].value().as_ref(), &TagValue::Str("DJI".into()));
     assert_eq!(typed.make(), Some("DJI"));
   }
 
@@ -533,11 +536,20 @@ mod tests {
     let (typed, emissions) = parse(&blob, ByteOrder::Little);
     assert_eq!(emissions.len(), 3);
     assert_eq!(emissions[0].name(), "SpeedX");
-    assert_eq!(emissions[0].value(), &TagValue::Str("+1.25".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("+1.25".into())
+    );
     assert_eq!(emissions[1].name(), "SpeedY");
-    assert_eq!(emissions[1].value(), &TagValue::Str("-3.50".into()));
+    assert_eq!(
+      emissions[1].value().as_ref(),
+      &TagValue::Str("-3.50".into())
+    );
     assert_eq!(emissions[2].name(), "SpeedZ");
-    assert_eq!(emissions[2].value(), &TagValue::Str("+0.00".into()));
+    assert_eq!(
+      emissions[2].value().as_ref(),
+      &TagValue::Str("+0.00".into())
+    );
     let triple = typed.flight_speed().expect("all three speed tags");
     assert!((triple.0 - 1.25).abs() < 1e-6);
     assert!((triple.1 + 3.5).abs() < 1e-6);

--- a/src/exif/makernotes/vendors/leica/tests.rs
+++ b/src/exif/makernotes/vendors/leica/tests.rs
@@ -387,8 +387,9 @@ fn leica4_descends_into_subdir_and_data1() {
   )
   .expect("Leica4 walk");
   let has = |name: &str, val: &str| {
-    em.iter()
-      .any(|e: &VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+    em.iter().any(|e: &VendorEmission<'_>| {
+      e.name() == name && e.value().as_ref() == &TagValue::Str(val.into())
+    })
   };
   let names: std::vec::Vec<&str> = em.iter().map(VendorEmission::name).collect();
   // Subdir leaves (descended Leica4 -> Subdir).
@@ -413,7 +414,9 @@ fn leica4_descends_into_subdir_and_data1() {
   // higher-priority `0x3405` value and the later Data1 value never overrides it.
   let prio = |name: &str, val: &str| -> Option<u8> {
     em.iter()
-      .find(|e: &&VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+      .find(|e: &&VendorEmission<'_>| {
+        e.name() == name && e.value().as_ref() == &TagValue::Str(val.into())
+      })
       .map(VendorEmission::priority)
   };
   assert_eq!(
@@ -507,8 +510,9 @@ fn leica4_subdir_child_decodes_under_its_own_byte_order() {
   )
   .expect("Leica4 walk");
   let has = |name: &str, val: &str| {
-    em.iter()
-      .any(|e: &VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+    em.iter().any(|e: &VendorEmission<'_>| {
+      e.name() == name && e.value().as_ref() == &TagValue::Str(val.into())
+    })
   };
   let names: std::vec::Vec<&str> = em.iter().map(VendorEmission::name).collect();
   // The BIG-endian child IFD's plain leaves decode under the child order.
@@ -536,7 +540,9 @@ fn leica4_subdir_child_decodes_under_its_own_byte_order() {
   // intact for the Data1 LensType.
   let prio = |name: &str, val: &str| -> Option<u8> {
     em.iter()
-      .find(|e: &&VendorEmission| e.name() == name && e.value() == &TagValue::Str(val.into()))
+      .find(|e: &&VendorEmission<'_>| {
+        e.name() == name && e.value().as_ref() == &TagValue::Str(val.into())
+      })
       .map(VendorEmission::priority)
   };
   assert_eq!(

--- a/src/exif/makernotes/vendors/mod.rs
+++ b/src/exif/makernotes/vendors/mod.rs
@@ -54,6 +54,36 @@ pub type AppleMakerNote = MakerNotesApple;
 /// Compatibility alias — Phase-1 API name preserved.
 pub type CanonMakerNote = MakerNotesCanon;
 
+/// A vendor emission's VALUE — either an owned, already-rendered
+/// [`TagValue`](crate::value::TagValue) (the common case: every named/computed
+/// leaf) or, from Phase 4 (#443), a `Borrowed(&'a [u8])` verbatim `undef[N]`
+/// span sliced zero-copy from the input buffer (the SUPPRESSED-`Unknown` Sony
+/// `0x94xx` `%unknownCipherData` leaves). Confining the suppressed-leaf value to
+/// a borrow — materialized only on read via [`VendorEmission::value`] — bounds
+/// the memory a crafted MakerNote can amplify (N leaves over one M-byte region
+/// retain O(N) span descriptors, not N copies of M).
+///
+/// COVARIANT in `'a` (`&'a [u8]` is covariant, `TagValue` is `'a`-free), so a
+/// detached `EmissionValue<'static>` (an all-owned producer) is usable wherever
+/// an `EmissionValue<'a>` is expected.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, PartialEq)]
+pub enum EmissionValue<'a> {
+  /// An owned, already-rendered value — the common case (every named/computed
+  /// vendor leaf).
+  Owned(crate::value::TagValue),
+  /// A verbatim `undef[N]` value span, borrowed ZERO-COPY from the input buffer
+  /// (#443). Used ONLY for a SUPPRESSED-`Unknown` Sony `0x94xx`
+  /// `%unknownCipherData` leaf: its value is the raw on-disk bytes
+  /// (`data[value_offset .. value_offset + value_size]`), which the default
+  /// output drops (`Unknown => 1`) and only the `-u`/API path materializes (via
+  /// [`VendorEmission::value`]). Borrowing — rather than copying into a
+  /// [`TagValue::Bytes`](crate::value::TagValue::Bytes) — is what bounds the
+  /// memory a crafted MakerNote (N leaves over one shared M-byte region) can
+  /// amplify: O(N) span descriptors sharing the buffer, not N copies of M.
+  Borrowed(&'a [u8]),
+}
+
 /// One vendor MakerNote emission — the rendered `(name, value)` pair plus the
 /// `Unknown => 1` flag the emission engine uses to suppress it from default
 /// output (`ExifTool.pm:9179-9185`).
@@ -65,6 +95,10 @@ pub type CanonMakerNote = MakerNotesCanon;
 /// `Unknown` ones once — exactly as it does for every other format, so the
 /// per-vendor `if def.is_unknown() { continue; }` is gone.
 ///
+/// The `'a` lifetime is the input buffer a [`Borrowed`](EmissionValue) value
+/// points into (Phase 4, #443, the Sony `0x94xx` suppressed-`Unknown` leaves);
+/// an all-owned emission ignores it.
+///
 /// D8: no public fields; accessors only. The constructor is `pub(crate)` (only
 /// the in-crate vendor body parsers build these), but the read accessors are
 /// `pub` so the captured-MakerNote accessors
@@ -72,11 +106,13 @@ pub type CanonMakerNote = MakerNotesCanon;
 /// remain usable from outside the crate.
 #[cfg(feature = "alloc")]
 #[derive(Debug, Clone, PartialEq)]
-pub struct VendorEmission {
+pub struct VendorEmission<'a> {
   /// The resolved tag name (the vendor table's `Name`).
   name: smol_str::SmolStr,
-  /// The rendered value for the active [`ConvMode`](crate::emit::ConvMode).
-  value: crate::value::TagValue,
+  /// The rendered value for the active [`ConvMode`](crate::emit::ConvMode) —
+  /// [`Owned`](EmissionValue::Owned) for a named/computed leaf, or a borrowed
+  /// verbatim span for a suppressed-`Unknown` cipher-data leaf (Phase 4, #443).
+  value: EmissionValue<'a>,
   /// ExifTool's `Unknown => 1` flag — `true` ⇒ the engine suppresses this tag
   /// from default output.
   unknown: bool,
@@ -98,7 +134,7 @@ pub struct VendorEmission {
 }
 
 #[cfg(feature = "alloc")]
-impl VendorEmission {
+impl<'a> VendorEmission<'a> {
   /// Compose a vendor emission from its name, rendered value, and `Unknown`
   /// flag, with ExifTool's default duplicate `Priority => 1`
   /// (`ExifTool.pm:9553`). (`pub(crate)`: only the in-crate vendor body parsers
@@ -124,7 +160,31 @@ impl VendorEmission {
   ) -> Self {
     Self {
       name,
-      value,
+      value: EmissionValue::Owned(value),
+      unknown,
+      priority,
+      group1_override: None,
+    }
+  }
+
+  /// Compose a SUPPRESSED-`Unknown` vendor emission whose value is a verbatim
+  /// `undef[N]` span BORROWED zero-copy from the input buffer (#443) — the Sony
+  /// `0x94xx` `%unknownCipherData` leaves. The value is NOT materialized here;
+  /// it becomes a [`TagValue::Bytes`](crate::value::TagValue::Bytes) only if
+  /// [`value`](Self::value) is read (the `-u`/API path), so N such leaves over
+  /// one shared M-byte region retain O(N) span descriptors, not N copies of M.
+  /// `group1_override` is `None` (the emission inherits the vendor group).
+  #[must_use]
+  #[inline(always)]
+  pub(crate) fn new_borrowed_span(
+    name: smol_str::SmolStr,
+    span: &'a [u8],
+    unknown: bool,
+    priority: u8,
+  ) -> Self {
+    Self {
+      name,
+      value: EmissionValue::Borrowed(span),
       unknown,
       priority,
       group1_override: None,
@@ -146,7 +206,7 @@ impl VendorEmission {
   ) -> Self {
     Self {
       name,
-      value,
+      value: EmissionValue::Owned(value),
       unknown,
       priority: 1,
       group1_override: Some(group1),
@@ -170,7 +230,7 @@ impl VendorEmission {
   ) -> Self {
     Self {
       name,
-      value,
+      value: EmissionValue::Owned(value),
       unknown,
       priority,
       group1_override,
@@ -184,11 +244,25 @@ impl VendorEmission {
     self.name.as_str()
   }
 
-  /// The rendered value.
+  /// The rendered value, materialized ON READ. An [`Owned`](EmissionValue::Owned)
+  /// value is returned by reference ([`Cow::Borrowed`](std::borrow::Cow::Borrowed),
+  /// zero-copy); a borrowed suppressed-`Unknown` cipher-data span (Phase 4, #443)
+  /// materializes into an owned [`TagValue::Bytes`](crate::value::TagValue::Bytes)
+  /// only here — so the default consumer, which drops `Unknown` leaves BEFORE
+  /// reading, never pays the copy, while the `-u`/API path recovers the exact
+  /// on-disk bytes.
   #[must_use]
-  #[inline(always)]
-  pub const fn value(&self) -> &crate::value::TagValue {
-    &self.value
+  #[inline]
+  pub fn value(&self) -> std::borrow::Cow<'_, crate::value::TagValue> {
+    match &self.value {
+      EmissionValue::Owned(v) => std::borrow::Cow::Borrowed(v),
+      // Materialize the borrowed verbatim span into an owned `TagValue::Bytes`
+      // (#443) — byte-identical to what the eager `raw_to_tag_value` produced
+      // from a `RawValue::Bytes(span.to_vec())`, but paid ONLY here, on read.
+      EmissionValue::Borrowed(span) => {
+        std::borrow::Cow::Owned(crate::value::TagValue::Bytes(span.to_vec()))
+      }
+    }
   }
 
   /// Whether this emission carries ExifTool's `Unknown => 1` flag — the

--- a/src/exif/makernotes/vendors/nikon/mod.rs
+++ b/src/exif/makernotes/vendors/nikon/mod.rs
@@ -293,7 +293,7 @@ pub(crate) fn emit_af_info(
   sub: &[u8],
   print_conv: bool,
   model: Option<&str>,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   // The AFInfo SubDirectory's own byte order (the table-level `ByteOrder`
   // directive). DSLRs → BigEndian; else LittleEndian. The parent IFD's order
@@ -436,7 +436,7 @@ pub(crate) fn emit_color_balance(
   order: ByteOrder,
   print_conv: bool,
   keys: Option<DecryptKeys>,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   // `ColorBalanceVersion` = the first 4 ASCII bytes (`Condition => '$$valPt =~
   // /^…/'`). A value shorter than 4 bytes matches no arm.
@@ -515,7 +515,7 @@ pub(crate) fn emit_flash_info(
   sub: &[u8],
   order: ByteOrder,
   print_conv: bool,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   // `FlashInfoVersion` = the first 4 ASCII bytes (`Format => 'string[4]'`).
   let Some(version) = sub.get(0..4).and_then(|v| <&[u8; 4]>::try_from(v).ok()) else {
@@ -537,16 +537,18 @@ pub(crate) fn emit_flash_info(
   // The shared int8u read + conv push (`FORMAT => 'int8u'` is the table
   // default). A byte past the value length emits nothing; a `None` from a
   // RawConv-undef drop (FlashFocalLength/RepeatingFlashRate 0) is skipped.
-  let push_u8 =
-    |emissions: &mut Vec<VendorEmission>, offset: usize, name: &'static str, conv: NikonConv| {
-      let Some(&byte) = sub.get(offset) else {
-        return;
-      };
-      let parsed = ParsedValue::new(RawValue::U64(std::vec![u64::from(byte)]));
-      if let Some(value) = conv.apply(&parsed, print_conv, None, order) {
-        emissions.push(VendorEmission::new(name.into(), value, false));
-      }
+  let push_u8 = |emissions: &mut Vec<VendorEmission<'_>>,
+                 offset: usize,
+                 name: &'static str,
+                 conv: NikonConv| {
+    let Some(&byte) = sub.get(offset) else {
+      return;
     };
+    let parsed = ParsedValue::new(RawValue::U64(std::vec![u64::from(byte)]));
+    if let Some(value) = conv.apply(&parsed, print_conv, None, order) {
+      emissions.push(VendorEmission::new(name.into(), value, false));
+    }
+  };
 
   // offset 4 `FlashSource` (int8u).
   push_u8(emissions, 4, "FlashSource", NikonConv::FlashSource);
@@ -741,7 +743,7 @@ pub(crate) fn emit_shot_info(
   sub: &[u8],
   print_conv: bool,
   keys: Option<DecryptKeys>,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   // `ShotInfoVersion` (offset 0, `Format => 'string[4]'`): the first 4 ASCII
   // bytes. Read from the ORIGINAL (cleartext) bytes — the version prefix is
@@ -924,7 +926,7 @@ fn emit_shot_info_u8(
   print_conv: bool,
   conv: NikonConv,
   name: &'static str,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   let Some(&byte) = body.get(offset) else {
     return;
@@ -945,7 +947,7 @@ fn emit_shot_info_int(
   format: Format,
   order: ByteOrder,
   name: &'static str,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   // The base ShotInfo counts are `Priority => 0` (`Nikon.pm:6019/6026/6058/6081`):
   // a duplicate must NOT override a higher-priority same-name tag (the Main 0x00a7
@@ -1021,7 +1023,7 @@ fn emit_masked_control_mode(
   name: &'static str,
   print_conv: bool,
   order: ByteOrder,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) -> Option<i64> {
   let &byte = sub.get(offset)?;
   let masked = i64::from(byte & 0x0f);
@@ -1054,7 +1056,7 @@ fn emit_flash_output_or_comp(
   // offset-17/18 `FlashGroup{A,B}Compensation`). The `FlashOutput` arm is never
   // `Priority => 0`.
   comp_priority: u8,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   let Some(&byte) = sub.get(offset) else {
     return;
@@ -1338,7 +1340,7 @@ pub(crate) fn emit_lens_data(
   print_conv: bool,
   keys: Option<DecryptKeys>,
   focus_mode: Option<&str>,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   // `LensDataVersion` = the first 4 ASCII bytes (`Format => 'string[4]'`).
   let Some(version) = sub.get(0..4).and_then(|v| <&[u8; 4]>::try_from(v).ok()) else {
@@ -1497,7 +1499,7 @@ fn emit_lens_data_0800_new(
   order: ByteOrder,
   print_conv: bool,
   focus_mode: Option<&str>,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   // `0x2f` NewLensData (`undef[17]`): set the flag UNLESS `/^.\0+$/s` (the lead
   // byte is anything and bytes 1..17 are all NUL) — the same forward-look test
@@ -1714,7 +1716,7 @@ fn emit_z_int16u(
   // NEW-block `MaxAperture`/`FNumber`/`FocalLength` rows,
   // `Nikon.pm:5891/5901/5911`; `1` for the firmware/focus members).
   priority: u8,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   let Some(n) = read_z_int16u(body, offset, order) else {
     return;
@@ -1740,7 +1742,7 @@ fn emit_z_int8u(
   conv: NikonConv,
   unknown: bool,
   name: &'static str,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   let Some(&byte) = body.get(offset) else {
     return;
@@ -1785,7 +1787,7 @@ fn emit_z_int32s(
   order: ByteOrder,
   print_conv: bool,
   name: &'static str,
-  emissions: &mut Vec<VendorEmission>,
+  emissions: &mut Vec<VendorEmission<'_>>,
 ) {
   let avail = match body.len().checked_sub(offset) {
     Some(a) => a,
@@ -1883,31 +1885,31 @@ mod tests {
   // layout cannot be resolved (`resolve_layout` fail); the oracle returned empties
   // there, so the shim maps `None` to `(MakerNotesNikon::new(), empty)` to preserve
   // that contract (e.g. the empty-blob test).
-  fn parse(
+  fn parse<'e>(
     blob: &[u8],
     order: ByteOrder,
     model: Option<&str>,
-  ) -> (MakerNotesNikon, Vec<VendorEmission>) {
+  ) -> (MakerNotesNikon, Vec<VendorEmission<'e>>) {
     parse_in_tiff(blob, 0, blob.len(), order, true, model)
   }
 
-  fn parse_with_print_conv(
+  fn parse_with_print_conv<'e>(
     blob: &[u8],
     order: ByteOrder,
     print_conv: bool,
     model: Option<&str>,
-  ) -> (MakerNotesNikon, Vec<VendorEmission>) {
+  ) -> (MakerNotesNikon, Vec<VendorEmission<'e>>) {
     parse_in_tiff(blob, 0, blob.len(), order, print_conv, model)
   }
 
-  fn parse_in_tiff(
+  fn parse_in_tiff<'e>(
     blob: &[u8],
     mn_offset: usize,
     mn_len: usize,
     order: ByteOrder,
     print_conv: bool,
     model: Option<&str>,
-  ) -> (MakerNotesNikon, Vec<VendorEmission>) {
+  ) -> (MakerNotesNikon, Vec<VendorEmission<'e>>) {
     match crate::exif::nikon_makernote_isolated(blob, mn_offset, mn_len, order, model, print_conv) {
       Some((emissions, typed)) => (typed, emissions),
       None => (MakerNotesNikon::new(), Vec::new()),
@@ -1943,7 +1945,7 @@ mod tests {
     assert!(names.contains(&"Quality"));
     assert!(names.contains(&"LensType"));
     let q = emissions.iter().find(|e| e.name() == "Quality").unwrap();
-    assert_eq!(q.value(), &TagValue::Str(SmolStr::new("Fine")));
+    assert_eq!(q.value().as_ref(), &TagValue::Str(SmolStr::new("Fine")));
   }
 
   /// An ENCRYPTED ShotInfo (`02xx`) with NO decryption keys emits NOTHING — not
@@ -2045,7 +2047,7 @@ mod tests {
       emissions
         .iter()
         .find(|e| e.name() == n)
-        .map(|e| e.value().clone())
+        .map(|e| e.value().into_owned())
     };
     assert_eq!(
       get("AFAreaMode"),
@@ -2096,7 +2098,7 @@ mod tests {
       emissions
         .iter()
         .find(|e| e.name() == n)
-        .map(|e| e.value().clone())
+        .map(|e| e.value().into_owned())
     };
     assert_eq!(
       get("AFAreaMode"),
@@ -2176,12 +2178,12 @@ mod tests {
       serial: KEY_SERIAL,
       count: KEY_COUNT,
     };
-    let mut em: Vec<VendorEmission> = Vec::new();
+    let mut em: Vec<VendorEmission<'_>> = Vec::new();
     emit_color_balance(&enc, ByteOrder::Big, false, Some(keys), &mut em);
     let wb = em
       .iter()
       .find(|e| e.name() == "WB_RGGBLevels")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(
       wb,
       Some(TagValue::Str(SmolStr::new("562 256 256 537"))),
@@ -2189,7 +2191,7 @@ mod tests {
     );
 
     // Without keys, ProcessNikonEncrypted extracts nothing.
-    let mut em_nokey: Vec<VendorEmission> = Vec::new();
+    let mut em_nokey: Vec<VendorEmission<'_>> = Vec::new();
     emit_color_balance(&enc, ByteOrder::Big, false, None, &mut em_nokey);
     assert!(
       em_nokey.is_empty(),
@@ -2222,12 +2224,12 @@ mod tests {
       serial: KEY_SERIAL,
       count: KEY_COUNT,
     };
-    let mut em: Vec<VendorEmission> = Vec::new();
+    let mut em: Vec<VendorEmission<'_>> = Vec::new();
     emit_color_balance(&enc, ByteOrder::Big, false, Some(keys), &mut em);
     let wb = em
       .iter()
       .find(|e| e.name() == "WB_GRBGLevels")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(
       wb,
       Some(TagValue::Str(SmolStr::new("600 256 256 580"))),
@@ -2341,7 +2343,7 @@ mod tests {
       emissions
         .iter()
         .find(|e| e.name() == n)
-        .map(|e| e.value().clone())
+        .map(|e| e.value().into_owned())
     };
     assert_eq!(get("Quality"), Some(TagValue::Str(SmolStr::new("F"))));
     assert!(
@@ -2432,7 +2434,7 @@ mod tests {
       emissions
         .iter()
         .find(|e| e.name() == n)
-        .map(|e| e.value().clone())
+        .map(|e| e.value().into_owned())
     };
     // The Type2 names — matching the oracle exactly.
     assert_eq!(get("Quality"), Some(TagValue::Str(SmolStr::new("F"))));
@@ -2472,7 +2474,7 @@ mod tests {
     let dz = emissions
       .iter()
       .find(|e| e.name() == "DigitalZoom")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(
       dz,
       Some(TagValue::I64(2)),
@@ -2676,11 +2678,11 @@ mod tests {
     buf
   }
 
-  fn lens_get(emissions: &[VendorEmission], name: &str) -> Option<TagValue> {
+  fn lens_get(emissions: &[VendorEmission<'_>], name: &str) -> Option<TagValue> {
     emissions
       .iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   }
 
   fn str_val(s: &str) -> TagValue {

--- a/src/exif/makernotes/vendors/panasonic/mod.rs
+++ b/src/exif/makernotes/vendors/panasonic/mod.rs
@@ -396,7 +396,7 @@ pub fn routes_to_leica10(blob: &[u8]) -> bool {
 /// (18 for Leica10) — threaded from the dispatcher rather than hard-coded,
 /// the cross-vendor generalization of the DC-FT7 base-threading.
 #[must_use]
-pub fn parse_leica10_gated(
+pub fn parse_leica10_gated<'e>(
   tiff_data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -404,7 +404,7 @@ pub fn parse_leica10_gated(
   parent_order: ByteOrder,
   print_conv: bool,
   model: Option<&str>,
-) -> Option<(MakerNotesPanasonic, Vec<VendorEmission>)> {
+) -> Option<(MakerNotesPanasonic, Vec<VendorEmission<'e>>)> {
   // The gate reads the captured MakerNote blob (the bytes the dispatcher
   // classified) — `tiff_data[mn_offset .. mn_offset + mn_len]`.
   let blob_end = mn_offset.saturating_add(mn_len).min(tiff_data.len());
@@ -512,7 +512,7 @@ pub fn routes_to_leica1(make: Option<&str>) -> bool {
 // (`tiff_data`/`mn_offset`/`mn_len`) plus the make-gate + model + body-offset
 // inputs are all load-bearing and threaded from the dispatcher.
 #[allow(clippy::too_many_arguments)]
-pub fn parse_leica1_gated(
+pub fn parse_leica1_gated<'e>(
   tiff_data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -521,7 +521,7 @@ pub fn parse_leica1_gated(
   print_conv: bool,
   make: Option<&str>,
   model: Option<&str>,
-) -> Option<(MakerNotesPanasonic, Vec<VendorEmission>)> {
+) -> Option<(MakerNotesPanasonic, Vec<VendorEmission<'e>>)> {
   // The Leica1 `Condition` is MAKE-only (`$$self{Make} eq "LEICA"`,
   // `MakerNotes.pm:602`) — it does NOT read the blob.
   if !routes_to_leica1(make) {
@@ -712,20 +712,20 @@ mod tests {
   // the `body_offset` argument the oracle took is always `HEADER_LEN` here; the
   // dynamic-base addend is the separate `base_offset`. The typed slot is installed
   // for both modes by this helper, so the `-n` typed tests are unaffected.
-  fn parse(blob: &[u8], order: ByteOrder) -> (MakerNotesPanasonic, Vec<VendorEmission>) {
+  fn parse<'e>(blob: &[u8], order: ByteOrder) -> (MakerNotesPanasonic, Vec<VendorEmission<'e>>) {
     parse_with_print_conv(blob, order, true)
   }
 
-  fn parse_with_print_conv(
+  fn parse_with_print_conv<'e>(
     blob: &[u8],
     order: ByteOrder,
     print_conv: bool,
-  ) -> (MakerNotesPanasonic, Vec<VendorEmission>) {
+  ) -> (MakerNotesPanasonic, Vec<VendorEmission<'e>>) {
     parse_in_tiff(blob, 0, blob.len(), HEADER_LEN, order, print_conv, None, 0)
   }
 
   #[allow(clippy::too_many_arguments)]
-  fn parse_in_tiff(
+  fn parse_in_tiff<'e>(
     tiff_data: &[u8],
     mn_offset: usize,
     mn_len: usize,
@@ -734,7 +734,7 @@ mod tests {
     print_conv: bool,
     model: Option<&str>,
     base_offset: usize,
-  ) -> (MakerNotesPanasonic, Vec<VendorEmission>) {
+  ) -> (MakerNotesPanasonic, Vec<VendorEmission<'e>>) {
     debug_assert_eq!(
       body_offset, HEADER_LEN,
       "the isolated Panasonic Main walk uses HEADER_LEN as the body offset"
@@ -764,7 +764,7 @@ mod tests {
       if e.unknown() {
         continue;
       }
-      into.push(group.clone(), e.name(), e.value().clone());
+      into.push(group.clone(), e.name(), e.value().into_owned());
     }
   }
 
@@ -809,7 +809,7 @@ mod tests {
     let (_typed, emissions) = parse(&blob, ByteOrder::Little);
     assert_eq!(emissions.len(), 1);
     assert_eq!(emissions[0].name(), "ImageQuality");
-    assert_eq!(emissions[0].value(), &TagValue::Str("High".into()));
+    assert_eq!(emissions[0].value().as_ref(), &TagValue::Str("High".into()));
   }
 
   #[test]
@@ -818,7 +818,10 @@ mod tests {
     let blob = build_blob(&[(0x1a, 0x03, 1, std::vec![0x04, 0x00, 0, 0])]);
     let (typed, emissions) = parse(&blob, ByteOrder::Little);
     assert_eq!(typed.image_stabilization(), Some(4));
-    assert_eq!(emissions[0].value(), &TagValue::Str("On, Mode 2".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("On, Mode 2".into())
+    );
   }
 
   #[test]
@@ -827,7 +830,10 @@ mod tests {
     let blob = build_blob(&[(0x02, 0x07, 4, std::vec![0x00, 0x01, 0x00, 0x08])]);
     let (typed, emissions) = parse(&blob, ByteOrder::Little);
     assert_eq!(typed.firmware_version(), Some("0.1.0.8"));
-    assert_eq!(emissions[0].value(), &TagValue::Str("0.1.0.8".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("0.1.0.8".into())
+    );
   }
 
   #[test]
@@ -842,7 +848,7 @@ mod tests {
       Some("(S00) 2004:07:19 no. 0102")
     );
     assert_eq!(
-      emissions[0].value(),
+      emissions[0].value().as_ref(),
       &TagValue::Str("(S00) 2004:07:19 no. 0102".into())
     );
   }
@@ -853,7 +859,10 @@ mod tests {
     let blob = build_blob(&[(0x1f, 0x03, 1, std::vec![0x06, 0x00, 0, 0])]);
     let (typed, emissions) = parse(&blob, ByteOrder::Little);
     assert_eq!(typed.shooting_mode(), Some(6));
-    assert_eq!(emissions[0].value(), &TagValue::Str("Program".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("Program".into())
+    );
   }
 
   #[test]
@@ -903,10 +912,10 @@ mod tests {
   }
 
   /// Find the first emission named `name`.
-  fn emit_value(em: &[VendorEmission], name: &str) -> Option<TagValue> {
+  fn emit_value(em: &[VendorEmission<'_>], name: &str) -> Option<TagValue> {
     em.iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   }
 
   /// 0x0f AFAreaMode model-conditional (`Panasonic.pm:336-382`). On DMC-FZ10

--- a/src/exif/makernotes/vendors/pentax/mod.rs
+++ b/src/exif/makernotes/vendors/pentax/mod.rs
@@ -218,7 +218,7 @@ pub(crate) fn populate_typed_value(typed: &mut MakerNotesPentax, tag_id: u16, ra
 pub(crate) fn emit_lens_rec(
   block: &[u8],
   print_conv: bool,
-  emissions: &mut std::vec::Vec<super::VendorEmission>,
+  emissions: &mut std::vec::Vec<super::VendorEmission<'_>>,
 ) {
   let (Some(&series), Some(&model)) = (block.first(), block.get(1)) else {
     return;
@@ -313,10 +313,10 @@ pub(crate) fn populate_lens_type(typed: &mut MakerNotesPentax, block: &[u8]) {
 /// the RIFF output is the emission stream only.
 #[cfg(feature = "alloc")]
 #[must_use]
-pub fn redispatch_avi_makernote(
+pub fn redispatch_avi_makernote<'e>(
   hymn_payload: &[u8],
   print_conv: bool,
-) -> std::vec::Vec<super::VendorEmission> {
+) -> std::vec::Vec<super::VendorEmission<'e>> {
   use crate::exif::ifd::ByteOrder;
   use crate::exif::makernotes::{BaseRule, ChildByteOrder, DetectedMakerNote, Vendor};
   // `%Pentax::AVI` hymn/mknt SubDirectory directives (`Pentax.pm:6376-6394`):

--- a/src/exif/makernotes/vendors/pentax/subtables.rs
+++ b/src/exif/makernotes/vendors/pentax/subtables.rs
@@ -154,7 +154,7 @@ fn fixed1_print(v: f64) -> TagValue {
 
 /// Push a leaf emission (never `Unknown`).
 #[inline]
-fn push(out: &mut std::vec::Vec<VendorEmission>, name: &'static str, value: TagValue) {
+fn push(out: &mut std::vec::Vec<VendorEmission<'_>>, name: &'static str, value: TagValue) {
   out.push(VendorEmission::new(SmolStr::new_static(name), value, false));
 }
 
@@ -206,7 +206,7 @@ pub(crate) fn emit_camera_settings(
   count: usize,
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // `Condition => '$count < 25'` (`Pentax.pm:2788`) — the K10D variant gate.
   if count >= 25 {
@@ -493,7 +493,7 @@ pub(crate) fn emit_aeinfo(
   block: &[u8],
   count: usize,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // `Condition => '$count <= 25 and $count != 21'` (`Pentax.pm:2804`). The
   // `$$self{AEInfoSize} = $count` assignment is an always-true side effect; for
@@ -711,7 +711,7 @@ pub(crate) fn emit_lens_info(
   count: usize,
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // The old-`LensInfo` (`%Pentax::LensInfo`) variant gate, which ExifTool tests
   // FIRST — BEFORE the `LensInfo2` `$count` condition (`Pentax.pm:2825-2833`):
@@ -772,7 +772,7 @@ fn emit_lens_data_leaves(
   lens_data: &[u8],
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let b = |i: usize| lens_data.get(i).copied();
 
@@ -928,7 +928,7 @@ pub(crate) fn emit_flashinfo(
   block: &[u8],
   count: usize,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // `Condition => '$count == 27'` (`Pentax.pm:2855`) — the K10D variant gate.
   if count != 27 {
@@ -1100,7 +1100,7 @@ pub(crate) fn emit_camera_info(
   block: &[u8],
   order: ByteOrder,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // offset 0 (byte 0): PentaxModelID — NOT emitted (owned by the 0x0005 leaf).
 
@@ -1139,7 +1139,7 @@ pub(crate) fn emit_sr_info(
   block: &[u8],
   count: usize,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // `Condition => '$count == 4'` (`Pentax.pm:2260`) — the SRInfo (vs SRInfo2)
   // variant gate.
@@ -1244,7 +1244,7 @@ fn battery_voltage32(raw: u32, print_conv: bool) -> TagValue {
 fn emit_battery_info_k3iii(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let b = |i: usize| block.get(i).copied();
   // 0.1: PowerSource (mask 0x0f). 0.2: PowerAvailable (mask 0xf0, BITMASK).
@@ -1323,7 +1323,7 @@ pub(crate) fn emit_battery_info(
   block: &[u8],
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // The exact `$$self{Model}` regexes from the BatteryInfo table, per offset.
   let is_k3iii = is_k3_mark_iii(model);
@@ -1685,7 +1685,7 @@ pub(crate) fn emit_af_info(
   block: &[u8],
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let b = |i: usize| block.get(i).copied();
 
@@ -1867,7 +1867,7 @@ fn is_af_points_in_focus_excluded(model: Option<&str>) -> bool {
 pub(crate) fn emit_color_info(
   block: &[u8],
   _print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // FORMAT => 'int8s' — read each leaf as a signed byte.
   if let Some(v) = block.get(16) {
@@ -1895,7 +1895,7 @@ pub(crate) fn emit_aeinfo3(
   block: &[u8],
   count: usize,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   if count != 48 && count != 64 {
     return;
@@ -1990,7 +1990,7 @@ pub(crate) fn emit_lens_info5(
   count: usize,
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   if count != 80 && count != 128 {
     return;
@@ -2011,7 +2011,7 @@ pub(crate) fn emit_lens_info5(
 pub(crate) fn emit_kelvin_wb(
   block: &[u8],
   order: ByteOrder,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // (name, element-offset). Element offset N is byte 2N (FORMAT int16u).
   const ENTRIES: &[(&str, usize)] = &[
@@ -2064,7 +2064,7 @@ pub(crate) fn emit_kelvin_wb(
 pub(crate) fn emit_time_info(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let b = |i: usize| block.get(i).copied();
   if let Some(v) = b(0) {
@@ -2113,7 +2113,7 @@ fn city(print_conv: bool, n: i64) -> TagValue {
 pub(crate) fn emit_lens_corr(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let b = |i: usize| block.get(i).copied();
   if let Some(v) = b(0) {
@@ -2156,7 +2156,7 @@ pub(crate) fn emit_lens_corr(
 /// `Pentax.pm:3154-3158`), NOT a 0x0060 variant; that tag is not yet ported (a
 /// deferred follow-up). Adding a model gate here would WRONGLY suppress FaceInfo
 /// for a K-3III body.
-pub(crate) fn emit_face_info(block: &[u8], out: &mut std::vec::Vec<VendorEmission>) {
+pub(crate) fn emit_face_info(block: &[u8], out: &mut std::vec::Vec<VendorEmission<'_>>) {
   if let Some(v) = block.first() {
     push(out, "FacesDetected", int_value(i64::from(*v)));
   }
@@ -2178,7 +2178,7 @@ pub(crate) fn emit_face_info(block: &[u8], out: &mut std::vec::Vec<VendorEmissio
 pub(crate) fn emit_awb_info(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   if let Some(v) = block.first() {
     push(
@@ -2203,7 +2203,7 @@ pub(crate) fn emit_awb_info(
 pub(crate) fn emit_evstep_info(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let b = |i: usize| block.get(i).copied();
   if let Some(v) = b(0) {
@@ -2242,7 +2242,7 @@ pub(crate) fn emit_evstep_info(
 pub(crate) fn emit_level_info(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // int8s — each byte read SIGNED. The mask leaves apply the mask to the raw
   // (unsigned-interpreted) byte; for byte 0 the masks 0x0f / 0xf0 select nibbles.
@@ -2299,7 +2299,7 @@ pub(crate) fn emit_level_info_k3iii(
   block: &[u8],
   order: ByteOrder,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // 1: CameraOrientation (int8s) — direct PrintConv hash.
   if let Some(&b) = block.get(1) {
@@ -2346,7 +2346,7 @@ fn neg_int(raw: i64) -> TagValue {
 pub(crate) fn emit_caf_point_info(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let Some(v1) = block.get(1).copied().map(i64::from) else {
     return;
@@ -2424,7 +2424,7 @@ pub(crate) fn emit_af_point_info(
   order: ByteOrder,
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // 2: NumAFPoints — `Format => 'int16u'`, `RawConv => '$$self{NumAFPoints} =
   // $val'`. UNCONDITIONAL. Read in the inherited MakerNote order. No PrintConv.
@@ -2542,7 +2542,7 @@ fn decode_af_points(
 pub(crate) fn emit_filter_info(
   block: &[u8],
   make: Option<&str>,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // `Make =~ /^RICOH/` ⇒ LittleEndian; otherwise BigEndian (`Pentax.pm:3032-3041`).
   let order = if is_ricoh_make(make) {
@@ -2578,7 +2578,7 @@ pub(crate) fn emit_sr_info2(
   block: &[u8],
   count: usize,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // `$count == 4` is the OLD `%Pentax::SRInfo` (handled by `emit_sr_info`); this
   // SRInfo2 variant is the fall-through (any other count, in practice 2).
@@ -2599,7 +2599,7 @@ pub(crate) fn emit_sr_info2(
 pub(crate) fn emit_pixel_shift_info(
   block: &[u8],
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   if let Some(v) = block.first() {
     push(
@@ -2623,7 +2623,7 @@ pub(crate) fn emit_temp_info(
   order: ByteOrder,
   model: Option<&str>,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   if !is_k3_mark_iii(model) {
     return;
@@ -2658,7 +2658,7 @@ pub(crate) fn emit_temp_info(
 pub(crate) fn emit_face_info_k3iii(
   block: &[u8],
   order: ByteOrder,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   // 0: FaceImageSize — int32u[2] (elements 0..=1 = bytes 0..8), space-joined.
   if let (Some(a), Some(b)) = (read_u32(block, 0, order), read_u32(block, 4, order)) {
@@ -2701,7 +2701,7 @@ pub(crate) fn emit_af_info_k3iii(
   block: &[u8],
   order: ByteOrder,
   print_conv: bool,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let u16_at = |elem: usize| read_u16(block, elem * 2, order);
   // 0.1: AFMode (the `0` whole-structure leaf is Unknown ⇒ skipped).
@@ -2800,7 +2800,7 @@ fn push_int16u_pair_k3iii(
   order: ByteOrder,
   print_conv: bool,
   name: &'static str,
-  out: &mut std::vec::Vec<VendorEmission>,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
 ) {
   let mut vals: std::vec::Vec<u16> = std::vec::Vec::with_capacity(2);
   for k in 0..2 {
@@ -2829,7 +2829,11 @@ fn push_int16u_pair_k3iii(
 /// PrintConv applied); a zero-count run is the raw empty value (`""`). The `(none)`
 /// scalar is purely the PrintConv `return '(none)' unless $val` and so appears only
 /// in PrintConv mode (bundled `-n` of a NumAFPoints==0 record yields `AFAreas=''`).
-fn push_af_areas_k3iii(vals: &[u16], print_conv: bool, out: &mut std::vec::Vec<VendorEmission>) {
+fn push_af_areas_k3iii(
+  vals: &[u16],
+  print_conv: bool,
+  out: &mut std::vec::Vec<VendorEmission<'_>>,
+) {
   if !print_conv {
     // `-n`: no PrintConv — the raw int16u run, space-joined; empty when zero-count.
     let joined = vals

--- a/src/exif/makernotes/vendors/pentax/subtables/tests.rs
+++ b/src/exif/makernotes/vendors/pentax/subtables/tests.rs
@@ -53,10 +53,10 @@ const CAMERAINFO_K10D: &[u8] = &[
   0x00, 0x02, 0x05, 0x00,
 ];
 
-fn find<'a>(em: &'a [VendorEmission], name: &str) -> Option<&'a TagValue> {
+fn find(em: &[VendorEmission<'_>], name: &str) -> Option<TagValue> {
   em.iter()
     .find(|e| e.name() == name)
-    .map(VendorEmission::value)
+    .map(|e| e.value().into_owned())
 }
 
 fn s(v: &str) -> TagValue {
@@ -81,38 +81,38 @@ fn camera_settings_k10d_print_conv_byte_exact() {
   let mut em = Vec::new();
   emit_camera_settings(CAMERA_SETTINGS_K10D, 23, Some("PENTAX K10D"), true, &mut em);
 
-  assert_eq!(find(&em, "PictureMode2"), Some(&s("Aperture Priority")));
-  assert_eq!(find(&em, "ProgramLine"), Some(&s("Normal")));
-  assert_eq!(find(&em, "EVSteps"), Some(&s("1/3 EV Steps")));
-  assert_eq!(find(&em, "E-DialInProgram"), Some(&s("Tv or Av")));
-  assert_eq!(find(&em, "ApertureRingUse"), Some(&s("Permitted")));
-  assert_eq!(find(&em, "FlashOptions"), Some(&s("Wireless (Master)")));
-  assert_eq!(find(&em, "MeteringMode2"), Some(&s("Multi-segment")));
-  assert_eq!(find(&em, "AFPointMode"), Some(&s("Select")));
-  assert_eq!(find(&em, "FocusMode2"), Some(&s("AF-S")));
-  assert_eq!(find(&em, "AFPointSelected2"), Some(&s("Center")));
-  assert_eq!(find(&em, "ISOFloor"), Some(&TagValue::I64(100)));
-  assert_eq!(find(&em, "DriveMode2"), Some(&s("Single-frame")));
-  assert_eq!(find(&em, "ExposureBracketStepSize"), Some(&s("0.3")));
-  assert_eq!(find(&em, "BracketShotNumber"), Some(&s("n/a")));
-  assert_eq!(find(&em, "WhiteBalanceSet"), Some(&s("Auto")));
-  assert_eq!(find(&em, "MultipleExposureSet"), Some(&s("Off")));
+  assert_eq!(find(&em, "PictureMode2"), Some(s("Aperture Priority")));
+  assert_eq!(find(&em, "ProgramLine"), Some(s("Normal")));
+  assert_eq!(find(&em, "EVSteps"), Some(s("1/3 EV Steps")));
+  assert_eq!(find(&em, "E-DialInProgram"), Some(s("Tv or Av")));
+  assert_eq!(find(&em, "ApertureRingUse"), Some(s("Permitted")));
+  assert_eq!(find(&em, "FlashOptions"), Some(s("Wireless (Master)")));
+  assert_eq!(find(&em, "MeteringMode2"), Some(s("Multi-segment")));
+  assert_eq!(find(&em, "AFPointMode"), Some(s("Select")));
+  assert_eq!(find(&em, "FocusMode2"), Some(s("AF-S")));
+  assert_eq!(find(&em, "AFPointSelected2"), Some(s("Center")));
+  assert_eq!(find(&em, "ISOFloor"), Some(TagValue::I64(100)));
+  assert_eq!(find(&em, "DriveMode2"), Some(s("Single-frame")));
+  assert_eq!(find(&em, "ExposureBracketStepSize"), Some(s("0.3")));
+  assert_eq!(find(&em, "BracketShotNumber"), Some(s("n/a")));
+  assert_eq!(find(&em, "WhiteBalanceSet"), Some(s("Auto")));
+  assert_eq!(find(&em, "MultipleExposureSet"), Some(s("Off")));
   // K10D-only (offset 13+).
   assert_eq!(
     find(&em, "RawAndJpgRecording"),
-    Some(&s("RAW+JPEG (PEF, Better)"))
+    Some(s("RAW+JPEG (PEF, Better)"))
   );
-  assert_eq!(find(&em, "JpgRecordedPixels"), Some(&s("6 MP")));
-  assert_eq!(find(&em, "FlashOptions2"), Some(&s("Wireless (Master)")));
-  assert_eq!(find(&em, "MeteringMode3"), Some(&s("Multi-segment")));
-  assert_eq!(find(&em, "SRActive"), Some(&s("Yes")));
-  assert_eq!(find(&em, "Rotation"), Some(&s("Rotate 270 CW")));
-  assert_eq!(find(&em, "ISOSetting"), Some(&s("Manual")));
-  assert_eq!(find(&em, "SensitivitySteps"), Some(&s("1 EV Steps")));
-  assert_eq!(find(&em, "TvExposureTimeSetting"), Some(&s("1/203")));
-  assert_eq!(find(&em, "AvApertureSetting"), Some(&s("12.7")));
-  assert_eq!(find(&em, "SvISOSetting"), Some(&TagValue::I64(100)));
-  assert_eq!(find(&em, "BaseExposureCompensation"), Some(&s("+0.7")));
+  assert_eq!(find(&em, "JpgRecordedPixels"), Some(s("6 MP")));
+  assert_eq!(find(&em, "FlashOptions2"), Some(s("Wireless (Master)")));
+  assert_eq!(find(&em, "MeteringMode3"), Some(s("Multi-segment")));
+  assert_eq!(find(&em, "SRActive"), Some(s("Yes")));
+  assert_eq!(find(&em, "Rotation"), Some(s("Rotate 270 CW")));
+  assert_eq!(find(&em, "ISOSetting"), Some(s("Manual")));
+  assert_eq!(find(&em, "SensitivitySteps"), Some(s("1 EV Steps")));
+  assert_eq!(find(&em, "TvExposureTimeSetting"), Some(s("1/203")));
+  assert_eq!(find(&em, "AvApertureSetting"), Some(s("12.7")));
+  assert_eq!(find(&em, "SvISOSetting"), Some(TagValue::I64(100)));
+  assert_eq!(find(&em, "BaseExposureCompensation"), Some(s("+0.7")));
   // 28 leaves total for the K10D variant.
   assert_eq!(em.len(), 28, "K10D CameraSettings emits 28 leaves");
 }
@@ -129,12 +129,12 @@ fn camera_settings_k10d_value_conv_floats() {
     &mut em,
   );
   // ISOFloor / SvISOSetting are integer (int(... + 0.5)).
-  assert_eq!(find(&em, "ISOFloor"), Some(&TagValue::I64(100)));
-  assert_eq!(find(&em, "SvISOSetting"), Some(&TagValue::I64(100)));
+  assert_eq!(find(&em, "ISOFloor"), Some(TagValue::I64(100)));
+  assert_eq!(find(&em, "SvISOSetting"), Some(TagValue::I64(100)));
   // The enum/bitfield leaves are raw ints under -n.
-  assert_eq!(find(&em, "PictureMode2"), Some(&TagValue::I64(5)));
-  assert_eq!(find(&em, "ApertureRingUse"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&em, "AFPointSelected2"), Some(&TagValue::I64(32)));
+  assert_eq!(find(&em, "PictureMode2"), Some(TagValue::I64(5)));
+  assert_eq!(find(&em, "ApertureRingUse"), Some(TagValue::I64(1)));
+  assert_eq!(find(&em, "AFPointSelected2"), Some(TagValue::I64(32)));
   // The float ValueConv leaves.
   let approx = |name: &str, want: f64| {
     let TagValue::F64(g) = find(&em, name).expect(name) else {
@@ -183,8 +183,8 @@ fn camera_settings_non_k10d_model_skips_offset13_leaves() {
     &mut em,
   );
   // Base leaf present.
-  assert_eq!(find(&em, "PictureMode2"), Some(&s("Aperture Priority")));
-  assert_eq!(find(&em, "ISOFloor"), Some(&TagValue::I64(100)));
+  assert_eq!(find(&em, "PictureMode2"), Some(s("Aperture Priority")));
+  assert_eq!(find(&em, "ISOFloor"), Some(TagValue::I64(100)));
   // K10D-only leaves ABSENT.
   assert!(
     find(&em, "RawAndJpgRecording").is_none(),
@@ -202,26 +202,26 @@ fn camera_settings_non_k10d_model_skips_offset13_leaves() {
     true,
     &mut em_gx,
   );
-  assert_eq!(find(&em_gx, "SRActive"), Some(&s("Yes")));
+  assert_eq!(find(&em_gx, "SRActive"), Some(s("Yes")));
 }
 
 #[test]
 fn aeinfo_k10d_print_conv_byte_exact() {
   let mut em = Vec::new();
   emit_aeinfo(AEINFO_K10D, 16, true, &mut em);
-  assert_eq!(find(&em, "AEExposureTime"), Some(&s("1/101")));
-  assert_eq!(find(&em, "AEAperture"), Some(&s("12.9")));
-  assert_eq!(find(&em, "AE_ISO"), Some(&TagValue::I64(100)));
-  assert_eq!(find(&em, "AEXv"), Some(&TagValue::F64(-0.625)));
-  assert_eq!(find(&em, "AEBXv"), Some(&TagValue::F64(0.0)));
-  assert_eq!(find(&em, "AEMinExposureTime"), Some(&s("1/3862")));
-  assert_eq!(find(&em, "AEProgramMode"), Some(&s("Av, B or X")));
-  assert_eq!(find(&em, "AEApertureSteps"), Some(&TagValue::I64(28)));
-  assert_eq!(find(&em, "AEMaxAperture"), Some(&s("4.0")));
-  assert_eq!(find(&em, "AEMaxAperture2"), Some(&s("4.0")));
-  assert_eq!(find(&em, "AEMinAperture"), Some(&s("23")));
-  assert_eq!(find(&em, "AEMeteringMode"), Some(&s("Multi-segment")));
-  assert_eq!(find(&em, "FlashExposureCompSet"), Some(&TagValue::I64(0)));
+  assert_eq!(find(&em, "AEExposureTime"), Some(s("1/101")));
+  assert_eq!(find(&em, "AEAperture"), Some(s("12.9")));
+  assert_eq!(find(&em, "AE_ISO"), Some(TagValue::I64(100)));
+  assert_eq!(find(&em, "AEXv"), Some(TagValue::F64(-0.625)));
+  assert_eq!(find(&em, "AEBXv"), Some(TagValue::F64(0.0)));
+  assert_eq!(find(&em, "AEMinExposureTime"), Some(s("1/3862")));
+  assert_eq!(find(&em, "AEProgramMode"), Some(s("Av, B or X")));
+  assert_eq!(find(&em, "AEApertureSteps"), Some(TagValue::I64(28)));
+  assert_eq!(find(&em, "AEMaxAperture"), Some(s("4.0")));
+  assert_eq!(find(&em, "AEMaxAperture2"), Some(s("4.0")));
+  assert_eq!(find(&em, "AEMinAperture"), Some(s("23")));
+  assert_eq!(find(&em, "AEMeteringMode"), Some(s("Multi-segment")));
+  assert_eq!(find(&em, "FlashExposureCompSet"), Some(TagValue::I64(0)));
   // AEFlags (offset 7) is NEVER emitted (RawConv drops it without -U).
   assert!(find(&em, "AEFlags").is_none());
   assert_eq!(em.len(), 13, "K10D AEInfo emits 13 leaves");
@@ -246,20 +246,20 @@ fn aeinfo_non_k10d_count_does_not_misdecode() {
 fn flashinfo_k10d_print_conv_byte_exact() {
   let mut em = Vec::new();
   emit_flashinfo(FLASHINFO_K10D, 27, true, &mut em);
-  assert_eq!(find(&em, "FlashStatus"), Some(&s("Off")));
+  assert_eq!(find(&em, "FlashStatus"), Some(s("Off")));
   assert_eq!(
     find(&em, "InternalFlashMode"),
-    Some(&s("Did not fire, Wireless (Master)"))
+    Some(s("Did not fire, Wireless (Master)"))
   );
-  assert_eq!(find(&em, "ExternalFlashMode"), Some(&s("Off")));
-  assert_eq!(find(&em, "InternalFlashStrength"), Some(&TagValue::I64(18)));
-  assert_eq!(find(&em, "TTL_DA_AUp"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "TTL_DA_ADown"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "TTL_DA_BUp"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "TTL_DA_BDown"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "ExternalFlashGuideNumber"), Some(&s("n/a")));
-  assert_eq!(find(&em, "ExternalFlashExposureComp"), Some(&s("n/a")));
-  assert_eq!(find(&em, "ExternalFlashBounce"), Some(&s("n/a")));
+  assert_eq!(find(&em, "ExternalFlashMode"), Some(s("Off")));
+  assert_eq!(find(&em, "InternalFlashStrength"), Some(TagValue::I64(18)));
+  assert_eq!(find(&em, "TTL_DA_AUp"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "TTL_DA_ADown"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "TTL_DA_BUp"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "TTL_DA_BDown"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "ExternalFlashGuideNumber"), Some(s("n/a")));
+  assert_eq!(find(&em, "ExternalFlashExposureComp"), Some(s("n/a")));
+  assert_eq!(find(&em, "ExternalFlashBounce"), Some(s("n/a")));
   assert_eq!(em.len(), 11, "K10D FlashInfo emits 11 leaves");
 }
 
@@ -295,8 +295,8 @@ fn truncated_block_skips_out_of_range_leaves() {
     &mut em,
   );
   // Offsets 0-2 decode (PictureMode2, the byte-1 + byte-2 bitfields).
-  assert_eq!(find(&em, "PictureMode2"), Some(&s("Aperture Priority")));
-  assert_eq!(find(&em, "FlashOptions"), Some(&s("Wireless (Master)")));
+  assert_eq!(find(&em, "PictureMode2"), Some(s("Aperture Priority")));
+  assert_eq!(find(&em, "FlashOptions"), Some(s("Wireless (Master)")));
   // Offset 3+ skipped.
   assert!(find(&em, "FocusMode2").is_none());
   assert!(find(&em, "ISOFloor").is_none());
@@ -310,11 +310,11 @@ fn aeinfo_size_over_20_shifts_offsets() {
   let mut em = Vec::new();
   emit_aeinfo(AEINFO_KX, 24, true, &mut em);
   // Offsets 0-7 are unshifted.
-  assert_eq!(find(&em, "AEProgramMode"), Some(&s("Standard"))); // byte 6 = 0x23 = 35
+  assert_eq!(find(&em, "AEProgramMode"), Some(s("Standard"))); // byte 6 = 0x23 = 35
   // Offset 8+ shifted: AEApertureSteps reads byte 9 = 0.
-  assert_eq!(find(&em, "AEApertureSteps"), Some(&TagValue::I64(0)));
+  assert_eq!(find(&em, "AEApertureSteps"), Some(TagValue::I64(0)));
   // FlashExposureCompSet reads byte 15 (= 0xf8 = -8 int8s) ⇒ PentaxEv(-8) = -1.
-  assert_eq!(find(&em, "FlashExposureCompSet"), Some(&s("-1.0")));
+  assert_eq!(find(&em, "FlashExposureCompSet"), Some(s("-1.0")));
   // The size-24-only AEWhiteBalance / AEMeteringMode2 / LevelIndicator are NOT
   // emitted by this Phase-2a port (deferred).
   assert!(find(&em, "AEWhiteBalance").is_none());
@@ -336,15 +336,15 @@ fn aeinfo_aeflags_shift_follows_byte_size_not_count() {
   let mut em = Vec::new();
   emit_aeinfo(AEINFO_KX, 12, true, &mut em);
   // Unshifted leaves (offsets 0-7) decode the same as any in-gate record.
-  assert_eq!(find(&em, "AEProgramMode"), Some(&s("Standard"))); // byte 6 = 0x23 = 35
+  assert_eq!(find(&em, "AEProgramMode"), Some(s("Standard"))); // byte 6 = 0x23 = 35
   // The shift follows byte size: AEApertureSteps reads byte 9 (= 0x00 = 0), NOT
   // byte 8 (= 0xa1 = 161) — i.e. NOT one byte early.
-  assert_eq!(find(&em, "AEApertureSteps"), Some(&TagValue::I64(0)));
-  assert_ne!(find(&em, "AEApertureSteps"), Some(&TagValue::I64(161)));
+  assert_eq!(find(&em, "AEApertureSteps"), Some(TagValue::I64(0)));
+  assert_ne!(find(&em, "AEApertureSteps"), Some(TagValue::I64(161)));
   // The remaining shifted offsets land on the SAME bytes as the undef-24 K-x
   // record (`aeinfo_size_over_20_shifts_offsets`), proving size-keyed parity: e.g.
   // FlashExposureCompSet reads byte 15 (= 0xf8 = -8 int8s) ⇒ PentaxEv(-8) = -1.
-  assert_eq!(find(&em, "FlashExposureCompSet"), Some(&s("-1.0")));
+  assert_eq!(find(&em, "FlashExposureCompSet"), Some(s("-1.0")));
   // A control: with a SMALL byte size (<= 20) the same small count yields NO shift
   // — AEApertureSteps then reads byte 8. The first 20 bytes of the K-x block keep
   // count 12 in-gate but drop the block to 20 bytes (20 > 20 is false ⇒ shift 0),
@@ -352,7 +352,7 @@ fn aeinfo_aeflags_shift_follows_byte_size_not_count() {
   // `block.len()` and not the (unchanged) count.
   let mut em20 = Vec::new();
   emit_aeinfo(&AEINFO_KX[..20], 12, true, &mut em20);
-  assert_eq!(find(&em20, "AEApertureSteps"), Some(&TagValue::I64(161)));
+  assert_eq!(find(&em20, "AEApertureSteps"), Some(TagValue::I64(161)));
 }
 
 #[test]
@@ -361,17 +361,17 @@ fn lens_info2_k10d_print_conv_byte_exact() {
   // set). Values verified against `exiftool -G1 -j Pentax.jpg`.
   let mut em = Vec::new();
   emit_lens_info(LENSINFO2_K10D, 69, Some("PENTAX K10D"), true, &mut em);
-  assert_eq!(find(&em, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(&em, "MinFocusDistance"), Some(&s("0.49-0.50 m")));
-  assert_eq!(find(&em, "LensFocalLength"), Some(&s("10.0 mm")));
-  assert_eq!(find(&em, "NominalMaxAperture"), Some(&s("4.0")));
-  assert_eq!(find(&em, "NominalMinAperture"), Some(&s("23")));
+  assert_eq!(find(&em, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(&em, "MinFocusDistance"), Some(s("0.49-0.50 m")));
+  assert_eq!(find(&em, "LensFocalLength"), Some(s("10.0 mm")));
+  assert_eq!(find(&em, "NominalMaxAperture"), Some(s("4.0")));
+  assert_eq!(find(&em, "NominalMinAperture"), Some(s("23")));
   // The four #173 LensData leaves now emit (verified against `exiftool -G1 -j
   // Pentax.jpg`).
-  assert_eq!(find(&em, "AutoAperture"), Some(&s("On")));
-  assert_eq!(find(&em, "MinAperture"), Some(&s("22")));
-  assert_eq!(find(&em, "FocusRangeIndex"), Some(&s("7 (very far)")));
-  assert_eq!(find(&em, "MaxAperture"), Some(&s("3.9")));
+  assert_eq!(find(&em, "AutoAperture"), Some(s("On")));
+  assert_eq!(find(&em, "MinAperture"), Some(s("22")));
+  assert_eq!(find(&em, "FocusRangeIndex"), Some(s("7 (very far)")));
+  assert_eq!(find(&em, "MaxAperture"), Some(s("3.9")));
   // LensType (offset 0-3) is NOT re-emitted here (Phase 1's 0x003f LensRec owns it).
   assert!(
     find(&em, "LensType").is_none(),
@@ -391,11 +391,11 @@ fn lens_info2_k10d_value_conv_floats() {
   // LensFocalLength 10, NominalMaxAperture 4, NominalMinAperture 22.6274…).
   let mut em = Vec::new();
   emit_lens_info(LENSINFO2_K10D, 69, Some("PENTAX K10D"), false, &mut em);
-  assert_eq!(find(&em, "LensFStops"), Some(&TagValue::F64(8.5)));
+  assert_eq!(find(&em, "LensFStops"), Some(TagValue::F64(8.5)));
   // MinFocusDistance under -n is the raw masked value (no PrintConv hash).
-  assert_eq!(find(&em, "MinFocusDistance"), Some(&TagValue::I64(6)));
-  assert_eq!(find(&em, "LensFocalLength"), Some(&TagValue::F64(10.0)));
-  assert_eq!(find(&em, "NominalMaxAperture"), Some(&TagValue::F64(4.0)));
+  assert_eq!(find(&em, "MinFocusDistance"), Some(TagValue::I64(6)));
+  assert_eq!(find(&em, "LensFocalLength"), Some(TagValue::F64(10.0)));
+  assert_eq!(find(&em, "NominalMaxAperture"), Some(TagValue::F64(4.0)));
   let approx = |name: &str, want: f64| {
     let TagValue::F64(g) = find(&em, name).expect(name) else {
       panic!("{name} is not F64");
@@ -432,10 +432,10 @@ fn lens_info2_focal_length_645z_gate() {
     "645Z must not emit LensFocalLength"
   );
   // The other leaves are unaffected.
-  assert_eq!(find(&em, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(&em, "NominalMaxAperture"), Some(&s("4.0")));
-  assert_eq!(find(&em, "AutoAperture"), Some(&s("On")));
-  assert_eq!(find(&em, "MaxAperture"), Some(&s("3.9")));
+  assert_eq!(find(&em, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(&em, "NominalMaxAperture"), Some(s("4.0")));
+  assert_eq!(find(&em, "AutoAperture"), Some(s("On")));
+  assert_eq!(find(&em, "MaxAperture"), Some(s("3.9")));
   assert_eq!(em.len(), 8, "645Z drops only LensFocalLength");
 }
 
@@ -468,8 +468,8 @@ fn lens_info2_truncated_block_no_panic() {
     true,
     &mut em1,
   );
-  assert_eq!(find(&em1, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(&em1, "MinFocusDistance"), Some(&s("0.49-0.50 m")));
+  assert_eq!(find(&em1, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(&em1, "MinFocusDistance"), Some(s("0.49-0.50 m")));
   assert!(
     find(&em1, "LensFocalLength").is_none(),
     "offset-9 leaf skipped when truncated"
@@ -486,8 +486,8 @@ fn lens_info2_truncated_block_no_panic() {
     true,
     &mut em2,
   );
-  assert_eq!(find(&em2, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(&em2, "LensFocalLength"), Some(&s("10.0 mm")));
+  assert_eq!(find(&em2, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(&em2, "LensFocalLength"), Some(s("10.0 mm")));
   assert!(
     find(&em2, "NominalMaxAperture").is_none(),
     "offset-10 leaf skipped when truncated"
@@ -511,14 +511,14 @@ const LENSINFO_OLD: &[u8] = &[
 
 /// Assert the nine OLD-format LensData leaves (identical to the K10D `LensInfo2`
 /// values) — the old `%LensInfo` decodes `LensData` from offset 3.
-fn assert_old_lens_info_leaves(em: &[VendorEmission]) {
-  assert_eq!(find(em, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(em, "MinFocusDistance"), Some(&s("0.49-0.50 m")));
-  assert_eq!(find(em, "LensFocalLength"), Some(&s("10.0 mm")));
-  assert_eq!(find(em, "NominalMaxAperture"), Some(&s("4.0")));
-  assert_eq!(find(em, "NominalMinAperture"), Some(&s("23")));
-  assert_eq!(find(em, "AutoAperture"), Some(&s("On")));
-  assert_eq!(find(em, "FocusRangeIndex"), Some(&s("7 (very far)")));
+fn assert_old_lens_info_leaves(em: &[VendorEmission<'_>]) {
+  assert_eq!(find(em, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(em, "MinFocusDistance"), Some(s("0.49-0.50 m")));
+  assert_eq!(find(em, "LensFocalLength"), Some(s("10.0 mm")));
+  assert_eq!(find(em, "NominalMaxAperture"), Some(s("4.0")));
+  assert_eq!(find(em, "NominalMinAperture"), Some(s("23")));
+  assert_eq!(find(em, "AutoAperture"), Some(s("On")));
+  assert_eq!(find(em, "FocusRangeIndex"), Some(s("7 (very far)")));
 }
 
 #[test]
@@ -579,13 +579,13 @@ fn lens_info_k100d_not_old_format_falls_through_to_lensinfo2() {
   // Decodes through LensInfo2 — the same nine leaves as the K10D path. Byte 20
   // (LensData offset 16) is not read by any ported leaf (they live at LensData
   // offsets 0/3/9/10/14), so the values match the K10D fixture exactly.
-  assert_eq!(find(&em, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(&em, "MinFocusDistance"), Some(&s("0.49-0.50 m")));
-  assert_eq!(find(&em, "LensFocalLength"), Some(&s("10.0 mm")));
-  assert_eq!(find(&em, "NominalMaxAperture"), Some(&s("4.0")));
-  assert_eq!(find(&em, "NominalMinAperture"), Some(&s("23")));
-  assert_eq!(find(&em, "AutoAperture"), Some(&s("On")));
-  assert_eq!(find(&em, "FocusRangeIndex"), Some(&s("7 (very far)")));
+  assert_eq!(find(&em, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(&em, "MinFocusDistance"), Some(s("0.49-0.50 m")));
+  assert_eq!(find(&em, "LensFocalLength"), Some(s("10.0 mm")));
+  assert_eq!(find(&em, "NominalMaxAperture"), Some(s("4.0")));
+  assert_eq!(find(&em, "NominalMinAperture"), Some(s("23")));
+  assert_eq!(find(&em, "AutoAperture"), Some(s("On")));
+  assert_eq!(find(&em, "FocusRangeIndex"), Some(s("7 (very far)")));
   assert_eq!(
     em.len(),
     9,
@@ -607,8 +607,8 @@ fn lens_info_old_format_short_block_falls_through() {
     true,
     &mut em,
   );
-  assert_eq!(find(&em, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(&em, "LensFocalLength"), Some(&s("10.0 mm")));
+  assert_eq!(find(&em, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(&em, "LensFocalLength"), Some(s("10.0 mm")));
   assert!(
     find(&em, "NominalMaxAperture").is_none(),
     "short block: offset-10 leaf skipped, but the record still decodes (not old)"
@@ -622,13 +622,13 @@ fn camera_info_k10d_print_conv_byte_exact() {
   // ProductionCode 2.1, InternalSerialNumber 132352.
   let mut em = Vec::new();
   emit_camera_info(CAMERAINFO_K10D, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "ManufactureDate"), Some(&s("2007:09:13")));
+  assert_eq!(find(&em, "ManufactureDate"), Some(s("2007:09:13")));
   // ProductionCode is the dotted ValueConv string "2.1" (renders as a JSON number);
   // the "(camera has been serviced)" suffix applies only to an 8.x value.
-  assert_eq!(find(&em, "ProductionCode"), Some(&s("2.1")));
+  assert_eq!(find(&em, "ProductionCode"), Some(s("2.1")));
   assert_eq!(
     find(&em, "InternalSerialNumber"),
-    Some(&TagValue::I64(132352))
+    Some(TagValue::I64(132352))
   );
   // PentaxModelID (offset 0) is NOT re-emitted from this path — Phase 1's 0x0005
   // leaf owns it (the guardrail).
@@ -645,11 +645,11 @@ fn camera_info_k10d_value_conv() {
   // is the bare dotted string, InternalSerialNumber the raw int.
   let mut em = Vec::new();
   emit_camera_info(CAMERAINFO_K10D, ByteOrder::Big, false, &mut em);
-  assert_eq!(find(&em, "ManufactureDate"), Some(&s("2007:09:13")));
-  assert_eq!(find(&em, "ProductionCode"), Some(&s("2.1")));
+  assert_eq!(find(&em, "ManufactureDate"), Some(s("2007:09:13")));
+  assert_eq!(find(&em, "ProductionCode"), Some(s("2.1")));
   assert_eq!(
     find(&em, "InternalSerialNumber"),
-    Some(&TagValue::I64(132352))
+    Some(TagValue::I64(132352))
   );
   assert!(find(&em, "PentaxModelID").is_none());
 }
@@ -666,11 +666,11 @@ fn camera_info_kx_avi_byte_exact() {
   ];
   let mut em = Vec::new();
   emit_camera_info(CAMERAINFO_KX, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "ManufactureDate"), Some(&s("2009:09:04")));
-  assert_eq!(find(&em, "ProductionCode"), Some(&s("2.3")));
+  assert_eq!(find(&em, "ManufactureDate"), Some(s("2009:09:04")));
+  assert_eq!(find(&em, "ProductionCode"), Some(s("2.3")));
   assert_eq!(
     find(&em, "InternalSerialNumber"),
-    Some(&TagValue::I64(8007725))
+    Some(TagValue::I64(8007725))
   );
   assert!(find(&em, "PentaxModelID").is_none());
 }
@@ -691,12 +691,12 @@ fn camera_info_production_code_serviced_suffix() {
   emit_camera_info(block, ByteOrder::Big, true, &mut em);
   assert_eq!(
     find(&em, "ProductionCode"),
-    Some(&s("8.1 (camera has been serviced)"))
+    Some(s("8.1 (camera has been serviced)"))
   );
   // -n: the bare dotted string, no suffix.
   let mut emn = Vec::new();
   emit_camera_info(block, ByteOrder::Big, false, &mut emn);
-  assert_eq!(find(&emn, "ProductionCode"), Some(&s("8.1")));
+  assert_eq!(find(&emn, "ProductionCode"), Some(s("8.1")));
 }
 
 #[test]
@@ -726,7 +726,7 @@ fn camera_info_truncated_block_partial_emit_no_panic() {
   // bytes 8-15, InternalSerialNumber needs byte 16 — both skipped.
   let mut em8 = Vec::new();
   emit_camera_info(&CAMERAINFO_K10D[..8], ByteOrder::Big, true, &mut em8);
-  assert_eq!(find(&em8, "ManufactureDate"), Some(&s("2007:09:13")));
+  assert_eq!(find(&em8, "ManufactureDate"), Some(s("2007:09:13")));
   assert!(
     find(&em8, "ProductionCode").is_none(),
     "int32u[2] ProductionCode needs bytes 8-15"
@@ -738,7 +738,7 @@ fn camera_info_truncated_block_partial_emit_no_panic() {
   // 12-15) is out of range ⇒ ProductionCode skipped (both elements required).
   let mut em12 = Vec::new();
   emit_camera_info(&CAMERAINFO_K10D[..12], ByteOrder::Big, true, &mut em12);
-  assert_eq!(find(&em12, "ManufactureDate"), Some(&s("2007:09:13")));
+  assert_eq!(find(&em12, "ManufactureDate"), Some(s("2007:09:13")));
   assert!(
     find(&em12, "ProductionCode").is_none(),
     "the second int32u element (byte 12-15) is out of range"
@@ -749,8 +749,8 @@ fn camera_info_truncated_block_partial_emit_no_panic() {
   // (byte 16) skipped.
   let mut em16 = Vec::new();
   emit_camera_info(&CAMERAINFO_K10D[..16], ByteOrder::Big, true, &mut em16);
-  assert_eq!(find(&em16, "ManufactureDate"), Some(&s("2007:09:13")));
-  assert_eq!(find(&em16, "ProductionCode"), Some(&s("2.1")));
+  assert_eq!(find(&em16, "ManufactureDate"), Some(s("2007:09:13")));
+  assert_eq!(find(&em16, "ProductionCode"), Some(s("2.1")));
   assert!(find(&em16, "InternalSerialNumber").is_none());
   assert_eq!(em16.len(), 2);
 
@@ -808,17 +808,17 @@ fn sr_info_k10d_byte_exact() {
   // -j — verified against `exiftool -G1 -j Pentax.jpg`.
   let mut em = Vec::new();
   emit_sr_info(SRINFO_K10D, 4, true, &mut em);
-  assert_eq!(find(&em, "SRResult"), Some(&s("Stabilized")));
-  assert_eq!(find(&em, "ShakeReduction"), Some(&s("On")));
-  assert_eq!(find(&em, "SRHalfPressTime"), Some(&s("1.53 s")));
-  assert_eq!(find(&em, "SRFocalLength"), Some(&s("10 mm")));
+  assert_eq!(find(&em, "SRResult"), Some(s("Stabilized")));
+  assert_eq!(find(&em, "ShakeReduction"), Some(s("On")));
+  assert_eq!(find(&em, "SRHalfPressTime"), Some(s("1.53 s")));
+  assert_eq!(find(&em, "SRFocalLength"), Some(s("10 mm")));
   assert_eq!(em.len(), 4);
   // -n — the post-ValueConv values.
   let mut emn = Vec::new();
   emit_sr_info(SRINFO_K10D, 4, false, &mut emn);
-  assert_eq!(find(&emn, "SRResult"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&emn, "ShakeReduction"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&emn, "SRFocalLength"), Some(&TagValue::F64(10.0)));
+  assert_eq!(find(&emn, "SRResult"), Some(TagValue::I64(1)));
+  assert_eq!(find(&emn, "ShakeReduction"), Some(TagValue::I64(1)));
+  assert_eq!(find(&emn, "SRFocalLength"), Some(TagValue::F64(10.0)));
 }
 
 #[test]
@@ -834,16 +834,13 @@ fn battery_info_k10d_byte_exact() {
   // -j — verified against `exiftool -G1 -j Pentax.jpg`.
   let mut em = Vec::new();
   emit_battery_info(BATTERYINFO_K10D, Some("PENTAX K10D"), true, &mut em);
-  assert_eq!(find(&em, "PowerSource"), Some(&s("Body Battery")));
-  assert_eq!(find(&em, "BodyBatteryState"), Some(&s("Full")));
-  assert_eq!(find(&em, "GripBatteryState"), Some(&s("Empty or Missing")));
-  assert_eq!(
-    find(&em, "BodyBatteryADNoLoad"),
-    Some(&s("173 (7.6V, 51%)"))
-  );
-  assert_eq!(find(&em, "BodyBatteryADLoad"), Some(&s("168 (7.4V, 47%)")));
-  assert_eq!(find(&em, "GripBatteryADNoLoad"), Some(&TagValue::I64(5)));
-  assert_eq!(find(&em, "GripBatteryADLoad"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "PowerSource"), Some(s("Body Battery")));
+  assert_eq!(find(&em, "BodyBatteryState"), Some(s("Full")));
+  assert_eq!(find(&em, "GripBatteryState"), Some(s("Empty or Missing")));
+  assert_eq!(find(&em, "BodyBatteryADNoLoad"), Some(s("173 (7.6V, 51%)")));
+  assert_eq!(find(&em, "BodyBatteryADLoad"), Some(s("168 (7.4V, 47%)")));
+  assert_eq!(find(&em, "GripBatteryADNoLoad"), Some(TagValue::I64(5)));
+  assert_eq!(find(&em, "GripBatteryADLoad"), Some(TagValue::I64(1)));
   assert_eq!(em.len(), 7);
 }
 
@@ -853,13 +850,10 @@ fn af_info_k10d_byte_exact() {
   // `Unknown => 1` AFPointsUnknown1/2 are suppressed.
   let mut em = Vec::new();
   emit_af_info(AFINFO_K10D, Some("PENTAX K10D"), true, &mut em);
-  assert_eq!(find(&em, "AFPredictor"), Some(&TagValue::I64(4)));
-  assert_eq!(find(&em, "AFDefocus"), Some(&TagValue::I64(2)));
-  assert_eq!(find(&em, "AFIntegrationTime"), Some(&s("0 ms")));
-  assert_eq!(
-    find(&em, "AFPointsInFocus"),
-    Some(&s("Center (horizontal)"))
-  );
+  assert_eq!(find(&em, "AFPredictor"), Some(TagValue::I64(4)));
+  assert_eq!(find(&em, "AFDefocus"), Some(TagValue::I64(2)));
+  assert_eq!(find(&em, "AFIntegrationTime"), Some(s("0 ms")));
+  assert_eq!(find(&em, "AFPointsInFocus"), Some(s("Center (horizontal)")));
   assert!(find(&em, "AFPointsUnknown1").is_none());
   assert!(find(&em, "AFPointsUnknown2").is_none());
   assert_eq!(em.len(), 4);
@@ -870,15 +864,15 @@ fn color_info_k10d_byte_exact() {
   // -j — `FORMAT => 'int8s'`; both WB shifts are 0 in Pentax.jpg.
   let mut em = Vec::new();
   emit_color_info(COLORINFO_K10D, true, &mut em);
-  assert_eq!(find(&em, "WBShiftAB"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "WBShiftGM"), Some(&TagValue::I64(0)));
+  assert_eq!(find(&em, "WBShiftAB"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "WBShiftGM"), Some(TagValue::I64(0)));
   assert_eq!(em.len(), 2);
   // A signed value reads as int8s (e.g. byte 0xff => -1).
   let mut signed = COLORINFO_K10D.to_vec();
   signed[16] = 0xff;
   let mut em2 = Vec::new();
   emit_color_info(&signed, true, &mut em2);
-  assert_eq!(find(&em2, "WBShiftAB"), Some(&TagValue::I64(-1)));
+  assert_eq!(find(&em2, "WBShiftAB"), Some(TagValue::I64(-1)));
 }
 
 // ---------------------------------------------------------------------------
@@ -917,7 +911,7 @@ fn battery_info_kx_does_not_emit_k10d_ad_layout() {
   assert!(find(&em, "PowerSource").is_some());
   assert_eq!(
     find(&em, "BodyBatteryState"),
-    Some(&TagValue::Str("Close to Full".into()))
+    Some(TagValue::Str("Close to Full".into()))
   );
 }
 
@@ -946,14 +940,14 @@ fn battery_info_k3iii_relayout_byte_exact() {
     true,
     &mut em,
   );
-  assert_eq!(find(&em, "PowerSource"), Some(&s("Body Battery")));
-  assert_eq!(find(&em, "PowerAvailable"), Some(&s("Body Battery")));
-  assert_eq!(find(&em, "BodyBatteryState"), Some(&s("Full")));
-  assert_eq!(find(&em, "BodyBatteryPercent"), Some(&TagValue::I64(100)));
-  assert_eq!(find(&em, "BodyBatteryVoltage"), Some(&s("7.48 V")));
-  assert_eq!(find(&em, "GripBatteryState"), Some(&s("Empty or Missing")));
-  assert_eq!(find(&em, "GripBatteryPercent"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "GripBatteryVoltage"), Some(&s("5.89 V")));
+  assert_eq!(find(&em, "PowerSource"), Some(s("Body Battery")));
+  assert_eq!(find(&em, "PowerAvailable"), Some(s("Body Battery")));
+  assert_eq!(find(&em, "BodyBatteryState"), Some(s("Full")));
+  assert_eq!(find(&em, "BodyBatteryPercent"), Some(TagValue::I64(100)));
+  assert_eq!(find(&em, "BodyBatteryVoltage"), Some(s("7.48 V")));
+  assert_eq!(find(&em, "GripBatteryState"), Some(s("Empty or Missing")));
+  assert_eq!(find(&em, "GripBatteryPercent"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "GripBatteryVoltage"), Some(s("5.89 V")));
   // The non-K-3III K10D AD layout must NOT appear (the K-3III branch is the sole
   // emitter — never a wrong-hash PowerSource or a K10D byte mis-read).
   for wrong in [
@@ -977,19 +971,19 @@ fn battery_info_k3iii_n_mode_raw_values() {
     false,
     &mut em,
   );
-  assert_eq!(find(&em, "PowerSource"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&em, "PowerAvailable"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&em, "BodyBatteryState"), Some(&TagValue::I64(5)));
+  assert_eq!(find(&em, "PowerSource"), Some(TagValue::I64(1)));
+  assert_eq!(find(&em, "PowerAvailable"), Some(TagValue::I64(1)));
+  assert_eq!(find(&em, "BodyBatteryState"), Some(TagValue::I64(5)));
   // The raw ValueConv f64 (`$val*4e-8+0.27219`). The serializer's `format_g`
   // renders these to the golden's `7.47863424` / `5.88731624` (10-sig-fig); the
   // stored f64 carries the full IEEE-754 precision.
   assert_eq!(
     find(&em, "BodyBatteryVoltage"),
-    Some(&TagValue::F64(f64::from(180161106u32) * 4e-8 + 0.27219))
+    Some(TagValue::F64(f64::from(180161106u32) * 4e-8 + 0.27219))
   );
   assert_eq!(
     find(&em, "GripBatteryVoltage"),
-    Some(&TagValue::F64(f64::from(140378156u32) * 4e-8 + 0.27219))
+    Some(TagValue::F64(f64::from(140378156u32) * 4e-8 + 0.27219))
   );
 }
 
@@ -1001,10 +995,10 @@ fn battery_info_istd_uses_raw_ad_variant() {
   // variant is selected (not the K10D PrintConv form).
   let mut em = Vec::new();
   emit_battery_info(BATTERYINFO_K10D, Some("PENTAX *ist D"), true, &mut em);
-  assert_eq!(find(&em, "BodyBatteryADNoLoad"), Some(&TagValue::I64(173)));
-  assert_eq!(find(&em, "BodyBatteryADLoad"), Some(&TagValue::I64(168)));
-  assert_eq!(find(&em, "GripBatteryADNoLoad"), Some(&TagValue::I64(5)));
-  assert_eq!(find(&em, "GripBatteryADLoad"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "BodyBatteryADNoLoad"), Some(TagValue::I64(173)));
+  assert_eq!(find(&em, "BodyBatteryADLoad"), Some(TagValue::I64(168)));
+  assert_eq!(find(&em, "GripBatteryADNoLoad"), Some(TagValue::I64(5)));
+  assert_eq!(find(&em, "GripBatteryADLoad"), Some(TagValue::I64(1)));
   assert!(find(&em, "GripBatteryState").is_none());
   // A `None` model (defensive — production always threads IFD0's Model) matches
   // ExifTool's `$$self{Model} !~ /K-3 Mark III/` on an undef Model = TRUE, so
@@ -1024,7 +1018,7 @@ fn battery_info_istd_uses_raw_ad_variant() {
   // BodyBatteryState emits — exactly as ExifTool would for an undef Model.
   assert_eq!(
     find(&emn, "BodyBatteryState"),
-    Some(&TagValue::Str("Close to Full".into()))
+    Some(TagValue::Str("Close to Full".into()))
   );
 }
 
@@ -1049,15 +1043,12 @@ fn af_info_excluded_models_drop_af_points_in_focus() {
       "{excluded} must not emit AFPointsInFocus"
     );
     // The unconditional AF leaves still emit (only 0x0b is gated).
-    assert_eq!(find(&em, "AFPredictor"), Some(&TagValue::I64(4)));
+    assert_eq!(find(&em, "AFPredictor"), Some(TagValue::I64(4)));
   }
   // A non-excluded model (e.g. the K-5) keeps AFPointsInFocus.
   let mut em = Vec::new();
   emit_af_info(AFINFO_K10D, Some("PENTAX K-5"), true, &mut em);
-  assert_eq!(
-    find(&em, "AFPointsInFocus"),
-    Some(&s("Center (horizontal)"))
-  );
+  assert_eq!(find(&em, "AFPointsInFocus"), Some(s("Center (horizontal)")));
 }
 
 // ---------------------------------------------------------------------------
@@ -1087,11 +1078,11 @@ fn lens_data_max_aperture_k5_gate_suppresses() {
     "an exactly-\"K-5\" model must suppress MaxAperture (ne \"K-5\")"
   );
   // The gate is leaf-local: the sibling LensData leaves are unaffected.
-  assert_eq!(find(&em, "AutoAperture"), Some(&s("On")));
-  assert_eq!(find(&em, "MinAperture"), Some(&s("22")));
-  assert_eq!(find(&em, "FocusRangeIndex"), Some(&s("7 (very far)")));
-  assert_eq!(find(&em, "LensFStops"), Some(&TagValue::F64(8.5)));
-  assert_eq!(find(&em, "NominalMaxAperture"), Some(&s("4.0")));
+  assert_eq!(find(&em, "AutoAperture"), Some(s("On")));
+  assert_eq!(find(&em, "MinAperture"), Some(s("22")));
+  assert_eq!(find(&em, "FocusRangeIndex"), Some(s("7 (very far)")));
+  assert_eq!(find(&em, "LensFStops"), Some(TagValue::F64(8.5)));
+  assert_eq!(find(&em, "NominalMaxAperture"), Some(s("4.0")));
   // The K10D fixture-equivalent count emits the OTHER eight leaves (all but
   // MaxAperture).
   assert_eq!(
@@ -1113,7 +1104,7 @@ fn lens_data_max_aperture_emits_for_full_pentax_k5_string() {
   emit_lens_info(LENSINFO2_K10D, 69, Some("PENTAX K-5"), true, &mut em);
   assert_eq!(
     find(&em, "MaxAperture"),
-    Some(&s("3.9")),
+    Some(s("3.9")),
     "a full \"PENTAX K-5\" model is not exactly \"K-5\" ⇒ MaxAperture still emits"
   );
   assert_eq!(em.len(), 9, "\"PENTAX K-5\" emits all nine LensData leaves");
@@ -1126,7 +1117,7 @@ fn lens_data_max_aperture_emits_for_k10d_fixture() {
   // gate does NOT over-suppress the fixture body.
   let mut em = Vec::new();
   emit_lens_info(LENSINFO2_K10D, 69, Some("PENTAX K10D"), true, &mut em);
-  assert_eq!(find(&em, "MaxAperture"), Some(&s("3.9")));
+  assert_eq!(find(&em, "MaxAperture"), Some(s("3.9")));
 }
 
 #[test]
@@ -1143,9 +1134,9 @@ fn af_info_af_points_in_focus_excluded_model_suppresses() {
     find(&em, "AFPointsInFocus").is_none(),
     "a K-3 (excluded) must suppress AFPointsInFocus"
   );
-  assert_eq!(find(&em, "AFPredictor"), Some(&TagValue::I64(4)));
-  assert_eq!(find(&em, "AFDefocus"), Some(&TagValue::I64(2)));
-  assert_eq!(find(&em, "AFIntegrationTime"), Some(&s("0 ms")));
+  assert_eq!(find(&em, "AFPredictor"), Some(TagValue::I64(4)));
+  assert_eq!(find(&em, "AFDefocus"), Some(TagValue::I64(2)));
+  assert_eq!(find(&em, "AFIntegrationTime"), Some(s("0 ms")));
   assert_eq!(em.len(), 3, "an excluded model drops only AFPointsInFocus");
 }
 
@@ -1174,7 +1165,7 @@ fn battery_info_non_k10d_model_suppresses_ad_layout() {
   // 5-entry hash), so it emits (byte 1 mask 0xf0 = 4 → 'Close to Full', #311).
   assert_eq!(
     find(&em, "BodyBatteryState"),
-    Some(&TagValue::Str("Close to Full".into()))
+    Some(TagValue::Str("Close to Full".into()))
   );
 }
 
@@ -1187,10 +1178,10 @@ fn lens_data_no_comment_only_gate_for_unconditional_leaves() {
   // over-suppress its neighbours.
   let mut em = Vec::new();
   emit_lens_info(LENSINFO2_K10D, 69, Some("K-5"), true, &mut em);
-  assert_eq!(find(&em, "MinFocusDistance"), Some(&s("0.49-0.50 m")));
-  assert_eq!(find(&em, "FocusRangeIndex"), Some(&s("7 (very far)")));
-  assert_eq!(find(&em, "NominalMaxAperture"), Some(&s("4.0")));
-  assert_eq!(find(&em, "NominalMinAperture"), Some(&s("23")));
+  assert_eq!(find(&em, "MinFocusDistance"), Some(s("0.49-0.50 m")));
+  assert_eq!(find(&em, "FocusRangeIndex"), Some(s("7 (very far)")));
+  assert_eq!(find(&em, "NominalMaxAperture"), Some(s("4.0")));
+  assert_eq!(find(&em, "NominalMinAperture"), Some(s("23")));
 }
 
 /// A crafted `%Pentax::FilterInfo` (`0x022a`) block with NON-ZERO
@@ -1219,27 +1210,27 @@ fn filter_info_non_ricoh_body_reads_big_endian() {
   emit_filter_info(FILTERINFO_NONZERO, Some("PENTAX"), &mut em);
   assert_eq!(
     find(&em, "SourceDirectoryIndex"),
-    Some(&TagValue::I64(0x1234)),
+    Some(TagValue::I64(0x1234)),
     "a non-RICOH body must read FilterInfo BigEndian"
   );
   // SourceFileIndex (key 2) is the int16u at BYTE 2 (FORMAT int8u ⇒ key = byte
   // offset), so BE bytes 2-3 (`56 78`) ⇒ 0x5678 — NOT bytes 4-5 (`ab cd`).
   assert_eq!(
     find(&em, "SourceFileIndex"),
-    Some(&TagValue::I64(0x5678)),
+    Some(TagValue::I64(0x5678)),
     "SourceFileIndex must read byte offset 2 (int8u-FORMAT key), not element index 2 (byte 4)"
   );
   // Regression: the pre-fix code read SourceFileIndex from bytes 4-5 (the decoy
   // `ab cd`). No emitted value may equal that BE/LE decoy.
   for e in &em {
     assert_ne!(
-      e.value(),
+      e.value().as_ref(),
       &TagValue::I64(0xabcd),
       "{}: bytes 4-5 (the element-index offset) must be IGNORED",
       e.name()
     );
     assert_ne!(
-      e.value(),
+      e.value().as_ref(),
       &TagValue::I64(0xcdab),
       "{}: bytes 4-5 (the element-index offset) must be IGNORED",
       e.name()
@@ -1262,13 +1253,13 @@ fn filter_info_ricoh_body_reads_little_endian() {
   );
   assert_eq!(
     find(&em, "SourceDirectoryIndex"),
-    Some(&TagValue::I64(0x3412)),
+    Some(TagValue::I64(0x3412)),
     "a RICOH body must read FilterInfo LittleEndian"
   );
   // SourceFileIndex at byte 2, LittleEndian ⇒ LE bytes 2-3 (`56 78`) → 0x7856.
   assert_eq!(
     find(&em, "SourceFileIndex"),
-    Some(&TagValue::I64(0x7856)),
+    Some(TagValue::I64(0x7856)),
     "a RICOH body must read FilterInfo LittleEndian at byte offset 2"
   );
 }
@@ -1297,7 +1288,7 @@ fn filter_info_byte_order_is_make_forced_not_parent_order() {
   emit_filter_info(FILTERINFO_NONZERO, None, &mut none);
   assert_eq!(
     find(&none, "SourceDirectoryIndex"),
-    Some(&TagValue::I64(0x1234)),
+    Some(TagValue::I64(0x1234)),
     "absent Make falls to the non-RICOH BigEndian arm"
   );
 }
@@ -1315,9 +1306,9 @@ fn level_info_k3iii_decodes_orientation_and_int16s_angles() {
   // PrintConv on the angles ⇒ the value is identical for `-j`/`-n`.
   let mut em = Vec::new();
   emit_level_info_k3iii(LEVELINFO_K3III, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "CameraOrientation"), Some(&s("Rotate 90 CW")));
-  assert_eq!(find(&em, "RollAngle"), Some(&TagValue::F64(-8.0)));
-  assert_eq!(find(&em, "PitchAngle"), Some(&TagValue::F64(8.0)));
+  assert_eq!(find(&em, "CameraOrientation"), Some(s("Rotate 90 CW")));
+  assert_eq!(find(&em, "RollAngle"), Some(TagValue::F64(-8.0)));
+  assert_eq!(find(&em, "PitchAngle"), Some(TagValue::F64(8.0)));
   // The K3III table has NO LevelOrientation / CompositionAdjust* leaves — they are
   // the K-5-style `%LevelInfo`'s, and must NOT appear here.
   assert!(find(&em, "LevelOrientation").is_none());
@@ -1331,9 +1322,9 @@ fn level_info_k3iii_int16s_angles_follow_parent_order() {
   // 4096 → -2048.0), proving the order is actually threaded (not hard-coded BE).
   let mut em = Vec::new();
   emit_level_info_k3iii(LEVELINFO_K3III, ByteOrder::Little, true, &mut em);
-  assert_eq!(find(&em, "RollAngle"), Some(&TagValue::F64(-2048.0)));
+  assert_eq!(find(&em, "RollAngle"), Some(TagValue::F64(-2048.0)));
   // PitchAngle bytes `ff f0` LE = `0xf0ff` = -3841 → -(-3841)/2 = 1920.5.
-  assert_eq!(find(&em, "PitchAngle"), Some(&TagValue::F64(1920.5)));
+  assert_eq!(find(&em, "PitchAngle"), Some(TagValue::F64(1920.5)));
 }
 
 #[test]
@@ -1356,8 +1347,8 @@ fn face_info_decodes_faces_detected_and_position() {
   let block: &[u8] = &[0x02, 0x00, 0x32, 0x28, 0x00];
   let mut em = Vec::new();
   emit_face_info(block, &mut em);
-  assert_eq!(find(&em, "FacesDetected"), Some(&TagValue::I64(2)));
-  assert_eq!(find(&em, "FacePosition"), Some(&s("50 40")));
+  assert_eq!(find(&em, "FacesDetected"), Some(TagValue::I64(2)));
+  assert_eq!(find(&em, "FacePosition"), Some(s("50 40")));
 }
 
 #[test]
@@ -1378,8 +1369,8 @@ fn face_info_0x0060_is_unconditional_not_k3iii_gated() {
   // `%FaceInfo` decode is produced (FacesDetected present).
   let mut em = Vec::new();
   emit_face_info(block, &mut em);
-  assert_eq!(find(&em, "FacesDetected"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&em, "FacePosition"), Some(&s("16 32")));
+  assert_eq!(find(&em, "FacesDetected"), Some(TagValue::I64(1)));
+  assert_eq!(find(&em, "FacePosition"), Some(s("16 32")));
   // Sanity: a body that WOULD match the LevelInfo K3III gate is still a normal
   // FaceInfo producer at 0x0060 — the gate is unrelated to this table.
   assert!(is_k3_mark_iii(Some("PENTAX K-3 Mark III")));
@@ -1448,14 +1439,14 @@ fn af_info_k3iii_complete_record_emits_areas() {
   // path the truncation guard must NOT regress.
   let mut em = Vec::new();
   emit_af_info_k3iii(AFINFO_K3III_COMPLETE, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "AFMode"), Some(&s("Phase Detect")));
-  assert_eq!(find(&em, "AFSelectionMode"), Some(&s("Spot")));
-  assert_eq!(find(&em, "MaxNumAFPoints"), Some(&TagValue::I64(101)));
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&em, "AFFrameSize"), Some(&s("600x400")));
+  assert_eq!(find(&em, "AFMode"), Some(s("Phase Detect")));
+  assert_eq!(find(&em, "AFSelectionMode"), Some(s("Spot")));
+  assert_eq!(find(&em, "MaxNumAFPoints"), Some(TagValue::I64(101)));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(1)));
+  assert_eq!(find(&em, "AFFrameSize"), Some(s("600x400")));
   assert_eq!(
     find(&em, "AFAreas"),
-    Some(&TagValue::List(vec![s(
+    Some(TagValue::List(vec![s(
       "300,200(central,peripheral,in-focus)"
     )]))
   );
@@ -1471,9 +1462,9 @@ fn af_info_k3iii_complete_record_value_conv_run() {
   // the full 7-value run for the single point.
   let mut em = Vec::new();
   emit_af_info_k3iii(AFINFO_K3III_COMPLETE, ByteOrder::Big, false, &mut em);
-  assert_eq!(find(&em, "AFFrameSize"), Some(&s("600 400")));
+  assert_eq!(find(&em, "AFFrameSize"), Some(s("600 400")));
   // The single 7-tuple: 600 400 300 200 0 0 20.
-  assert_eq!(find(&em, "AFAreas"), Some(&s("600 400 300 200 0 0 20")));
+  assert_eq!(find(&em, "AFAreas"), Some(s("600 400 300 200 0 0 20")));
 }
 
 #[test]
@@ -1491,7 +1482,7 @@ fn af_info_k3iii_truncated_before_area_skips_afareas() {
     true,
     &mut em,
   );
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(1)));
   // AFFrameSize (element 7..=8) and AFAreas (element 7+) are both absent — NOT an
   // empty list, NOT `(none)`.
   assert!(find(&em, "AFFrameSize").is_none());
@@ -1511,7 +1502,7 @@ fn af_info_k3iii_truncated_before_area_value_conv_also_skips() {
     false,
     &mut em,
   );
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(1)));
   assert!(find(&em, "AFAreas").is_none());
 }
 
@@ -1530,13 +1521,13 @@ fn af_info_k3iii_partial_area_tuple_keeps_whole_int16u() {
   // present — the row is NOT skipped, only its single tuple is incomplete).
   let mut em = Vec::new();
   emit_af_info_k3iii(AFINFO_K3III_PARTIAL_AREA, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&em, "AFFrameSize"), Some(&s("600x400"))); // elements 7,8 present
-  assert_eq!(find(&em, "AFAreas"), Some(&TagValue::List(vec![])));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(1)));
+  assert_eq!(find(&em, "AFFrameSize"), Some(s("600x400"))); // elements 7,8 present
+  assert_eq!(find(&em, "AFAreas"), Some(TagValue::List(vec![])));
   // `-n`: the space-joined run of the 3 readable int16u (600 400 300).
   let mut em_n = Vec::new();
   emit_af_info_k3iii(AFINFO_K3III_PARTIAL_AREA, ByteOrder::Big, false, &mut em_n);
-  assert_eq!(find(&em_n, "AFAreas"), Some(&s("600 400 300")));
+  assert_eq!(find(&em_n, "AFAreas"), Some(s("600 400 300")));
 }
 
 #[test]
@@ -1551,13 +1542,13 @@ fn af_info_k3iii_partial_frame_size_keeps_single_int16u() {
   let block = &AFINFO_K3III_COMPLETE[..16]; // elements 0..=7 (element 7 = 600)
   let mut em = Vec::new();
   emit_af_info_k3iii(block, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(1)));
-  assert_eq!(find(&em, "AFFrameSize"), Some(&s("600")));
-  assert_eq!(find(&em, "AFAreas"), Some(&TagValue::List(vec![]))); // raw "600" < 7-tuple
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(1)));
+  assert_eq!(find(&em, "AFFrameSize"), Some(s("600")));
+  assert_eq!(find(&em, "AFAreas"), Some(TagValue::List(vec![]))); // raw "600" < 7-tuple
   let mut em_n = Vec::new();
   emit_af_info_k3iii(block, ByteOrder::Big, false, &mut em_n);
-  assert_eq!(find(&em_n, "AFFrameSize"), Some(&s("600")));
-  assert_eq!(find(&em_n, "AFAreas"), Some(&s("600")));
+  assert_eq!(find(&em_n, "AFFrameSize"), Some(s("600")));
+  assert_eq!(find(&em_n, "AFAreas"), Some(s("600")));
 }
 
 /// A 24-byte contrast-detect record (elements 0..=11): NumAFPoints=1, areaW (element
@@ -1588,8 +1579,8 @@ fn af_info_k3iii_partial_area_size_keeps_single_int16u() {
   // `$$valPt` slice or a both-present guard would have wrongly suppressed it.
   let mut em = Vec::new();
   emit_af_info_k3iii(AFINFO_K3III_PARTIAL_AREASIZE, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "AFFrameSize"), Some(&s("600x400")));
-  assert_eq!(find(&em, "AFAreaSize"), Some(&s("64")));
+  assert_eq!(find(&em, "AFFrameSize"), Some(s("600x400")));
+  assert_eq!(find(&em, "AFAreaSize"), Some(s("64")));
   let mut em_n = Vec::new();
   emit_af_info_k3iii(
     AFINFO_K3III_PARTIAL_AREASIZE,
@@ -1597,7 +1588,7 @@ fn af_info_k3iii_partial_area_size_keeps_single_int16u() {
     false,
     &mut em_n,
   );
-  assert_eq!(find(&em_n, "AFAreaSize"), Some(&s("64")));
+  assert_eq!(find(&em_n, "AFAreaSize"), Some(s("64")));
 }
 
 /// A FULL `%AFInfoK3III` record (28 bytes, element 7 = byte 14 readable) with
@@ -1634,8 +1625,8 @@ fn af_info_k3iii_num_af_points_zero_present_record_emits_empty_afareas() {
   // case below, where element 7 is ABSENT and AFAreas is skipped entirely.)
   let mut em = Vec::new();
   emit_af_info_k3iii(AFINFO_K3III_NUM_ZERO_PRESENT, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "AFAreas"), Some(&s("(none)")));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "AFAreas"), Some(s("(none)")));
   assert!(find(&em, "AFFrameSize").is_none());
   assert!(find(&em, "AFAreaSize").is_none());
 
@@ -1647,7 +1638,7 @@ fn af_info_k3iii_num_af_points_zero_present_record_emits_empty_afareas() {
     false,
     &mut em_n,
   );
-  assert_eq!(find(&em_n, "AFAreas"), Some(&s("")));
+  assert_eq!(find(&em_n, "AFAreas"), Some(s("")));
   assert!(find(&em_n, "AFFrameSize").is_none());
   assert!(find(&em_n, "AFAreaSize").is_none());
 }
@@ -1662,7 +1653,7 @@ fn af_info_k3iii_num_af_points_zero_truncated_before_area_skips_afareas() {
   let block = &AFINFO_K3III_NUM_ZERO_PRESENT[..14];
   let mut em = Vec::new();
   emit_af_info_k3iii(block, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(0)));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(0)));
   assert!(find(&em, "AFAreas").is_none());
   assert!(find(&em, "AFFrameSize").is_none());
   assert!(find(&em, "AFAreaSize").is_none());
@@ -1699,8 +1690,8 @@ fn af_info_k3iii_row_start_only_num_zero_emits_empty_afareas() {
     true,
     &mut em,
   );
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(0)));
-  assert_eq!(find(&em, "AFAreas"), Some(&s("(none)")));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(0)));
+  assert_eq!(find(&em, "AFAreas"), Some(s("(none)")));
   // AFFrameSize/AFAreaSize stay suppressed by the NumAFPoints>0 Condition.
   assert!(find(&em, "AFFrameSize").is_none());
   assert!(find(&em, "AFAreaSize").is_none());
@@ -1713,7 +1704,7 @@ fn af_info_k3iii_row_start_only_num_zero_emits_empty_afareas() {
     false,
     &mut em_n,
   );
-  assert_eq!(find(&em_n, "AFAreas"), Some(&s("")));
+  assert_eq!(find(&em_n, "AFAreas"), Some(s("")));
 }
 
 /// Same 15-byte row-start-only record but with NumAFPoints=1 (count = 7*1 = 7).
@@ -1743,7 +1734,7 @@ fn af_info_k3iii_row_start_only_num_one_skips_afareas() {
     true,
     &mut em,
   );
-  assert_eq!(find(&em, "NumAFPoints"), Some(&TagValue::I64(1)));
+  assert_eq!(find(&em, "NumAFPoints"), Some(TagValue::I64(1)));
   assert!(find(&em, "AFAreas").is_none());
   // AFFrameSize (fixed int16u[2] at element 7) also shortens to 0 whole int16u here
   // (only byte 14) ⇒ ReadValue undef ⇒ skipped.
@@ -1786,7 +1777,7 @@ fn af_info_k3iii_contrast_detect_emits_afareasize() {
   ];
   let mut em = Vec::new();
   emit_af_info_k3iii(block, ByteOrder::Big, true, &mut em);
-  assert_eq!(find(&em, "AFAreaSize"), Some(&s("64x48")));
+  assert_eq!(find(&em, "AFAreaSize"), Some(s("64x48")));
 }
 
 #[test]
@@ -1798,10 +1789,10 @@ fn push_af_areas_k3iii_empty_value_render() {
   // (Bundled ExifTool on a NumAFPoints==0 record: `AFAreas=(none)` vs `AFAreas=''`.)
   let mut em_j = Vec::new();
   push_af_areas_k3iii(&[], true, &mut em_j);
-  assert_eq!(find(&em_j, "AFAreas"), Some(&s("(none)")));
+  assert_eq!(find(&em_j, "AFAreas"), Some(s("(none)")));
   let mut em_n = Vec::new();
   push_af_areas_k3iii(&[], false, &mut em_n);
-  assert_eq!(find(&em_n, "AFAreas"), Some(&s("")));
+  assert_eq!(find(&em_n, "AFAreas"), Some(s("")));
 }
 
 #[test]
@@ -1812,8 +1803,8 @@ fn push_af_areas_k3iii_short_nonempty_run_is_empty_list_not_none() {
   // Under `-n` it is the space-joined raw run. Pins the `(none)`-vs-`[]` boundary.
   let mut em_j = Vec::new();
   push_af_areas_k3iii(&[600, 400, 300], true, &mut em_j);
-  assert_eq!(find(&em_j, "AFAreas"), Some(&TagValue::List(vec![])));
+  assert_eq!(find(&em_j, "AFAreas"), Some(TagValue::List(vec![])));
   let mut em_n = Vec::new();
   push_af_areas_k3iii(&[600, 400, 300], false, &mut em_n);
-  assert_eq!(find(&em_n, "AFAreas"), Some(&s("600 400 300")));
+  assert_eq!(find(&em_n, "AFAreas"), Some(s("600 400 300")));
 }

--- a/src/exif/makernotes/vendors/pentax/tests.rs
+++ b/src/exif/makernotes/vendors/pentax/tests.rs
@@ -27,13 +27,16 @@ fn emit_lens_rec_pentax_jpg_pair() {
   // #284: `%Pentax::LensRec` `LensType` is `Priority => 0` (`Pentax.pm:4202`).
   assert_eq!(em[0].priority(), 0, "LensRec LensType Priority=>0");
   assert_eq!(
-    em[0].value(),
+    em[0].value().as_ref(),
     &crate::value::TagValue::Str("Sigma or Tamron Lens (3 44)".into())
   );
   // -n: the raw "series model" pair.
   let mut em_n = std::vec::Vec::new();
   emit_lens_rec(&block, false, &mut em_n);
-  assert_eq!(em_n[0].value(), &crate::value::TagValue::Str("3 44".into()));
+  assert_eq!(
+    em_n[0].value().as_ref(),
+    &crate::value::TagValue::Str("3 44".into())
+  );
 }
 
 #[test]

--- a/src/exif/makernotes/vendors/samsung/mod.rs
+++ b/src/exif/makernotes/vendors/samsung/mod.rs
@@ -218,7 +218,7 @@ fn first_u32(raw: &RawValue) -> Option<u32> {
 pub(crate) fn emit_picture_wizard(
   members: &[u64],
   print_conv: bool,
-  out: &mut Vec<VendorEmission>,
+  out: &mut Vec<VendorEmission<'_>>,
 ) {
   // (member index, name, conv) — FORMAT int16u ⇒ array index N.
   const MEMBERS: &[(usize, &str, SamsungPrintConv)] = &[
@@ -314,7 +314,7 @@ pub(crate) fn emit_crypt(
   raw: &RawValue,
   key: &[i64],
   unknown: bool,
-  out: &mut Vec<VendorEmission>,
+  out: &mut Vec<VendorEmission<'_>>,
 ) {
   // `split(" ",$val)` over the RENDERED value — `None` for a shape that does not
   // render to integers (a parseable wrong-format Crypt entry). ExifTool's RawConv

--- a/src/exif/makernotes/vendors/samsung/tests.rs
+++ b/src/exif/makernotes/vendors/samsung/tests.rs
@@ -36,15 +36,18 @@ fn emit_picture_wizard_nx500_members() {
   let members = [0u64, 65535, 0, 0, 0];
   let mut out = Vec::new();
   emit_picture_wizard(&members, true, &mut out);
-  let pairs: Vec<(&str, &TagValue)> = out.iter().map(|e| (e.name(), e.value())).collect();
+  let pairs: Vec<(&str, TagValue)> = out
+    .iter()
+    .map(|e| (e.name(), e.value().into_owned()))
+    .collect();
   assert_eq!(
     pairs,
     std::vec![
-      ("PictureWizardMode", &TagValue::Str("Standard".into())),
-      ("PictureWizardColor", &TagValue::I64(65535)),
-      ("PictureWizardSaturation", &TagValue::I64(-4)),
-      ("PictureWizardSharpness", &TagValue::I64(-4)),
-      ("PictureWizardContrast", &TagValue::I64(-4)),
+      ("PictureWizardMode", TagValue::Str("Standard".into())),
+      ("PictureWizardColor", TagValue::I64(65535)),
+      ("PictureWizardSaturation", TagValue::I64(-4)),
+      ("PictureWizardSharpness", TagValue::I64(-4)),
+      ("PictureWizardContrast", TagValue::I64(-4)),
     ]
   );
 }
@@ -118,12 +121,15 @@ fn emit_crypt_decrypts_under_signed_encoded_key() {
   // Collect (name, value) without indexing (the module `#![deny]`s
   // indexing_slicing) — the same iterate-then-assert pattern the PictureWizard
   // tests use.
-  let pairs: Vec<(&str, &TagValue)> = out.iter().map(|e| (e.name(), e.value())).collect();
+  let pairs: Vec<(&str, TagValue)> = out
+    .iter()
+    .map(|e| (e.name(), e.value().into_owned()))
+    .collect();
   assert_eq!(
     pairs,
     std::vec![(
       "WB_RGGBLevelsUncorrected",
-      &TagValue::Str("6576 4096 4096 8608".into())
+      TagValue::Str("6576 4096 4096 8608".into())
     )],
     "byte-exact NX500 plaintext regardless of the key's TIFF encoding"
   );
@@ -147,10 +153,10 @@ fn emit_crypt_signed_encoded_key_and_value() {
     false,
     &mut out,
   );
-  let values: Vec<&TagValue> = out.iter().map(super::VendorEmission::value).collect();
+  let values: Vec<TagValue> = out.iter().map(|e| e.value().into_owned()).collect();
   assert_eq!(
     values,
-    std::vec![&TagValue::Str("6576 4096 4096 8608".into())]
+    std::vec![TagValue::Str("6576 4096 4096 8608".into())]
   );
 }
 

--- a/src/exif/makernotes/vendors/sony/mod.rs
+++ b/src/exif/makernotes/vendors/sony/mod.rs
@@ -374,6 +374,79 @@ pub fn routes_to_main(blob: &[u8], make: Option<&str>, model: Option<&str>) -> b
   false
 }
 
+/// The seven `%Sony::Main` `%unknownCipherData` LEAF tags — `Sony_0x9407`,
+/// `0x9408`, `0x9409`, `0x940b`, `0x940d`, `0x940f`, `0x9411`
+/// (`Sony.pm:2055-2114`): each is `SubDirectory`-less (`sub_table: None`),
+/// `Unknown => 1`, and rendered by `SonyPrintConv::None` — so its value is the
+/// VERBATIM on-disk `undef[N]` span (the raw bytes), dropped from default output
+/// but recoverable via the `-u`/API path.
+///
+/// This is the exact set the #443 borrowed-span fix confines: the walk stores a
+/// zero-copy empty `RawValue` for these (skipping the `read_value` copy) and the
+/// Sony capture loop emits a [`VendorEmission`](super::VendorEmission) borrowing
+/// the span from the input buffer, so a crafted MakerNote with N such leaves
+/// pointing at one shared M-byte region retains O(N) span descriptors, not N
+/// copies of M. The conditional-ARRAY dispatchers `0x2010`/`0x940a`/`0x940c`/
+/// `0x940e` are `sub_table: Some(...)` and, on a non-matching model, fall
+/// through to `%unknownCipherData` which emits NOTHING
+/// (`exif::mod::sony_emit_enciphered_subblock`'s `_ => {}`), so they are NOT in
+/// this LEAF set — those `sub_table: Some(...)` dispatchers are covered by their
+/// `SubTable` variant instead (see [`value_resliced_from_data`]). This LEAF
+/// predicate stays SEPARATE because a leaf's span IS its emitted value (borrowed
+/// via `push_borrowed_span`): the emit path at `exif::mod` keys the borrow off
+/// this exact set.
+#[must_use]
+#[inline]
+pub(crate) fn is_suppressed_cipher_leaf(tag_id: u16) -> bool {
+  matches!(
+    tag_id,
+    0x9407 | 0x9408 | 0x9409 | 0x940b | 0x940d | 0x940f | 0x9411
+  )
+}
+
+/// `true` when a `%Sony::Main` row's decoded value is NEVER read from the walk's
+/// materialized `RawValue` — because the Sony capture loop re-slices the verbatim
+/// on-disk value span from the input buffer instead. The shared `Walker`'s #443
+/// zero-copy guard keys off this to store an EMPTY `RawValue` for such a row
+/// (gated to an `undef` block with `count != 1`), bounding the O(N·M) heap a
+/// crafted IFD with N such rows over one shared in-bounds M-byte region would
+/// otherwise amplify to O(N + M) — WITHOUT changing any emitted value (the
+/// re-slice reads the same span the clone would have held).
+///
+/// Two DISJOINT sub-classes, both re-sliced-from-`data`, never from the clone:
+///
+/// - The SUPPRESSED `%unknownCipherData` LEAVES ([`is_suppressed_cipher_leaf`]) —
+///   `sub_table: None`, emitted as a BORROWED span via `push_borrowed_span`.
+/// - The enciphered-`SubDirectory` dispatchers — every row whose `sub_table` is a
+///   variant `exif::mod::sony_emit_enciphered_subblock` handles
+///   ([`SubTable::dispatched_by_enciphered_subblock`]): `Tag2010` (`0x2010`), the
+///   whole `Tag9xxx` family (13 IDs incl. `0x9400`/`0x9402`/`0x9404`/`0x9405`/
+///   `0x9406`/`0x9050`/`0x9401`/`0x9403`/`0x9416`/`0x202a`/`0x900b`/`0x940a`/
+///   `0x940c`) and `AFInfo`/`Tag940e` (`0x940e`). Both the model/byte-matched
+///   decode AND the `%unknownCipherData` fallback re-slice the span, and
+///   `exif::mod::emit_sony_value` returns at its SubDirectory guard reading
+///   nothing.
+///
+/// The SubDirectory side is DERIVED FROM THE `SubTable` VARIANT (the routing),
+/// NOT a hand-maintained tag-ID list — so a future enciphered dispatcher added
+/// under `Tag9xxx` is covered automatically. This SUPERSEDES the #443 R1
+/// suppressed-leaf list + the R2 `is_conditional_cipher_subdir` id list, whose
+/// enumeration kept missing members (`0x9400`/`0x9402`/`0x9404`/`0x9405`/`0x9406`/
+/// `0x9050`/…) — the whack-a-mole this closes (#443 R3).
+///
+/// The older PLAIN binary sub-tables (`CameraInfo`/`FocusInfo`/`CameraSettings`/
+/// `ExtraInfo`/`ShotInfo`) also re-slice their span (via
+/// `exif::mod::sony_emit_binary_subdir`) but are intentionally left on the
+/// `read_value` path — this fix is scoped to the enciphered-subblock class, and
+/// they stay byte-identical either way.
+#[must_use]
+pub(crate) fn value_resliced_from_data(tag_id: u16) -> bool {
+  is_suppressed_cipher_leaf(tag_id)
+    || lookup(tag_id)
+      .and_then(|t| t.sub_table)
+      .is_some_and(|s| s.dispatched_by_enciphered_subblock())
+}
+
 /// Populate the typed struct from one Sony Main-IFD leaf-tag emission. `raw` is
 /// the entry's post-Format-decode [`RawValue`]; `val` the already-rendered
 /// [`TagValue`] (read ONLY by 0xb020's string fallback).
@@ -563,23 +636,23 @@ mod tests {
   // the shims pass `make = Some("SONY")` — the Sony5 make-gate (and a no-op for the
   // prefixed variants) — to route them exactly as the oracle decoded. (Routes-AWAY
   // bodies are covered by the surviving `routes_to_main` unit tests above.)
-  fn parse(
-    blob: &[u8],
+  fn parse<'a>(
+    blob: &'a [u8],
     body_offset: usize,
     order: ByteOrder,
-  ) -> (MakerNotesSony, Vec<VendorEmission>) {
+  ) -> (MakerNotesSony, Vec<VendorEmission<'a>>) {
     parse_in_tiff(blob, 0, blob.len(), body_offset, order, true, None)
   }
 
-  fn parse_in_tiff(
-    blob: &[u8],
+  fn parse_in_tiff<'a>(
+    blob: &'a [u8],
     mn_offset: usize,
     mn_len: usize,
     body_offset: usize,
     order: ByteOrder,
     print_conv: bool,
     model: Option<&str>,
-  ) -> (MakerNotesSony, Vec<VendorEmission>) {
+  ) -> (MakerNotesSony, Vec<VendorEmission<'a>>) {
     // `build_blob` always materializes the 12-byte `SONY DSC` prefix, so the IFD
     // is at the fixed body offset 12 (the `MakerNoteSony` Start) regardless of the
     // caller's `body_offset` argument (the retired headerless oracle path took 0).
@@ -620,7 +693,7 @@ mod tests {
       if e.unknown() {
         continue;
       }
-      into.push(group.clone(), e.name(), e.value().clone());
+      into.push(group.clone(), e.name(), e.value().into_owned());
     }
   }
 
@@ -734,7 +807,7 @@ mod tests {
     let (typed, emissions) = parse(&blob, 0, ByteOrder::Little);
     assert_eq!(typed.quality(), Some(2));
     assert_eq!(emissions[0].name(), "Quality");
-    assert_eq!(emissions[0].value(), &TagValue::Str("Fine".into()));
+    assert_eq!(emissions[0].value().as_ref(), &TagValue::Str("Fine".into()));
   }
 
   #[test]
@@ -746,7 +819,7 @@ mod tests {
     );
     let (typed, emissions) = parse(&blob, 12, ByteOrder::Little);
     assert_eq!(typed.quality(), Some(0));
-    assert_eq!(emissions[0].value(), &TagValue::Str("RAW".into()));
+    assert_eq!(emissions[0].value().as_ref(), &TagValue::Str("RAW".into()));
   }
 
   #[test]
@@ -756,7 +829,10 @@ mod tests {
     let (typed, emissions) = parse(&blob, 0, ByteOrder::Little);
     assert_eq!(typed.model_id(), Some(358));
     assert_eq!(typed.model_name(), Some("ILCE-9"));
-    assert_eq!(emissions[0].value(), &TagValue::Str("ILCE-9".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("ILCE-9".into())
+    );
   }
 
   #[test]
@@ -773,7 +849,7 @@ mod tests {
       Some("E-Mount, T-Mount, Other Lens or no lens")
     );
     assert_eq!(
-      emissions[0].value(),
+      emissions[0].value().as_ref(),
       &TagValue::Str("E-Mount, T-Mount, Other Lens or no lens".into())
     );
 
@@ -791,7 +867,10 @@ mod tests {
     let blob = build_blob(&[], &[(0x200e, 0x03, 1, std::vec![0x02, 0, 0, 0])]);
     let (typed, emissions) = parse(&blob, 0, ByteOrder::Little);
     assert_eq!(typed.picture_effect(), Some(2));
-    assert_eq!(emissions[0].value(), &TagValue::Str("Pop Color".into()));
+    assert_eq!(
+      emissions[0].value().as_ref(),
+      &TagValue::Str("Pop Color".into())
+    );
   }
 
   #[test]
@@ -915,10 +994,10 @@ mod tests {
   }
 
   /// Find an emission by name.
-  fn emit_value(em: &[VendorEmission], name: &str) -> Option<TagValue> {
+  fn emit_value(em: &[VendorEmission<'_>], name: &str) -> Option<TagValue> {
     em.iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   }
 
   /// End-to-end DataMember threading (`Sony.pm:1278-1279,1326-1330`): 0x201c
@@ -1041,10 +1120,11 @@ mod tests {
     let one = |tag: u16| build_blob(&[], &[(tag, 0x01, 1, std::vec![0x05, 0, 0, 0])]);
 
     // 0x201c — DSC-RX100 matches no branch ⇒ absent.
+    let b201c = one(0x201c);
     let (_t, em) = parse_in_tiff(
-      &one(0x201c),
+      &b201c,
       0,
-      one(0x201c).len(),
+      b201c.len(),
       0,
       ByteOrder::Little,
       true,
@@ -1060,10 +1140,11 @@ mod tests {
     // branch 1 needs AFAreaILCE==4 (undef), branch 5 needs NEX/.../DSC-RX
     // (ILCE-9 IS in branch 5's NEX/ILCE set) → matches branch 5. So instead
     // verify the genuine 0x201e miss: an ILCA body without AFAreaILCA set.
+    let b201e = one(0x201e);
     let (_t2, em2) = parse_in_tiff(
-      &one(0x201e),
+      &b201e,
       0,
-      one(0x201e).len(),
+      b201e.len(),
       0,
       ByteOrder::Little,
       true,
@@ -1095,10 +1176,11 @@ mod tests {
     );
 
     // 0x2022 — ILCE-9 writes neither variant ⇒ absent.
+    let b2022 = one(0x2022);
     let (_t4, em4) = parse_in_tiff(
-      &one(0x2022),
+      &b2022,
       0,
-      one(0x2022).len(),
+      b2022.len(),
       0,
       ByteOrder::Little,
       true,
@@ -1111,10 +1193,11 @@ mod tests {
     );
 
     // POSITIVE control — a matching body still emits the tag.
+    let b2022_pos = one(0x2022);
     let (_t5, em5) = parse_in_tiff(
-      &one(0x2022),
+      &b2022_pos,
       0,
-      one(0x2022).len(),
+      b2022_pos.len(),
       0,
       ByteOrder::Little,
       true,

--- a/src/exif/makernotes/vendors/sony/tags.rs
+++ b/src/exif/makernotes/vendors/sony/tags.rs
@@ -190,6 +190,40 @@ pub enum SubTable {
   PrintIm,
 }
 
+impl SubTable {
+  /// `true` when a `%Sony::Main` row carrying this SubDirectory target is decoded
+  /// by `exif::mod::sony_emit_enciphered_subblock` — the `ProcessEnciphered`/
+  /// `ProcessBinaryData` shot/AF/lens series `Tag2010` (0x2010), the whole
+  /// `Tag9xxx` family, and `AFInfo`/`Tag940e` (0x940e), plus the one PLAIN
+  /// `Tag202a` block that shares that dispatcher.
+  ///
+  /// That dispatcher decodes the block by re-slicing the verbatim on-disk value
+  /// span from the input buffer (`data[value_offset..]`) for BOTH the model/byte-
+  /// matched decode AND the `%unknownCipherData` fallback (its `_ => {}` arm), and
+  /// `exif::mod::emit_sony_value` returns at its Step-2 SubDirectory guard WITHOUT
+  /// reading the value — so the walk's decoded [`RawValue`](crate::exif::ifd::RawValue)
+  /// clone of such a row is DEAD (never read). This is the routing fact the #443
+  /// zero-copy walk guard keys off (via [`super::value_resliced_from_data`]).
+  ///
+  /// `Tag9xxx` alone groups THIRTEEN tag IDs (`0x9050`, `0x9400`-`0x9406`,
+  /// `0x940a`, `0x940c`, `0x9416`, `0x900b`, `0x202a`), so a new enciphered
+  /// dispatcher row added under it is covered here AUTOMATICALLY — the guard needs
+  /// no hand-maintained tag-ID list (superseding the #443 R1/R2 lists that kept
+  /// missing members, #443 R3).
+  ///
+  /// Returns `false` for the older PLAIN binary sub-tables (`CameraInfo`,
+  /// `FocusInfo`, `CameraSettings`, `ExtraInfo`, `ShotInfo`) — those are decoded by
+  /// the SEPARATE `exif::mod::sony_emit_binary_subdir` dispatcher and are left on
+  /// the `read_value` path (this fix is scoped to the enciphered-subblock class;
+  /// they are byte-identical either way) — and for the non-`ProcessBinaryData`
+  /// targets (`Panorama`, `HiddenInfo`, `MinoltaMakerNote`, `PrintIm`).
+  #[must_use]
+  #[inline]
+  pub(crate) const fn dispatched_by_enciphered_subblock(&self) -> bool {
+    matches!(self, Self::Tag2010 | Self::Tag9xxx | Self::AfInfo)
+  }
+}
+
 /// `%Sony::Main` (`Sony.pm:707-2711`). Sorted by tag ID.
 ///
 /// 114 rows — one per numeric key of the bundled hash.
@@ -1352,6 +1386,70 @@ mod tests {
     let t = lookup(0x202a).unwrap();
     assert_eq!(t.name, "Tag202a");
     assert_eq!(t.sub_table, Some(SubTable::Tag9xxx));
+  }
+
+  /// The #443 R3 CLASS-KILLER routing fact: `dispatched_by_enciphered_subblock`
+  /// is true for EXACTLY the three SubDirectory variants
+  /// `sony_emit_enciphered_subblock` handles (`Tag2010`, `Tag9xxx`, `AfInfo`) and
+  /// false for the plain-binary + non-`ProcessBinaryData` variants. This is what
+  /// lets the walk guard cover the whole enciphered class from ONE variant check,
+  /// with no hand-maintained tag-ID list.
+  #[test]
+  fn enciphered_subblock_class_is_variant_derived() {
+    for v in [SubTable::Tag2010, SubTable::Tag9xxx, SubTable::AfInfo] {
+      assert!(
+        v.dispatched_by_enciphered_subblock(),
+        "{v:?} is decoded by sony_emit_enciphered_subblock"
+      );
+    }
+    for v in [
+      SubTable::CameraInfo,
+      SubTable::FocusInfo,
+      SubTable::CameraSettings,
+      SubTable::ExtraInfo,
+      SubTable::ShotInfo,
+      SubTable::Panorama,
+      SubTable::HiddenInfo,
+      SubTable::MinoltaMakerNote,
+      SubTable::PrintIm,
+    ] {
+      assert!(
+        !v.dispatched_by_enciphered_subblock(),
+        "{v:?} is NOT an enciphered-subblock dispatcher (left on the read_value path)"
+      );
+    }
+  }
+
+  /// EVERY tag ID `sony_emit_enciphered_subblock` decodes must resolve — via its
+  /// `SubTable` variant — to the enciphered-subblock class, so the routing-derived
+  /// walk guard confines its walk clone. This pins the exact ID set (incl. the
+  /// members `0x9400`/`0x9402`/`0x9404`/`0x9405`/`0x9406`/`0x9050`/`0x9401`/
+  /// `0x9403`/`0x9416`/`0x202a`/`0x900b` that the R1/R2 hand lists MISSED) so a
+  /// future edit that drops one from `Tag9xxx` — or adds a dispatcher arm without
+  /// wiring its variant — is caught here, not by a fuzzer (#443 R3).
+  #[test]
+  fn every_enciphered_subblock_id_is_in_the_class() {
+    for id in [
+      0x2010u16, 0x9050, 0x9400, 0x9401, 0x9402, 0x9403, 0x9404, 0x9405, 0x9406, 0x940a, 0x940c,
+      0x940e, 0x9416, 0x900b, 0x202a,
+    ] {
+      let sub = lookup(id)
+        .unwrap_or_else(|| panic!("0x{id:04x} is a %Sony::Main row"))
+        .sub_table
+        .unwrap_or_else(|| panic!("0x{id:04x} is a SubDirectory dispatcher"));
+      assert!(
+        sub.dispatched_by_enciphered_subblock(),
+        "0x{id:04x} ({sub:?}) must be in the enciphered-subblock class"
+      );
+    }
+    // The plain binary sub-tables are deliberately OUTSIDE the class.
+    for id in [0x0010u16, 0x0020, 0x0114, 0x0116, 0x3000] {
+      let sub = lookup(id).unwrap().sub_table.unwrap();
+      assert!(
+        !sub.dispatched_by_enciphered_subblock(),
+        "0x{id:04x} ({sub:?}) is a plain binary sub-table, not enciphered-subblock"
+      );
+    }
   }
 
   /// The `%unknownCipherData` rows carry `Unknown => 1` (`Sony.pm:676`).

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -1444,13 +1444,17 @@ enum MakerNoteValueConvDecode<'a> {
 }
 
 #[cfg(feature = "alloc")]
-impl MakerNoteValueConvDecode<'_> {
+impl<'a> MakerNoteValueConvDecode<'a> {
   /// Re-run the vendor decoder for `-n` (ValueConv) and return its emissions.
   /// The gated variants `.expect(...)` a `Some` result — faithful to the eager
   /// walk's invariant that a route which matched in PrintConv matches in
   /// ValueConv too (same gate, PrintConv-independent).
+  ///
+  /// The emissions borrow the input buffer `'a` (the Sony suppressed-`Unknown`
+  /// `0x94xx` leaves carry a zero-copy span, #443); every other variant is
+  /// all-owned, so its free element lifetime unifies with `'a` at no cost.
   #[must_use]
-  fn recompute(&self) -> std::vec::Vec<makernotes::VendorEmission> {
+  fn recompute(&self) -> std::vec::Vec<makernotes::VendorEmission<'a>> {
     use makernotes::vendors::{dji, panasonic};
     match self {
       MakerNoteValueConvDecode::None => std::vec::Vec::new(),
@@ -1725,7 +1729,7 @@ pub struct MakerNote<'a> {
   /// re-resolve out-of-line offsets against the TIFF block. The PrintConv
   /// decode ALSO yields the typed vendor [`MakerNotesMeta`] slot, which the
   /// domain projection / dispatch tests read, so it stays EAGER.
-  cached_emissions_print_conv: std::vec::Vec<makernotes::VendorEmission>,
+  cached_emissions_print_conv: std::vec::Vec<makernotes::VendorEmission<'a>>,
   /// How to recompute the `-n` (post-ValueConv raw) emissions ON DEMAND —
   /// Golden-v2 P0 single-mode decode. The eager walk decodes the vendor body
   /// ONCE (PrintConv, above); the ValueConv emissions are needed only by the
@@ -1826,7 +1830,7 @@ impl<'a> MakerNote<'a> {
   /// have a body parser yet).
   #[must_use]
   #[inline(always)]
-  pub fn emissions_print_conv(&self) -> &[makernotes::VendorEmission] {
+  pub fn emissions_print_conv(&self) -> &[makernotes::VendorEmission<'a>] {
     &self.cached_emissions_print_conv
   }
 
@@ -1841,7 +1845,7 @@ impl<'a> MakerNote<'a> {
   /// parser yet (Phase 3/4) and for a gated vendor whose `%Main` route did not
   /// match (its PrintConv decode produced no emissions either).
   #[must_use]
-  pub fn emissions_value_conv(&self) -> std::vec::Vec<makernotes::VendorEmission> {
+  pub fn emissions_value_conv(&self) -> std::vec::Vec<makernotes::VendorEmission<'a>> {
     self.value_conv_decode.recompute()
   }
 
@@ -6433,6 +6437,26 @@ impl Walker<'_, '_> {
       && makernotes::vendors::nikon::is_implicit_undef_subdir(tag_id))
       || (self.active_table == TableRef::Pentax
         && makernotes::vendors::pentax::is_implicit_undef_subdir(tag_id))
+      // Sony `%unknownCipherData` cipher rows (#443): the SUPPRESSED-`Unknown`
+      // LEAVES *and* the enciphered-`SubDirectory` dispatchers — every row whose
+      // value the Sony capture loop re-slices from `self.data`, never reading this
+      // decoded `RawValue`. A leaf (`sub_table: None`) is emitted as a ZERO-COPY
+      // BORROWED span; a dispatcher (`sub_table: Some(Tag2010|Tag9xxx|AfInfo)`) is
+      // decoded by `sony_emit_enciphered_subblock`, which re-slices the verbatim
+      // span for BOTH the model/byte-matched decode AND the `%unknownCipherData`
+      // fallback while `emit_sony_value` returns at its SubDirectory guard reading
+      // nothing. `value_resliced_from_data` derives the whole class from the
+      // ROUTING (`SubTable::dispatched_by_enciphered_subblock` + the leaf set), so
+      // a crafted IFD with N such rows over one shared in-bounds region retains
+      // O(N) descriptors, not N clones of the (possibly-huge) `undef[N]` block —
+      // with NO change to any emitted value. Gated to `undef` with `count != 1`
+      // (the `count == 1` int8u carve-out decodes to a scalar and stays on the
+      // normal path), matching the capture loop's borrow guard. Supersedes the
+      // R1/R2 hand-listed tag-ID predicates that kept missing members (#443 R3).
+      || (self.active_table == TableRef::Sony
+        && makernotes::vendors::sony::value_resliced_from_data(tag_id)
+        && matches!(format, Format::Undef)
+        && count != 1)
     {
       RawValue::Bytes(Vec::new())
     } else {
@@ -7049,11 +7073,11 @@ impl Walker<'_, '_> {
   /// `canon_start` afterward (the dispatch does, so the Canon leaves emit via the
   /// cached emissions, NOT inline in `push_exif_tags`).
   #[must_use]
-  fn capture_canon_emissions(
+  fn capture_canon_emissions<'e>(
     &self,
     canon_start: usize,
     print_conv: bool,
-  ) -> std::vec::Vec<makernotes::VendorEmission> {
+  ) -> std::vec::Vec<makernotes::VendorEmission<'e>> {
     let mut emissions = std::vec::Vec::new();
     let mut sink = VendorEmissionSink::new(&mut emissions);
     for entry in self.entries.get(canon_start..).unwrap_or(&[]) {
@@ -7260,7 +7284,7 @@ impl Walker<'_, '_> {
             // out-of-line value offsets resolve against the parent TIFF block
             // (Canon/Sony/Panasonic), not the captured blob.
             let mut meta = makernotes::MakerNotesMeta::from_detected(detected);
-            let mut cached_pc = std::vec::Vec::<makernotes::VendorEmission>::new();
+            let mut cached_pc = std::vec::Vec::<makernotes::VendorEmission<'_>>::new();
             let mut value_conv_decode = MakerNoteValueConvDecode::None;
             // The family-1 group for the cached emissions. Defaults to the
             // dispatched vendor's `group1()`; the cross-table Leica10 arm
@@ -9750,9 +9774,19 @@ impl ExifMeta<'_> {
     // the vendor body ONCE on demand (P0 — owned `Vec`). A shared push folds
     // either slice into `out`.
     let push = |out: &mut std::vec::Vec<crate::emit::EmittedTag>,
-                emissions: &[makernotes::VendorEmission]| {
+                emissions: &[makernotes::VendorEmission<'_>]| {
       out.reserve(emissions.len());
       for e in emissions {
+        // DROP the `Unknown => 1` leaves BEFORE materializing the value (#443):
+        // every consumer of this stream ([`run_emission`](crate::emit::run_emission),
+        // `collect_deduped_tags`, `emits_movable_tag`) suppresses `Unknown` leaves,
+        // so skipping them here is byte-identical — AND it means a borrowed
+        // suppressed-`Unknown` cipher-data span (the Sony `0x94xx` leaves) is NEVER
+        // materialized on this path (`e.value()` below only ever sees an `Owned`
+        // value), closing the transient copy the old drop-AFTER-materialize made.
+        if e.unknown() {
+          continue;
+        }
         // The family-1 group: the captured MakerNote's `group1` by default, OR
         // the emission's own override when set — the Samsung `0x0035 PreviewIFD`
         // descent emits its `%Nikon::PreviewIFD` leaves under `PreviewIFD`
@@ -9764,7 +9798,7 @@ impl ExifMeta<'_> {
         out.push(crate::emit::EmittedTag::new_with_priority(
           crate::value::Group::new("MakerNotes", g1),
           smol_str::SmolStr::new(e.name()),
-          e.value().clone(),
+          e.value().into_owned(),
           e.unknown(),
           e.priority(),
         ));
@@ -10628,23 +10662,45 @@ impl ExifSink for EmittedTagSink<'_> {
 /// (a safe no-op) rather than `unreachable!()`, so a stray core entry can never
 /// turn into a malformed-input panic (defense in depth).
 #[cfg(feature = "alloc")]
-struct VendorEmissionSink<'v> {
+struct VendorEmissionSink<'v, 'a> {
   /// The destination [`VendorEmission`] buffer (borrowed) — pushed in walk
-  /// (emission) order.
-  emissions: &'v mut std::vec::Vec<makernotes::VendorEmission>,
+  /// (emission) order. The element lifetime `'a` is the input buffer a Phase-4
+  /// borrowed span (#443) points into; owned emissions ignore it.
+  emissions: &'v mut std::vec::Vec<makernotes::VendorEmission<'a>>,
 }
 
 #[cfg(feature = "alloc")]
-impl<'v> VendorEmissionSink<'v> {
+impl<'v, 'a> VendorEmissionSink<'v, 'a> {
   /// Wrap a destination buffer.
   #[inline(always)]
-  fn new(emissions: &'v mut std::vec::Vec<makernotes::VendorEmission>) -> Self {
+  fn new(emissions: &'v mut std::vec::Vec<makernotes::VendorEmission<'a>>) -> Self {
     Self { emissions }
+  }
+
+  /// Capture a SUPPRESSED-`Unknown` leaf as a BORROWED verbatim value span
+  /// (#443) — zero-copy from the walker's input buffer `'a`. Used by the Sony
+  /// capture loop for the `0x94xx` `%unknownCipherData` leaves (whose value is
+  /// the raw on-disk `undef[N]` bytes and is dropped from default output); the
+  /// borrow is materialized only if the `-u`/API path reads it, so N leaves
+  /// over one shared region cannot amplify to N copies. INHERENT (not on
+  /// [`ExifSink`]): the borrowed-span emission is confined to this capture sink,
+  /// so the trait — and its ~19 generic `emit_*` consumers — keep their owned
+  /// `TagValue` contract unchanged.
+  #[inline(always)]
+  fn push_borrowed_span(&mut self, name: &str, span: &'a [u8], unknown: bool, priority: u8) {
+    self
+      .emissions
+      .push(makernotes::VendorEmission::new_borrowed_span(
+        smol_str::SmolStr::new(name),
+        span,
+        unknown,
+        priority,
+      ));
   }
 }
 
 #[cfg(feature = "alloc")]
-impl ExifSink for VendorEmissionSink<'_> {
+impl ExifSink for VendorEmissionSink<'_, '_> {
   // The scalar writers are the core Exif/GPS leaf path and are not reached by a
   // Canon walk (every Canon emission goes through `write_vendor_value`). They
   // DROP the value (`Ok(())`) instead of `unreachable!()` so a stray core entry
@@ -10756,15 +10812,15 @@ fn canon_capture_group1_override(family1: &str) -> Option<&'static str> {
 /// DISCARDED — the family-1 group is the fixed override, faithful to
 /// `%Nikon::PreviewIFD`'s `GROUPS => { 1 => PreviewIFD }`.
 #[cfg(feature = "alloc")]
-struct PreviewIfdSink<'v> {
+struct PreviewIfdSink<'v, 'a> {
   /// The destination [`VendorEmission`] buffer (borrowed) — pushed in walk order.
-  emissions: &'v mut std::vec::Vec<makernotes::VendorEmission>,
+  emissions: &'v mut std::vec::Vec<makernotes::VendorEmission<'a>>,
   /// The family-1 group every captured emission carries (`"PreviewIFD"`).
   group1: &'static str,
 }
 
 #[cfg(feature = "alloc")]
-impl ExifSink for PreviewIfdSink<'_> {
+impl ExifSink for PreviewIfdSink<'_, '_> {
   #[inline(always)]
   fn write_str(
     &mut self,
@@ -12179,14 +12235,14 @@ fn populate_canon_typed(
 /// carried for symmetry with the dispatch capture inputs and the bounds it
 /// documents, not consumed by the walk.
 #[cfg(feature = "alloc")]
-fn canon_recompute_value_conv(
+fn canon_recompute_value_conv<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
   order: ByteOrder,
   model: Option<&str>,
   file_type: Option<&str>,
-) -> std::vec::Vec<makernotes::VendorEmission> {
+) -> std::vec::Vec<makernotes::VendorEmission<'e>> {
   // The `-n` recompute is the isolated walk with `print_conv = false` and the
   // typed slot discarded (the `-n` path needs only the ValueConv emissions).
   canon_makernote_isolated(data, mn_offset, mn_len, order, model, file_type, false).0
@@ -12225,13 +12281,13 @@ fn canon_recompute_value_conv(
 /// and is ALWAYS returned (non-Option — the oracle's `MakerNotesApple` is always
 /// present, even empty).
 #[cfg(feature = "alloc")]
-pub(in crate::exif) fn apple_makernote_isolated(
+pub(in crate::exif) fn apple_makernote_isolated<'e>(
   blob: &[u8],
   parent_order: ByteOrder,
   print_conv: bool,
   make: Option<&str>,
 ) -> (
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   Option<makernotes::vendors::apple::MakerNotesApple>,
 ) {
   // The oracle's `blob.len() < 14` guard (`apple/mod.rs`): a blob too short to
@@ -12429,8 +12485,8 @@ pub(in crate::exif) fn apple_makernote_isolated(
 /// matching `parse_in_tiff`).
 #[cfg(feature = "alloc")]
 #[allow(clippy::too_many_arguments)]
-pub(in crate::exif) fn sony_makernote_isolated(
-  data: &[u8],
+pub(in crate::exif) fn sony_makernote_isolated<'a>(
+  data: &'a [u8],
   mn_offset: usize,
   mn_len: usize,
   body_offset: usize,
@@ -12440,7 +12496,7 @@ pub(in crate::exif) fn sony_makernote_isolated(
   software: Option<&str>,
   print_conv: bool,
 ) -> Option<(
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'a>>,
   makernotes::vendors::sony::MakerNotesSony,
 )> {
   use makernotes::vendors::sony;
@@ -12619,16 +12675,45 @@ pub(in crate::exif) fn sony_makernote_isolated(
       // rides in the entry's `conv`. A defensive non-Sony conv (never produced
       // under `TableRef::Sony`) is skipped — `emit_sony_value` needs the `SonyTag`.
       if let ResolvedConv::Sony(sony_tag) = entry.conv {
-        let Ok(()) = emit_sony_value(
-          g1,
-          entry,
-          sony_tag,
-          model,
-          af_area,
-          print_conv,
-          Some(&mut typed),
-          &mut sink,
-        );
+        // The seven `%unknownCipherData` suppressed-`Unknown` LEAVES (#443): emit
+        // the verbatim on-disk `undef[N]` value span ZERO-COPY as a BORROWED
+        // `VendorEmission`, materialized into `TagValue::Bytes` only if the
+        // `-u`/API path reads it — instead of cloning it into the cached emission.
+        // Byte-identical to the eager `raw_to_tag_value(RawValue::Bytes(span))`
+        // (same name, `Unknown => 1`, and `Priority`), but it bounds the memory a
+        // crafted MakerNote with many such leaves over ONE shared region can
+        // amplify (O(N) span descriptors, not N copies of the region). The walk
+        // stored an EMPTY `RawValue` for exactly this set (the `walk_entry`
+        // zero-copy guard), so `emit_sony_value`'s render is BYPASSED; the guard
+        // MATCHES that walk guard (`undef`, `value_size != 1` == `count != 1`), and
+        // the value extent is already range-checked in-bounds by the walk, so the
+        // span slice always resolves. A `count == 1` leaf (the `int8u` scalar
+        // carve-out) stays on the normal `emit_sony_value` path below.
+        let off = entry.value_offset();
+        if sony::is_suppressed_cipher_leaf(entry.tag_id)
+          && matches!(entry.on_disk_format, Format::Undef)
+          && entry.value_size() != 1
+          && let Some(end) = off.checked_add(entry.value_size())
+          && let Some(span) = data.get(off..end)
+        {
+          sink.push_borrowed_span(
+            sony_tag.name(),
+            span,
+            sony_tag.is_unknown(),
+            sony_tag.tag_priority(),
+          );
+        } else {
+          let Ok(()) = emit_sony_value(
+            g1,
+            entry,
+            sony_tag,
+            model,
+            af_area,
+            print_conv,
+            Some(&mut typed),
+            &mut sink,
+          );
+        }
       }
       // The enciphered `Tag9050x`/`Tag9400x` `ProcessBinaryData` sub-blocks
       // (`emit_sony_value` skips them as deferred SubDirectory rows). They are
@@ -13166,7 +13251,7 @@ fn sony_tag9050c_model(model: Option<&str>) -> bool {
 /// `-n` emissions (the typed slot is the SAME for both and ALWAYS returned,
 /// non-Option, matching `parse_in_tiff`).
 #[cfg(feature = "alloc")]
-pub(in crate::exif) fn panasonic_makernote_isolated(
+pub(in crate::exif) fn panasonic_makernote_isolated<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -13175,7 +13260,7 @@ pub(in crate::exif) fn panasonic_makernote_isolated(
   model: Option<&str>,
   print_conv: bool,
 ) -> Option<(
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   makernotes::vendors::panasonic::MakerNotesPanasonic,
 )> {
   use makernotes::vendors::panasonic;
@@ -13226,7 +13311,7 @@ pub(in crate::exif) fn panasonic_makernote_isolated(
 /// replaced by `body_offset`).
 #[cfg(feature = "alloc")]
 #[allow(clippy::too_many_arguments)]
-pub(in crate::exif) fn panasonic_makernote_isolated_with_offset(
+pub(in crate::exif) fn panasonic_makernote_isolated_with_offset<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -13236,7 +13321,7 @@ pub(in crate::exif) fn panasonic_makernote_isolated_with_offset(
   model: Option<&str>,
   print_conv: bool,
 ) -> Option<(
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   makernotes::vendors::panasonic::MakerNotesPanasonic,
 )> {
   use makernotes::vendors::panasonic;
@@ -13496,7 +13581,7 @@ pub(in crate::exif) fn panasonic_makernote_isolated_with_offset(
 /// emissions (the typed slot is the SAME for both and ALWAYS returned, non-Option,
 /// matching `parse_in_tiff`).
 #[cfg(feature = "alloc")]
-pub(in crate::exif) fn nikon_makernote_isolated(
+pub(in crate::exif) fn nikon_makernote_isolated<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -13504,7 +13589,7 @@ pub(in crate::exif) fn nikon_makernote_isolated(
   model: Option<&str>,
   print_conv: bool,
 ) -> Option<(
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   makernotes::vendors::nikon::MakerNotesNikon,
 )> {
   use makernotes::vendors::nikon::{self, MakerNotesNikon, ParsedValue, SubTable};
@@ -13855,7 +13940,7 @@ fn pentax_decrypt_shutter_count(
 
 #[cfg(feature = "alloc")]
 #[allow(clippy::too_many_arguments)]
-pub(in crate::exif) fn pentax_makernote_isolated(
+pub(in crate::exif) fn pentax_makernote_isolated<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -13865,7 +13950,7 @@ pub(in crate::exif) fn pentax_makernote_isolated(
   model: Option<&str>,
   print_conv: bool,
 ) -> Option<(
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   makernotes::vendors::pentax::MakerNotesPentax,
 )> {
   use makernotes::vendors::pentax::{self, MakerNotesPentax, SubTable};
@@ -14358,7 +14443,7 @@ pub(in crate::exif) fn pentax_makernote_isolated(
 /// `Some(empty)` (vendor identified, nothing decoded), never `None`.
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "alloc")]
-pub(in crate::exif) fn samsung_makernote_isolated(
+pub(in crate::exif) fn samsung_makernote_isolated<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -14373,7 +14458,7 @@ pub(in crate::exif) fn samsung_makernote_isolated(
   file_type: Option<&str>,
   print_conv: bool,
 ) -> Option<(
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   makernotes::vendors::samsung::MakerNotesSamsung,
 )> {
   use makernotes::vendors::samsung::{self, MakerNotesSamsung, SubTable};
@@ -14671,7 +14756,7 @@ pub(in crate::exif) fn samsung_makernote_isolated(
 /// `Some(empty)` (vendor identified, nothing decoded), never `None`.
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "alloc")]
-pub(in crate::exif) fn leica_makernote_isolated(
+pub(in crate::exif) fn leica_makernote_isolated<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -14682,7 +14767,7 @@ pub(in crate::exif) fn leica_makernote_isolated(
   model: Option<&str>,
   print_conv: bool,
 ) -> Option<(
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   makernotes::vendors::leica::MakerNotesLeica,
 )> {
   use makernotes::vendors::leica::MakerNotesLeica;
@@ -14924,7 +15009,7 @@ pub(in crate::exif) fn leica_makernote_isolated(
 /// `data` at `mn_offset` (it does not slice to `mn_len`), so the parameter is
 /// carried for symmetry with the decode inputs, not consumed by the walk.
 #[cfg(feature = "alloc")]
-pub(in crate::exif) fn canon_makernote_isolated(
+pub(in crate::exif) fn canon_makernote_isolated<'e>(
   data: &[u8],
   mn_offset: usize,
   mn_len: usize,
@@ -14933,7 +15018,7 @@ pub(in crate::exif) fn canon_makernote_isolated(
   file_type: Option<&str>,
   print_conv: bool,
 ) -> (
-  std::vec::Vec<makernotes::VendorEmission>,
+  std::vec::Vec<makernotes::VendorEmission<'e>>,
   Option<makernotes::vendors::canon::MakerNotesCanon>,
 ) {
   // The SAME entry-region guard `walk_canon_in_tiff` applies at its top
@@ -22512,7 +22597,7 @@ mod tests {
     let e = emitted.get(0).expect("emission 0");
     assert_eq!(e.name(), "RunTime");
     assert_eq!(
-      e.value(),
+      e.value().as_ref(),
       &TagValue::I64(42),
       "the int8u 0x2a renders as the scalar 42, not a bytes blob"
     );
@@ -22569,7 +22654,7 @@ mod tests {
     );
     assert_eq!(emitted.get(0).expect("0").name(), "HDRImageType");
     assert_eq!(
-      emitted.get(0).expect("0").value(),
+      emitted.get(0).expect("0").value().as_ref(),
       &TagValue::Str("".into()),
       "count-0 numeric renders the empty string"
     );
@@ -22713,7 +22798,7 @@ mod tests {
         .find(|e| e.name() == "AETarget")
         .expect("AETarget (the index-0 int64u entry) must be emitted");
       assert_eq!(
-        ae_target.value(),
+        ae_target.value().as_ref(),
         &crate::value::TagValue::U64(0x8899_AABB_CCDD_EEFF),
         "print_conv={print_conv}: the index-0 int64u value decodes via Format::Int64u"
       );
@@ -24046,7 +24131,7 @@ mod tests {
       .find(|e| e.name() == "LensType")
       .expect("LensType emits");
     assert_eq!(
-      lens.value(),
+      lens.value().as_ref(),
       &crate::value::TagValue::Str("G".into()),
       "undef[1] LensType must coerce to int8u then render via the LensType conv ⇒ \"G\""
     );
@@ -24079,7 +24164,7 @@ mod tests {
       .find(|e| e.name() == "AFAreaMode")
       .expect("the undef[1] AFInfo SubDirectory must emit its offset-0 AFAreaMode");
     assert_eq!(
-      af.value(),
+      af.value().as_ref(),
       &crate::value::TagValue::Str("Single Area".into()),
       "the inline AFInfo byte 0x00 ⇒ AFAreaMode \"Single Area\" (offset-0 int8u)"
     );
@@ -24270,7 +24355,7 @@ mod tests {
     makernotes::vendors::pentax::emit_lens_rec(span, true, &mut emissions);
     let lens = emissions.iter().find(|e| e.name() == "LensType");
     assert_eq!(
-      lens.map(|e| e.value().clone()),
+      lens.map(|e| e.value().into_owned()),
       Some(crate::value::TagValue::Str(
         "Sigma or Tamron Lens (3 44)".into()
       )),
@@ -25003,7 +25088,7 @@ mod tests {
       assert!(
         emi
           .iter()
-          .any(|e| e.name() == "FocalLength" && e.value() == &want),
+          .any(|e| e.name() == "FocalLength" && e.value().as_ref() == &want),
         "print_conv={print_conv}: an undef[100001] 0x02 is EXEMPT from the \
          excessive-count guard ⇒ FocalLength 550; emi={:?}",
         emi
@@ -26419,7 +26504,7 @@ mod tests {
       emissions
         .iter()
         .find(|e| e.name() == n)
-        .map(|e| e.value().clone())
+        .map(|e| e.value().into_owned())
     };
     assert_eq!(find("Quality"), Some(TagValue::Str("Fine".into())));
     assert_eq!(find("SonyModelID"), Some(TagValue::Str("ILCE-9".into())));
@@ -26517,7 +26602,7 @@ mod tests {
         .iter()
         .rev()
         .find(|e| e.name() == n)
-        .map(|e| e.value().clone())
+        .map(|e| e.value().into_owned())
     };
     // 0x9050 was deciphered ONCE (latch still unset at its walk position), so the
     // single-enciphered ShutterCount recovers correctly — matching bundled.
@@ -26581,7 +26666,7 @@ mod tests {
     let mis_color_mode = mis_emit
       .iter()
       .find(|e| e.name() == "ColorMode")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(
       mis_color_mode,
       Some(TagValue::Str("WRONG".into())),
@@ -26715,7 +26800,11 @@ mod tests {
       true,
     );
     let typed = typed.expect("pc=true ⇒ typed slot installed");
-    let find = |n: &str| em.iter().find(|e| e.name() == n).map(|e| e.value().clone());
+    let find = |n: &str| {
+      em.iter()
+        .find(|e| e.name() == n)
+        .map(|e| e.value().into_owned())
+    };
     assert_eq!(
       find("AFAreaMode"),
       Some(TagValue::Str("Single-point AF".into()))
@@ -26796,7 +26885,7 @@ mod tests {
       let emitted = em
         .iter()
         .find(|e| e.name() == "ImageUniqueID")
-        .map(|e| e.value().clone());
+        .map(|e| e.value().into_owned());
       assert_eq!(
         emitted,
         Some(TagValue::Str(ID_HEX.into())),
@@ -26821,7 +26910,7 @@ mod tests {
       let emitted = em
         .iter()
         .find(|e| e.name() == "ImageUniqueID")
-        .map(|e| e.value().clone());
+        .map(|e| e.value().into_owned());
       assert_eq!(
         emitted,
         Some(TagValue::Str(SHORT_ZERO_HEX.into())),
@@ -26849,7 +26938,7 @@ mod tests {
     let emitted = em
       .iter()
       .find(|e| e.name() == "ImageUniqueID")
-      .map(|e| e.value().clone());
+      .map(|e| e.value().into_owned());
     assert_eq!(emitted, Some(TagValue::Str(NUL_HEX.into())));
     assert_eq!(typed.image_unique_id(), Some(NUL_HEX));
   }
@@ -26873,7 +26962,7 @@ mod tests {
       let emitted = em
         .iter()
         .find(|e| e.name() == "ImageUniqueID")
-        .map(|e| e.value().clone());
+        .map(|e| e.value().into_owned());
       assert_eq!(emitted, Some(TagValue::Str("".into())), "format {format}");
       assert_eq!(typed.image_unique_id(), Some(""));
     }
@@ -27307,7 +27396,7 @@ for my $n (sort {{ $a <=> $b }} grep {{ /^\d+$/ }} keys %main) {{
       emissions
         .iter()
         .find(|e| e.name() == "SerialNumber")
-        .map(|e| e.value().clone())
+        .map(|e| e.value().into_owned())
     }
 
     for print_conv in [true, false] {

--- a/src/formats/quicktime.rs
+++ b/src/formats/quicktime.rs
@@ -16022,7 +16022,7 @@ fn emit_ctmd_exif_info(
         out.push(EmittedTag::new_with_priority(
           group.clone(),
           smol_str::SmolStr::new(e.name()),
-          e.value().clone(),
+          e.value().into_owned(),
           e.unknown(),
           e.priority(),
         ));

--- a/src/formats/quicktime_brands.rs
+++ b/src/formats/quicktime_brands.rs
@@ -1692,7 +1692,7 @@ fn render_cmt3_block(
     EmittedTag::new_with_priority(
       Group::new("MakerNotes", group1),
       smol_str::SmolStr::new(e.name()),
-      e.value().clone(),
+      e.value().into_owned(),
       e.unknown(),
       e.priority(),
     )

--- a/src/formats/riff.rs
+++ b/src/formats/riff.rs
@@ -3649,7 +3649,7 @@ impl crate::emit::Taggable for RiffMeta<'_> {
             tags.push(crate::emit::EmittedTag::new_with_priority(
               group.clone(),
               smol_str::SmolStr::new(e.name()),
-              e.value().clone(),
+              e.value().into_owned(),
               e.unknown(),
               e.priority(),
             ));

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -132,6 +132,12 @@ const FIXTURES: &[&str] = &[
   "ID3v2_4_big.mp3",
   "QuickTime_frea_rexing17b.mov",
   "Real.ra",
+  // Real Sony ARWs — the `%Sony::Main` walk (#443 confines its suppressed-Unknown
+  // `0x94xx` cipher-leaf values to a BORROWED span, so their per-leaf value clone
+  // is gone). Pinned so a regression that re-materializes them trips the gate.
+  "Sony_ILME-FX3_real.ARW",
+  "Sony_SLT-A33_real.ARW",
+  "Sony_DSLR-A200_real.ARW",
 ];
 
 /// Measure + report + assert the per-fixture allocation counts for both the
@@ -212,6 +218,9 @@ fn alloc_budget() {
 
   read_value_byte_len_float_rational_is_zero_heap();
   geotiff_block_capture_is_single_copy();
+  sony_cipher_data_is_borrowed_not_amplified();
+  sony_conditional_subdir_fallback_is_borrowed_not_amplified();
+  sony_raw_selector_subdir_fallback_is_borrowed_not_amplified();
 }
 
 /// The placeholder-length path ([`exifast::exif::ifd::read_value_byte_len`]) for
@@ -409,6 +418,344 @@ fn geotiff_block_capture_is_single_copy() {
   );
 }
 
+/// The seven `%Sony::Main` `%unknownCipherData` SUPPRESSED-`Unknown` LEAF tag
+/// IDs (`Sony_0x9407`/`8`/`9`/`b`/`d`/`f` + `0x9411`, `Sony.pm:2055-2114`).
+const SONY_CIPHER_IDS: [u16; 7] = [0x9407, 0x9408, 0x9409, 0x940b, 0x940d, 0x940f, 0x9411];
+
+/// The value offset (TIFF-absolute) where [`sony_cipher_tiff`] places the shared
+/// region — after the 8-byte header, IFD0, ExifIFD, the 12-byte `SONY DSC`
+/// prefix, and the `n` cipher-leaf entries of the Sony Main IFD.
+fn sony_region_off(n: usize) -> usize {
+  // 8 (header) + 18 (IFD0: 1 entry) + 18 (ExifIFD: 1 entry) + 12 ("SONY DSC ..")
+  // = MN body IFD at 56, then 2 (count) + n*12 (entries) + 4 (next-IFD).
+  56 + 2 + n * 12 + 4
+}
+
+/// Craft a MINIMAL little-endian TIFF whose Sony MakerNote is a `%Sony::Main`
+/// IFD of `%unknownCipherData` SUPPRESSED-`Unknown` cipher rows (`ids` — either
+/// the suppressed LEAVES or the conditional-`SubDirectory` dispatchers, and
+/// `ids` MAY repeat a single id), each an out-of-line `undef[span]` value
+/// pointing at a 1-byte-SHIFTED, OVERLAPPING, DISTINCT window of ONE shared
+/// `region`-byte block:
+///
+/// `IFD0(ExifOffset)` → `ExifIFD(MakerNote 0x927c)` → `"SONY DSC \0\0\0"` +
+/// `Sony Main IFD(ids…)` + the shared region.
+///
+/// The Sony Main IFD is `Base => Inherit` (offsets are TIFF-absolute), so every
+/// leaf's value pointer resolves into the shared region. `span` is FIXED
+/// (`region - 16`, independent of `ids.len()`) so scaling the leaf count keeps
+/// the per-leaf window identical; the 16-byte margin keeps up to 16 shifted
+/// windows in-bounds. `span` stays below the 100 000-element excessive-count
+/// gate so the walk raises no warnings.
+fn sony_cipher_tiff(ids: &[u16], region: usize) -> Vec<u8> {
+  assert!(
+    ids.len() <= 16 && region >= 32,
+    "up to 16 shifted windows fit"
+  );
+  let span = u32::try_from(region - 16).expect("span fits u32");
+  assert!(span < 100_000, "keep count below the excessive-count gate");
+  let region_off = sony_region_off(ids.len());
+  let total = region_off + region;
+  const EXIF_OFF: u32 = 26;
+  const MN_OFF: usize = 44;
+
+  let mut t: Vec<u8> = Vec::with_capacity(total);
+  // [0..8] TIFF header — little-endian, IFD0 at offset 8.
+  t.extend_from_slice(&[b'I', b'I', 0x2a, 0x00]);
+  t.extend_from_slice(&8u32.to_le_bytes());
+  // [8] IFD0 — a single ExifOffset (0x8769) pointer.
+  t.extend_from_slice(&1u16.to_le_bytes());
+  t.extend_from_slice(&0x8769u16.to_le_bytes());
+  t.extend_from_slice(&4u16.to_le_bytes()); // LONG
+  t.extend_from_slice(&1u32.to_le_bytes());
+  t.extend_from_slice(&EXIF_OFF.to_le_bytes());
+  t.extend_from_slice(&0u32.to_le_bytes());
+  assert_eq!(t.len(), EXIF_OFF as usize);
+  // [26] ExifIFD — a single MakerNote (0x927c) whose value is the Sony blob.
+  let mn_len = u32::try_from(total - MN_OFF).expect("mn_len fits u32");
+  t.extend_from_slice(&1u16.to_le_bytes());
+  t.extend_from_slice(&0x927cu16.to_le_bytes());
+  t.extend_from_slice(&7u16.to_le_bytes()); // UNDEF
+  t.extend_from_slice(&mn_len.to_le_bytes());
+  t.extend_from_slice(&u32::try_from(MN_OFF).unwrap().to_le_bytes());
+  t.extend_from_slice(&0u32.to_le_bytes());
+  assert_eq!(t.len(), MN_OFF);
+  // [44] `MakerNoteSony` primary signature (Start = $valuePtr + 12).
+  t.extend_from_slice(b"SONY DSC \x00\x00\x00");
+  // [56] Sony Main IFD — the cipher leaves, ASCENDING (a valid sorted IFD).
+  t.extend_from_slice(&u16::try_from(ids.len()).unwrap().to_le_bytes());
+  for (i, &id) in ids.iter().enumerate() {
+    t.extend_from_slice(&id.to_le_bytes());
+    t.extend_from_slice(&7u16.to_le_bytes()); // UNDEF
+    t.extend_from_slice(&span.to_le_bytes()); // count
+    // 1-byte-shifted, overlapping, DISTINCT windows of the shared region.
+    t.extend_from_slice(&u32::try_from(region_off + i).unwrap().to_le_bytes());
+  }
+  t.extend_from_slice(&0u32.to_le_bytes());
+  assert_eq!(t.len(), region_off);
+  // [region_off] the shared region every leaf's window overlaps.
+  t.resize(total, 0x5a);
+  t
+}
+
+/// #443 — the Sony `0x94xx` `%unknownCipherData` suppressed-`Unknown` leaves are
+/// emitted as BORROWED value spans (zero-copy from the input buffer), so a
+/// crafted MakerNote cannot amplify memory: N such leaves over one M-byte region
+/// retain O(N) span descriptors, not the pre-fix O(N·M) (each leaf materialized a
+/// throwaway `RawValue::Bytes` PLUS a cached `TagValue::Bytes`).
+///
+/// Two byte-volume probes prove invariants (iv) [O(N+M), not N·M] and (v)
+/// [overlapping 1-byte-shifted DISTINCT spans share the buffer]:
+///   1. N→2N leaves over the SAME (large) region — the delta must be O(N·span-
+///      descriptor), far below even ONE span copy.
+///   2. small-M vs large-M region (fixed 7 leaves) — the growth must be O(1) in
+///      the region size, not the pre-fix ~2·N·ΔM.
+/// A third probe (invariant ii/vii) reads a suppressed leaf's value through the
+/// PUBLIC accessor and asserts it materializes the EXACT on-disk span bytes.
+///
+/// Called INLINE from the single `alloc_budget` test (the counters are
+/// process-global; see the module doc).
+fn sony_cipher_data_is_borrowed_not_amplified() {
+  use exifast::parse_exif;
+
+  // Overlapping-span windows, all deep enough that the pre-fix copy would be a
+  // clear multiple of the region growth. `span = region - 16` in every build.
+  const SMALL: usize = 8_016; // span 8000
+  const LARGE: usize = 90_016; // span 90000 (< the 100k excessive-count gate)
+
+  // --- (a) N→2N leaves over the SAME large region. ---
+  let tiff_n = sony_cipher_tiff(&SONY_CIPHER_IDS[0..3], LARGE);
+  let tiff_2n = sony_cipher_tiff(&SONY_CIPHER_IDS[0..6], LARGE);
+  // Warm-up OUTSIDE the measured region (lazy statics / first-call init).
+  assert!(parse_exif(&tiff_n).is_some(), "3-leaf Sony TIFF parses");
+  assert!(parse_exif(&tiff_2n).is_some(), "6-leaf Sony TIFF parses");
+  let (_n_ok, bytes_n) = count_alloc_bytes(|| parse_exif(&tiff_n).is_some());
+  let (_2n_ok, bytes_2n) = count_alloc_bytes(|| parse_exif(&tiff_2n).is_some());
+
+  // --- (b) small-M vs large-M region, fixed 7 leaves. ---
+  let tiff_small = sony_cipher_tiff(&SONY_CIPHER_IDS, SMALL);
+  let tiff_large = sony_cipher_tiff(&SONY_CIPHER_IDS, LARGE);
+  assert!(
+    parse_exif(&tiff_small).is_some(),
+    "small-region Sony TIFF parses"
+  );
+  assert!(
+    parse_exif(&tiff_large).is_some(),
+    "large-region Sony TIFF parses"
+  );
+  let (_s_ok, small_bytes) = count_alloc_bytes(|| parse_exif(&tiff_small).is_some());
+  let (_l_ok, large_bytes) = count_alloc_bytes(|| parse_exif(&tiff_large).is_some());
+
+  println!("\n=== alloc_budget: sony 0x94xx cipher-leaf borrow (single-copy) ===");
+  println!("  N=3 leaves={bytes_n}B  N=6 leaves={bytes_2n}B  (same {LARGE}B region)");
+  println!("  M=small({SMALL})={small_bytes}B  M=large({LARGE})={large_bytes}B");
+
+  let span = LARGE - 16; // 90000 — the per-leaf window / pre-fix per-copy volume
+
+  // (a) Doubling the leaf count over the SAME region adds only O(N descriptors)
+  // — FAR below one span copy. The pre-fix path would add 3 leaves × (throwaway
+  // RawValue + cached copy) ≈ 6·span here.
+  let n_delta = bytes_2n.saturating_sub(bytes_n);
+  assert!(
+    n_delta < span,
+    "N→2N cipher leaves grew {n_delta} bytes for the SAME region — a borrowed \
+     span must add O(N descriptors), NOT O(N·M); a growth ≥ one span ({span}) \
+     means a per-leaf value copy regressed back in (#443)."
+  );
+
+  // (b) Growing the region (fixed 7 leaves) must be O(1) — the spans are
+  // borrowed from the input buffer, never copied. The pre-fix path copied each
+  // of the 7 overlapping windows TWICE, so it would grow ~14·ΔM.
+  let region_delta = LARGE - SMALL; // 82000
+  let m_growth = large_bytes.saturating_sub(small_bytes);
+  assert!(
+    m_growth < region_delta,
+    "the 7 cipher leaves grew {m_growth} bytes for a {region_delta}-byte region \
+     increase — a borrowed span must be O(1) in the region size; a growth near \
+     14·ΔM means the overlapping windows are being COPIED (#443)."
+  );
+
+  // --- (c) invariant (ii)/(vii): the PUBLIC accessor materializes the EXACT
+  // on-disk span for a SUPPRESSED leaf (non-empty, correct window). ---
+  let meta = parse_exif(&tiff_small).expect("small Sony TIFF parses");
+  let mn = meta.maker_note().expect("Sony MakerNote captured");
+  let leaf = mn
+    .emissions_print_conv()
+    .iter()
+    .find(|e| e.name() == "Sony_0x9407")
+    .expect("the 0x9407 %unknownCipherData leaf is cached");
+  assert!(
+    leaf.unknown(),
+    "0x9407 is Unknown => 1 (suppressed by default)"
+  );
+  // `Sony_0x9407` is leaf index 0 ⇒ its window starts at the region base.
+  let base = sony_region_off(SONY_CIPHER_IDS.len());
+  let want = &tiff_small[base..base + (SMALL - 16)];
+  assert!(!want.is_empty(), "the on-disk span is non-empty");
+  assert_eq!(
+    leaf.value().as_ref(),
+    &exifast::value::TagValue::Bytes(want.to_vec()),
+    "the suppressed cipher leaf materializes the EXACT on-disk span bytes"
+  );
+}
+
+/// #443 R2 — the Sony CONDITIONAL-`SubDirectory` cipher dispatchers
+/// (`0x2010`/`0x940a`/`0x940c`/`0x940e`) also confine their walk-clone. Each is
+/// a `sub_table: Some(...)` row that decodes a real enciphered sub-table when the
+/// `Model` matches a branch and falls through to `%unknownCipherData` (emitting
+/// NOTHING) when none does. Pre-fix the walk still `read_value`-cloned the
+/// (crafted-huge) `undef[N]` value span onto EACH entry, so N duplicate
+/// dispatcher rows over one shared M-byte region retained O(N·M); the #443 R2
+/// walk-guard extension stores a zero-copy empty `RawValue` for these rows too
+/// (their decode re-slices the span from the input buffer for BOTH the matched
+/// and the fallback path), bounding the retained heap to O(N + M).
+///
+/// This TIFF carries NO `Model`, so every dispatcher's model gate fails and all
+/// N `0x940e` rows fall back (`sony_emit_enciphered_subblock`'s `_ => {}` — no
+/// `process_enciphered`, zero decode allocation), isolating the walk clone the
+/// fix removes. It repeats a SINGLE id (the walker processes every entry with no
+/// ascending/dedup gate) over 1-byte-shifted overlapping windows so N scales
+/// while the shared region stays fixed. Proves invariant (vi) for the fallback
+/// shape (the leaf-ID probe above covers the leaf shape).
+///
+/// Called INLINE from the single `alloc_budget` test (the counters are
+/// process-global; see the module doc).
+fn sony_conditional_subdir_fallback_is_borrowed_not_amplified() {
+  use exifast::parse_exif;
+
+  // The per-row window; `span = region - 16` in the crafted TIFF (< the 100k
+  // excessive-count gate, so the walk raises no warnings + processes every row).
+  const LARGE: usize = 90_016; // span 90000
+
+  // N→2N duplicate `0x940e` dispatcher rows over the SAME large region. With no
+  // Model they all fall back to `%unknownCipherData` (emit nothing); pre-fix each
+  // still retained a `read_value` clone of the 90000-byte window.
+  let ids_n = [0x940e_u16; 4];
+  let ids_2n = [0x940e_u16; 8];
+  let tiff_n = sony_cipher_tiff(&ids_n, LARGE);
+  let tiff_2n = sony_cipher_tiff(&ids_2n, LARGE);
+  // Warm-up OUTSIDE the measured region (lazy statics / first-call init).
+  assert!(
+    parse_exif(&tiff_n).is_some(),
+    "4-dispatcher Sony TIFF parses"
+  );
+  assert!(
+    parse_exif(&tiff_2n).is_some(),
+    "8-dispatcher Sony TIFF parses"
+  );
+  let (_n_ok, bytes_n) = count_alloc_bytes(|| parse_exif(&tiff_n).is_some());
+  let (_2n_ok, bytes_2n) = count_alloc_bytes(|| parse_exif(&tiff_2n).is_some());
+
+  println!("\n=== alloc_budget: sony conditional-subdir fallback borrow (single-copy) ===");
+  println!("  N=4 dispatchers={bytes_n}B  N=8 dispatchers={bytes_2n}B  (same {LARGE}B region)");
+
+  // Doubling the fallback-dispatcher count over the SAME region adds only O(N
+  // descriptors) — FAR below one span copy. The pre-fix path added 4 rows ×
+  // one `read_value` clone ≈ 4·span here (each retained on its walked entry).
+  let span = LARGE - 16; // 90000 — the per-row window / pre-fix per-clone volume
+  let n_delta = bytes_2n.saturating_sub(bytes_n);
+  assert!(
+    n_delta < span,
+    "N→2N conditional-subdir fallback rows grew {n_delta} bytes for the SAME \
+     region — the walk must store a zero-copy empty RawValue (O(N descriptors)), \
+     NOT O(N·M); a growth ≥ one span ({span}) means the fallback rows' \
+     read_value clone regressed back in (#443 R2)."
+  );
+
+  // Confirm we exercised the FALLBACK path (not a matched decode): with no Model
+  // the `0x940e` dispatcher falls to `%unknownCipherData` and emits NO leaf, so
+  // the Sony MakerNote carries zero emissions. A non-zero count would mean a
+  // matched sub-table decode ran (the probe would no longer test the fallback).
+  let meta = parse_exif(&tiff_n).expect("dispatcher Sony TIFF parses");
+  let dispatcher_leaves = meta
+    .maker_note()
+    .map_or(0, |mn| mn.emissions_print_conv().len());
+  assert_eq!(
+    dispatcher_leaves, 0,
+    "0x940e with no Model must fall back to %unknownCipherData (emit no leaf); \
+     a non-zero count means a matched decode ran (test no longer exercises the \
+     fallback path)."
+  );
+}
+
+/// #443 R3 — the CLASS-KILLER regression probe. The R1 (suppressed-leaf) and R2
+/// (`0x2010`/`0x940a`/`0x940c`/`0x940e`) predicates were HAND-LISTED tag IDs, so
+/// they kept missing members of the same enciphered-`SubDirectory` class — e.g.
+/// `0x9405` (a `sub_table: Some(Tag9xxx)` row selected by the RAW value's FIRST
+/// BYTE, not by `Model`): pre-R3 its walk clone was NOT confined, re-amplifying
+/// O(N·M). R3 derives the class from the `SubTable` variant
+/// (`dispatched_by_enciphered_subblock`), so `0x9405` — and every other `Tag9xxx`
+/// ID — is covered WITHOUT a hand-maintained list.
+///
+/// This probes the RAW-SELECTOR fallback shape the reviewer named (distinct from
+/// the R2 MODEL-selector probe above): the crafted region is all `0x5a`, which is
+/// NEITHER a `Tag9405a` selector (`/^[\x1b\x40\x7d]/`) NOR a `Tag9405b` selector
+/// (`/^[\x3a\xb3\x7e\x9a\x25\xe1\x76\x8b]/`), so `sony_emit_enciphered_subblock`
+/// falls to its `_ => {}` `%unknownCipherData` arm (no `process_enciphered`, zero
+/// decode allocation) — isolating the walk clone the fix removes. N duplicate
+/// `0x9405` rows over 1-byte-shifted overlapping windows of ONE fixed region make
+/// N scale while M stays fixed. Pre-R3 this FAILS (the `0x9405` clone regresses);
+/// post-R3 the delta is O(N descriptors).
+///
+/// Called INLINE from the single `alloc_budget` test (the counters are
+/// process-global; see the module doc).
+fn sony_raw_selector_subdir_fallback_is_borrowed_not_amplified() {
+  use exifast::parse_exif;
+
+  // The per-row window; `span = region - 16` (< the 100k excessive-count gate, so
+  // the walk raises no warnings + processes every row).
+  const LARGE: usize = 90_016; // span 90000
+
+  // N→2N duplicate `0x9405` RAW-SELECTOR dispatcher rows over the SAME large
+  // region. Every window's first byte is `0x5a` (a non-matching selector), so all
+  // fall back to `%unknownCipherData` (emit nothing); pre-R3 each still retained a
+  // `read_value` clone of the 90000-byte window (0x9405 ∉ the R2 hand list).
+  let ids_n = [0x9405_u16; 4];
+  let ids_2n = [0x9405_u16; 8];
+  let tiff_n = sony_cipher_tiff(&ids_n, LARGE);
+  let tiff_2n = sony_cipher_tiff(&ids_2n, LARGE);
+  // Warm-up OUTSIDE the measured region (lazy statics / first-call init).
+  assert!(parse_exif(&tiff_n).is_some(), "4-selector Sony TIFF parses");
+  assert!(
+    parse_exif(&tiff_2n).is_some(),
+    "8-selector Sony TIFF parses"
+  );
+  let (_n_ok, bytes_n) = count_alloc_bytes(|| parse_exif(&tiff_n).is_some());
+  let (_2n_ok, bytes_2n) = count_alloc_bytes(|| parse_exif(&tiff_2n).is_some());
+
+  println!("\n=== alloc_budget: sony raw-selector-subdir fallback borrow (single-copy) ===");
+  println!("  N=4 selectors={bytes_n}B  N=8 selectors={bytes_2n}B  (same {LARGE}B region)");
+
+  // Doubling the fallback-row count over the SAME region adds only O(N
+  // descriptors) — FAR below one span copy. The pre-R3 path added 4 rows × one
+  // `read_value` clone ≈ 4·span here (each retained on its walked entry).
+  let span = LARGE - 16; // 90000 — the per-row window / pre-fix per-clone volume
+  let n_delta = bytes_2n.saturating_sub(bytes_n);
+  assert!(
+    n_delta < span,
+    "N→2N raw-selector fallback rows grew {n_delta} bytes for the SAME region — \
+     the routing-derived guard must store a zero-copy empty RawValue for a \
+     `Tag9xxx` `0x9405` row (O(N descriptors)), NOT O(N·M); a growth ≥ one span \
+     ({span}) means an enciphered-subdir ID slipped the class-killer predicate \
+     (the #443 R1/R2 whack-a-mole)."
+  );
+
+  // Confirm we exercised the RAW-SELECTOR FALLBACK (not a matched decode): the
+  // all-`0x5a` region matches neither `Tag9405a` nor `Tag9405b`, so `0x9405`
+  // falls to `%unknownCipherData` and emits NO leaf. A non-zero count would mean a
+  // matched sub-table decode ran (the probe would no longer test the fallback).
+  let meta = parse_exif(&tiff_n).expect("selector Sony TIFF parses");
+  let selector_leaves = meta
+    .maker_note()
+    .map_or(0, |mn| mn.emissions_print_conv().len());
+  assert_eq!(
+    selector_leaves, 0,
+    "0x9405 with a non-matching first byte must fall back to %unknownCipherData \
+     (emit no leaf); a non-zero count means a matched decode ran (test no longer \
+     exercises the raw-selector fallback path)."
+  );
+}
+
 // ---------------------------------------------------------------------------
 // PINNED BUDGETS — set after the Phase-A.3 perf items landed (see report).
 // Each is the measured improved count plus a small headroom margin so trivial,
@@ -438,6 +785,13 @@ fn media_metadata_budget(name: &str) -> usize {
     "ID3v2_4_big.mp3" => 225,      // measured 209 (Contract A: 194 → 209)
     "QuickTime_frea_rexing17b.mov" => 40, // measured 31 (no EXIF string leaf)
     "Real.ra" => 30,               // measured 21 (P8: 31 → 21)
+    // Real Sony ARWs (#443) — POST-fix, the `%Sony::Main` suppressed-Unknown
+    // `0x94xx` cipher leaves no longer clone their value into the cached
+    // emission (they carry a BORROWED span), so these are a lower/equal
+    // baseline: measured FX3 485 / A33 329 / A200 258, each + ~7% headroom.
+    "Sony_ILME-FX3_real.ARW" => 520,  // measured 485
+    "Sony_SLT-A33_real.ARW" => 355,   // measured 329
+    "Sony_DSLR-A200_real.ARW" => 280, // measured 258
     // An unlisted fixture: no pinned budget (the harness still prints + checks
     // parse acceptance, just no ceiling).
     _ => usize::MAX,
@@ -558,6 +912,13 @@ fn extract_info_budget(name: &str) -> (usize, usize) {
     // Ceilings raised to (252, 270).
     "QuickTime_frea_rexing17b.mov" => (252, 270), // measured (237, 254) — +Canon composite-def scratch
     "Real.ra" => (100, 100),                      // measured (88, 87)
+    // Real Sony ARWs (#443) — POST-fix `-j`/`-n` render budgets. The
+    // suppressed-Unknown `0x94xx` cipher leaves are dropped BEFORE materializing
+    // (the `push_maker_note_tags` reorder), so their transient value clone is
+    // gone from BOTH render modes: measured + ~7% headroom.
+    "Sony_ILME-FX3_real.ARW" => (3300, 3440), // measured (3083, 3213)
+    "Sony_SLT-A33_real.ARW" => (2230, 2380),  // measured (2083, 2225)
+    "Sony_DSLR-A200_real.ARW" => (2120, 2250), // measured (1979, 2098)
     _ => (usize::MAX, usize::MAX),
   }
 }

--- a/tests/exif_makernotes_dispatch.rs
+++ b/tests/exif_makernotes_dispatch.rs
@@ -336,7 +336,7 @@ fn apple_iphone_real_fixture_emits_makernote_group() {
   let mnv = emissions
     .iter()
     .find(|e| e.name() == "MakerNoteVersion")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert!(mnv.is_some(), "MakerNoteVersion emitted");
 }
 
@@ -378,7 +378,7 @@ fn pentax_k10d_real_fixture_decodes_typed_and_emits() {
     emissions
       .iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   };
   use exifast::value::TagValue;
   assert_eq!(
@@ -833,7 +833,7 @@ fn canon_serialinfo_5d_decodes_internal_serial_number2() {
   let isn2 = emissions
     .iter()
     .find(|e| e.name() == "InternalSerialNumber2")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_eq!(
     isn2,
     Some(exifast::TagValue::Str("ABC123XYZ".into())),
@@ -842,7 +842,7 @@ fn canon_serialinfo_5d_decodes_internal_serial_number2() {
   let isn = emissions
     .iter()
     .find(|e| e.name() == "InternalSerialNumber")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_eq!(isn, Some(exifast::TagValue::Str("DEF456".into())));
 
   // The bogus `SerialInfo` SubDirectory parent is NEVER emitted (#177).
@@ -873,7 +873,7 @@ fn canon_serialinfo_rawconv_drops_non_word() {
   let isn = emissions
     .iter()
     .find(|e| e.name() == "InternalSerialNumber")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_eq!(isn, Some(exifast::TagValue::Str("DEF456".into())));
 }
 
@@ -995,7 +995,7 @@ fn panasonic_lumix_real_fixture_emits_print_conv_labels() {
     emissions
       .iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   };
   use exifast::value::TagValue;
   assert_eq!(find("ImageQuality"), Some(TagValue::Str("High".into())));
@@ -1114,7 +1114,7 @@ fn panasonic3_dcft7_base12_out_of_line_lenstype() {
     mn.emissions_print_conv()
       .iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   };
   assert_eq!(
     find("LensType"),
@@ -1137,7 +1137,7 @@ fn panasonic3_dcft7_base0_offset_is_corrupted() {
     .emissions_print_conv()
     .iter()
     .find(|e| e.name() == "LensType")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_ne!(
     lens,
     Some(TagValue::Str("LUMIX-LENS-12".into())),
@@ -1362,7 +1362,7 @@ fn canon_eos_real_fixture_emits_print_conv_labels() {
     emissions
       .iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   };
   use exifast::value::TagValue;
   assert_eq!(
@@ -2226,7 +2226,7 @@ fn leica10_dispatches_to_panasonic_main_image_quality() {
     .emissions_print_conv()
     .iter()
     .find(|e| e.name() == "ImageQuality")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_eq!(
     iq,
     Some(TagValue::Str("High".into())),
@@ -2504,7 +2504,7 @@ fn leica1_dispatches_to_panasonic_main_image_quality() {
     .emissions_print_conv()
     .iter()
     .find(|e| e.name() == "ImageQuality")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_eq!(
     iq,
     Some(TagValue::Str("High".into())),
@@ -3041,7 +3041,7 @@ fn synthetic_dji_typed_populates_all_main_tags() {
     emissions
       .iter()
       .find(|e| e.name() == n)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   };
   assert_eq!(find("Make"), Some(TagValue::Str("DJI".into())));
   assert_eq!(find("SpeedX"), Some(TagValue::Str("+1.50".into())));
@@ -5032,7 +5032,7 @@ fn canon_makernote_dirsize_overrun_salvages_clamped_entries() {
   let owner = emissions
     .iter()
     .find(|e| e.name() == "OwnerName")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_eq!(
     owner,
     Some(exifast::TagValue::Str("OwnerX".into())),
@@ -5041,7 +5041,7 @@ fn canon_makernote_dirsize_overrun_salvages_clamped_entries() {
   let imgtype = emissions
     .iter()
     .find(|e| e.name() == "CanonImageType")
-    .map(|e| e.value().clone());
+    .map(|e| e.value().into_owned());
   assert_eq!(
     imgtype,
     Some(exifast::TagValue::Str("CanonImg".into())),
@@ -5322,7 +5322,7 @@ fn canon_salvaged_dir_prescan_drives_focallength_and_lenstype() {
     emissions
       .iter()
       .find(|e| e.name() == name)
-      .map(|e| e.value().clone())
+      .map(|e| e.value().into_owned())
   };
   // The dependent FocalLength sub-table emission scaled by the pre-scanned
   // FocalUnits = 2 ⇒ 100/2 = "50 mm" (the salvage drove the pre-scan).


### PR DESCRIPTION
Fixes the Sony 0x94xx suppressed-Unknown crafted-input memory-amplification DoS via a CONFINED lazy/borrowed vendor-emission value — the golden design from a 4-auditor deep audit (correctness + performance).

EmissionValue<'a> = Owned(TagValue) | Borrowed(&'a [u8]) on VendorEmission<'a>, tied to the lifetime MakerNote<'a> already carries. Suppressed-Unknown undef spans borrow the input zero-copy (no clone, no Arc, no whole-file copy); value() materializes on read (Cow). Confined to the emission subsystem — ZERO change to TagValue/RawValue/serialize/composite/the 174 format files (~21 files). Satisfies all 7 audit invariants (byte-exact default output, correct materialize-on-read, no whole-file copy, O(N+M), overlapping-span-safe, uniform over all shapes, no API-empty) and avoids all 4 prior failure modes.

The DoS bound covers ALL suppressed-Unknown shapes via a ROUTING-DERIVED predicate (SubTable::dispatched_by_enciphered_subblock: Tag2010|Tag9xxx|AfInfo — the class, not a hardcoded id list; future dispatchers auto-covered), excluding the RawValue-reading rows so matched decode stays byte-identical.

Perf: a genuine common-case WIN — real Sony ARW allocations DROPPED (FX3 media_metadata 485->473) as the suppressed-leaf clones are eliminated. Crafted-DoS proving tests (N overlapping 1-byte-shifted undef leaves + conditional-subdir + raw-selector fallbacks) assert O(N+M) via count_alloc_bytes; the 3 Sony ARWs added to alloc_budget.

Verify: conformance 514/0 byte-identical (FX3/A33/A200 unchanged), lib 4362/0, alloc_budget pass, typed_serde/timed_metadata/xtask green. Codex adversarial review R1-R3: R1 confirmed confined+lifetime-safe (found leaf-only coverage); R2 added conditional-subdir; R3 the structural class-killer covering the whole enciphered class. Deferred: the crate-wide pure-borrow (broader common-case perf) is a separate Phase-E roadmap. Closes #443.