### PR TITLE
fix(sony): widen resliced-value DoS bound to all sub_table rows, not just enciphered sub-blocks (#486)

### DIFF
--- a/src/exif/makernotes/vendors/sony/mod.rs
+++ b/src/exif/makernotes/vendors/sony/mod.rs
@@ -391,10 +391,12 @@ pub fn routes_to_main(blob: &[u8], make: Option<&str>, model: Option<&str>) -> b
 /// through to `%unknownCipherData` which emits NOTHING
 /// (`exif::mod::sony_emit_enciphered_subblock`'s `_ => {}`), so they are NOT in
 /// this LEAF set — those `sub_table: Some(...)` dispatchers are covered by their
-/// `SubTable` variant instead (see [`value_resliced_from_data`]). This LEAF
+/// `SubTable` variant instead (see [`sony_tag_has_sub_table`]). This LEAF
 /// predicate stays SEPARATE because a leaf's span IS its emitted value (borrowed
 /// via `push_borrowed_span`): the emit path at `exif::mod` keys the borrow off
-/// this exact set.
+/// this exact set, AND — unlike the SubDirectory class — a leaf is dead ONLY at
+/// `$format == undef` (a non-`undef` cipher leaf is READ as its emission), so the
+/// walk guard keeps its `undef` gate for this class.
 #[must_use]
 #[inline]
 pub(crate) fn is_suppressed_cipher_leaf(tag_id: u16) -> bool {
@@ -404,47 +406,62 @@ pub(crate) fn is_suppressed_cipher_leaf(tag_id: u16) -> bool {
   )
 }
 
-/// `true` when a `%Sony::Main` row's decoded value is NEVER read from the walk's
-/// materialized `RawValue` — because the Sony capture loop re-slices the verbatim
-/// on-disk value span from the input buffer instead. The shared `Walker`'s #443
-/// zero-copy guard keys off this to store an EMPTY `RawValue` for such a row
-/// (gated to an `undef` block with `count != 1`), bounding the O(N·M) heap a
-/// crafted IFD with N such rows over one shared in-bounds M-byte region would
-/// otherwise amplify to O(N + M) — WITHOUT changing any emitted value (the
-/// re-slice reads the same span the clone would have held).
+/// `true` when a `%Sony::Main` row carries a `SubDirectory` (`sub_table: Some(_)`)
+/// — the routing fact that makes its decoded leaf value DEAD regardless of the
+/// on-disk `$format`, the FORMAT-INDEPENDENT half of the shared `Walker`'s #443/#486
+/// zero-copy guard.
 ///
-/// Two DISJOINT sub-classes, both re-sliced-from-`data`, never from the clone:
+/// A Sony Main SubDirectory NEVER emits the parent pointer as a value:
+/// `exif::mod::emit_sony_value` returns at its Step-2 SubDirectory guard
+/// (`sub_table.is_some()`) BEFORE reading the decoded `RawValue`, and each of three
+/// disjoint dispatchers re-slices the verbatim on-disk value span from the input
+/// buffer keyed on `tag_id` + `value_size`, NEVER on the decoded value:
 ///
-/// - The SUPPRESSED `%unknownCipherData` LEAVES ([`is_suppressed_cipher_leaf`]) —
-///   `sub_table: None`, emitted as a BORROWED span via `push_borrowed_span`.
-/// - The enciphered-`SubDirectory` dispatchers — every row whose `sub_table` is a
-///   variant `exif::mod::sony_emit_enciphered_subblock` handles
-///   ([`SubTable::dispatched_by_enciphered_subblock`]): `Tag2010` (`0x2010`), the
-///   whole `Tag9xxx` family (13 IDs incl. `0x9400`/`0x9402`/`0x9404`/`0x9405`/
-///   `0x9406`/`0x9050`/`0x9401`/`0x9403`/`0x9416`/`0x202a`/`0x900b`/`0x940a`/
-///   `0x940c`) and `AFInfo`/`Tag940e` (`0x940e`). Both the model/byte-matched
-///   decode AND the `%unknownCipherData` fallback re-slice the span, and
-///   `exif::mod::emit_sony_value` returns at its SubDirectory guard reading
-///   nothing.
+/// - The enciphered `ProcessEnciphered`/`ProcessBinaryData` blocks (`Tag2010`
+///   `0x2010`, the whole `Tag9xxx` family incl. `0x9400`/`0x9402`/`0x9404`/
+///   `0x9405`/`0x9406`/`0x9050`/`0x9401`/`0x9403`/`0x9416`/`0x202a`/`0x900b`/
+///   `0x940a`/`0x940c`, and `AFInfo`/`Tag940e` `0x940e`), decoded by
+///   `exif::mod::sony_emit_enciphered_subblock` — both the model/byte-matched decode
+///   AND the `%unknownCipherData` fallback re-slice the span.
+/// - The older PLAIN (un-enciphered) `ProcessBinaryData` sub-tables (`CameraInfo`
+///   `0x0010`/`FocusInfo` `0x0020`/`CameraSettings` `0x0114`/`ExtraInfo` `0x0116`/
+///   `ShotInfo` `0x3000`), decoded by `exif::mod::sony_emit_binary_subdir` — it
+///   re-slices `data[value_offset..]` for the `$count`-matched table and emits
+///   nothing (its `_ => return` arm) on a non-matching count, reading the decoded
+///   value in NEITHER case.
+/// - The remaining deferred `SubDirectory` targets (`Panorama` `0x1003`,
+///   `HiddenInfo` `0x2044`, `MinoltaMakerNote` `0xb028`, `PrintIm` `0x0e00`), which
+///   no dispatcher walks (so they emit nothing) — the `0x1003` `Panorama` DataMember
+///   side-effect (`Sony.pm:902`) that gates the `0x2010` `Tag2010d` variant
+///   re-slices its match span from `data` too (`exif::mod`'s `0x1003` walk arm reads
+///   `data.get(value_offset..)`), NOT the decoded `RawValue` — so zeroing the clone
+///   leaves the latch intact.
 ///
-/// The SubDirectory side is DERIVED FROM THE `SubTable` VARIANT (the routing),
-/// NOT a hand-maintained tag-ID list — so a future enciphered dispatcher added
-/// under `Tag9xxx` is covered automatically. This SUPERSEDES the #443 R1
-/// suppressed-leaf list + the R2 `is_conditional_cipher_subdir` id list, whose
-/// enumeration kept missing members (`0x9400`/`0x9402`/`0x9404`/`0x9405`/`0x9406`/
-/// `0x9050`/…) — the whack-a-mole this closes (#443 R3).
+/// Because that early-return + span re-slice are FORMAT-INDEPENDENT (they key off
+/// the STATIC table row + the on-disk byte extent, not the declared `$format`), a
+/// crafted duplicate SubDirectory row encoded as `int8u`/`int16u`/`ascii` (any
+/// NON-`undef` format, under the excessive-count gate) has an equally-dead decoded
+/// value. So the shared `Walker`'s guard keys off THIS predicate WITHOUT an `undef`
+/// gate (unlike [`is_suppressed_cipher_leaf`], whose non-`undef` encoding IS read as
+/// the leaf's emitted value, so the leaf class KEEPS its `undef` gate). The guard
+/// stores an EMPTY `RawValue` for such a row (with `count != 1`), bounding the O(N·M)
+/// heap a crafted IFD with N such rows over one shared in-bounds M-byte region would
+/// otherwise amplify to O(N + M) — WITHOUT changing any emitted value (the re-slice
+/// reads the same span the clone would have held). See the per-class split at
+/// `exif::mod`'s `walk_entry` guard.
 ///
-/// The older PLAIN binary sub-tables (`CameraInfo`/`FocusInfo`/`CameraSettings`/
-/// `ExtraInfo`/`ShotInfo`) also re-slice their span (via
-/// `exif::mod::sony_emit_binary_subdir`) but are intentionally left on the
-/// `read_value` path — this fix is scoped to the enciphered-subblock class, and
-/// they stay byte-identical either way.
+/// DERIVED FROM `sub_table: Some(_)` (the routing), NOT a hand-maintained tag-ID
+/// list — so a future SubDirectory row (enciphered or plain) is covered
+/// automatically. This SUPERSEDES the #443 R1 suppressed-leaf list + the R2
+/// `is_conditional_cipher_subdir` id list, whose enumeration kept missing members
+/// (`0x9400`/`0x9402`/`0x9404`/`0x9405`/`0x9406`/`0x9050`/…) — the whack-a-mole this
+/// closes (#443 R3) — AND the #443 enciphered-only carve-out that still eager-cloned
+/// the plain-binary rows (#486 R1) + the R1 SubDirectory `undef` format-gate that
+/// still eager-cloned the non-`undef` encodings (#486 R2).
 #[must_use]
-pub(crate) fn value_resliced_from_data(tag_id: u16) -> bool {
-  is_suppressed_cipher_leaf(tag_id)
-    || lookup(tag_id)
-      .and_then(|t| t.sub_table)
-      .is_some_and(|s| s.dispatched_by_enciphered_subblock())
+#[inline]
+pub(crate) fn sony_tag_has_sub_table(tag_id: u16) -> bool {
+  lookup(tag_id).is_some_and(|t| t.sub_table.is_some())
 }
 
 /// Populate the typed struct from one Sony Main-IFD leaf-tag emission. `raw` is

--- a/src/exif/makernotes/vendors/sony/tags.rs
+++ b/src/exif/makernotes/vendors/sony/tags.rs
@@ -190,40 +190,6 @@ pub enum SubTable {
   PrintIm,
 }
 
-impl SubTable {
-  /// `true` when a `%Sony::Main` row carrying this SubDirectory target is decoded
-  /// by `exif::mod::sony_emit_enciphered_subblock` — the `ProcessEnciphered`/
-  /// `ProcessBinaryData` shot/AF/lens series `Tag2010` (0x2010), the whole
-  /// `Tag9xxx` family, and `AFInfo`/`Tag940e` (0x940e), plus the one PLAIN
-  /// `Tag202a` block that shares that dispatcher.
-  ///
-  /// That dispatcher decodes the block by re-slicing the verbatim on-disk value
-  /// span from the input buffer (`data[value_offset..]`) for BOTH the model/byte-
-  /// matched decode AND the `%unknownCipherData` fallback (its `_ => {}` arm), and
-  /// `exif::mod::emit_sony_value` returns at its Step-2 SubDirectory guard WITHOUT
-  /// reading the value — so the walk's decoded [`RawValue`](crate::exif::ifd::RawValue)
-  /// clone of such a row is DEAD (never read). This is the routing fact the #443
-  /// zero-copy walk guard keys off (via [`super::value_resliced_from_data`]).
-  ///
-  /// `Tag9xxx` alone groups THIRTEEN tag IDs (`0x9050`, `0x9400`-`0x9406`,
-  /// `0x940a`, `0x940c`, `0x9416`, `0x900b`, `0x202a`), so a new enciphered
-  /// dispatcher row added under it is covered here AUTOMATICALLY — the guard needs
-  /// no hand-maintained tag-ID list (superseding the #443 R1/R2 lists that kept
-  /// missing members, #443 R3).
-  ///
-  /// Returns `false` for the older PLAIN binary sub-tables (`CameraInfo`,
-  /// `FocusInfo`, `CameraSettings`, `ExtraInfo`, `ShotInfo`) — those are decoded by
-  /// the SEPARATE `exif::mod::sony_emit_binary_subdir` dispatcher and are left on
-  /// the `read_value` path (this fix is scoped to the enciphered-subblock class;
-  /// they are byte-identical either way) — and for the non-`ProcessBinaryData`
-  /// targets (`Panorama`, `HiddenInfo`, `MinoltaMakerNote`, `PrintIm`).
-  #[must_use]
-  #[inline]
-  pub(crate) const fn dispatched_by_enciphered_subblock(&self) -> bool {
-    matches!(self, Self::Tag2010 | Self::Tag9xxx | Self::AfInfo)
-  }
-}
-
 /// `%Sony::Main` (`Sony.pm:707-2711`). Sorted by tag ID.
 ///
 /// 114 rows — one per numeric key of the bundled hash.
@@ -1388,66 +1354,76 @@ mod tests {
     assert_eq!(t.sub_table, Some(SubTable::Tag9xxx));
   }
 
-  /// The #443 R3 CLASS-KILLER routing fact: `dispatched_by_enciphered_subblock`
-  /// is true for EXACTLY the three SubDirectory variants
-  /// `sony_emit_enciphered_subblock` handles (`Tag2010`, `Tag9xxx`, `AfInfo`) and
-  /// false for the plain-binary + non-`ProcessBinaryData` variants. This is what
-  /// lets the walk guard cover the whole enciphered class from ONE variant check,
-  /// with no hand-maintained tag-ID list.
+  /// The #443/#486 CLASS-KILLER routing fact: the dead-value walk guard's
+  /// FORMAT-INDEPENDENT class (`sony_tag_has_sub_table`) is derived from
+  /// `sub_table: Some(_)`, so it covers EVERY `%Sony::Main` SubDirectory row — the
+  /// enciphered (`Tag2010`/`Tag9xxx`/`AfInfo`), the plain-binary
+  /// (`CameraInfo`/`FocusInfo`/`CameraSettings`/`ExtraInfo`/`ShotInfo`) AND the
+  /// deferred (`Panorama`/`HiddenInfo`/`MinoltaMakerNote`/`PrintIm`) targets — with
+  /// no hand-maintained tag-ID list, and (#486 R2) with NO on-disk-`$format` gate: a
+  /// SubDirectory's decoded value is dead whether it is encoded `undef` or a
+  /// duplicate `int8u`/`int16u`/`ascii`. A plain LEAF (`sub_table: None`, not a
+  /// suppressed-cipher leaf) is NOT covered (its decoded value IS its emission).
   #[test]
-  fn enciphered_subblock_class_is_variant_derived() {
-    for v in [SubTable::Tag2010, SubTable::Tag9xxx, SubTable::AfInfo] {
-      assert!(
-        v.dispatched_by_enciphered_subblock(),
-        "{v:?} is decoded by sony_emit_enciphered_subblock"
-      );
+  fn every_subdirectory_row_is_resliced_from_data() {
+    // Every `sub_table: Some(_)` row → its decoded RawValue is dead (re-sliced
+    // from `data` or read by no dispatcher), so the guard zeroes the walk clone
+    // FOR ANY on-disk format (the guard applies `sony_tag_has_sub_table` without an
+    // `undef` gate — the #486 R2 non-`undef` DoS close).
+    for t in SONY_TAGS {
+      if t.sub_table.is_some() {
+        assert!(
+          super::super::sony_tag_has_sub_table(t.id),
+          "0x{:04x} ({}) is a SubDirectory row — its decoded value must be dead \
+           (guard covers the whole `sub_table: Some(_)` class, format-independent)",
+          t.id,
+          t.name
+        );
+      }
     }
-    for v in [
-      SubTable::CameraInfo,
-      SubTable::FocusInfo,
-      SubTable::CameraSettings,
-      SubTable::ExtraInfo,
-      SubTable::ShotInfo,
-      SubTable::Panorama,
-      SubTable::HiddenInfo,
-      SubTable::MinoltaMakerNote,
-      SubTable::PrintIm,
-    ] {
+    // A plain (non-suppressed) LEAF is neither a SubDirectory row nor a suppressed
+    // cipher leaf → its decoded value IS its emission (read, not resliced).
+    for id in [0x0102u16, 0x0104, 0x201d] {
       assert!(
-        !v.dispatched_by_enciphered_subblock(),
-        "{v:?} is NOT an enciphered-subblock dispatcher (left on the read_value path)"
+        !super::super::sony_tag_has_sub_table(id) && !super::super::is_suppressed_cipher_leaf(id),
+        "0x{id:04x} is a plain leaf — its decoded value is read, not resliced"
       );
     }
   }
 
-  /// EVERY tag ID `sony_emit_enciphered_subblock` decodes must resolve — via its
-  /// `SubTable` variant — to the enciphered-subblock class, so the routing-derived
-  /// walk guard confines its walk clone. This pins the exact ID set (incl. the
-  /// members `0x9400`/`0x9402`/`0x9404`/`0x9405`/`0x9406`/`0x9050`/`0x9401`/
-  /// `0x9403`/`0x9416`/`0x202a`/`0x900b` that the R1/R2 hand lists MISSED) so a
-  /// future edit that drops one from `Tag9xxx` — or adds a dispatcher arm without
-  /// wiring its variant — is caught here, not by a fuzzer (#443 R3).
+  /// EVERY tag ID either dispatcher decodes must resolve to a `SubTable` variant,
+  /// so the `sub_table: Some(_)`-derived guard confines its walk clone. This pins
+  /// the exact enciphered ID set (incl. `0x9400`/`0x9402`/`0x9404`/`0x9405`/
+  /// `0x9406`/`0x9050`/`0x9401`/`0x9403`/`0x9416`/`0x202a`/`0x900b` — the members
+  /// the #443 R1/R2 hand lists MISSED) AND the plain-binary set (`0x0010`/`0x0020`/
+  /// `0x0114`/`0x0116`/`0x3000` — the ones #443's enciphered-only predicate left
+  /// eager-cloning), so a future edit dropping a member — or adding a dispatcher
+  /// arm without wiring its `sub_table` — is caught here, not by a fuzzer
+  /// (#443 R3 / #486).
   #[test]
-  fn every_enciphered_subblock_id_is_in_the_class() {
+  fn every_dispatched_subdir_id_is_resliced() {
+    // The enciphered `sony_emit_enciphered_subblock` IDs.
     for id in [
       0x2010u16, 0x9050, 0x9400, 0x9401, 0x9402, 0x9403, 0x9404, 0x9405, 0x9406, 0x940a, 0x940c,
       0x940e, 0x9416, 0x900b, 0x202a,
     ] {
-      let sub = lookup(id)
+      lookup(id)
         .unwrap_or_else(|| panic!("0x{id:04x} is a %Sony::Main row"))
         .sub_table
         .unwrap_or_else(|| panic!("0x{id:04x} is a SubDirectory dispatcher"));
       assert!(
-        sub.dispatched_by_enciphered_subblock(),
-        "0x{id:04x} ({sub:?}) must be in the enciphered-subblock class"
+        super::super::sony_tag_has_sub_table(id),
+        "0x{id:04x} (enciphered) must be resliced-from-data (dead walk clone)"
       );
     }
-    // The plain binary sub-tables are deliberately OUTSIDE the class.
+    // The plain-binary `sony_emit_binary_subdir` IDs — #486 R1 brings them into the
+    // guard too (they re-slice `data`, never the decoded value); #486 R2 makes that
+    // FORMAT-INDEPENDENT (`sony_tag_has_sub_table`, no `undef` gate).
     for id in [0x0010u16, 0x0020, 0x0114, 0x0116, 0x3000] {
-      let sub = lookup(id).unwrap().sub_table.unwrap();
+      lookup(id).unwrap().sub_table.unwrap();
       assert!(
-        !sub.dispatched_by_enciphered_subblock(),
-        "0x{id:04x} ({sub:?}) is a plain binary sub-table, not enciphered-subblock"
+        super::super::sony_tag_has_sub_table(id),
+        "0x{id:04x} (plain-binary) must be resliced-from-data (#486 dead walk clone)"
       );
     }
   }

--- a/src/exif/mod.rs
+++ b/src/exif/mod.rs
@@ -6437,26 +6437,48 @@ impl Walker<'_, '_> {
       && makernotes::vendors::nikon::is_implicit_undef_subdir(tag_id))
       || (self.active_table == TableRef::Pentax
         && makernotes::vendors::pentax::is_implicit_undef_subdir(tag_id))
-      // Sony `%unknownCipherData` cipher rows (#443): the SUPPRESSED-`Unknown`
-      // LEAVES *and* the enciphered-`SubDirectory` dispatchers — every row whose
-      // value the Sony capture loop re-slices from `self.data`, never reading this
-      // decoded `RawValue`. A leaf (`sub_table: None`) is emitted as a ZERO-COPY
-      // BORROWED span; a dispatcher (`sub_table: Some(Tag2010|Tag9xxx|AfInfo)`) is
-      // decoded by `sony_emit_enciphered_subblock`, which re-slices the verbatim
-      // span for BOTH the model/byte-matched decode AND the `%unknownCipherData`
-      // fallback while `emit_sony_value` returns at its SubDirectory guard reading
-      // nothing. `value_resliced_from_data` derives the whole class from the
-      // ROUTING (`SubTable::dispatched_by_enciphered_subblock` + the leaf set), so
-      // a crafted IFD with N such rows over one shared in-bounds region retains
-      // O(N) descriptors, not N clones of the (possibly-huge) `undef[N]` block —
-      // with NO change to any emitted value. Gated to `undef` with `count != 1`
-      // (the `count == 1` int8u carve-out decodes to a scalar and stays on the
-      // normal path), matching the capture loop's borrow guard. Supersedes the
-      // R1/R2 hand-listed tag-ID predicates that kept missing members (#443 R3).
+      // Sony dead-value rows (#443/#486): the SUPPRESSED-`Unknown` cipher LEAVES
+      // *and* EVERY `SubDirectory` row — every row whose value the Sony capture
+      // loop re-slices from `self.data`, never reading this decoded `RawValue`. A
+      // leaf (`sub_table: None`) is emitted as a ZERO-COPY BORROWED span; a
+      // `SubDirectory` row (`sub_table: Some(_)`) is decoded by re-slicing the
+      // verbatim span — the enciphered blocks via `sony_emit_enciphered_subblock`
+      // (both the model/byte-matched decode AND the `%unknownCipherData` fallback),
+      // the plain-binary sub-tables via `sony_emit_binary_subdir` (the
+      // `$count`-matched table or its no-op `_ => return`) — while `emit_sony_value`
+      // returns at its Step-2 SubDirectory guard reading nothing. The `0x1003`
+      // `Panorama` DataMember side-effect likewise re-slices its match span from
+      // `self.data`, so zeroing the clone leaves that latch intact. So a crafted
+      // IFD with N such rows over one shared in-bounds region retains O(N)
+      // descriptors, not N clones of the (possibly-huge) value block — with NO
+      // change to any emitted value.
+      //
+      // The `$format` gate DIFFERS per class (#486 R2 — the R1 blanket
+      // `format == undef` was still format-gated for the SubDirectory class, so a
+      // duplicate `0x0010`/`0x0020`/… SubDirectory row encoded as
+      // `int8u`/`int16u`/`ascii` (any NON-`undef` format, under the excessive-count
+      // gate) MISSED this guard and retained a dead `read_value` clone — the N×M DoS
+      // for the non-`undef` encoding):
+      //   - a SubDirectory row (`sony_tag_has_sub_table`) is dead REGARDLESS of the
+      //     on-disk `$format` — the dispatchers key on `tag_id`/`value_size` + the
+      //     `emit_sony_value` Step-2 return fire off the STATIC table row, never the
+      //     declared format — so NO `undef` gate;
+      //   - a suppressed cipher LEAF (`is_suppressed_cipher_leaf`) is dead ONLY at
+      //     `$format == undef`: the leaf's borrowed span IS its emitted value, and a
+      //     non-`undef` cipher leaf falls through to `emit_sony_value`'s Step-6
+      //     `apply(raw)`, which READS this decoded value — so KEEP the `undef` gate
+      //     (matching the capture loop's `on_disk_format == Undef` borrow guard).
+      // Both keep `count != 1` (the `count == 1` int8u carve-out decodes to a scalar
+      // — a few inline bytes, no large allocation to zero — and stays on the normal
+      // `read_value`/`emit_sony_value` path). Supersedes the R1/R2 hand-listed
+      // tag-ID predicates that kept missing members (#443 R3) + the #443
+      // enciphered-only carve-out (#486 R1) + the R1 SubDirectory format-gate
+      // (#486 R2).
       || (self.active_table == TableRef::Sony
-        && makernotes::vendors::sony::value_resliced_from_data(tag_id)
-        && matches!(format, Format::Undef)
-        && count != 1)
+        && count != 1
+        && (makernotes::vendors::sony::sony_tag_has_sub_table(tag_id)
+          || (makernotes::vendors::sony::is_suppressed_cipher_leaf(tag_id)
+            && matches!(format, Format::Undef))))
     {
       RawValue::Bytes(Vec::new())
     } else {

--- a/tests/alloc_budget.rs
+++ b/tests/alloc_budget.rs
@@ -221,6 +221,8 @@ fn alloc_budget() {
   sony_cipher_data_is_borrowed_not_amplified();
   sony_conditional_subdir_fallback_is_borrowed_not_amplified();
   sony_raw_selector_subdir_fallback_is_borrowed_not_amplified();
+  sony_plain_binary_subdir_is_borrowed_not_amplified();
+  sony_nonundef_subdir_is_borrowed_not_amplified();
 }
 
 /// The placeholder-length path ([`exifast::exif::ifd::read_value_byte_len`]) for
@@ -448,12 +450,34 @@ fn sony_region_off(n: usize) -> usize {
 /// windows in-bounds. `span` stays below the 100 000-element excessive-count
 /// gate so the walk raises no warnings.
 fn sony_cipher_tiff(ids: &[u16], region: usize) -> Vec<u8> {
+  // The #443 leaves are `undef` (format 7, 1-byte element); `count == span`.
+  sony_subdir_tiff_fmt(ids, region, 7, 1)
+}
+
+/// Craft the SAME MakerNote as [`sony_cipher_tiff`] but with a caller-chosen on-disk
+/// `format_code` (+ its `elem_size`) for every `%Sony::Main` row — used by the #486
+/// R2 probe to encode duplicate `SubDirectory` rows as a NON-`undef` format (`int8u`
+/// / `int16u` / `ascii`). Each row's on-disk value byte extent (`value_size ==
+/// count * elem_size`) stays `span == region - 16`, so the shared-region overlap +
+/// the per-row window are byte-identical to the `undef` builder; only the declared
+/// `$format` (and thus the decoded `RawValue`'s SHAPE) changes. The dead-value walk
+/// guard's SubDirectory class is format-INDEPENDENT, so it must zero the walk clone
+/// for these too — the DoS the R1 `undef`-gated guard still admitted.
+fn sony_subdir_tiff_fmt(ids: &[u16], region: usize, format_code: u16, elem_size: usize) -> Vec<u8> {
   assert!(
     ids.len() <= 16 && region >= 32,
     "up to 16 shifted windows fit"
   );
-  let span = u32::try_from(region - 16).expect("span fits u32");
-  assert!(span < 100_000, "keep count below the excessive-count gate");
+  let span_bytes = region - 16;
+  assert!(
+    span_bytes % elem_size == 0,
+    "value byte extent must be a whole number of elements"
+  );
+  // The on-disk value byte size (`$size == $count * $formatSize`) is what the
+  // dispatchers re-slice + the guard would clone; keep it FIXED at `span_bytes`
+  // across formats so the probe isolates the format gate, not the region size.
+  let count = u32::try_from(span_bytes / elem_size).expect("count fits u32");
+  assert!(count < 100_000, "keep count below the excessive-count gate");
   let region_off = sony_region_off(ids.len());
   let total = region_off + region;
   const EXIF_OFF: u32 = 26;
@@ -475,25 +499,25 @@ fn sony_cipher_tiff(ids: &[u16], region: usize) -> Vec<u8> {
   let mn_len = u32::try_from(total - MN_OFF).expect("mn_len fits u32");
   t.extend_from_slice(&1u16.to_le_bytes());
   t.extend_from_slice(&0x927cu16.to_le_bytes());
-  t.extend_from_slice(&7u16.to_le_bytes()); // UNDEF
+  t.extend_from_slice(&7u16.to_le_bytes()); // UNDEF (the MakerNote wrapper itself)
   t.extend_from_slice(&mn_len.to_le_bytes());
   t.extend_from_slice(&u32::try_from(MN_OFF).unwrap().to_le_bytes());
   t.extend_from_slice(&0u32.to_le_bytes());
   assert_eq!(t.len(), MN_OFF);
   // [44] `MakerNoteSony` primary signature (Start = $valuePtr + 12).
   t.extend_from_slice(b"SONY DSC \x00\x00\x00");
-  // [56] Sony Main IFD — the cipher leaves, ASCENDING (a valid sorted IFD).
+  // [56] Sony Main IFD — the rows, ASCENDING (a valid sorted IFD).
   t.extend_from_slice(&u16::try_from(ids.len()).unwrap().to_le_bytes());
   for (i, &id) in ids.iter().enumerate() {
     t.extend_from_slice(&id.to_le_bytes());
-    t.extend_from_slice(&7u16.to_le_bytes()); // UNDEF
-    t.extend_from_slice(&span.to_le_bytes()); // count
+    t.extend_from_slice(&format_code.to_le_bytes()); // caller-chosen on-disk format
+    t.extend_from_slice(&count.to_le_bytes()); // count (value_size == count*elem_size)
     // 1-byte-shifted, overlapping, DISTINCT windows of the shared region.
     t.extend_from_slice(&u32::try_from(region_off + i).unwrap().to_le_bytes());
   }
   t.extend_from_slice(&0u32.to_le_bytes());
   assert_eq!(t.len(), region_off);
-  // [region_off] the shared region every leaf's window overlaps.
+  // [region_off] the shared region every row's window overlaps.
   t.resize(total, 0x5a);
   t
 }
@@ -683,9 +707,9 @@ fn sony_conditional_subdir_fallback_is_borrowed_not_amplified() {
 /// they kept missing members of the same enciphered-`SubDirectory` class — e.g.
 /// `0x9405` (a `sub_table: Some(Tag9xxx)` row selected by the RAW value's FIRST
 /// BYTE, not by `Model`): pre-R3 its walk clone was NOT confined, re-amplifying
-/// O(N·M). R3 derives the class from the `SubTable` variant
-/// (`dispatched_by_enciphered_subblock`), so `0x9405` — and every other `Tag9xxx`
-/// ID — is covered WITHOUT a hand-maintained list.
+/// O(N·M). R3 (now #486) derives the class from `sub_table: Some(_)` (the routing),
+/// so `0x9405` — and every other `Tag9xxx` ID — is covered WITHOUT a
+/// hand-maintained list.
 ///
 /// This probes the RAW-SELECTOR fallback shape the reviewer named (distinct from
 /// the R2 MODEL-selector probe above): the crafted region is all `0x5a`, which is
@@ -754,6 +778,180 @@ fn sony_raw_selector_subdir_fallback_is_borrowed_not_amplified() {
      (emit no leaf); a non-zero count means a matched decode ran (test no longer \
      exercises the raw-selector fallback path)."
   );
+}
+
+/// #486 — the residual eager-clone the #443 enciphered-only guard left. The
+/// older PLAIN (un-enciphered) `ProcessBinaryData` sub-tables (`CameraInfo`
+/// `0x0010`/`FocusInfo` `0x0020`/`CameraSettings` `0x0114`/`ExtraInfo` `0x0116`/
+/// `ShotInfo` `0x3000`) ALSO decode by re-slicing the verbatim span from `data`
+/// (`sony_emit_binary_subdir`, `exif/mod.rs`), NEVER reading the walk's decoded
+/// `RawValue` — yet #443's enciphered-only guard covered ONLY the
+/// enciphered-subblock class, so each such row still `read_value`-cloned its
+/// (possibly-huge, in-bounds) `undef[N]` block. #486 R1 widens the guard to EVERY
+/// `sub_table: Some(_)` row (`sony_tag_has_sub_table`), so the plain-binary rows now
+/// store a zero-copy empty `RawValue` too. (#486 R2 then drops the residual `undef`
+/// format-gate for this class — see `sony_nonundef_subdir_is_borrowed_not_amplified`.)
+///
+/// The probe uses `0x0010` `CameraInfo` with a `$count` (`span == 90000`) that
+/// matches NONE of the ported tables (368/5478/5506/6118/15360), so
+/// `sony_emit_binary_subdir` hits its `_ => return` arm (re-slices `data`, emits
+/// NOTHING) — isolating the walk clone the fix removes. N→2N duplicate rows over
+/// ONE fixed region make N scale while M stays fixed; pre-#486 each row retained a
+/// 90000-byte clone (a plain-binary sub_table ∉ the enciphered class), so the
+/// N→2N delta was ≈ N·span; post-#486 it is O(N descriptors).
+///
+/// Called INLINE from the single `alloc_budget` test (the counters are
+/// process-global; see the module doc).
+fn sony_plain_binary_subdir_is_borrowed_not_amplified() {
+  use exifast::parse_exif;
+
+  // The per-row window; `span = region - 16` (< the 100k excessive-count gate, so
+  // the walk raises no warnings + processes every row). 90000 matches no ported
+  // CameraInfo `$count` → the plain-binary dispatcher's no-op `_ => return`.
+  const LARGE: usize = 90_016; // span 90000
+
+  // N→2N duplicate `0x0010` PLAIN-BINARY sub-table rows over the SAME large
+  // region. The non-matching count falls to `sony_emit_binary_subdir`'s no-op arm
+  // (emits nothing); pre-#486 each still retained a `read_value` clone of the
+  // 90000-byte window (a plain-binary sub_table was OUTSIDE the enciphered class).
+  let ids_n = [0x0010_u16; 4];
+  let ids_2n = [0x0010_u16; 8];
+  let tiff_n = sony_cipher_tiff(&ids_n, LARGE);
+  let tiff_2n = sony_cipher_tiff(&ids_2n, LARGE);
+  // Warm-up OUTSIDE the measured region (lazy statics / first-call init).
+  assert!(
+    parse_exif(&tiff_n).is_some(),
+    "4-row plain-binary Sony TIFF parses"
+  );
+  assert!(
+    parse_exif(&tiff_2n).is_some(),
+    "8-row plain-binary Sony TIFF parses"
+  );
+  let (_n_ok, bytes_n) = count_alloc_bytes(|| parse_exif(&tiff_n).is_some());
+  let (_2n_ok, bytes_2n) = count_alloc_bytes(|| parse_exif(&tiff_2n).is_some());
+
+  println!("\n=== alloc_budget: sony plain-binary-subdir borrow (single-copy) ===");
+  println!("  N=4 rows={bytes_n}B  N=8 rows={bytes_2n}B  (same {LARGE}B region)");
+
+  // Doubling the plain-binary row count over the SAME region adds only O(N
+  // descriptors) — FAR below one span copy. The pre-#486 path added 4 rows × one
+  // `read_value` clone ≈ 4·span here (each retained on its walked entry).
+  let span = LARGE - 16; // 90000 — the per-row window / pre-fix per-clone volume
+  let n_delta = bytes_2n.saturating_sub(bytes_n);
+  assert!(
+    n_delta < span,
+    "N→2N plain-binary sub-table rows grew {n_delta} bytes for the SAME region — \
+     the widened guard must store a zero-copy empty RawValue for a `0x0010` \
+     `CameraInfo` row (O(N descriptors)), NOT O(N·M); a growth ≥ one span \
+     ({span}) means the plain-binary rows' read_value clone is still eager (the \
+     #486 gap the #443 enciphered-only predicate left)."
+  );
+
+  // Confirm we exercised the PLAIN-BINARY no-op path (not a matched decode): the
+  // 90000-byte count matches no ported `CameraInfo` table, so `0x0010` re-slices
+  // `data` and emits NO leaf. A non-zero count would mean a matched sub-table
+  // decode ran (the probe would no longer isolate the eager-clone the fix removes).
+  let meta = parse_exif(&tiff_n).expect("plain-binary Sony TIFF parses");
+  let plain_leaves = meta
+    .maker_note()
+    .map_or(0, |mn| mn.emissions_print_conv().len());
+  assert_eq!(
+    plain_leaves, 0,
+    "0x0010 with a non-matching count must fall to sony_emit_binary_subdir's no-op \
+     arm (emit no leaf); a non-zero count means a matched decode ran (test no \
+     longer isolates the plain-binary eager-clone)."
+  );
+}
+
+/// #486 R2 — the residual eager-clone the R1 (`undef`-gated) guard STILL left for a
+/// NON-`undef` SubDirectory encoding. The R1 guard zeroed the walk clone only for
+/// `matches!(format, Format::Undef)`, but a `%Sony::Main` `SubDirectory` row's
+/// decoded value is dead REGARDLESS of the on-disk `$format`: `emit_sony_value`
+/// returns at its Step-2 `sub_table.is_some()` guard (a STATIC table fact, not a
+/// format check) and `sony_emit_binary_subdir` re-slices `data` keyed on
+/// `tag_id`/`value_size`, so it reads the decoded `RawValue` for NO format. A
+/// crafted IFD can therefore encode duplicate `0x0010` `CameraInfo` rows as `int8u`
+/// (format 1) / `int16u` (format 3) / `ascii` (format 2) over one shared span — all
+/// NON-`undef` — and (pre-R2) each retained a large dead `read_value` clone, the
+/// SAME N×M DoS #486 R1 closed for `undef`, re-opened for every other format.
+///
+/// This probe mirrors `sony_plain_binary_subdir_is_borrowed_not_amplified` but sweeps
+/// the three attacker-reachable non-`undef` shapes (each with a `count > 1` under the
+/// 100 000 excessive-count gate, so no warning fires and the guard's `count != 1`
+/// carve-out does not apply). For each, doubling the row count over the SAME region
+/// must add only O(N descriptors) — proving the guard's SubDirectory class is now
+/// FORMAT-INDEPENDENT (the R2 fix). `int8u`/`ascii` (1-byte element) worst-case:
+/// their `read_value` clone is a `Vec<u64>`/`Box<[u8]>` of `span` elements — for
+/// `int8u` that is 8·span bytes, LARGER than the `undef` case, so the R1 gap this
+/// closes was strictly worse for the integer encoding.
+///
+/// Called INLINE from the single `alloc_budget` test (the counters are
+/// process-global; see the module doc).
+fn sony_nonundef_subdir_is_borrowed_not_amplified() {
+  use exifast::parse_exif;
+
+  // span 90000 (< the 100k excessive-count gate). 90000 matches no ported
+  // CameraInfo `$count`/`value_size` → the plain-binary dispatcher's `_ => return`.
+  const LARGE: usize = 90_016;
+  let span = LARGE - 16; // 90000 — the per-row window / pre-fix per-clone volume
+
+  println!("\n=== alloc_budget: sony NON-undef subdir borrow (#486 R2, single-copy) ===");
+
+  // (format_code, elem_size, label) — the three attacker-reachable non-`undef`
+  // encodings of a `0x0010` SubDirectory row. `value_size == count * elem_size ==
+  // span` in every build, so the shared-region window is byte-identical to the
+  // `undef` probe; only the declared `$format` (⇒ decoded `RawValue` shape) differs.
+  for &(fmt, elem, label) in &[(1u16, 1usize, "int8u"), (3, 2, "int16u"), (2, 1, "ascii")] {
+    let ids_n = [0x0010_u16; 4];
+    let ids_2n = [0x0010_u16; 8];
+    let tiff_n = sony_subdir_tiff_fmt(&ids_n, LARGE, fmt, elem);
+    let tiff_2n = sony_subdir_tiff_fmt(&ids_2n, LARGE, fmt, elem);
+    // Warm-up OUTSIDE the measured region (lazy statics / first-call init).
+    assert!(
+      parse_exif(&tiff_n).is_some(),
+      "4-row {label} Sony TIFF parses"
+    );
+    assert!(
+      parse_exif(&tiff_2n).is_some(),
+      "8-row {label} Sony TIFF parses"
+    );
+    let (_n_ok, bytes_n) = count_alloc_bytes(|| parse_exif(&tiff_n).is_some());
+    let (_2n_ok, bytes_2n) = count_alloc_bytes(|| parse_exif(&tiff_2n).is_some());
+    let n_delta = bytes_2n.saturating_sub(bytes_n);
+    println!(
+      "  {label:<6}  N=4 rows={bytes_n}B  N=8 rows={bytes_2n}B  Δ(N→2N)={n_delta}B  (same {span}B span)"
+    );
+
+    // Doubling the NON-`undef` SubDirectory row count over the SAME region adds only
+    // O(N descriptors) — FAR below one span copy. The pre-R2 (`undef`-gated) guard
+    // MISSED these rows, so each of the 4 extra rows retained one `read_value` clone
+    // (≥ span bytes; for `int8u`/`ascii` a `Vec<u64>`/`Box<[u8]>` of `span` elements),
+    // so the delta was ≈ 4·span. A growth ≥ one span means the guard is STILL
+    // format-gated (the #486 R2 gap).
+    assert!(
+      n_delta < span,
+      "N→2N {label} SubDirectory rows grew {n_delta} bytes for the SAME region — the \
+       widened guard must store a zero-copy empty RawValue for a `0x0010` `CameraInfo` \
+       row REGARDLESS of its on-disk format (O(N descriptors)), NOT O(N·M); a growth ≥ \
+       one span ({span}) means the SubDirectory guard is still `undef`-gated (the #486 \
+       R2 non-`undef` DoS bypass)."
+    );
+
+    // Confirm the NON-`undef` no-op path (not a matched decode): the 90000-byte
+    // value_size matches no ported `CameraInfo` table, so `0x0010` re-slices `data`
+    // and emits NO leaf — the same isolation the R1 `undef` probe asserts. (A
+    // matched decode would mean the probe no longer isolates the eager-clone.)
+    let meta = parse_exif(&tiff_n).unwrap_or_else(|| panic!("{label} Sony TIFF parses"));
+    let leaves = meta
+      .maker_note()
+      .map_or(0, |mn| mn.emissions_print_conv().len());
+    assert_eq!(
+      leaves, 0,
+      "0x0010 ({label}) with a non-matching value_size must fall to \
+       sony_emit_binary_subdir's no-op arm (emit no leaf); a non-zero count means a \
+       matched decode ran (test no longer isolates the eager-clone)."
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Widen the merged-#443 Sony resliced-value DoS bound from the enciphered-sub-block-only carve-out to **all** Sony `sub_table` rows, and make the guard **format-independent** for that class (#486 R1 + R2).

The #443 zero-copy guard zeroed the dead `read_value` clone only for the enciphered sub-blocks (`Tag2010`/`Tag9xxx`/`AfInfo`). The plain-binary Sony sub-directories (`CameraInfo` 0x0010 / `FocusInfo` 0x0020 / `CameraSettings` 0x0114 / `ExtraInfo` 0x0116 / `ShotInfo` 0x3000) also re-slice their value span from `data` via `sony_emit_binary_subdir` and never read the decoded value, yet still retained an eager clone — the residual N×M crafted-DoS gap this closes.

## Details

- **R1** — widen the predicate to cover all `sub_table` rows; remove the now-dead `dispatched_by_enciphered_subblock`. The 0x1003 Panorama latch was ground-truthed to read from `data` (not the decoded value), so zeroing the clone leaves it intact.
- **R2 (Codex [high])** — the widened guard was still gated by `matches!(format, Undef)`, so a crafted **non-undef** (int8u/int16u/ascii, under the excessive-count gate) `sub_table` row bypassed it and retained a dead clone. Split the guard by class: a `sub_table` row (`sony_tag_has_sub_table`) is zeroed **regardless of on-disk format** — the dead-value invariant is format-independent (`emit_sony_value` early-returns at its Step-2 SubDirectory guard and the three dispatchers re-slice from `data` keyed on tag_id/value_size) — while a suppressed cipher **leaf** keeps its `undef` gate, because a non-undef leaf's borrowed span *is* read as its emitted value (Step-6 `apply(raw)`). Renamed `value_resliced_from_data` → `sony_tag_has_sub_table` (sub_table-only).
- Added `tests/alloc_budget.rs::sony_nonundef_subdir_is_borrowed_not_amplified` — duplicate 0x0010 rows encoded as int8u/int16u/ascii over one shared span → O(N descriptors), not O(N·span).

## Verify

`fmt=0  build(-D warnings, --all-features --all-targets)=0  alloc_budget=0  conformance=515/0 (byte-identical)  typed_serde_parity=0  timed_metadata=163/0  lib=4377/0  xtask=0`

Byte-identical to bundled ExifTool 13.59 for all real fixtures (this is a crafted-DoS-completeness change, not an output change). All Sony latch tests (0x1003 Panorama, 0x9050 double-cipher) and the rewritten resliced-invariant tests pass.

Codex adversarial review: **APPROVE** (R2, no material findings).

Closes #486.
