### PR TITLE
refactor(tagmap): thread a per-entry walk-sequence (byte-identical) — #474 PR 1/2 infra

### DIFF
--- a/src/composite/mod.rs
+++ b/src/composite/mod.rs
@@ -166,6 +166,7 @@ impl CompositeSink for crate::tagmap::TagMap {
       u8,
       TagValue,
       smol_str::SmolStr,
+      u32,
     )| {
       (groups.is_empty() || groups.contains(&entry.2.as_str()))
         && group0.is_none_or(|g0| entry.6.as_str() == g0)
@@ -180,6 +181,7 @@ impl CompositeSink for crate::tagmap::TagMap {
         u8,
         TagValue,
         smol_str::SmolStr,
+        u32,
       )| { entry.0 == d && entry.3.as_str() == name && group_ok(entry) }
     };
     // Within a single document, a GROUP-SCOPED input (`groups` non-empty) takes
@@ -194,21 +196,33 @@ impl CompositeSink for crate::tagmap::TagMap {
     // 3872) over the earlier-emitted `SubIFD:ImageWidth` (the `%Exif::Main`
     // `Priority => 0` tag, 3880); a Pentax `File:ImageWidth` (`Priority => 1`)
     // beats an `XMP-tiff:ImageWidth` (`%XMP::tiff PRIORITY => 0`). Among EQUAL max
-    // priority we keep the FIRST-emitted (today's tiebreak) — the equal-priority
-    // true file-walk-order recency tiebreak (ExifTool's `$priority >= $oldPriority`
-    // last-wins) is deferred to #474, because exifast's emission order is NOT file
-    // order, so a last-match flip would regress the 6 Pentax composites.
+    // priority the tiebreak is the MIN walk-`seq` (entry.7) — the earliest-inserted
+    // = first-emitted entry (#474 PR 1). Because `seq` == first-occurrence order
+    // (never re-stamped, see `TagMap::insert`), this is BYTE-IDENTICAL to the prior
+    // first-among-equals tiebreak; reading `seq` makes the walk-order axis explicit.
+    // #474 PR 2 flips MIN→MAX `seq` for ExifTool's true `$priority >= $oldPriority`
+    // last-walked `FoundTag` tiebreak (ExifTool.pm:9564), together with a PngMeta
+    // chunk-walk-order emission override — a flip today (without that override, and
+    // given exifast's emission order is NOT file order) would regress the 6 Pentax
+    // composites, so it is intentionally split into PR 2.
     let find_in = |d: u32| {
       if groups.is_empty() {
-        // MAX effective priority, FIRST-emitted among equals (`>` is strict, so a
-        // later equal-priority entry never displaces the first match).
+        // MAX effective priority; among EQUAL priority, MIN walk-`seq` (entry.7,
+        // the earliest-inserted = first-emitted). PR 2 flips `<` to `>` for the
+        // last-walked tiebreak.
         self
           .entries()
           .iter()
           .filter(pred_in(d))
-          .map(|e| (e, crate::tagmap::effective_priority(e.3.as_str(), e.4)))
-          .reduce(|best, cur| if cur.1 > best.1 { cur } else { best })
-          .map(|(e, _)| e)
+          .map(|e| (e, crate::tagmap::effective_priority(e.3.as_str(), e.4), e.7))
+          .reduce(|best, cur| {
+            if cur.1 > best.1 || (cur.1 == best.1 && cur.2 < best.2) {
+              cur
+            } else {
+              best
+            }
+          })
+          .map(|(e, _, _)| e)
       } else {
         self.entries().iter().rev().find(pred_in(d))
       }
@@ -228,6 +242,7 @@ impl CompositeSink for crate::tagmap::TagMap {
           u8,
           TagValue,
           smol_str::SmolStr,
+          u32,
         )| { entry.0 != 0 && entry.3.as_str() == name && group_ok(entry) };
         // First cross-doc match by emission order (the lowest `Doc<N>` first,
         // i.e. ExifTool's earliest-extracted base key).
@@ -243,7 +258,7 @@ impl CompositeSink for crate::tagmap::TagMap {
     self
       .entries()
       .iter()
-      .any(|(d, _sub, fam1, n, _pri, _val, _f0)| {
+      .any(|(d, _sub, fam1, n, _pri, _val, _f0, _seq)| {
         *d == doc && fam1.as_str() == "Composite" && n.as_str() == name
       })
   }
@@ -284,22 +299,34 @@ impl CompositeSink for std::vec::Vec<(crate::value::Tag, u8)> {
         item.0.group_ref().doc() == d && item.0.name() == name && group_ok(&item.0)
       }
     };
-    // Bare-name (empty `groups`) ⇒ the HIGHEST effective priority wins, FIRST-
-    // emitted among equals; group-scoped ⇒ LAST match (the duplicate-override).
-    // See the `TagMap` impl's note (equal-priority recency is #474).
+    // Bare-name (empty `groups`) ⇒ the HIGHEST effective priority wins; among
+    // EQUAL priority, the MIN positional index — this `Vec`'s position IS its
+    // walk-`seq` (it is built in emission order and a winning duplicate replaces
+    // IN PLACE, keeping position), so min-index = first-emitted, byte-identical to
+    // the prior first-among-equals AND consistent with the `TagMap` sink's MIN
+    // `seq`. Group-scoped ⇒ LAST match (the duplicate-override). #474 PR 2 flips
+    // this to MAX for the last-walked tiebreak (see the `TagMap` impl's note).
     let find_in = |d: u32| {
       if groups.is_empty() {
         self
           .iter()
-          .filter(pred_in(d))
-          .map(|item| {
+          .enumerate()
+          .filter(|(_i, item)| pred_in(d)(item))
+          .map(|(i, item)| {
             (
               item,
               crate::tagmap::effective_priority(item.0.name(), item.1),
+              i,
             )
           })
-          .reduce(|best, cur| if cur.1 > best.1 { cur } else { best })
-          .map(|(item, _)| item)
+          .reduce(|best, cur| {
+            if cur.1 > best.1 || (cur.1 == best.1 && cur.2 < best.2) {
+              cur
+            } else {
+              best
+            }
+          })
+          .map(|(item, _, _)| item)
       } else {
         self.iter().rev().find(pred_in(d))
       }
@@ -413,7 +440,7 @@ pub(crate) fn make_context(
     value_view
       .entries()
       .iter()
-      .map(|(_d, _s, g, n, _p, v, _f0)| (g.as_str(), n.as_str(), v)),
+      .map(|(_d, _s, g, n, _p, v, _f0, _seq)| (g.as_str(), n.as_str(), v)),
   );
   CompositeContext::new(media_data_total, rotation)
 }

--- a/src/composite/tests.rs
+++ b/src/composite/tests.rs
@@ -532,6 +532,48 @@ fn signed_and_whitespace_string_ingredients_coerce_via_shared_perl_rule() {
   assert_eq!(composite(&m3, "Sum"), Some(TagValue::F64(100.0)));
 }
 
+/// #474 PR 1 — the bare-name `FoundTag` resolver settles an EQUAL-effective-
+/// priority tie by the MIN walk-`seq` (the FIRST-emitted entry), while priority
+/// still DOMINATES the seq (a higher-priority entry wins regardless of order).
+/// This locks the byte-identical PR-1 semantics (min-seq = first-emitted); PR 2
+/// flips the tiebreak to MAX-`seq` for ExifTool's last-walked `>=` rule.
+#[test]
+fn bare_name_resolver_breaks_equal_priority_ties_by_min_seq() {
+  // (a) Two EQUAL-priority (both `1`) same-name entries in DIFFERENT groups ⇒
+  // the resolver returns the FIRST-emitted (min-`seq`) one.
+  let mut m = TagMap::new();
+  let _ = m.write_value_doc(0, "", "First", "Foo", 1, TagValue::U64(10), "First");
+  let _ = m.write_value_doc(0, "", "Second", "Foo", 1, TagValue::U64(20), "Second");
+  assert_eq!(
+    m.resolve(&[], None, "Foo", DocScope::Main),
+    CompositeValue::Present(TagValue::U64(10)),
+    "equal priority ⇒ the first-emitted (min-seq) entry wins"
+  );
+
+  // (b) Priority DOMINATES seq: a higher-priority LATER entry beats a
+  // lower-effective-priority EARLIER one (so the tiebreak is only consulted at
+  // equal priority).
+  let mut m = TagMap::new();
+  let _ = m.write_value_doc(0, "", "Early", "Bar", 0, TagValue::U64(1), "Early");
+  let _ = m.write_value_doc(0, "", "Late", "Bar", 1, TagValue::U64(2), "Late");
+  assert_eq!(
+    m.resolve(&[], None, "Bar", DocScope::Main),
+    CompositeValue::Present(TagValue::U64(2)),
+    "a higher-priority later entry wins over a lower-priority earlier one"
+  );
+
+  // (c) ...and a higher-priority EARLIER entry beats a lower-priority LATER one
+  // (priority dominates in either order).
+  let mut m = TagMap::new();
+  let _ = m.write_value_doc(0, "", "Early", "Baz", 1, TagValue::U64(1), "Early");
+  let _ = m.write_value_doc(0, "", "Late", "Baz", 0, TagValue::U64(2), "Late");
+  assert_eq!(
+    m.resolve(&[], None, "Baz", DocScope::Main),
+    CompositeValue::Present(TagValue::U64(1)),
+    "a higher-priority earlier entry wins over a lower-priority later one"
+  );
+}
+
 // ===========================================================================
 // The registered GPS Composites (GPS.pm / Exif.pm) — end-to-end through the
 // real `REGISTRY` over a two-view (ValueConv + PrintConv) GPS TagMap pair. These
@@ -2233,8 +2275,10 @@ mod subdoc {
   fn composite_at(m: &TagMap, doc: u32, name: &str) -> Option<TagValue> {
     m.entries()
       .iter()
-      .find(|(d, _s, g, n, _p, _v, _)| *d == doc && g.as_str() == "Composite" && n.as_str() == name)
-      .map(|(_d, _s, _g, _n, _p, v, _)| v.clone())
+      .find(|(d, _s, g, n, _p, _v, _, _)| {
+        *d == doc && g.as_str() == "Composite" && n.as_str() == name
+      })
+      .map(|(_d, _s, _g, _n, _p, v, _, _)| v.clone())
   }
 
   #[test]
@@ -2608,7 +2652,7 @@ mod subdoc {
       map
         .entries()
         .iter()
-        .filter(|(d, _s, _g1, n, _p, _v, _f0)| *d == 1 && n.as_str() == "GPSLatitude")
+        .filter(|(d, _s, _g1, n, _p, _v, _f0, _seq)| *d == 1 && n.as_str() == "GPSLatitude")
         .count(),
       1,
       "mixed-family-0 duplicate must collapse to one entry"
@@ -2781,7 +2825,7 @@ mod subdoc {
         map
           .entries()
           .iter()
-          .filter(|(d, _s, _g1, n, _p, _v, _f0)| *d == 1 && n.as_str() == name)
+          .filter(|(d, _s, _g1, n, _p, _v, _f0, _seq)| *d == 1 && n.as_str() == name)
           .count(),
         1,
         "the {name} loser duplicate must collapse to one entry"

--- a/src/format_parser.rs
+++ b/src/format_parser.rs
@@ -2154,7 +2154,7 @@ const _: () = {
       // `Doc<N>…:`.
       let group_mode = self.group_mode;
       let mut key = std::string::String::new();
-      for (doc, doc_subpath, group, name, _priority, value, _family0) in entries {
+      for (doc, doc_subpath, group, name, _priority, value, _family0, _seq) in entries {
         crate::serialize_key::group_key_into(
           &mut key,
           *doc,

--- a/src/formats/ape.rs
+++ b/src/formats/ape.rs
@@ -3306,11 +3306,11 @@ mod tests {
     let desc_idx = tm
       .entries()
       .iter()
-      .position(|(_, _, g, n, _, _, _)| g == "APE" && n == "CoverArtFrontDesc");
+      .position(|(_, _, g, n, _, _, _, _)| g == "APE" && n == "CoverArtFrontDesc");
     let cover_idx = tm
       .entries()
       .iter()
-      .position(|(_, _, g, n, _, _, _)| g == "APE" && n == "CoverArtFront");
+      .position(|(_, _, g, n, _, _, _, _)| g == "APE" && n == "CoverArtFront");
     assert!(desc_idx < cover_idx);
   }
 
@@ -3443,7 +3443,7 @@ mod tests {
     let names: Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, _, g, n, _, _, _)| (g == "APE").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _, _, _)| (g == "APE").then_some(n.as_str()))
       .collect();
     assert_eq!(names, &["Title", "Artist"]);
     assert_eq!(

--- a/src/formats/audible.rs
+++ b/src/formats/audible.rs
@@ -1735,7 +1735,7 @@ mod tests {
     let tm = emit_into_tagmap(&meta, true);
     tm.entries()
       .iter()
-      .filter_map(|(_, _, g, n, _, v, _)| (g == "Audible").then(|| (n.to_string(), v.clone())))
+      .filter_map(|(_, _, g, n, _, v, _, _)| (g == "Audible").then(|| (n.to_string(), v.clone())))
       .collect()
   }
 

--- a/src/formats/dsf.rs
+++ b/src/formats/dsf.rs
@@ -1904,7 +1904,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, _, g, n, _, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
+        .any(|(_, _, g, n, _, _, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 trailer tags present in the engine output"
     );
   }

--- a/src/formats/flac.rs
+++ b/src/formats/flac.rs
@@ -2366,7 +2366,7 @@ mod tests {
     let names: Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, _, g, n, _, _, _)| (g == "FLAC").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _, _, _)| (g == "FLAC").then_some(n.as_str()))
       .filter(|n| n.starts_with("Picture"))
       .collect();
     assert_eq!(
@@ -2837,7 +2837,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, _, g, n, _, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
+        .any(|(_, _, g, n, _, _, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 tags present in the engine output"
     );
   }

--- a/src/formats/h264.rs
+++ b/src/formats/h264.rs
@@ -3787,7 +3787,7 @@ mod tests {
     let wb_keys = j
       .entries()
       .iter()
-      .filter(|(_, _, _, n, _, _, _)| n.contains("WhiteBalance"))
+      .filter(|(_, _, _, n, _, _, _, _)| n.contains("WhiteBalance"))
       .count();
     assert_eq!(wb_keys, 1, "only the priority winner is emitted");
   }
@@ -3891,7 +3891,7 @@ mod tests {
     let wb_keys = j
       .entries()
       .iter()
-      .filter(|(_, _, _, n, _, _, _)| n.contains("WhiteBalance"))
+      .filter(|(_, _, _, n, _, _, _, _)| n.contains("WhiteBalance"))
       .count();
     assert_eq!(wb_keys, 1, "only the first-wins survivor is emitted");
   }

--- a/src/formats/id3/process.rs
+++ b/src/formats/id3/process.rs
@@ -3031,7 +3031,7 @@ mod tests {
     // `(family1, name, value)` shape this comparison helper compares.
     tm.entries()
       .iter()
-      .map(|(_, _, g, n, _, v, _)| (g.clone(), n.clone(), v.clone()))
+      .map(|(_, _, g, n, _, v, _, _)| (g.clone(), n.clone(), v.clone()))
       .collect()
   }
 
@@ -3086,7 +3086,7 @@ mod tests {
       out
         .entries()
         .iter()
-        .map(|(_, _, g, n, _, v, _)| (g.clone(), n.clone(), v.clone()))
+        .map(|(_, _, g, n, _, v, _, _)| (g.clone(), n.clone(), v.clone()))
         .collect()
     }
 

--- a/src/formats/moi.rs
+++ b/src/formats/moi.rs
@@ -1326,7 +1326,7 @@ mod tests {
     let format_names: std::vec::Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, _, g, n, _, _, _)| (g == "MOI").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _, _, _)| (g == "MOI").then_some(n.as_str()))
       .collect();
     assert_eq!(
       format_names,

--- a/src/formats/mpc.rs
+++ b/src/formats/mpc.rs
@@ -1513,7 +1513,11 @@ mod tests {
     // No MPC:* tags emitted (sv7_header is None). The format-tag entries
     // carry the `"<Group1>:<Name>"` keys; warnings live in their own
     // accumulator (`TagMap::warnings`).
-    assert!(w.entries().iter().all(|(_, _, g, _, _, _, _)| g != "MPC"));
+    assert!(
+      w.entries()
+        .iter()
+        .all(|(_, _, g, _, _, _, _, _)| g != "MPC")
+    );
     // The warning is pushed through write_warning ⇒ TagMap::warnings.
     assert_eq!(
       w.warnings(),
@@ -1728,7 +1732,7 @@ mod tests {
     let keys: std::vec::Vec<&str> = w
       .entries()
       .iter()
-      .map(|(_, _, g, _, _, _, _)| g.as_str())
+      .map(|(_, _, g, _, _, _, _, _)| g.as_str())
       .collect();
     let mpc_pos = keys.iter().position(|g| *g == "MPC");
     let ape_pos = keys.iter().position(|g| *g == "APE");

--- a/src/formats/ogg.rs
+++ b/src/formats/ogg.rs
@@ -3443,7 +3443,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, _, g, n, _, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3527,7 +3527,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, _, g, n, _, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3566,7 +3566,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, _, g, n, _, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3607,7 +3607,7 @@ mod tests {
     let keys: Vec<String> = tm
       .entries()
       .iter()
-      .map(|(_, _, g, n, _, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _, _, _)| std::format!("{g}:{n}"))
       .collect();
     assert_eq!(
       keys,
@@ -3680,7 +3680,7 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, _, g, n, _, _, _)| g == "Vorbis" && n != "Vendor"),
+        .any(|(_, _, g, n, _, _, _, _)| g == "Vorbis" && n != "Vendor"),
       "at least one Vorbis comment beyond vendor: {:?}",
       w.entries()
     );
@@ -3970,13 +3970,13 @@ mod tests {
     assert!(
       w.entries()
         .iter()
-        .any(|(_, _, g, n, _, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
+        .any(|(_, _, g, n, _, _, _, _)| g.starts_with("ID3v2") || (g == "File" && n == "ID3Size")),
       "ID3 tags present in the engine output"
     );
     assert!(
       w.entries()
         .iter()
-        .any(|(_, _, g, _, _, _, _)| g == "Vorbis"),
+        .any(|(_, _, g, _, _, _, _, _)| g == "Vorbis"),
       "OGG body tags present in the engine output"
     );
   }

--- a/src/formats/real.rs
+++ b/src/formats/real.rs
@@ -3060,7 +3060,7 @@ mod tests {
   fn keys(tm: &crate::tagmap::TagMap) -> Vec<String> {
     tm.entries()
       .iter()
-      .map(|(_, _, g, n, _, _, _)| std::format!("{g}:{n}"))
+      .map(|(_, _, g, n, _, _, _, _)| std::format!("{g}:{n}"))
       .collect()
   }
 

--- a/src/formats/wavpack.rs
+++ b/src/formats/wavpack.rs
@@ -1469,7 +1469,7 @@ mod tests {
     let names: std::vec::Vec<&str> = tm
       .entries()
       .iter()
-      .filter_map(|(_, _, g, n, _, _, _)| (g == "File").then_some(n.as_str()))
+      .filter_map(|(_, _, g, n, _, _, _, _)| (g == "File").then_some(n.as_str()))
       .collect();
     assert_eq!(
       names,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1124,6 +1124,8 @@ struct DocObject<'a> {
     crate::value::TagValue,
     // family-0 — Composite-resolution metadata only; the JSON key is family-1.
     smol_str::SmolStr,
+    // walk-seq — Composite-resolution bookkeeping only; not part of the JSON key.
+    u32,
   )],
   /// The group-key form: `-G1` (collapse the doc axis — the conformance golden
   /// form) vs `-G3` (`Doc<N>:` prefix). The engine renders `-G1` by default.
@@ -1144,7 +1146,7 @@ impl serde::Serialize for DocObject<'_> {
     // prefixes `Doc<N>…:`), skip any key already emitted by `obj` (first-wins),
     // and serialize the value straight through `TagValue::Serialize`.
     let mut key = String::new();
-    for (doc, doc_subpath, group, name, _priority, value, _family0) in self.entries {
+    for (doc, doc_subpath, group, name, _priority, value, _family0, _seq) in self.entries {
       crate::serialize_key::group_key_into(
         &mut key,
         *doc,

--- a/src/tagmap.rs
+++ b/src/tagmap.rs
@@ -167,7 +167,7 @@ pub(crate) fn emitted_dedup_override(
 /// emission. Net per-insert: one `HashMap` probe + (on a new key) two inline
 /// `SmolStr` clones, vs the old heap `format!` + a growing linear scan.
 pub(crate) struct TagMap {
-  /// `(doc, doc_subpath, family1, name, priority, value, family0)` in
+  /// `(doc, doc_subpath, family1, name, priority, value, family0, seq)` in
   /// first-occurrence order. A repeated `(doc, doc_subpath, family1, name)`
   /// overrides the stored `(priority, value)` in place IFF the NEW duplicate's
   /// effective priority is non-zero AND `>=` the stored priority (ExifTool's
@@ -202,7 +202,21 @@ pub(crate) struct TagMap {
   /// family-0 (the video track-scoped Sony/QuickTime/GoPro case). A priority-0
   /// `Warning`/`Error` duplicate never wins, so its slot keeps the first
   /// (surviving) family0 — also consistent.
-  entries: Vec<(u32, SmolStr, SmolStr, SmolStr, u8, TagValue, SmolStr)>,
+  ///
+  /// The trailing `seq` is the entry's WALK SEQUENCE: the value of
+  /// [`next_seq`](Self::next_seq) at the [`insert`](Self::insert) that FIRST
+  /// created this slot. It is assigned ONCE and never re-stamped — a later
+  /// same-key duplicate that wins the last-wins override updates
+  /// `(priority, value, family0)` but leaves `seq`, so `seq` increases strictly
+  /// with first-occurrence POSITION. It exists so the bare-name Composite
+  /// resolver can break an equal-effective-priority tie by walk order
+  /// (`FoundTag`, ExifTool.pm:9564); today it reads the MIN `seq` among equals,
+  /// which — because `seq` == position order — is exactly the first-inserted =
+  /// first-emitted entry, i.e. BYTE-IDENTICAL to the pre-`seq` first-among-equals
+  /// tiebreak and consistent with the `Vec<(Tag, u8)>` sink's positional index.
+  /// #474 PR 2 flips the resolver to MAX `seq` for the faithful last-walked
+  /// tiebreak, and re-stamps on a winning replace at that point.
+  entries: Vec<(u32, SmolStr, SmolStr, SmolStr, u8, TagValue, SmolStr, u32)>,
   /// `(doc, doc_subpath, family1, name) → index into `entries`` for O(1) dedup.
   /// The key clones the short `SmolStr`s (inline for ≤23 bytes — no heap), so
   /// the dedup probe never builds the `"g:n"` string the old design allocated
@@ -213,6 +227,12 @@ pub(crate) struct TagMap {
   index: HashMap<(u32, SmolStr, SmolStr, SmolStr), usize>,
   warnings: Vec<String>,
   errors: Vec<String>,
+  /// Monotonic walk-sequence counter: the `seq` stamped on the NEXT
+  /// [`insert`](Self::insert), incremented once per `insert` call (so a slot's
+  /// `seq` reflects its insertion order in the emission walk). See the `entries`
+  /// `seq` field doc — it is the walk-order axis the bare-name Composite resolver
+  /// uses to break equal-priority ties (min-`seq` today = first-emitted).
+  next_seq: u32,
 }
 
 impl TagMap {
@@ -223,6 +243,7 @@ impl TagMap {
       index: HashMap::new(),
       warnings: Vec::new(),
       errors: Vec::new(),
+      next_seq: 0,
     }
   }
 
@@ -295,6 +316,14 @@ impl TagMap {
     // `Warning`/`Error` name fallback forces effective priority to `0` even when
     // the producer passed the default `1`, preserving their first-wins.
     let effective_priority = effective_priority(name, priority);
+    // The walk-sequence stamp for THIS insertion (insertion order in the
+    // emission walk). Consumed once per `insert` call — even a losing duplicate
+    // (a no-op) advances the counter, so gaps are harmless: only the RELATIVE
+    // order of surviving `seq`s matters to the resolver. `saturating_add` avoids
+    // a debug overflow panic on a pathological tag count (well beyond the DoS
+    // budget) while staying monotonic non-decreasing.
+    let seq = self.next_seq;
+    self.next_seq = self.next_seq.saturating_add(1);
     let key = (
       doc,
       SmolStr::new(doc_subpath),
@@ -324,6 +353,16 @@ impl TagMap {
         self.entries[idx].4 = effective_priority;
         self.entries[idx].5 = value;
         self.entries[idx].6 = SmolStr::new(family0);
+        // NOTE (#474 PR 1/2): `seq` is deliberately NOT re-stamped on a winning
+        // replace, so an entry keeps its FIRST-insertion `seq` for its whole
+        // life. That makes `seq` strictly increase with first-occurrence POSITION
+        // (a later same-key duplicate never reorders `seq`), which is exactly
+        // what keeps the bare-name resolver's MIN-`seq` tiebreak byte-identical to
+        // the pre-`seq` first-among-equals — AND keeps it consistent with the
+        // `Vec<(Tag, u8)>` sink, whose positional index is its `seq`. PR 2 flips
+        // the resolver to MAX-`seq` for the faithful last-walked `FoundTag`
+        // tiebreak (ExifTool.pm:9564) and, AT THAT POINT, re-stamps here so the
+        // surviving `seq` tracks the last-walked contributor.
       }
       return;
     }
@@ -336,6 +375,7 @@ impl TagMap {
       effective_priority,
       value,
       SmolStr::new(family0),
+      seq,
     ));
     self.index.insert(key, idx);
   }
@@ -483,15 +523,18 @@ impl TagMap {
   }
 
   /// The collected format-tag entries
-  /// `(doc, doc_subpath, family1, name, priority, value, family0)` in
+  /// `(doc, doc_subpath, family1, name, priority, value, family0, seq)` in
   /// first-occurrence order (the priority-aware dedup already applied). The
   /// consumer builds the JSON key ONCE per entry here via
   /// [`crate::serialize_key::group_key`] (not per emission) — `-G1` collapses
   /// the leading `(doc, doc_subpath)`, `-G3` renders it as a `Doc<N>…:` prefix;
-  /// the `priority` is dedup bookkeeping the consumers ignore. Slice view of the
-  /// backing `Vec` (§3: never expose `&Vec<T>`).
+  /// the `priority`, `family0` and `seq` are dedup / Composite-resolution
+  /// bookkeeping the JSON consumers ignore. Slice view of the backing `Vec`
+  /// (§3: never expose `&Vec<T>`).
   #[inline(always)]
-  pub(crate) const fn entries(&self) -> &[(u32, SmolStr, SmolStr, SmolStr, u8, TagValue, SmolStr)] {
+  pub(crate) const fn entries(
+    &self,
+  ) -> &[(u32, SmolStr, SmolStr, SmolStr, u8, TagValue, SmolStr, u32)] {
     self.entries.as_slice()
   }
 
@@ -619,7 +662,7 @@ mod tests {
     let doc2 = m
       .entries()
       .iter()
-      .filter(|(d, _, _, _, _, _, _)| *d == 2)
+      .filter(|(d, _, _, _, _, _, _, _)| *d == 2)
       .count();
     assert_eq!(doc2, 1);
   }
@@ -668,7 +711,7 @@ mod tests {
     let deep = m
       .entries()
       .iter()
-      .find(|(d, sub, _, _, _, _, _)| *d == 1 && sub.as_str() == "-1-1")
+      .find(|(d, sub, _, _, _, _, _, _)| *d == 1 && sub.as_str() == "-1-1")
       .expect("the Doc1-1-1 entry survives");
     assert_eq!(deep.5, TagValue::Str("three-again".into()));
   }
@@ -732,7 +775,7 @@ mod tests {
     let names: std::vec::Vec<&str> = m
       .entries()
       .iter()
-      .map(|(_, _, _, n, _, _, _)| n.as_str())
+      .map(|(_, _, _, n, _, _, _, _)| n.as_str())
       .collect();
     assert_eq!(names, ["A", "B"]);
   }
@@ -873,5 +916,69 @@ mod tests {
       !emitted_dedup_override(&new_p1, &stored_p2),
       "a Priority=>1 duplicate must NOT override a stored Priority=>2 survivor"
     );
+  }
+
+  /// #474 PR 1 — the per-entry walk-`seq`. It is a monotonic insertion counter
+  /// stamped ONCE at an entry's first insertion and NEVER re-stamped, so it
+  /// tracks first-occurrence order (this is what keeps the bare-name Composite
+  /// resolver's MIN-`seq` tiebreak byte-identical to the pre-`seq` first-among-
+  /// equals). Reading `entries()[i].7` — the private `seq` slot — from the test
+  /// module (same crate) is fine.
+  #[test]
+  fn walk_seq_is_the_first_insertion_order_and_not_restamped() {
+    let seq_of = |m: &TagMap, name: &str| -> u32 {
+      m.entries()
+        .iter()
+        .find(|e| e.3.as_str() == name)
+        .expect("entry present")
+        .7
+    };
+
+    // (a) Distinct keys get strictly increasing `seq`s in insertion order.
+    let mut m = TagMap::new();
+    m.insert(0, "", "G", "A", 1, TagValue::U64(1), "G");
+    m.insert(0, "", "G", "B", 1, TagValue::U64(2), "G");
+    m.insert(0, "", "G", "C", 1, TagValue::U64(3), "G");
+    let seqs: std::vec::Vec<u32> = m.entries().iter().map(|e| e.7).collect();
+    assert_eq!(seqs, [0, 1, 2], "seq is the monotonic insertion order");
+
+    // (b) A last-wins REPLACE (ordinary priority `1 >= 1`) updates the value but
+    // KEEPS the slot's FIRST-insertion `seq` (NOT re-stamped) — the keep-first
+    // invariant that guarantees min-seq ≡ first-emitted. The counter still
+    // advanced (the next new key gets `seq == 4`, not `3`).
+    m.insert(0, "", "G", "A", 1, TagValue::U64(99), "G"); // wins, replaces A's value
+    assert_eq!(seq_of(&m, "A"), 0, "winning replace keeps the FIRST seq");
+    assert_eq!(
+      m.get("G", "A"),
+      Some(&TagValue::U64(99)),
+      "value is last-wins-replaced"
+    );
+    m.insert(0, "", "G", "D", 1, TagValue::U64(4), "G");
+    assert_eq!(
+      seq_of(&m, "D"),
+      4,
+      "the insert counter advanced past the replace"
+    );
+
+    // (c) A priority-0 `Warning`/`Error` duplicate LOSES (first-wins) and its
+    // slot likewise keeps its first `seq` (nothing is touched).
+    let mut m = TagMap::new();
+    m.insert(0, "", "G", "Warning", 1, TagValue::Str("first".into()), "G");
+    let first_warn_seq = seq_of(&m, "Warning");
+    m.insert(
+      0,
+      "",
+      "G",
+      "Warning",
+      1,
+      TagValue::Str("second".into()),
+      "G",
+    ); // loses
+    assert_eq!(
+      seq_of(&m, "Warning"),
+      first_warn_seq,
+      "a losing Warning duplicate leaves the first seq untouched"
+    );
+    assert_eq!(m.get("G", "Warning"), Some(&TagValue::Str("first".into())));
   }
 }


### PR DESCRIPTION
## Summary

PR **1 of 2** for #474 (faithful ExifTool FoundTag equal-priority tiebreak). This PR is the **byte-identical infrastructure**: it threads a per-entry walk-sequence through the TagMap and wires the bare-name Composite resolver to read it — with **no behavior change**. PR 2 flips the tiebreak to max-seq (last-walked) and gives PngMeta a faithful chunk-walk override, which is what actually resolves #474.

## Changes

- **TagMap entry** widened 7-tuple → 8-tuple with a trailing `seq: u32` (walk/insertion sequence), assigned at the single `insert()` choke-point from a monotonic `next_seq` counter. Every emit path flows through `insert()`, so **no threading through the 518 `EmittedTag` constructors** — ~39 destructure/construct sites updated (seq placed LAST so `.0`..`.6` positional accessors are unaffected).
- **seq is keep-first**: assigned once at first push, never re-stamped on a last-wins dedup replace → `seq` equals first-occurrence position unconditionally. (Re-stamping would let a bumped entry's seq leapfrog a different-key equal-priority sibling and break byte-identity + two-sink parity.)
- **Resolver** (both bare-name reduces) reads the seq as (max effective priority, then **MIN seq** among equals) — exactly the prior first-emitted behavior (min-seq = first-by-iteration), hence byte-identical. The Vec `(Tag,u8)` sink uses its `enumerate()` index as its seq (consistent first-occurrence order, no widening).

## Verify

`fmt=0  build(-D warnings, --all-features --all-targets)=0  alloc_budget=0  conformance=515/0 (byte-identical, incl. MNG_embedded_ihdr.mng + the 6 Pentax)  typed_serde_parity=337 (EXPECTED_ACTIVE unchanged)  timed_metadata=163/0  lib=4379/0 (+2 new tests)  xtask=26/0`

Codex adversarial review: **APPROVE** (no material findings — min-seq reducers verified byte-identical, tuple widening complete, scope contained).

Part of #474 (**does not close it**; PR 2 does).
